### PR TITLE
Improved bootstrap, README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ The Java API supports the following core features of the MarkLogic database:
 *  Execute ACID modifications so the change either succeeds or throws an exception.
 *  Execute multi-statement transactions so changes to multiple documents succeed or fail together.
 
+### QuickStart
+
+For people working with MarkLogic 8 EA
+
+mvn test-compile
+sh src/test/resources/boot-test.sh
+mvn test
+
 ### Learning More
 
 The following resources introduce and document the Java API:

--- a/src/test/resources/bootstrap.xqy
+++ b/src/test/resources/bootstrap.xqy
@@ -746,17 +746,18 @@ declare function bootstrap:post(
     $input as document-node()*
 ) as document-node()*
 {
-    for $user in ("rest-admin", "rest-reader", "rest-writer", "valid")
+    for $user in ("rest-admin", "rest-reader", "rest-writer", "valid") 
     let $user-id := 
         try {
             xdmp:user($user)
         } catch($e) {
+            xdmp:log("User "||$user||" not found.")
         }
     return
-        if (exists($user-id)) then ()
+        if (exists($user-id)) then xdmp:log("User "|| $user || ", id "||$user-id|| "already exists")
         else if ($user eq "valid")
         then bootstrap:security-config('sec:create-user("valid", "valid unprivileged user", "x", (), (), (), ())')
-        else bootstrap:security-config('sec:create-user($user, $user||" user", "x", ($user), (), (), () )'),
+        else bootstrap:security-config('sec:create-user("'||$user||'", "'||$user||' user", "x", ("'||$user||'"), (), (), () )'),
 
     let $dbid := xdmp:database("java-unittest")
     return (


### PR DESCRIPTION
The current java client api doesn't provide an out-of-box bootstrap... its user creation is broken.  This patch fixes that situation.  Should be put into 7 branch as well.  README updated to give quick start.
