### PR TITLE
Issue #19. Mvn site repository configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,15 @@
 		<javadoc-title>${project.name} 2.0 ${maven.build.timestamp}</javadoc-title>
 		<maven.build.timestamp.format>yyyy-MM-dd</maven.build.timestamp.format>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <github.global.server>github</github.global.server>
 	</properties>
+    <distributionManagement>
+        <repository>
+            <id>internal.repo</id>
+            <name>Temporary Staging Repository</name>
+            <url>file://${project.build.directory}/mvn-repo</url>
+        </repository>
+    </distributionManagement>
 	<build>
 		<plugins>
 			<plugin>
@@ -120,6 +128,36 @@
 					</execution>
 				</executions>
 			</plugin>
+            <plugin>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>2.8.1</version>
+                <configuration>
+                    <altDeploymentRepository>internal.repo::default::file://${project.build.directory}/mvn-repo</altDeploymentRepository>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.github.github</groupId>
+                <artifactId>site-maven-plugin</artifactId>
+                <version>0.9</version>
+                <configuration>
+                    <message>Maven artifacts for ${project.version}</message>
+                    <noJekyll>true</noJekyll>
+                    <outputDirectory>${project.build.directory}/mvn-repo</outputDirectory>
+                    <branch>refs/heads/mvn-repo</branch>
+                    <includes><include>**/*</include></includes>
+                    <repositoryName>java-client-api</repositoryName>
+                    <repositoryOwner>marklogic</repositoryOwner>
+                </configuration>
+                <executions>
+                    <!-- run site-maven-plugin's 'site' target as part of the build's normal 'deploy' phase -->
+                    <execution>
+                        <goals>
+                            <goal>site</goal>
+                        </goals>
+                        <phase>deploy</phase>
+                    </execution>
+                </executions>
+        </plugin>
 		</plugins>
 	</build>
 	<dependencies>


### PR DESCRIPTION
This change introduces a method to manage snapshot builds for the public and for samplestack.  It works great!

I made a wiki page about what this does

https://github.com/marklogic/java-client-api/wiki/Using-snapshot-builds

It works for samplestack just fine, so I'm happy with the results for EA-2.  I do want everyone to understand what's going on.
