### PR TITLE
issue #89 close input streams

### DIFF
--- a/src/main/java/com/marklogic/client/alerting/RuleDefinition.java
+++ b/src/main/java/com/marklogic/client/alerting/RuleDefinition.java
@@ -301,6 +301,11 @@ public class RuleDefinition extends BaseHandle<InputStream, OutputStreamSender>
 		HandleAccessor.receiveContent(handle, content);
 		Element ruleElement = handle.get().getDocumentElement();
 		receiveElement(ruleElement);
+		try {
+			content.close();
+		} catch (IOException e) {
+			//ignore
+		}
 	}
 
 	void receiveElement(Element ruleElement) {

--- a/src/main/java/com/marklogic/client/extra/dom4j/DOM4JHandle.java
+++ b/src/main/java/com/marklogic/client/extra/dom4j/DOM4JHandle.java
@@ -222,7 +222,14 @@ public class DOM4JHandle
 			throw new MarkLogicIOException(e);
 		} catch (DocumentException e) {
 			throw new MarkLogicIOException(e);
+		} finally {
+			try {
+				content.close();
+			} catch (IOException e) {
+				// ignore.
+			}
 		}
+
 	}
 
 	@Override

--- a/src/main/java/com/marklogic/client/extra/gson/GSONHandle.java
+++ b/src/main/java/com/marklogic/client/extra/gson/GSONHandle.java
@@ -16,6 +16,7 @@
 package com.marklogic.client.extra.gson;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
@@ -182,7 +183,14 @@ public class GSONHandle
 			throw new MarkLogicIOException(e);
 		} catch (UnsupportedEncodingException e) {
 			throw new MarkLogicIOException(e);
+		} finally {
+			try {
+				content.close();
+			} catch (IOException e) {
+				// ignore.
+			}
 		}
+
 
 	}
 	@Override

--- a/src/main/java/com/marklogic/client/extra/jdom/JDOMHandle.java
+++ b/src/main/java/com/marklogic/client/extra/jdom/JDOMHandle.java
@@ -223,6 +223,12 @@ public class JDOMHandle
 			throw new MarkLogicIOException(e);
 		} catch (IOException e) {
 			throw new MarkLogicIOException(e);
+		} finally {
+			try {
+				content.close();
+			} catch (IOException e) {
+				// ignore.
+			}
 		}
 	}
 

--- a/src/main/java/com/marklogic/client/extra/xom/XOMHandle.java
+++ b/src/main/java/com/marklogic/client/extra/xom/XOMHandle.java
@@ -203,6 +203,12 @@ public class XOMHandle
 			throw new MarkLogicIOException(e);
 		} catch (IOException e) {
 			throw new MarkLogicIOException(e);
+		} finally {
+			try {
+				content.close();
+			} catch (IOException e) {
+				// ignore.
+			}
 		}
 	}
 

--- a/src/main/java/com/marklogic/client/io/JAXBHandle.java
+++ b/src/main/java/com/marklogic/client/io/JAXBHandle.java
@@ -278,6 +278,12 @@ public class JAXBHandle<C>
 		} catch (UnsupportedEncodingException e) {
 			logger.error("Failed to unmarshall object read from database document",e);
 			throw new MarkLogicIOException(e);
+		}  finally {
+			try {
+				content.close();
+			} catch (IOException e) {
+				// ignore.
+			}
 		}
 	}
     @Override

--- a/src/main/java/com/marklogic/client/io/JacksonDatabindHandle.java
+++ b/src/main/java/com/marklogic/client/io/JacksonDatabindHandle.java
@@ -138,8 +138,13 @@ public class JacksonDatabindHandle<T>
             throw new MarkLogicIOException(e);
         } catch (IOException e) {
             throw new MarkLogicIOException(e);
-        }
-
+        } finally {
+			try {
+				content.close();
+			} catch (IOException e) {
+				// ignore.
+			}
+		}
     }
     @Override
     protected boolean hasContent() {

--- a/src/main/java/com/marklogic/client/io/JacksonHandle.java
+++ b/src/main/java/com/marklogic/client/io/JacksonHandle.java
@@ -134,6 +134,12 @@ public class JacksonHandle
 			throw new MarkLogicIOException(e);
 		} catch (IOException e) {
 			throw new MarkLogicIOException(e);
+		} finally {
+			try {
+				content.close();
+			} catch (IOException e) {
+				// ignore.
+			}
 		}
 
 	}

--- a/src/main/java/com/marklogic/client/io/QueryOptionsHandle.java
+++ b/src/main/java/com/marklogic/client/io/QueryOptionsHandle.java
@@ -1038,7 +1038,13 @@ public final class QueryOptionsHandle
         } catch (UnsupportedEncodingException e) {
             // This can't actually happen...stupid checked exceptions
             throw new MarkLogicBindingException(e);
-        }
+        } finally {
+			try {
+				content.close();
+			} catch (IOException e) {
+				// ignore.
+			}
+		}
 	}
 	
 	protected OutputStreamSender sendContent() {

--- a/src/main/java/com/marklogic/client/io/TuplesHandle.java
+++ b/src/main/java/com/marklogic/client/io/TuplesHandle.java
@@ -15,6 +15,7 @@
  */
 package com.marklogic.client.io;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
@@ -24,19 +25,19 @@ import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
 
-import com.marklogic.client.query.AggregateResult;
-import com.marklogic.client.query.ValuesMetrics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.marklogic.client.MarkLogicBindingException;
 import com.marklogic.client.MarkLogicIOException;
-import com.marklogic.client.query.Tuple;
 import com.marklogic.client.impl.TuplesBuilder;
-import com.marklogic.client.query.TuplesResults;
-import com.marklogic.client.query.ValuesDefinition;
 import com.marklogic.client.io.marker.OperationNotSupported;
 import com.marklogic.client.io.marker.TuplesReadHandle;
+import com.marklogic.client.query.AggregateResult;
+import com.marklogic.client.query.Tuple;
+import com.marklogic.client.query.TuplesResults;
+import com.marklogic.client.query.ValuesDefinition;
+import com.marklogic.client.query.ValuesMetrics;
 
 /**
  * A TuplesHandle represents a set of tuples returned by a query on the server.
@@ -109,7 +110,13 @@ public class TuplesHandle
         } catch (JAXBException e) {
 			logger.error("Failed to unmarshall tuples",e);
 			throw new MarkLogicIOException(e);
-        }
+        } finally {
+			try {
+				content.close();
+			} catch (IOException e) {
+				// ignore.
+			}
+		}
     }
 
     /**

--- a/src/main/java/com/marklogic/client/io/ValuesHandle.java
+++ b/src/main/java/com/marklogic/client/io/ValuesHandle.java
@@ -15,6 +15,7 @@
  */
 package com.marklogic.client.io;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
@@ -24,19 +25,19 @@ import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
 
-import com.marklogic.client.query.AggregateResult;
-import com.marklogic.client.query.ValuesMetrics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.marklogic.client.MarkLogicBindingException;
 import com.marklogic.client.MarkLogicIOException;
-import com.marklogic.client.query.CountedDistinctValue;
 import com.marklogic.client.impl.ValuesBuilder;
-import com.marklogic.client.query.ValuesDefinition;
-import com.marklogic.client.query.ValuesResults;
 import com.marklogic.client.io.marker.OperationNotSupported;
 import com.marklogic.client.io.marker.ValuesReadHandle;
+import com.marklogic.client.query.AggregateResult;
+import com.marklogic.client.query.CountedDistinctValue;
+import com.marklogic.client.query.ValuesDefinition;
+import com.marklogic.client.query.ValuesMetrics;
+import com.marklogic.client.query.ValuesResults;
 
 /**
  * A ValuesHandle represents a list of values or of tuples
@@ -114,7 +115,13 @@ public class ValuesHandle
         } catch (JAXBException e) {
 			logger.error("Failed to unmarshall values",e);
 			throw new MarkLogicIOException(e);
-        }
+        } finally {
+			try {
+				content.close();
+			} catch (IOException e) {
+				// ignore.
+			}
+		}
     }
 
     /**

--- a/src/main/java/com/marklogic/client/io/ValuesListHandle.java
+++ b/src/main/java/com/marklogic/client/io/ValuesListHandle.java
@@ -15,6 +15,7 @@
  */
 package com.marklogic.client.io;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
@@ -30,9 +31,9 @@ import org.slf4j.LoggerFactory;
 import com.marklogic.client.MarkLogicBindingException;
 import com.marklogic.client.MarkLogicIOException;
 import com.marklogic.client.impl.ValuesListBuilder;
-import com.marklogic.client.query.ValuesListResults;
 import com.marklogic.client.io.marker.OperationNotSupported;
 import com.marklogic.client.io.marker.ValuesListReadHandle;
+import com.marklogic.client.query.ValuesListResults;
 
 /**
  * A ValuesListHandle represents a list of available named lexicon configurations
@@ -127,7 +128,14 @@ public class ValuesListHandle
         } catch (JAXBException e) {
 			logger.error("Failed to unmarshall values list",e);
 			throw new MarkLogicIOException(e);
-        }
+        } finally {
+			try {
+				content.close();
+			} catch (IOException e) {
+				// ignore.
+			}
+		}
+
     }
 
     /**

--- a/src/test/java/com/marklogic/client/test/JacksonHandleTest.java
+++ b/src/test/java/com/marklogic/client/test/JacksonHandleTest.java
@@ -15,8 +15,12 @@
  */
 package com.marklogic.client.test;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -28,6 +32,12 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.client.document.JSONDocumentManager;
 import com.marklogic.client.io.JacksonHandle;
+import com.marklogic.client.io.SearchHandle;
+import com.marklogic.client.query.MatchDocumentSummary;
+import com.marklogic.client.query.MatchLocation;
+import com.marklogic.client.query.QueryDefinition;
+import com.marklogic.client.query.QueryManager;
+import com.marklogic.client.query.StructuredQueryBuilder;
 import com.marklogic.client.test.Common;
 
 public class JacksonHandleTest {
@@ -80,4 +90,24 @@ public class JacksonHandleTest {
 		// delete the document
 		docMgr.delete(docId);
 	}
+
+	@Test
+	public void test105Searches() throws IOException {
+		QueryManager queryMgr = Common.client.newQueryManager();
+		StructuredQueryBuilder qb = queryMgr.newStructuredQueryBuilder();
+		
+		for (int i=0;i<105;i++) {
+			for (QueryDefinition t : new QueryDefinition[] { qb.term("leaf3"),
+					qb.build(qb.value(qb.element("leaf"), "leaf3")) }) {
+				JacksonHandle results = queryMgr.search(t, new JacksonHandle());
+				assertNotNull(results);
+				JsonNode jsonResults =results.get();
+				@SuppressWarnings("unused")
+				String resultString = results.getMapper().writeValueAsString(jsonResults);
+				// ignore.
+			}
+		}
+	}	
+
 }
+


### PR DESCRIPTION
This fix should be reviewed a little carefully.  I found that this issue is potentially all over the place in handles that ignore input streams.  I made a test that hits a JacksonHandle 105 times to ensure that the streams are closed, but have not duplicated that task for every handle affected.

Existing tests all still pass, so I'm not closing anything prematurely (that's under test coverage)
