### PR TITLE
Ignore IntelliJ IDEA project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,11 @@ target/
 *.class
 test-complete/build/
 
+# Ignore IntelliJ IDEA files
+*.ipr
+*.iws
+*.iml
+
 # Package Files #
 *.jar
 *.war


### PR DESCRIPTION
Makes life easier for developers using IntelliJ IDEA not accidentally commit their project files.