### PR TITLE
Added some tests for PatchBuilder replaceInsert

### DIFF
--- a/src/test/java/com/marklogic/client/test/JSONDocumentTest.java
+++ b/src/test/java/com/marklogic/client/test/JSONDocumentTest.java
@@ -16,8 +16,7 @@
 package com.marklogic.client.test;
 
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.io.File;
 import java.io.IOException;
@@ -42,14 +41,7 @@ import com.marklogic.client.document.DocumentPatchBuilder;
 import com.marklogic.client.document.DocumentPatchBuilder.PathLanguage;
 import com.marklogic.client.document.DocumentPatchBuilder.Position;
 import com.marklogic.client.document.JSONDocumentManager;
-import com.marklogic.client.io.BytesHandle;
-import com.marklogic.client.io.DocumentMetadataHandle.Capability;
-import com.marklogic.client.io.FileHandle;
-import com.marklogic.client.io.Format;
-import com.marklogic.client.io.InputStreamHandle;
-import com.marklogic.client.io.ReaderHandle;
-import com.marklogic.client.io.StringHandle;
-import com.marklogic.client.io.marker.DocumentPatchHandle;
+import com.marklogic.client.io.*;
 
 public class JSONDocumentTest {
 


### PR DESCRIPTION
With the current situation of the `b3_0` sources, it looks like there are no tests for the straight replaceInsert functionality of the patch builder (EDIT: there seems to be one test under `test-complete` directory called `TestPartialUpdate` which replace/inserts on array elements). In a recent project I found out, that the behavior of the patch builder does differ if the node does exist (replace) vs. if does not yet exist (insert: will put the whole fragment instead of the selectPath). This behavior is for the application developer a bit inconvenient, since you have to check first wether the node does exist or not, and then to decide how you structure the fragment node in question.

NOTE: Therefore this test case highlights the current problem and the second assertion (L. 357, "please make me not nested") will fail.