### PR TITLE
Graph delete, Default parameters for query definition

### DIFF
--- a/src/main/java/com/marklogic/client/impl/GraphManagerImpl.java
+++ b/src/main/java/com/marklogic/client/impl/GraphManagerImpl.java
@@ -225,19 +225,17 @@ public class GraphManagerImpl<R extends TriplesReadHandle, W extends TriplesWrit
     public void writeAs(String uri, Object graphData,
             GraphPermissions permissions, Transaction transaction) {
         // TODO Auto-generated method stub
-        
+
     }
 
     @Override
     public void delete(String uri) {
-        // TODO Auto-generated method stub
-        
+        services.deleteGraph(requestLogger, uri, null);
     }
 
     @Override
     public void delete(String uri, Transaction transaction) {
-        // TODO Auto-generated method stub
-        
+        services.deleteGraph(requestLogger, uri, transaction);
     }
 
     @Override

--- a/src/main/java/com/marklogic/client/impl/JerseyServices.java
+++ b/src/main/java/com/marklogic/client/impl/JerseyServices.java
@@ -5378,6 +5378,19 @@ public class JerseyServices implements RESTServices {
 	}
 
 	@Override
+	public Object deleteGraph(RequestLogger reqlog, String uri,
+			Transaction transaction) throws ForbiddenUserException,
+			FailedRequestException {
+		RequestParameters params = new RequestParameters();
+		if ( uri != null ) {
+			params.add("graph", uri);
+		} else {
+			params.add("default", "");
+		}
+		return deleteResource(reqlog, "graphs", transaction, params, null);
+
+	}
+	@Override
 	public <R extends AbstractReadHandle> R executeSparql(RequestLogger reqlog, 
 		SPARQLQueryDefinition qdef, R output, long start, long pageLength,
 		Transaction transaction, boolean isUpdate)
@@ -5431,4 +5444,5 @@ public class JerseyServices implements RESTServices {
 		if ( transaction == null ) return null;
 		return transaction.getTransactionId();
 	}
+
 }

--- a/src/main/java/com/marklogic/client/impl/JerseyServices.java
+++ b/src/main/java/com/marklogic/client/impl/JerseyServices.java
@@ -5429,6 +5429,26 @@ public class JerseyServices implements RESTServices {
 			String mimetype = isUpdate ? "application/sparql-update" : "application/sparql-query";
 			input = new StringHandle(sparql).withMimetype(mimetype);
 		}
+		if (qdef.getDefaultGraphUris() != null) {
+		    for (String defaultGraphUri : qdef.getDefaultGraphUris()) {
+		        params.add("default-graph-uri", defaultGraphUri);
+		    }
+		}
+		if (qdef.getNamedGraphUris() != null) {
+            for (String namedGraphUri : qdef.getNamedGraphUris()) {
+                params.add("named-graph-uri", namedGraphUri);
+            }
+        }
+		if (qdef.getUsingGraphUris() != null) {
+            for (String usingGraphUri : qdef.getUsingGraphUris()) {
+                params.add("using-graph-uri", usingGraphUri);
+            }
+        }
+		if (qdef.getUsingNamedUris() != null) {
+            for (String usingGraphUri : qdef.getUsingGraphUris()) {
+                params.add("using-named-uri", usingGraphUri);
+            }
+        }
 
 		// TODO: do we want this default?
 		HandleImplementation baseHandle = HandleAccessor.checkHandle(output, "graphs/sparql");

--- a/src/main/java/com/marklogic/client/impl/JerseyServices.java
+++ b/src/main/java/com/marklogic/client/impl/JerseyServices.java
@@ -130,6 +130,7 @@ import com.marklogic.client.semantics.GraphPermissions;
 import com.marklogic.client.semantics.SPARQLBinding;
 import com.marklogic.client.semantics.SPARQLBindings;
 import com.marklogic.client.semantics.SPARQLQueryDefinition;
+import com.marklogic.client.semantics.SPARQLRuleset;
 import com.marklogic.client.util.EditableNamespaceContext;
 import com.marklogic.client.util.RequestLogger;
 import com.marklogic.client.util.RequestParameters;
@@ -5449,6 +5450,13 @@ public class JerseyServices implements RESTServices {
                 params.add("using-named-uri", usingGraphUri);
             }
         }
+		
+		// rulesets
+		if (qdef.getRulesets() != null) {
+		    for (SPARQLRuleset ruleset : qdef.getRulesets()) {
+		        params.add("ruleset", ruleset.getName());
+		    }
+		}
 
 		// TODO: do we want this default?
 		HandleImplementation baseHandle = HandleAccessor.checkHandle(output, "graphs/sparql");

--- a/src/main/java/com/marklogic/client/impl/RESTServices.java
+++ b/src/main/java/com/marklogic/client/impl/RESTServices.java
@@ -283,6 +283,9 @@ public interface RESTServices {
 	public <R extends AbstractReadHandle> R writeGraph(RequestLogger reqlog, String uri,
 		AbstractWriteHandle input, GraphPermissions permissions, Transaction transaction)
 		throws ResourceNotFoundException, ForbiddenUserException, FailedRequestException;
+	public Object deleteGraph(RequestLogger requestLogger, String uri,
+			Transaction transaction)
+			throws ForbiddenUserException, FailedRequestException;
 	public <R extends AbstractReadHandle> R executeSparql(RequestLogger reqlog, 
 		SPARQLQueryDefinition qdef, R output, long start, long pageLength,
 		Transaction transaction, boolean isUpdate);

--- a/src/main/java/com/marklogic/client/impl/SPARQLQueryDefinitionImpl.java
+++ b/src/main/java/com/marklogic/client/impl/SPARQLQueryDefinitionImpl.java
@@ -30,6 +30,10 @@ public class SPARQLQueryDefinitionImpl implements SPARQLQueryDefinition {
 
     private String sparql;
     private SPARQLBindings bindings = new SPARQLBindingsImpl();
+    private String[] defaultGraphUris;
+    private String[] namedGraphUris;
+    private String[] usingGraphUris;
+    private String[] usingNamedUris;
 
     public SPARQLQueryDefinitionImpl(String sparql) {
         this.sparql = sparql;
@@ -156,16 +160,36 @@ public class SPARQLQueryDefinitionImpl implements SPARQLQueryDefinition {
 
     @Override
     public void setDefaultGraphUris(String... uris) {
-        // TODO Auto-generated method stub
-        
+        this.defaultGraphUris = uris;
     }
 
     @Override
     public void setNamedGraphUris(String... uris) {
-        // TODO Auto-generated method stub
-        
+        this.namedGraphUris = uris;
     }
 
+
+    @Override
+    public String[] getDefaultGraphUris() {
+        return this.defaultGraphUris;
+    }
+
+    @Override
+    public String[] getNamedGraphUris() {
+        return this.namedGraphUris;
+    }
+
+    @Override
+    public String[] getUsingGraphUris() {
+        return this.usingGraphUris;
+    }
+
+    @Override
+    public String[] getUsingNamedUris() {
+        return this.usingNamedUris;
+    }
+
+    
     @Override
     public void setConstrainingQueryDefinintion(QueryDefinition query) {
         // TODO Auto-generated method stub
@@ -207,6 +231,16 @@ public class SPARQLQueryDefinitionImpl implements SPARQLQueryDefinition {
             QueryDefinition structuredQuery) {
         // TODO Auto-generated method stub
         return this;
+    }
+
+    @Override
+    public void setUsingGraphUris(String... uris) {
+        this.usingGraphUris = uris;
+    }
+
+    @Override
+    public void setUsingNamedUris(String... uris) {
+        this.usingNamedUris = uris;
     }
 
 }

--- a/src/main/java/com/marklogic/client/impl/SPARQLQueryDefinitionImpl.java
+++ b/src/main/java/com/marklogic/client/impl/SPARQLQueryDefinitionImpl.java
@@ -15,6 +15,7 @@
  */
 package com.marklogic.client.impl;
 
+import java.util.Arrays;
 import java.util.Locale;
 
 import com.marklogic.client.document.ServerTransform;
@@ -34,6 +35,7 @@ public class SPARQLQueryDefinitionImpl implements SPARQLQueryDefinition {
     private String[] namedGraphUris;
     private String[] usingGraphUris;
     private String[] usingNamedUris;
+    private SPARQLRuleset[] ruleSets;
 
     public SPARQLQueryDefinitionImpl(String sparql) {
         this.sparql = sparql;
@@ -210,19 +212,22 @@ public class SPARQLQueryDefinitionImpl implements SPARQLQueryDefinition {
 
     @Override
     public void setRulesets(SPARQLRuleset... ruleset) {
-        // TODO Auto-generated method stub
-        
+        this.ruleSets = ruleset;
     }
 
     @Override
     public SPARQLRuleset[] getRulesets() {
-        // TODO Auto-generated method stub
-        return null;
+        return ruleSets;
     }
 
     @Override
     public SPARQLQueryDefinition withRuleset(SPARQLRuleset ruleset) {
-        // TODO Auto-generated method stub
+        if (this.ruleSets == null) {
+            this.ruleSets = new SPARQLRuleset[] { ruleset };
+        }
+        else {
+            Arrays.asList(this.ruleSets).add(ruleset);
+        }
         return this;
     }
 

--- a/src/main/java/com/marklogic/client/semantics/RDFMimeTypes.java
+++ b/src/main/java/com/marklogic/client/semantics/RDFMimeTypes.java
@@ -1,0 +1,19 @@
+package com.marklogic.client.semantics;
+
+
+/**
+ * Some static constants to provide enum-like access
+ * to MimeTypes in use by the Semantics endpoints. 
+ */
+public final class RDFMimeTypes {
+
+    public final static String NTRIPLES  = "application/n-triples";
+    public final static String TURTLE    = "text/turtle";
+    public final static String N3        = "text/n3";
+    public final static String RDFXML    = "application/rdf+xml";
+    public final static String RDFJSON   = "applicatoin/rdf+json";
+    public final static String NQUADS    = "application/n-quads";
+    public final static String TRIG      = "text/trig";
+    public final static String TRIPLEXML = "application/vnd.marklogic.triples+xml";
+
+}

--- a/src/main/java/com/marklogic/client/semantics/SPARQLQueryDefinition.java
+++ b/src/main/java/com/marklogic/client/semantics/SPARQLQueryDefinition.java
@@ -40,8 +40,15 @@ public interface SPARQLQueryDefinition extends QueryDefinition {
     public void setUpdatePermissions(GraphPermissions permissions);
     public GraphPermissions getUpdatePermissions();
     public SPARQLQueryDefinition withUpdatePermission(String role, Capability capability);
+
+    public String[] getDefaultGraphUris();
+    public String[] getNamedGraphUris();
+    public String[] getUsingGraphUris();
+    public String[] getUsingNamedUris();
     public void setDefaultGraphUris(String... uris);
     public void setNamedGraphUris(String... uris);
+    public void setUsingGraphUris(String... uris);
+    public void setUsingNamedUris(String... uris);
 
     public void setConstrainingQueryDefinintion(QueryDefinition query);
     public QueryDefinition getConstrainingQueryDefinintion();
@@ -51,4 +58,5 @@ public interface SPARQLQueryDefinition extends QueryDefinition {
     public SPARQLRuleset[] getRulesets();
     public SPARQLQueryDefinition withRuleset(SPARQLRuleset ruleset);
     public SPARQLQueryDefinition withStructuredQuery(QueryDefinition structuredQuery);
+    
 }

--- a/src/main/java/com/marklogic/client/semantics/SPARQLRuleset.java
+++ b/src/main/java/com/marklogic/client/semantics/SPARQLRuleset.java
@@ -15,33 +15,42 @@
  */
 package com.marklogic.client.semantics;
 
-public enum SPARQLRuleset {
-    ALL_VALUES_FROM,
-    DOMAIN,
-    EQUIVALENT_CLASS,
-    RANGE,
-    EQUIVALENT_PROPERTY,
-    FUNCTIONAL_PROPERTY,
-    HAS_VALUE,
-    INTERSECTION_OF,
-    INVERSE_FUNCTIONAL_PROPERTY,
-    INVERSE_OF,
-    ON_PROPERTY,
-    OWL_HORST_FULL,
-    OWL_HORST,
-    RDFS_FULL,
-    RDFS_PLUS_FULL,
-    RDFS_PLUS,
-    RDFS,
-    SAME_AS,
-    SOME_VALUES_FROM,
-    SUBCLASS_OF,
-    SUBPROPERTY_OF,
-    SYMMETRIC_PROPERTY,
-    TRANSITIVE_PROPERTY;
+public class SPARQLRuleset {
+    public static SPARQLRuleset ALL_VALUES_FROM = new SPARQLRuleset("allValuesFrom.rules");
+    public static SPARQLRuleset DOMAIN = new SPARQLRuleset("domain.rules");
+    public static SPARQLRuleset EQUIVALENT_CLASS = new SPARQLRuleset("equivalentClass.rules");
+    public static SPARQLRuleset RANGE = new SPARQLRuleset("range.rules");
+    public static SPARQLRuleset EQUIVALENT_PROPERTY = new SPARQLRuleset("equivalentProperty.rules");
+    public static SPARQLRuleset FUNCTIONAL_PROPERTY = new SPARQLRuleset("FunctionalProperty.rules");
+    public static SPARQLRuleset HAS_VALUE = new SPARQLRuleset("hasValue.rules");
+    public static SPARQLRuleset INTERSECTION_OF = new SPARQLRuleset("intersectionOf.rules");
+    public static SPARQLRuleset INVERSE_FUNCTIONAL_PROPERTY = new SPARQLRuleset("InverseFunctionalProperty.rules");
+    public static SPARQLRuleset INVERSE_OF = new SPARQLRuleset("inverseOf.rules");
+    public static SPARQLRuleset ON_PROPERTY = new SPARQLRuleset("onProperty.rules");
+    public static SPARQLRuleset OWL_HORST_FULL = new SPARQLRuleset("owl-horst-full.rules");
+    public static SPARQLRuleset OWL_HORST = new SPARQLRuleset("owl-horst.rules");
+    public static SPARQLRuleset RDFS_FULL = new SPARQLRuleset("rdfs-full.rules");
+    public static SPARQLRuleset RDFS_PLUS_FULL = new SPARQLRuleset("rdfs-plus-full.rules");
+    public static SPARQLRuleset RDFS_PLUS = new SPARQLRuleset("rdfs-plus.rules");
+    public static SPARQLRuleset RDFS = new SPARQLRuleset("rdfs.rules");
+    public static SPARQLRuleset SAME_AS = new SPARQLRuleset("sameAs.rules");
+    public static SPARQLRuleset SOME_VALUES_FROM = new SPARQLRuleset("someValuesFrom.rules");
+    public static SPARQLRuleset SUBCLASS_OF = new SPARQLRuleset("subClassOf.rules");
+    public static SPARQLRuleset SUBPROPERTY_OF = new SPARQLRuleset("subPropertyOf.rules");
+    public static SPARQLRuleset SYMMETRIC_PROPERTY = new SPARQLRuleset("SymmetricProperty.rules");
+    public static SPARQLRuleset TRANSITIVE_PROPERTY = new SPARQLRuleset("TransitiveProperty.rules");
     
-    public static SPARQLRuleset ruleset(String name){
-        // TODO: implement
-        return null;
+    private String rulesetName;
+    
+    public String getName() {
+        return rulesetName;
+    }
+    
+    public static SPARQLRuleset ruleset(String rulesetName) {
+        return new SPARQLRuleset(rulesetName);
+    }
+
+    private SPARQLRuleset(String rulesetName){
+        this.rulesetName = rulesetName;
     }
 }


### PR DESCRIPTION
This is a candidate to merge into develop.  It enables some of the Jena work.  The tests and implementation for graph delete are good, and transactions also have some coverage.

The inclusion of new fields on SPARQLQueryDefinition enables the use of some of the important parameters for graph manipulation.  See if you think this PR is good @sammefford @xquery 