### PR TITLE
Allow error propagation from server eval 500s

### DIFF
--- a/src/main/java/com/marklogic/client/impl/JerseyServices.java
+++ b/src/main/java/com/marklogic/client/impl/JerseyServices.java
@@ -4581,7 +4581,7 @@ public class JerseyServices implements RESTServices {
 			}
 			throw new FailedRequestException("failed to " + operation + " "
 					+ entityType + " at " + path + ": "
-					+ status.getReasonPhrase(), extractErrorFields(response));
+					+ status.getReasonPhrase(), failure);
 		}
 	}
 


### PR DESCRIPTION
For example, the errorCode in variable "failure" might be "XDMP-SPQLNOSUCHGRAPH", but when extractErrorFields(response) is called a second time, the errorCode that ends up in the stack trace is null. 