### PR TITLE
Added missing extract-resolution QName

### DIFF
--- a/src/main/java/com/marklogic/client/io/SearchHandle.java
+++ b/src/main/java/com/marklogic/client/io/SearchHandle.java
@@ -1505,7 +1505,8 @@ public class SearchHandle
             QName facetName    = new QName(SEARCH_NS, "facet-resolution-time");
             QName snippetName  = new QName(SEARCH_NS, "snippet-resolution-time");
             QName metadataName = new QName(SEARCH_NS, "metadata-resolution-time");
-            QName totalName    = new QName(SEARCH_NS, "total-time");
+            QName extractName  = new QName(SEARCH_NS, "extract-resolution-time");
+	    QName totalName    = new QName(SEARCH_NS, "total-time");
 	
             long qrTime = -1;
             long frTime = -1;


### PR DESCRIPTION
Added a missing QName which was causing a Warn level log message due to its absence 

```
Unexpected metrics element {http://marklogic.com/appservices/search}extract-resolution-time
```