### PR TITLE
Fix handling of lang literals (in Jena 3 they have both type and lang)

### DIFF
--- a/src/main/java/com/marklogic/client/impl/JerseyServices.java
+++ b/src/main/java/com/marklogic/client/impl/JerseyServices.java
@@ -4861,10 +4861,10 @@ public class JerseyServices implements RESTServices {
 			String paramName = "bind:" + bindingName;
 			String typeOrLang = "";
 			for ( SPARQLBinding binding : bindings.get(bindingName) ) {
-				if ( binding.getDatatype() != null ) {
-					typeOrLang = ":" + binding.getDatatype();
-				} else if ( binding.getLanguageTag() != null ) {
+				if ( binding.getLanguageTag() != null ) {
 					typeOrLang = "@" + binding.getLanguageTag().toLanguageTag();
+				} else if ( binding.getDatatype() != null ) {
+					typeOrLang = ":" + binding.getDatatype();
 				}
 				params.add(paramName + typeOrLang, binding.getValue());
 			}

--- a/src/main/java/com/marklogic/client/semantics/RDFTypes.java
+++ b/src/main/java/com/marklogic/client/semantics/RDFTypes.java
@@ -21,6 +21,7 @@ package com.marklogic.client.semantics;
  */
 public enum RDFTypes {
     STRING             ("string"),
+    LANGSTRING         ("langString"),
     BOOLEAN            ("boolean"),
     DECIMAL            ("decimal"),
     INTEGER            ("integer"),


### PR DESCRIPTION
This is a fix for incorrect handling of literals with language tags passed as SPARQL bindings.

Without the fix, when passing a SPARQL binding for a literal with language tag, the driver would ignore the language and do not send it to the server in the REST API call.

In Jena 2 such literals did not have any type, so that the original code worked properly (in master branch).

In Jena 3 they have both the xsd:langString type AND the language tag, so the code needs to be fixed to take that into account. This fix is only need for Jena 3 version of this library (develop branch).
