### PR TITLE
Providing a portable variant to initialize (and teardown) a test database

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,8 +115,16 @@ Be sure to run the tests before submitting your pull request. PRs with failing
 tests won't be accepted. 
 
     $ mvn test-compile
-    $ sh src/test/resources/boot-test.sh
+    $ mvn exec:java@test-server-init
     $ mvn test
+
+If your Maven installation is older than 3.3.1 you will get an error from the
+`mvn exec:java@...` command as this syntax variant was introduced with Maven
+3.3.1. Simply replace the original command with
+
+    $ ...
+    $ mvn exec:java -DexecutionId=test-server-init
+    $ ...
 
 #### Push your changes
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for more on contributing to this github p
 ### Running JUnit Tests
 
     $ mvn test-compile
-    $ sh src/test/resources/boot-test.sh
+    $ mvn exec:java@test-server-init
     $ mvn test
 
 ## Support

--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,35 @@
                         <phase>deploy</phase>
                     </execution>
                 </executions>
-        </plugin>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.5.0</version>
+                <executions>
+                    <execution>
+                        <id>test-server-init</id>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>test-server-teardown</id>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>
+                                <argument>teardown</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <mainClass>com.marklogic.client.test.util.TestServerBootstrapper</mainClass>
+                    <classpathScope>test</classpathScope>
+                </configuration>
+            </plugin>
 		</plugins>
 	</build>
 	<dependencies>

--- a/src/test/java/com/marklogic/client/test/BitemporalTest.java
+++ b/src/test/java/com/marklogic/client/test/BitemporalTest.java
@@ -54,7 +54,7 @@ import com.marklogic.client.query.StructuredQueryDefinition;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class BitemporalTest {
-	// src/test/resources/bootstrap.xqy is run by src/test/resources/boot-test.sh
+	// src/test/resources/bootstrap.xqy is run by com.marklogic.client.test.util.TestServerBootstrapper
 	// and sets up the "temporal-collection" and required underlying axes
 	// system-axis and valid-axis which have required underlying range indexes
 	// system-start, system-end, valid-start, and valid-end


### PR DESCRIPTION
Having to use shell scripts may confuse non-Linux/Mac contributors.

Additionally, this will use the classpath as modeled in pom.xml and avoids the
need to keep shell scripts in sync. If this gets accepted, may the
`bootstrap-test.sh`and `bootstrap-test-cygwin.sh` scripts become obsolete?