### PR TITLE
#371 - caching JAXBContexts after initialization

### DIFF
--- a/src/main/java/com/marklogic/client/io/QueryOptionsHandle.java
+++ b/src/main/java/com/marklogic/client/io/QueryOptionsHandle.java
@@ -115,7 +115,6 @@ public final class QueryOptionsHandle
         pfactory.setNamespaceAware(true);
     }
 
-    private JAXBContext jc;
 	private Marshaller marshaller;
 	private QueryOptions optionsHolder;
 	private Unmarshaller unmarshaller;
@@ -135,7 +134,7 @@ public final class QueryOptionsHandle
             QueryOptionsTransformExtractNS transform = new QueryOptionsTransformExtractNS();
             transform.setParent(reader);
 
-            jc = JAXBContext.newInstance(QueryOptions.class);
+            JAXBContext jc = JaxbContextLoader.CACHED_CONTEXT;
             marshaller = jc.createMarshaller();
             marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
             unmarshaller = jc.createUnmarshaller();
@@ -145,6 +144,8 @@ public final class QueryOptionsHandle
             throw new MarkLogicBindingException(e);
         } catch (ParserConfigurationException e) {
             throw new MarkLogicBindingException(e);
+        } catch (NoClassDefFoundError ncdfe) {
+            throw new MarkLogicBindingException(new JAXBException("JAXB context initialization failed"));
         }
     }
 
@@ -1133,7 +1134,20 @@ public final class QueryOptionsHandle
 		return this;
 	}
 
-	
+    /**
+     * Initialization-on-demand holder for {@link QueryOptionsHandle}'s JAXB context.
+     */
+    private static class JaxbContextLoader {
 
+        private static final JAXBContext CACHED_CONTEXT;
+
+        static {
+            try {
+                CACHED_CONTEXT = JAXBContext.newInstance(QueryOptions.class);
+            } catch (JAXBException e) {
+                throw new MarkLogicBindingException(e);
+            }
+        }
+    }
 
 }

--- a/src/main/java/com/marklogic/client/io/QueryOptionsListHandle.java
+++ b/src/main/java/com/marklogic/client/io/QueryOptionsListHandle.java
@@ -45,7 +45,6 @@ public class QueryOptionsListHandle
     static final private Logger logger = LoggerFactory.getLogger(QueryOptionsListHandle.class);
 
     private QueryOptionsListBuilder.OptionsList optionsHolder;
-    private JAXBContext jc;
     private Marshaller marshaller;
     private Unmarshaller unmarshaller;
 
@@ -56,12 +55,14 @@ public class QueryOptionsListHandle
     	super();
     	super.setFormat(Format.XML);
         try {
-            jc = JAXBContext.newInstance(QueryOptionsListBuilder.OptionsList.class);
+            JAXBContext jc = JaxbContextLoader.CACHED_CONTEXT;
             marshaller = jc.createMarshaller();
             marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
             unmarshaller = jc.createUnmarshaller();
         } catch (JAXBException e) {
             throw new MarkLogicBindingException(e);
+        } catch (NoClassDefFoundError ncdfe) {
+            throw new MarkLogicBindingException(new JAXBException("JAXB context initialization failed"));
         }
     }
 
@@ -122,5 +123,21 @@ public class QueryOptionsListHandle
     public HashMap<String, String> getValuesMap() {
     	if (optionsHolder == null ) return null;
     	else return optionsHolder.getOptionsMap();
+    }
+
+    /**
+     * Initialization-on-demand holder for {@link QueryOptionsListHandle}'s JAXB context.
+     */
+    private static class JaxbContextLoader {
+
+        private static final JAXBContext CACHED_CONTEXT;
+
+        static {
+            try {
+                CACHED_CONTEXT = JAXBContext.newInstance(QueryOptionsListBuilder.OptionsList.class);
+            } catch (JAXBException e) {
+                throw new MarkLogicBindingException(e);
+            }
+        }
     }
 }

--- a/src/main/java/com/marklogic/client/io/TuplesHandle.java
+++ b/src/main/java/com/marklogic/client/io/TuplesHandle.java
@@ -49,7 +49,6 @@ public class TuplesHandle
     static final private Logger logger = LoggerFactory.getLogger(DOMHandle.class);
 
     private TuplesBuilder.Tuples tuplesHolder;
-    private JAXBContext jc;
     private Unmarshaller unmarshaller;
 
     private ValuesDefinition valdef = null;
@@ -60,10 +59,12 @@ public class TuplesHandle
     	super.setFormat(Format.XML);
 
         try {
-            jc = JAXBContext.newInstance(TuplesBuilder.Tuples.class);
+            JAXBContext jc = JaxbContextLoader.CACHED_CONTEXT;
             unmarshaller = jc.createUnmarshaller();
         } catch (JAXBException e) {
             throw new MarkLogicBindingException(e);
+        } catch (NoClassDefFoundError ncdfe) {
+            throw new MarkLogicBindingException(new JAXBException("JAXB context initialization failed"));
         }
     }
 
@@ -174,4 +175,21 @@ public class TuplesHandle
     public ValuesMetrics getMetrics() {
         return tuplesHolder.getMetrics();
     }
+
+    /**
+     * Initialization-on-demand holder for {@link TuplesHandle}'s JAXB context.
+     */
+    private static class JaxbContextLoader {
+
+        private static final JAXBContext CACHED_CONTEXT;
+
+        static {
+            try {
+                CACHED_CONTEXT = JAXBContext.newInstance(TuplesBuilder.Tuples.class);
+            } catch (JAXBException e) {
+                throw new MarkLogicBindingException(e);
+            }
+        }
+    }
+
 }

--- a/src/main/java/com/marklogic/client/io/ValuesHandle.java
+++ b/src/main/java/com/marklogic/client/io/ValuesHandle.java
@@ -51,7 +51,6 @@ public class ValuesHandle
     static final private Logger logger = LoggerFactory.getLogger(DOMHandle.class);
 
     private ValuesBuilder.Values valuesHolder;
-    private JAXBContext jc;
     private Unmarshaller unmarshaller;
     private HashMap<String, AggregateResult> hashedAggregates = null;
 
@@ -65,10 +64,12 @@ public class ValuesHandle
     	super.setFormat(Format.XML);
 
         try {
-            jc = JAXBContext.newInstance(ValuesBuilder.Values.class);
+            JAXBContext jc = JaxbContextLoader.CACHED_CONTEXT;
             unmarshaller = jc.createUnmarshaller();
         } catch (JAXBException e) {
             throw new MarkLogicBindingException(e);
+        } catch (NoClassDefFoundError ncdfe) {
+            throw new MarkLogicBindingException(new JAXBException("JAXB context initialization failed"));
         }
     }
 
@@ -180,4 +181,21 @@ public class ValuesHandle
     public ValuesMetrics getMetrics() {
         return valuesHolder.getMetrics();
     }
+
+    /**
+     * Initialization-on-demand holder for {@link ValuesHandle}'s JAXB context.
+     */
+    private static class JaxbContextLoader {
+
+        private static final JAXBContext CACHED_CONTEXT;
+
+        static {
+            try {
+                CACHED_CONTEXT = JAXBContext.newInstance(ValuesBuilder.Values.class);
+            } catch (JAXBException e) {
+                throw new MarkLogicBindingException(e);
+            }
+        }
+    }
+
 }

--- a/src/main/java/com/marklogic/client/io/ValuesListHandle.java
+++ b/src/main/java/com/marklogic/client/io/ValuesListHandle.java
@@ -46,7 +46,6 @@ public class ValuesListHandle
     static final private Logger logger = LoggerFactory.getLogger(ValuesListHandle.class);
 
     private ValuesListBuilder.ValuesList valuesHolder;
-    private JAXBContext jc;
     private Unmarshaller unmarshaller;
 
     String optionsName = null;
@@ -59,10 +58,12 @@ public class ValuesListHandle
     	super.setFormat(Format.XML);
 
         try {
-            jc = JAXBContext.newInstance(ValuesListBuilder.ValuesList.class);
+            JAXBContext jc = JaxbContextLoader.CACHED_CONTEXT;
             unmarshaller = jc.createUnmarshaller();
         } catch (JAXBException e) {
             throw new MarkLogicBindingException(e);
+        } catch (NoClassDefFoundError ncdfe) {
+            throw new MarkLogicBindingException(new JAXBException("JAXB context initialization failed"));
         }
     }
 
@@ -148,5 +149,21 @@ public class ValuesListHandle
     @Override
     public HashMap<String, String> getValuesMap() {
         return valuesHolder.getValuesMap();
+    }
+
+    /**
+     * Initialization-on-demand holder for {@link ValuesListHandle}'s JAXB context.
+     */
+    private static class JaxbContextLoader {
+
+        private static final JAXBContext CACHED_CONTEXT;
+
+        static {
+            try {
+                CACHED_CONTEXT = JAXBContext.newInstance(ValuesListBuilder.ValuesList.class);
+            } catch (JAXBException e) {
+                throw new MarkLogicBindingException(e);
+            }
+        }
     }
 }


### PR DESCRIPTION
Applying an initialization-on-demand holder pattern for lazy thread-safe JAXB context
initialization.