### PR TITLE
Use equals() rather than comparing String object using == or !=

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -292,6 +292,12 @@
 			<version>4.11</version>
 			<scope>test</scope>
 		</dependency>
+        <dependency>
+          <groupId>org.mockito</groupId>
+          <artifactId>mockito-all</artifactId>
+          <version>1.10.19</version>
+          <scope>test</scope>
+        </dependency>
 		<dependency>
 			<groupId>xmlunit</groupId>
 			<artifactId>xmlunit</artifactId>

--- a/src/main/java/com/marklogic/client/alerting/RuleDefinition.java
+++ b/src/main/java/com/marklogic/client/alerting/RuleDefinition.java
@@ -175,7 +175,7 @@ public class RuleDefinition extends BaseHandle<InputStream, OutputStreamSender>
 		if (firstEvent.getEventType() ==  XMLStreamConstants.START_ELEMENT) {
 			logger.info("Get element.");
 			StartElement startElement = firstEvent.asStartElement();
-			if (startElement.getName().getNamespaceURI() == RequestConstants.SEARCH_NS &&
+			if (RequestConstants.SEARCH_NS.equals(startElement.getName().getNamespaceURI()) &&
 					startElement.getName().getLocalPart().equals("query")) {
 				logger.info("It's a structured query!!!");
 				//wrap in search.

--- a/src/main/java/com/marklogic/client/impl/JerseyServices.java
+++ b/src/main/java/com/marklogic/client/impl/JerseyServices.java
@@ -42,7 +42,6 @@ import java.util.function.Function;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLException;
-import javax.ws.rs.core.Cookie;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
@@ -72,7 +71,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.client.DatabaseClientFactory;
@@ -99,9 +97,6 @@ import com.marklogic.client.document.DocumentUriTemplate;
 import com.marklogic.client.document.ServerTransform;
 import com.marklogic.client.eval.EvalResult;
 import com.marklogic.client.eval.EvalResultIterator;
-import com.marklogic.client.eval.ServerEvaluationCall;
-import com.marklogic.client.extensions.ResourceServices.ServiceResult;
-import com.marklogic.client.extensions.ResourceServices.ServiceResultIterator;
 import com.marklogic.client.io.BytesHandle;
 import com.marklogic.client.io.Format;
 import com.marklogic.client.io.JacksonParserHandle;
@@ -2338,7 +2333,7 @@ public class JerseyServices implements RESTServices {
 					addEncodedParam(docParams, "options", optionsName);
 				}
 			} else if (queryDef.getOptionsName() != null) {
-				if (optionsName != queryDef.getOptionsName()
+				if (!queryDef.getOptionsName().equals(optionsName)
 						&& logger.isWarnEnabled())
 					logger.warn("values definition options take precedence over query definition options");
 			}

--- a/src/main/java/com/marklogic/client/impl/SPARQLQueryManagerImpl.java
+++ b/src/main/java/com/marklogic/client/impl/SPARQLQueryManagerImpl.java
@@ -124,11 +124,11 @@ public class SPARQLQueryManagerImpl extends AbstractLoggingManager implements SP
     private void setRdfXmlOrJsonMimetype(TriplesReadHandle handle) {
         HandleImplementation baseHandle = HandleAccessor.as(handle);
         if ( baseHandle.getFormat() == Format.JSON ) {
-            if ( baseHandle.getMimetype() == Format.JSON.getDefaultMimetype() ) {
+            if ( Format.JSON.getDefaultMimetype().equals(baseHandle.getMimetype()) ) {
                 baseHandle.setMimetype(RDFMimeTypes.RDFJSON);
             }
         } else if ( baseHandle.getFormat() == Format.XML ) {
-            if ( baseHandle.getMimetype() == Format.XML.getDefaultMimetype()) {
+            if ( Format.XML.getDefaultMimetype().equals(baseHandle.getMimetype())) {
                 baseHandle.setMimetype(RDFMimeTypes.RDFXML);
             }
         }

--- a/src/test/java/com/marklogic/client/impl/SPARQLQueryManagerImplTest.java
+++ b/src/test/java/com/marklogic/client/impl/SPARQLQueryManagerImplTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2012-2016 MarkLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.marklogic.client.impl;
+
+import com.marklogic.client.io.Format;
+import com.marklogic.client.io.marker.TriplesReadHandle;
+import com.marklogic.client.semantics.RDFMimeTypes;
+import com.marklogic.client.semantics.SPARQLQueryDefinition;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import static org.mockito.Mockito.*;
+
+/**
+ *
+ */
+public class SPARQLQueryManagerImplTest {
+
+    public SPARQLQueryManagerImplTest() {
+    }
+
+    /**
+     * Test of executeDescribe method, of class SPARQLQueryManagerImpl.
+     */
+    @Test
+    public void testExecuteDescribeWithJSON() {
+        HandleImplementation triplesHandle = executeSetRdfXmlOrJsonMimetype(Format.JSON, Format.JSON.getDefaultMimetype());
+        assertTrue(triplesHandle.getMimetype().equals(RDFMimeTypes.RDFJSON));
+    }
+
+    @Test
+    public void testExecuteDescribeWithJSONNotMime() {
+        HandleImplementation triplesHandle = executeSetRdfXmlOrJsonMimetype(Format.JSON, Format.TEXT.getDefaultMimetype());
+        assertFalse(triplesHandle.getMimetype().equals(RDFMimeTypes.RDFJSON));
+        assertTrue(triplesHandle.getMimetype().equals(Format.TEXT.getDefaultMimetype()));
+    }
+
+    @Test
+    public void testExecuteDescribeWithUNKNOWNFormat() {
+        HandleImplementation triplesHandle = executeSetRdfXmlOrJsonMimetype(Format.UNKNOWN, Format.JSON.getDefaultMimetype());
+        assertFalse(triplesHandle.getMimetype().equals(RDFMimeTypes.RDFJSON));
+    }
+
+    @Test
+    public void testExecuteDescribeWithXML() {
+        HandleImplementation triplesHandle = executeSetRdfXmlOrJsonMimetype(Format.XML, Format.XML.getDefaultMimetype());
+        assertTrue(triplesHandle.getMimetype().equals(RDFMimeTypes.RDFXML));
+    }
+
+    @Test
+    public void testExecuteDescribeWithXMLNotMime() {
+        HandleImplementation triplesHandle = executeSetRdfXmlOrJsonMimetype(Format.XML, Format.TEXT.getDefaultMimetype());
+        assertFalse(triplesHandle.getMimetype().equals(RDFMimeTypes.RDFXML));
+        assertTrue(triplesHandle.getMimetype().equals(Format.TEXT.getDefaultMimetype()));
+    }
+
+    private HandleImplementation executeSetRdfXmlOrJsonMimetype(Format format, String mimeType) {
+        HandleImplementation triplesHandle = new HandleImplementationTester();
+        triplesHandle.setFormat(format);
+        triplesHandle.setMimetype(mimeType);
+
+        RESTServices services = mock(RESTServices.class);
+        SPARQLQueryManagerImpl sparqlQueryManager = new SPARQLQueryManagerImpl(services);
+        SPARQLQueryDefinition qdef = new SPARQLQueryDefinitionImpl();
+
+        sparqlQueryManager.executeDescribe(qdef, (TriplesReadHandle) triplesHandle);
+        return triplesHandle;
+    }
+
+    protected class HandleImplementationTester extends HandleImplementation implements TriplesReadHandle {
+
+        private String mimeType;
+        private Format format;
+
+        @Override
+        public Format getFormat() {
+            return format;
+        }
+
+        @Override
+        public void setFormat(Format format) {
+            this.format = format;
+        }
+
+        @Override
+        public String getMimetype() {
+            return mimeType;
+        }
+
+        @Override
+        public void setMimetype(String mimeType) {
+            this.mimeType = mimeType;
+        }
+
+        @Override
+        public long getByteLength() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void setByteLength(long length) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+    }
+}


### PR DESCRIPTION
- Changed == and != to use equals() when comparing strings
- Added a unit test with positive/negative tests
- Added Mockito to test dependencies