### PR TITLE
Code to interface and use diamond operator to eliminate redundant type args

### DIFF
--- a/src/main/java/com/marklogic/client/admin/ExtensionLibraryDescriptor.java
+++ b/src/main/java/com/marklogic/client/admin/ExtensionLibraryDescriptor.java
@@ -71,7 +71,7 @@ public class ExtensionLibraryDescriptor {
 	 * No-argument constructor.
 	 */
 	public ExtensionLibraryDescriptor() {
-		this.permissions = new ArrayList<Permission>();
+		this.permissions = new ArrayList<>();
 	}
 	
 	/**

--- a/src/main/java/com/marklogic/client/admin/config/QueryOptions.java
+++ b/src/main/java/com/marklogic/client/admin/config/QueryOptions.java
@@ -129,7 +129,7 @@ public final class QueryOptions implements Annotatable<QueryOptions> {
 		 */
 		public QueryConstraint(String name) {
 			this();
-			annotations = new ArrayList<QueryAnnotation>();
+			annotations = new ArrayList<>();
 			setName(name);
 		}
 
@@ -272,7 +272,7 @@ public final class QueryOptions implements Annotatable<QueryOptions> {
 		 * Construct a new BaseConstraintItem
 		 */
 		public BaseConstraintItem() {
-			this.termOptions = new ArrayList<String>();
+			this.termOptions = new ArrayList<>();
 		}
 
 		/**
@@ -447,7 +447,7 @@ public final class QueryOptions implements Annotatable<QueryOptions> {
 		 * @param termOptions A list of term options.
 		 */
 		public void setTermOptions(List<String> termOptions) {
-			this.termOptions = new ArrayList<String>();
+			this.termOptions = new ArrayList<>();
 			this.termOptions.addAll(termOptions);
 		}
 
@@ -483,7 +483,7 @@ public final class QueryOptions implements Annotatable<QueryOptions> {
 		 * Zero-argument constructor.
 		 */
 		public FacetableConstraintConfiguration() {
-			facetOptions = new ArrayList<String>();
+			facetOptions = new ArrayList<>();
 		}
 
 		/**
@@ -559,7 +559,7 @@ public final class QueryOptions implements Annotatable<QueryOptions> {
 		 * @param facetOptions	options for faceting on the constraint
 		 */
 		public void setFacetOptions(List<String> facetOptions) {
-			this.facetOptions = new ArrayList<String>();
+			this.facetOptions = new ArrayList<>();
 			for (String option : facetOptions) {
 				this.facetOptions.add(option);
 			}
@@ -636,7 +636,7 @@ public final class QueryOptions implements Annotatable<QueryOptions> {
 		}
 
 		QueryCustom() {
-			annotations = new ArrayList<QueryAnnotation>();
+			annotations = new ArrayList<>();
 		}
 
 		/**
@@ -963,8 +963,8 @@ public final class QueryOptions implements Annotatable<QueryOptions> {
 		 * Zero-argument constructor.
 		 */
 		public QueryRange() {
-			buckets = new ArrayList<Bucket>();
-			computedBuckets = new ArrayList<ComputedBucket>();
+			buckets = new ArrayList<>();
+			computedBuckets = new ArrayList<>();
 		}
 
 		/**
@@ -994,7 +994,7 @@ public final class QueryOptions implements Annotatable<QueryOptions> {
 		 */
 		public void deleteBuckets() {
 			this.computedBuckets = new ArrayList<ComputedBucket>();
-			this.buckets = new ArrayList<Bucket>();
+			this.buckets = new ArrayList<>();
 		}
 
 		/**
@@ -1200,8 +1200,8 @@ public final class QueryOptions implements Annotatable<QueryOptions> {
 		 * Zero-argument constructor.
 		 */
 		public QueryGeospatial() {
-			this.geoOptions = new ArrayList<String>();
-			this.facetOptions = new ArrayList<String>();
+			this.geoOptions = new ArrayList<>();
+			this.facetOptions = new ArrayList<>();
 
 		}
 
@@ -1747,9 +1747,9 @@ public final class QueryOptions implements Annotatable<QueryOptions> {
 		 * Zero-argument constructor.
 		 */
 		public QueryExtractMetadata() {
-			this.qnames = new ArrayList<AttributeOrElementValue>();
-			this.constraintValues = new ArrayList<ConstraintValue>();
-			this.jsonKeys = new ArrayList<JsonKey>();
+			this.qnames = new ArrayList<>();
+			this.constraintValues = new ArrayList<>();
+			this.jsonKeys = new ArrayList<>();
 
 		}
 
@@ -1928,11 +1928,11 @@ public final class QueryOptions implements Annotatable<QueryOptions> {
 		private List<org.w3c.dom.Element> annotations;
 
 		public QueryAnnotation() {
-			annotations = new ArrayList<org.w3c.dom.Element>();
+			annotations = new ArrayList<>();
 		}
 		
 		public QueryAnnotation(String xmlString) {
-			annotations = new ArrayList<org.w3c.dom.Element>();
+			annotations = new ArrayList<>();
 			annotations.add(Utilities.domElement(xmlString));
 		}
 		
@@ -2024,7 +2024,7 @@ public final class QueryOptions implements Annotatable<QueryOptions> {
 
 
 		public void deleteSuggestionOptions() {
-			suggestionOptions = new ArrayList<String>();
+			suggestionOptions = new ArrayList<>();
 		}
 
 		
@@ -2469,8 +2469,8 @@ public final class QueryOptions implements Annotatable<QueryOptions> {
 		private List<QueryStarter> starters;
 
 		public QueryGrammar() {
-			joiners = new ArrayList<QueryJoiner>();
-			starters = new ArrayList<QueryStarter>();
+			joiners = new ArrayList<>();
+			starters = new ArrayList<>();
 		}
 
 		public void addJoiner(QueryJoiner joiner) {
@@ -2626,7 +2626,7 @@ public final class QueryOptions implements Annotatable<QueryOptions> {
 
 		public void addForest(Long forest) {
 			if (forests == null) {
-				forests = new ArrayList<Long>();
+				forests = new ArrayList<>();
 			}
 			this.forests.add(forest);
 		}
@@ -2637,7 +2637,7 @@ public final class QueryOptions implements Annotatable<QueryOptions> {
 		}
 
 		public void deleteSortOrders() {
-			sortOrders = new ArrayList<QuerySortOrder>();
+			sortOrders = new ArrayList<>();
 		}
 
 		public org.w3c.dom.Element getAdditionalQuery() {
@@ -2819,7 +2819,7 @@ public final class QueryOptions implements Annotatable<QueryOptions> {
 		private List<QueryAnnotation> annotations;
 		
 		public QuerySortOrder() {
-			annotations = new ArrayList<QueryAnnotation>();
+			annotations = new ArrayList<>();
 		}
 		
 		public List<QueryAnnotation> getAnnotations() {
@@ -2977,7 +2977,7 @@ public final class QueryOptions implements Annotatable<QueryOptions> {
 		private XQueryExtension xQueryExtension;
 
 		public QueryTerm() {
-			annotations = new ArrayList<QueryAnnotation>();
+			annotations = new ArrayList<>();
 		}
 
 
@@ -3075,7 +3075,7 @@ public final class QueryOptions implements Annotatable<QueryOptions> {
 		private List<QueryAnnotation> annotations;
 		
 		public DefaultTermSource() {
-			annotations = new ArrayList<QueryAnnotation>();
+			annotations = new ArrayList<>();
 		}
 		public List<QueryAnnotation> getAnnotations() {
 			return this.annotations;
@@ -3226,7 +3226,7 @@ public final class QueryOptions implements Annotatable<QueryOptions> {
 		private List<MarkLogicQName> elements;
 
 		public PreferredElements() {
-			elements = new ArrayList<MarkLogicQName>();
+			elements = new ArrayList<>();
 		}
 
 		public void addElement(MarkLogicQName element) {
@@ -3287,14 +3287,14 @@ public final class QueryOptions implements Annotatable<QueryOptions> {
 		}
 		
 		public QueryTuples() {
-			annotations = new ArrayList<QueryAnnotation>();
-			field = new ArrayList<Field>();
-			jsonKey = new ArrayList<JsonKey>();
-			geoAttrPair = new ArrayList<QueryGeospatialAttributePair>();
-			geoElem = new ArrayList<QueryGeospatialElement>();
-			geoElemPair = new ArrayList<QueryGeospatialElementPair>();
-			range = new ArrayList<QueryRange>();
-			valuesOptions = new ArrayList<String>();
+			annotations = new ArrayList<>();
+			field = new ArrayList<>();
+			jsonKey = new ArrayList<>();
+			geoAttrPair = new ArrayList<>();
+			geoElem = new ArrayList<>();
+			geoElemPair = new ArrayList<>();
+			range = new ArrayList<>();
+			valuesOptions = new ArrayList<>();
 		}
 
 		public void addRange(QueryRange queryRange) {
@@ -3449,8 +3449,8 @@ public final class QueryOptions implements Annotatable<QueryOptions> {
 		}
 		
 		public QueryValues() {
-			annotations = new ArrayList<QueryAnnotation>();
-			this.valuesOptions = new ArrayList<String>();
+			annotations = new ArrayList<>();
+			this.valuesOptions = new ArrayList<>();
 		}
 
 		public void setJsonKey(JsonKey jsonKey) {
@@ -3574,7 +3574,7 @@ public final class QueryOptions implements Annotatable<QueryOptions> {
 		private List<ExpressionNamespaceBinding> bindings;
 
 		public ExpressionNamespaceBindings() {
-			bindings = new ArrayList<ExpressionNamespaceBinding>();
+			bindings = new ArrayList<>();
 		}
 
 		public void addBinding(String prefix, String uri) {
@@ -3782,15 +3782,15 @@ public final class QueryOptions implements Annotatable<QueryOptions> {
 	public QueryOptions() {
 		// options that can have more than one cardinality
 		// are in lists.
-		queryConstraints = new ArrayList<QueryConstraint>();
-		operators = new ArrayList<QueryOperator>();
-		sortOrders = new ArrayList<QuerySortOrder>();
-		suggestionSources = new ArrayList<QuerySuggestionSource>();
-		forests = new ArrayList<Long>();
-		searchOptions = new ArrayList<String>();
-		annotations = new ArrayList<QueryAnnotation>();
-		queryValues = new ArrayList<QueryValues>();
-		queryTuples = new ArrayList<QueryTuples>();
+		queryConstraints = new ArrayList<>();
+		operators = new ArrayList<>();
+		sortOrders = new ArrayList<>();
+		suggestionSources = new ArrayList<>();
+		forests = new ArrayList<>();
+		searchOptions = new ArrayList<>();
+		annotations = new ArrayList<>();
+		queryValues = new ArrayList<>();
+		queryTuples = new ArrayList<>();
 	}
 
 	public void setSearchableExpressionNamespaceContext(
@@ -3862,7 +3862,7 @@ public final class QueryOptions implements Annotatable<QueryOptions> {
 
 	public List<QueryConstraint> getQueryConstraints() {
 		if (queryConstraints == null) {
-			return new ArrayList<QueryConstraint>();
+			return new ArrayList<>();
 		} else {
 			return queryConstraints;
 		}
@@ -3987,7 +3987,7 @@ public final class QueryOptions implements Annotatable<QueryOptions> {
 	}
 
 	public void setForests(List<Long> forests) {
-		this.forests = new ArrayList<Long>();
+		this.forests = new ArrayList<>();
 		if (forests != null) this.forests.addAll(forests);
 	}
 
@@ -4085,13 +4085,13 @@ public final class QueryOptions implements Annotatable<QueryOptions> {
 	}
 
 	public void setSearchOptions(List<String> searchOptions) {
-		this.searchOptions = new ArrayList<String>();
+		this.searchOptions = new ArrayList<>();
 		if (searchOptions != null)		
 			this.searchOptions.addAll(searchOptions);
 	}
 
 	public void setSortOrders(List<QuerySortOrder> sortOrders) {
-		this.sortOrders = new ArrayList<QuerySortOrder>();
+		this.sortOrders = new ArrayList<>();
 		this.sortOrders.addAll(sortOrders);
 	}
 
@@ -4135,7 +4135,7 @@ public final class QueryOptions implements Annotatable<QueryOptions> {
      * @param constraints the constraints
      */
 	public void setConstraints(List<QueryConstraint> constraints) {
-		this.queryConstraints = new ArrayList<QueryConstraint>();
+		this.queryConstraints = new ArrayList<>();
 		this.queryConstraints.addAll(constraints);
 	}
 

--- a/src/main/java/com/marklogic/client/alerting/RuleDefinition.java
+++ b/src/main/java/com/marklogic/client/alerting/RuleDefinition.java
@@ -179,7 +179,7 @@ public class RuleDefinition extends BaseHandle<InputStream, OutputStreamSender>
 					startElement.getName().getLocalPart().equals("query")) {
 				logger.info("It's a structured query!!!");
 				//wrap in search.
-				List<XMLEvent> wrappedList = new ArrayList<XMLEvent>();
+				List<XMLEvent> wrappedList = new ArrayList<>();
 				XMLEventFactory  eventFactory = XMLEventFactory.newInstance();
 				XMLEvent startSearchElement = eventFactory.createStartElement("search", RequestConstants.SEARCH_NS, "search");
 				XMLEvent endSearchElement = eventFactory.createEndElement("search", RequestConstants.SEARCH_NS, "search");

--- a/src/main/java/com/marklogic/client/alerting/RuleDefinitionList.java
+++ b/src/main/java/com/marklogic/client/alerting/RuleDefinitionList.java
@@ -65,7 +65,7 @@ implements Iterable<RuleDefinition>, RuleListReadHandle {
 	}
 	
 	protected void receiveContent(InputStream content) {
-		rules = new ArrayList<RuleDefinition>();
+		rules = new ArrayList<>();
 		DOMHandle domHandle = new DOMHandle();
 		HandleAccessor.receiveContent(domHandle, content);
 		Document document = domHandle.get();

--- a/src/main/java/com/marklogic/client/example/cookbook/JAXBDocument.java
+++ b/src/main/java/com/marklogic/client/example/cookbook/JAXBDocument.java
@@ -133,7 +133,7 @@ public class JAXBDocument {
 		// identified to the JAXB context, use a <?> wildcard instead of
 		// a specific class and call the get(class) method instead of
 		// the get() method.
-		JAXBHandle<Product> handle = new JAXBHandle<Product>(context);
+		JAXBHandle<Product> handle = new JAXBHandle<>(context);
 
 		// create an instance of the POJO class
 		Product product = new Product();

--- a/src/main/java/com/marklogic/client/example/cookbook/JavascriptResourceExtension.java
+++ b/src/main/java/com/marklogic/client/example/cookbook/JavascriptResourceExtension.java
@@ -21,12 +21,6 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.XMLConstants;
-import javax.xml.namespace.QName;
-import javax.xml.stream.XMLStreamException;
-import javax.xml.stream.XMLStreamReader;
-
-import org.w3c.dom.Document;
 
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.DatabaseClientFactory;
@@ -43,10 +37,7 @@ import com.marklogic.client.example.cookbook.Util.ExampleProperties;
 import com.marklogic.client.extensions.ResourceManager;
 import com.marklogic.client.extensions.ResourceServices.ServiceResult;
 import com.marklogic.client.extensions.ResourceServices.ServiceResultIterator;
-import com.marklogic.client.io.DOMHandle;
-import com.marklogic.client.io.InputStreamHandle;
 import com.marklogic.client.io.StringHandle;
-import com.marklogic.client.io.XMLStreamReaderHandle;
 import com.marklogic.client.util.RequestParameters;
 
 /**
@@ -108,7 +99,7 @@ public class JavascriptResourceExtension {
 			ServiceResultIterator resultItr = getServices().get(params, mimetypes);
 
 			// iterate over the results
-			List<String> responses = new ArrayList<String>();
+			List<String> responses = new ArrayList<>();
 			StringHandle readHandle = new StringHandle();
 			while (resultItr.hasNext()) {
 				ServiceResult result = resultItr.next();

--- a/src/main/java/com/marklogic/client/example/cookbook/ResourceExtension.java
+++ b/src/main/java/com/marklogic/client/example/cookbook/ResourceExtension.java
@@ -126,7 +126,7 @@ public class ResourceExtension {
 			ServiceResultIterator resultItr = getServices().get(params, mimetypes);
 
 			// iterate over the results
-			List<Document> documents = new ArrayList<Document>();
+			List<Document> documents = new ArrayList<>();
 			DOMHandle readHandle = new DOMHandle();
 			while (resultItr.hasNext()) {
 				ServiceResult result = resultItr.next();
@@ -199,7 +199,7 @@ public class ResourceExtension {
 
 				QName wordName = new QName("http://marklogic.com/xdmp/spell", "word");
 
-				ArrayList<String> words  = new ArrayList<String>();
+				List<String> words  = new ArrayList<>();
 
 				while (streamReader.hasNext()) {
 					int current = streamReader.next();

--- a/src/main/java/com/marklogic/client/example/extension/BatchManager.java
+++ b/src/main/java/com/marklogic/client/example/extension/BatchManager.java
@@ -51,7 +51,7 @@ import com.marklogic.client.util.RequestParameters;
  */
 public class BatchManager extends ResourceManager {
 	public class BatchRequest {
-		private LinkedHashMap<String,InputItem> items = new LinkedHashMap<String,InputItem>();
+		private Map<String,InputItem> items = new LinkedHashMap<>();
 
 		BatchRequest() {
 			super();
@@ -62,7 +62,7 @@ public class BatchManager extends ResourceManager {
 				return null;
 			}
 
-			Set<DocumentManager.Metadata> catSet = new HashSet<DocumentManager.Metadata>();
+			Set<DocumentManager.Metadata> catSet = new HashSet<>();
 			for (DocumentManager.Metadata category: categories) {
 				catSet.add(category);
 			}
@@ -320,14 +320,14 @@ public class BatchManager extends ResourceManager {
 
 		StringHandle requestManifest  = new StringHandle();
 
-		ArrayList<AbstractWriteHandle> requestHandles = new ArrayList<AbstractWriteHandle>();
+		List<AbstractWriteHandle> requestHandles = new ArrayList<>();
 		requestHandles.add(requestManifest);
 
 		StringBuilder manifestBuilder = new StringBuilder();
 		manifestBuilder.append("<?xml version='1.0' encoding='UTF-8'?>\n");
 		manifestBuilder.append("<rapi:batch-requests xmlns:rapi='http://marklogic.com/rest-api'>\n");
 
-		ArrayList<String> readMimetypes = new ArrayList<String>();
+		List<String> readMimetypes = new ArrayList<>();
 		// read the response manifest first
 		readMimetypes.add("application/xml");
 		for (Map.Entry<String,InputItem> entry: request.items.entrySet()) {
@@ -411,7 +411,7 @@ public class BatchManager extends ResourceManager {
 		
 		DOMHandle responseManifest = resultItr.next().getContent(new DOMHandle());
 
-		List<OutputItem> items = new ArrayList<OutputItem>();
+		List<OutputItem> items = new ArrayList<>();
 
 		boolean requestSuccess = true;
 

--- a/src/main/java/com/marklogic/client/example/handle/URIHandle.java
+++ b/src/main/java/com/marklogic/client/example/handle/URIHandle.java
@@ -109,7 +109,7 @@ public class URIHandle
 
         DefaultHttpClient defaultClient = new DefaultHttpClient(connMgr);
 
-        List<String> prefList = new ArrayList<String>();
+        List<String> prefList = new ArrayList<>();
 		if (authType == Authentication.BASIC)
 			prefList.add(AuthPolicy.BASIC);
 		else if (authType == Authentication.DIGEST)

--- a/src/main/java/com/marklogic/client/example/util/Bootstrapper.java
+++ b/src/main/java/com/marklogic/client/example/util/Bootstrapper.java
@@ -34,7 +34,6 @@ import org.apache.http.StatusLine;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.auth.params.AuthPNames;
-import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.params.AuthPolicy;
 import org.apache.http.entity.StringEntity;
@@ -122,7 +121,7 @@ public class Bootstrapper {
 // TODO: SSL
         Authentication authType = configServer.getAuthType();
         if (authType != null) {
-            List<String> prefList = new ArrayList<String>();
+            List<String> prefList = new ArrayList<>();
             if (authType == Authentication.BASIC)
         		prefList.add(AuthPolicy.BASIC);
         	else if (authType == Authentication.DIGEST)
@@ -207,7 +206,7 @@ public class Bootstrapper {
 				continue;
 
 			if (invalid == null)
-				invalid = new ArrayList<String>();
+				invalid = new ArrayList<>();
 
 			invalid.add(key);
 		}
@@ -233,7 +232,7 @@ public class Bootstrapper {
 		return buffer.toString();
 	}
 	static private Map<String,String> getPropNames() {
-		Map<String,String> propNames = new HashMap<String, String>();
+		Map<String,String> propNames = new HashMap<>();
 		propNames.put("confighost",
 			"the host for configuring a new REST server");
 		propNames.put("configport",

--- a/src/main/java/com/marklogic/client/impl/AbstractQueryDefinition.java
+++ b/src/main/java/com/marklogic/client/impl/AbstractQueryDefinition.java
@@ -19,10 +19,11 @@ import java.util.HashSet;
 
 import com.marklogic.client.document.ServerTransform;
 import com.marklogic.client.query.QueryDefinition;
+import java.util.Set;
 
 public abstract class AbstractQueryDefinition implements QueryDefinition {
     protected String optionsUri = null;
-    private HashSet<String> collections = new HashSet<String>();
+    private Set<String> collections = new HashSet<>();
     private String          directory   = null;
 	private ServerTransform transform   = null;
 

--- a/src/main/java/com/marklogic/client/impl/BaseTypeImpl.java
+++ b/src/main/java/com/marklogic/client/impl/BaseTypeImpl.java
@@ -31,10 +31,10 @@ public class BaseTypeImpl {
     }
 
 	static BaseListImpl<BaseArgImpl> baseListImpl(Object[] items) {
-		return new BaseListImpl<BaseArgImpl>(convertList(items));
+		return new BaseListImpl<>(convertList(items));
 	}
 	static <T extends BaseArgImpl> BaseListImpl<T> baseListImpl(Object[] items, Class<T> as) {
-		return new BaseListImpl<T>(convertList(items, as));
+		return new BaseListImpl<>(convertList(items, as));
 	}
 	static class BaseListImpl<T extends BaseArgImpl> implements BaseArgImpl {
 		protected T[] items;
@@ -55,10 +55,10 @@ public class BaseTypeImpl {
     }
 
 	static BaseCallImpl<BaseArgImpl> baseCallImpl(String fnPrefix, String fnName, Object[] items) {
-		return new BaseCallImpl<BaseArgImpl>(fnPrefix, fnName, convertList(items));
+		return new BaseCallImpl<>(fnPrefix, fnName, convertList(items));
 	}
 	static <T extends BaseArgImpl> BaseCallImpl<T> baseCallImpl(String fnPrefix, String fnName, Object[] items, Class<T> as) {
-		return new BaseCallImpl<T>(fnPrefix, fnName, convertList(items, as));
+		return new BaseCallImpl<>(fnPrefix, fnName, convertList(items, as));
 	}
 	static class BaseCallImpl<T extends BaseArgImpl> extends BaseListImpl<T> {
 		protected String fnPrefix = null;
@@ -83,7 +83,7 @@ public class BaseTypeImpl {
 		private BaseCallImpl<T>[] chain = null;
 		@SuppressWarnings("unchecked")
 		protected BaseChainImpl(BaseChainImpl<T> prior, String fnPrefix, String fnName, T[] fnArgs) {
-			BaseCallImpl<T> call = new BaseCallImpl<T>(fnPrefix, fnName, fnArgs);
+			BaseCallImpl<T> call = new BaseCallImpl<>(fnPrefix, fnName, fnArgs);
 			if (prior == null) {
 				chain = (BaseCallImpl<T>[]) Array.newInstance(BaseCallImpl.class, 1);
 				chain[0] = call;

--- a/src/main/java/com/marklogic/client/impl/DatabaseClientImpl.java
+++ b/src/main/java/com/marklogic/client/impl/DatabaseClientImpl.java
@@ -21,7 +21,6 @@ import java.io.Serializable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.marklogic.client.admin.ExtensionMetadata;
 import com.marklogic.client.document.BinaryDocumentManager;
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.FailedRequestException;
@@ -43,8 +42,6 @@ import com.marklogic.client.Transaction;
 import com.marklogic.client.document.XMLDocumentManager;
 import com.marklogic.client.pojo.PojoRepository;
 import com.marklogic.client.impl.PojoRepositoryImpl;
-import com.marklogic.client.io.marker.TriplesReadHandle;
-import com.marklogic.client.io.marker.TriplesWriteHandle;
 import com.marklogic.client.DatabaseClientFactory.Authentication;
 import com.marklogic.client.DatabaseClientFactory.SSLHostnameVerifier;
 import com.marklogic.client.DatabaseClientFactory.SecurityContext;
@@ -161,7 +158,7 @@ public class DatabaseClientImpl implements DatabaseClient {
 	}
 	@Override
 	public <T, ID extends Serializable> PojoRepository<T, ID> newPojoRepository(Class<T> clazz, Class<ID> idClass) {
-		return new PojoRepositoryImpl<T, ID>(this, clazz, idClass);
+		return new PojoRepositoryImpl<>(this, clazz, idClass);
 
 	}
 
@@ -220,7 +217,7 @@ public class DatabaseClientImpl implements DatabaseClient {
 
 	@Override
 	public GraphManager newGraphManager() {
-		return new GraphManagerImpl<TriplesReadHandle, TriplesWriteHandle>(services, getHandleRegistry());
+		return new GraphManagerImpl<>(services, getHandleRegistry());
 	}
 
 	@Override

--- a/src/main/java/com/marklogic/client/impl/DocumentMetadataPatchBuilderImpl.java
+++ b/src/main/java/com/marklogic/client/impl/DocumentMetadataPatchBuilderImpl.java
@@ -46,7 +46,7 @@ implements DocumentMetadataPatchBuilder
 	final static protected String REST_API_NS     = "http://marklogic.com/rest-api";
 	final static protected String PROPERTY_API_NS = "http://marklogic.com/xdmp/property";
 
-	final static protected Map<String,String> reserved = new HashMap<String,String>();
+	final static protected Map<String,String> reserved = new HashMap<>();
 	static {
 		reserved.put("rapi", REST_API_NS);
 		reserved.put("prop", PROPERTY_API_NS);
@@ -913,7 +913,7 @@ implements DocumentMetadataPatchBuilder
 
 	private CallBuilderImpl callBuilder;
 
-	protected List<PatchOperation>      operations       = new ArrayList<PatchOperation>();
+	protected List<PatchOperation>      operations       = new ArrayList<>();
 	protected EditableNamespaceContext  namespaces;
 	protected String                    libraryNs;
 	protected String                    libraryAt;
@@ -1163,7 +1163,7 @@ implements DocumentMetadataPatchBuilder
 
 	private void onMetadata(Metadata category) {
 		if (processedMetadata == null) {
-			processedMetadata = new HashSet<Metadata>();
+			processedMetadata = new HashSet<>();
 		} else if (processedMetadata.contains(category)) {
 			return;
 		}

--- a/src/main/java/com/marklogic/client/impl/ExtensionLibrariesManagerImpl.java
+++ b/src/main/java/com/marklogic/client/impl/ExtensionLibrariesManagerImpl.java
@@ -53,7 +53,7 @@ public class ExtensionLibrariesManagerImpl
 		XMLEventReaderHandle handle = services.getResource(requestLogger, directory, null, null, new XMLEventReaderHandle());
 		
 		XMLEventReader reader = handle.get();
-		List<ExtensionLibraryDescriptor> modules = new ArrayList<ExtensionLibraryDescriptor>();
+		List<ExtensionLibraryDescriptor> modules = new ArrayList<>();
 		while (reader.hasNext()) {
 				XMLEvent event;
 				try {

--- a/src/main/java/com/marklogic/client/impl/GraphManagerImpl.java
+++ b/src/main/java/com/marklogic/client/impl/GraphManagerImpl.java
@@ -16,7 +16,6 @@
 package com.marklogic.client.impl;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
@@ -26,7 +25,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.client.DatabaseClientFactory.HandleFactoryRegistry;
-import com.marklogic.client.FailedRequestException;
 import com.marklogic.client.Transaction;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.StringHandle;
@@ -104,7 +102,7 @@ public class GraphManagerImpl<R extends TriplesReadHandle, W extends TriplesWrit
         GraphPermissions perms = new GraphPermissionsImpl();
         for ( JsonNode permission : json.path("permissions") ) {
             String role = permission.path("role-name").asText();
-            Set<Capability> capabilities = new HashSet<Capability>();
+            Set<Capability> capabilities = new HashSet<>();
             for ( JsonNode capability : permission.path("capabilities") ) {
                 String value = capability.asText();
                 if ( value != null ) {
@@ -390,7 +388,7 @@ public class GraphManagerImpl<R extends TriplesReadHandle, W extends TriplesWrit
     @Override
     public GraphPermissions permission(String role, Capability... capabilities) {
         GraphPermissionsImpl perms = new GraphPermissionsImpl();
-        perms.put(role, new HashSet<Capability>(Arrays.asList(capabilities)));
+        perms.put(role, new HashSet<>(Arrays.asList(capabilities)));
         return perms;
     }
 

--- a/src/main/java/com/marklogic/client/impl/GraphPermissionsImpl.java
+++ b/src/main/java/com/marklogic/client/impl/GraphPermissionsImpl.java
@@ -28,7 +28,7 @@ public class GraphPermissionsImpl extends HashMap<String, Set<Capability>> imple
     public GraphPermissions permission(String role, Capability... capabilities) {
         if ( capabilities == null ) throw new IllegalArgumentException("capabilities cannot be null");
         if ( this.get(role) == null ) {
-            this.put(role, new HashSet<Capability>(Arrays.asList(capabilities)) );
+            this.put(role, new HashSet<>(Arrays.asList(capabilities)) );
         } else {
             this.get(role).addAll(Arrays.asList(capabilities));
         }

--- a/src/main/java/com/marklogic/client/impl/HTTPKerberosAuthFilter.java
+++ b/src/main/java/com/marklogic/client/impl/HTTPKerberosAuthFilter.java
@@ -78,7 +78,7 @@ class HTTPKerberosAuthFilter extends ClientFilter {
         }
         @Override
         public AppConfigurationEntry[] getAppConfigurationEntry(String name) {
-            Map<String, String> options = new HashMap<String, String>();
+            Map<String, String> options = new HashMap<>();
             options.put("refreshKrb5Config", "true");
             options.put("useTicketCache", "true");
             options.put("doNotPrompt", "true");

--- a/src/main/java/com/marklogic/client/impl/HandleFactoryRegistryImpl.java
+++ b/src/main/java/com/marklogic/client/impl/HandleFactoryRegistryImpl.java
@@ -37,7 +37,7 @@ import com.marklogic.client.io.marker.ContentHandleFactory;
 
 public class HandleFactoryRegistryImpl implements HandleFactoryRegistry {
 	private Map<Class<?>,ContentHandleFactory> factories =
-		new HashMap<Class<?>,ContentHandleFactory>();
+		new HashMap<>();
 
 	public static HandleFactoryRegistry newDefault() {
 		return registerDefaults(new HandleFactoryRegistryImpl());

--- a/src/main/java/com/marklogic/client/impl/JerseyServices.java
+++ b/src/main/java/com/marklogic/client/impl/JerseyServices.java
@@ -42,7 +42,6 @@ import java.util.function.Function;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLException;
-import javax.ws.rs.core.Cookie;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
@@ -72,7 +71,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.client.DatabaseClientFactory;
@@ -99,9 +97,6 @@ import com.marklogic.client.document.DocumentUriTemplate;
 import com.marklogic.client.document.ServerTransform;
 import com.marklogic.client.eval.EvalResult;
 import com.marklogic.client.eval.EvalResultIterator;
-import com.marklogic.client.eval.ServerEvaluationCall;
-import com.marklogic.client.extensions.ResourceServices.ServiceResult;
-import com.marklogic.client.extensions.ResourceServices.ServiceResultIterator;
 import com.marklogic.client.io.BytesHandle;
 import com.marklogic.client.io.Format;
 import com.marklogic.client.io.JacksonParserHandle;
@@ -378,7 +373,7 @@ public class JerseyServices implements RESTServices {
 		HttpParams httpParams = new BasicHttpParams();
 
 		if (authenType != null && authenType != Authentication.CERTIFICATE) {
-			List<String> authpref = new ArrayList<String>();
+			List<String> authpref = new ArrayList<>();
 			if (authenType == Authentication.BASIC)
 				authpref.add(AuthPolicy.BASIC);
 			else if (authenType == Authentication.DIGEST)
@@ -839,7 +834,7 @@ public class JerseyServices implements RESTServices {
 
 		JerseyDocumentPage(JerseyResultIterator iterator, boolean hasContent, boolean hasMetadata) {
 			super(
-				new ArrayList<DocumentRecord>().iterator(),
+				new ArrayList<T>().iterator(),
 				iterator != null ? iterator.getStart() : 1,
 				iterator != null ? iterator.getPageSize() : 0,
 				iterator != null ? iterator.getTotalSize() : 0
@@ -3248,8 +3243,8 @@ public class JerseyServices implements RESTServices {
 			String temporalCollection)
 		throws ForbiddenUserException,  FailedRequestException
 	{
-		ArrayList<AbstractWriteHandle> writeHandles = new ArrayList<AbstractWriteHandle>();
-		ArrayList<Map<String, List<String>>> headerList = new ArrayList<Map<String, List<String>>>();
+		List<AbstractWriteHandle> writeHandles = new ArrayList<>();
+		List<Map<String, List<String>>> headerList = new ArrayList<>();
 		for ( DocumentWriteOperation write: writeSet ) {
 			String temporalDocumentURI = write.getTemporalDocumentURI();
 			HandleImplementation metadata =
@@ -3971,7 +3966,7 @@ public class JerseyServices implements RESTServices {
 		if (oldSize == 0)
 			return null;
 
-		List<String> newValues = new ArrayList<String>(oldSize);
+		List<String> newValues = new ArrayList<>(oldSize);
 		for (String value : oldValues) {
 			String newValue = encodeParamValue(value);
 			if (newValue == null)
@@ -3990,7 +3985,7 @@ public class JerseyServices implements RESTServices {
 		if (oldSize == 0)
 			return null;
 
-		List<String> newValues = new ArrayList<String>(oldSize);
+		List<String> newValues = new ArrayList<>(oldSize);
 		for (String value : oldValues) {
 			String newValue = encodeParamValue(value);
 			if (newValue == null)
@@ -4441,7 +4436,7 @@ public class JerseyServices implements RESTServices {
             this.reqlog = reqlog;
             if (partList != null && partList.size() > 0) {
                 this.size = partList.size();
-                this.partQueue = new ConcurrentLinkedQueue<BodyPart>(
+                this.partQueue = new ConcurrentLinkedQueue<>(
                         partList).iterator();
             } else {
                 this.size = 0;

--- a/src/main/java/com/marklogic/client/impl/JerseyServices.java
+++ b/src/main/java/com/marklogic/client/impl/JerseyServices.java
@@ -193,6 +193,7 @@ public class JerseyServices implements RESTServices {
 
 	private DatabaseClient databaseClient;
 	private String database = null;
+	private ThreadSafeClientConnManager connMgr;
 	private ApacheHttpClient4 client;
 	private WebResource connection;
 	private boolean released = false;
@@ -285,6 +286,10 @@ public class JerseyServices implements RESTServices {
 
 		if (connection != null)
 			connection = null;
+		if (connMgr != null) {
+			connMgr.shutdown();
+			connMgr = null;
+		}
 		if (client != null) {
 			client.destroy();
 			client = null;
@@ -357,7 +362,7 @@ public class JerseyServices implements RESTServices {
 		 *     maxRouteConnections);
 		 */
 		// start 4.1
-		ThreadSafeClientConnManager connMgr = new ThreadSafeClientConnManager(
+		connMgr = new ThreadSafeClientConnManager(
 				schemeRegistry);
 		connMgr.setMaxTotal(maxTotalConnections);
 		connMgr.setDefaultMaxPerRoute(maxRouteConnections);
@@ -478,6 +483,8 @@ public class JerseyServices implements RESTServices {
 			logger.debug("Releasing connection");
 
 		connection = null;
+		connMgr.shutdown();
+		connMgr = null;
 		client.destroy();
 		client = null;
 	}

--- a/src/main/java/com/marklogic/client/impl/KeyValueQueryDefinitionImpl.java
+++ b/src/main/java/com/marklogic/client/impl/KeyValueQueryDefinitionImpl.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import java.util.Set;
 
 public class KeyValueQueryDefinitionImpl extends AbstractQueryDefinition implements KeyValueQueryDefinition {
-    Map<ValueLocator, String> defs = new Hashtable<ValueLocator, String> ();
+    Map<ValueLocator, String> defs = new Hashtable<> ();
     
     protected KeyValueQueryDefinitionImpl(String uri) {
         optionsUri = uri;

--- a/src/main/java/com/marklogic/client/impl/PlanBuilderBase.java
+++ b/src/main/java/com/marklogic/client/impl/PlanBuilderBase.java
@@ -227,7 +227,7 @@ abstract class PlanBuilderBase extends PlanBuilder {
 	    		throw new IllegalArgumentException("cannot set value with unknown implementation");
 	    	}
 	    	if (params == null) {
-	    		params = new HashMap<PlanParamBase,XsValueImpl.AnyAtomicTypeValImpl>();
+	    		params = new HashMap<>();
 	    	}
 	    	params.put((PlanParamBase) param, (XsValueImpl.AnyAtomicTypeValImpl)literal);
 // TODO: return clone with param for immutability

--- a/src/main/java/com/marklogic/client/impl/PojoPageImpl.java
+++ b/src/main/java/com/marklogic/client/impl/PojoPageImpl.java
@@ -19,7 +19,6 @@ import java.util.Iterator;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.marklogic.client.Page;
 import com.marklogic.client.impl.BasicPage;
 import com.marklogic.client.io.JacksonDatabindHandle;
 import com.marklogic.client.document.DocumentPage;
@@ -52,7 +51,7 @@ public class PojoPageImpl<T> extends BasicPage<T> implements PojoPage<T>, Iterat
 
     @Override
     public T next() {
-        JacksonDatabindHandle<T> handle = new JacksonDatabindHandle<T>(entityClass);
+        JacksonDatabindHandle<T> handle = new JacksonDatabindHandle<>(entityClass);
         handle.getMapper().enableDefaultTyping(
             ObjectMapper.DefaultTyping.NON_FINAL, JsonTypeInfo.As.WRAPPER_OBJECT);
         return docPage.nextContent(handle).get();

--- a/src/main/java/com/marklogic/client/impl/PojoQueryBuilderImpl.java
+++ b/src/main/java/com/marklogic/client/impl/PojoQueryBuilderImpl.java
@@ -28,10 +28,11 @@ import com.marklogic.client.pojo.PojoQueryBuilder;
 import com.marklogic.client.pojo.PojoQueryDefinition;
 import com.marklogic.client.query.StructuredQueryBuilder;
 import com.marklogic.client.query.StructuredQueryDefinition;
+import java.util.Map;
  
 public class PojoQueryBuilderImpl<T> extends StructuredQueryBuilder implements PojoQueryBuilder<T> {
-    private HashMap<String, Class<?>> types = new HashMap<String, Class<?>>();
-    private HashMap<String, String> rangeIndextypes = new HashMap<String, String>();
+    private Map<String, Class<?>> types = new HashMap<>();
+    private Map<String, String> rangeIndextypes = new HashMap<>();
     private Class<?> clazz;
     private String classWrapper;
     private boolean wrapQueries = false;
@@ -63,7 +64,7 @@ public class PojoQueryBuilderImpl<T> extends StructuredQueryBuilder implements P
     }
     @SuppressWarnings("unchecked")
     public <C> PojoQueryBuilder<C> containerQueryBuilder(String pojoProperty, Class<C> clazz) {
-        return new PojoQueryBuilderImpl<C>((Class<C>) getType(pojoProperty), true);
+        return new PojoQueryBuilderImpl<>((Class<C>) getType(pojoProperty), true);
     }
     @Override
     public StructuredQueryBuilder.GeospatialIndex

--- a/src/main/java/com/marklogic/client/impl/PojoRepositoryImpl.java
+++ b/src/main/java/com/marklogic/client/impl/PojoRepositoryImpl.java
@@ -61,6 +61,7 @@ import com.marklogic.client.query.DeleteQueryDefinition;
 import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.query.QueryManager.QueryView;
 import com.sun.jersey.api.client.ClientHandlerException;
+import java.util.Set;
 
 public class PojoRepositoryImpl<T, ID extends Serializable>
     implements PojoRepository<T, ID>
@@ -114,7 +115,7 @@ public class PojoRepositoryImpl<T, ID extends Serializable>
         this.entityClass = entityClass;
         this.idClass = null;
         this.docMgr = client.newJSONDocumentManager();
-        this.qb = new PojoQueryBuilderImpl<T>(entityClass);
+        this.qb = new PojoQueryBuilderImpl<>(entityClass);
     }
 
     PojoRepositoryImpl(DatabaseClient client, Class<T> entityClass, Class<ID> idClass) {
@@ -142,7 +143,7 @@ public class PojoRepositoryImpl<T, ID extends Serializable>
     @Override
     public void write(T entity, Transaction transaction, String... collections) {
         if ( entity == null ) return;
-        JacksonDatabindHandle<T> contentHandle = new JacksonDatabindHandle<T>(entity);
+        JacksonDatabindHandle<T> contentHandle = new JacksonDatabindHandle<>(entity);
         contentHandle.setMapper(objectMapper); 
         DocumentMetadataHandle metadataHandle = new DocumentMetadataHandle();
         metadataHandle = metadataHandle.withCollections(entityClass.getName());
@@ -270,7 +271,7 @@ public class PojoRepositoryImpl<T, ID extends Serializable>
     }
     @Override
     public T read(ID id, Transaction transaction) {
-        ArrayList<ID> ids = new ArrayList<ID>();
+        List<ID> ids = new ArrayList<>();
         ids.add(id);
         @SuppressWarnings("unchecked")
         PojoPage<T> page = read(ids.toArray((ID[])new Serializable[0]), transaction);
@@ -286,12 +287,12 @@ public class PojoRepositoryImpl<T, ID extends Serializable>
     }
     @Override
     public PojoPage<T> read(ID[] ids, Transaction transaction) {
-        ArrayList<String> uris = new ArrayList<String>();
+        List<String> uris = new ArrayList<>();
         for ( ID id : ids ) {
             uris.add(createUri(id));
         }
         DocumentPage docPage = (DocumentPage) docMgr.read(transaction, uris.toArray(new String[0]));
-        PojoPage<T> pojoPage = new PojoPageImpl<T>(docPage, entityClass);
+        PojoPage<T> pojoPage = new PojoPageImpl<>(docPage, entityClass);
         return pojoPage;
     }
     @Override
@@ -338,7 +339,7 @@ public class PojoRepositoryImpl<T, ID extends Serializable>
         }
 
         DocumentPage docPage = docMgr.search(wrapQuery(query), start, searchHandle, transaction);
-        PojoPage<T> pojoPage = new PojoPageImpl<T>(docPage, entityClass);
+        PojoPage<T> pojoPage = new PojoPageImpl<>(docPage, entityClass);
         return pojoPage;
     }
  
@@ -377,7 +378,7 @@ public class PojoRepositoryImpl<T, ID extends Serializable>
             return qb.collection(entityClass.getName());
         } else {
             List<String> collections = Arrays.asList(query.getCollections());
-            HashSet<String> collectionSet = new HashSet<String>(collections);
+            Set<String> collectionSet = new HashSet<>(collections);
             collectionSet.add(entityClass.getName());
             query.setCollections(collectionSet.toArray(new String[0]));
             return query;

--- a/src/main/java/com/marklogic/client/impl/QueryManagerImpl.java
+++ b/src/main/java/com/marklogic/client/impl/QueryManagerImpl.java
@@ -395,7 +395,7 @@ public class QueryManagerImpl
 
         Document doc = handle.get();
         NodeList nodeList = doc.getDocumentElement().getChildNodes();
-        List<String> suggestions = new ArrayList<String>();
+        List<String> suggestions = new ArrayList<>();
         for (int i=0; i <nodeList.getLength(); i++) {
             suggestions.add(nodeList.item(i).getTextContent());
         }

--- a/src/main/java/com/marklogic/client/impl/QueryOptionsTransformExtractNS.java
+++ b/src/main/java/com/marklogic/client/impl/QueryOptionsTransformExtractNS.java
@@ -20,11 +20,12 @@ import org.xml.sax.SAXException;
 import org.xml.sax.helpers.XMLFilterImpl;
 
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Vector;
 
 public class QueryOptionsTransformExtractNS extends XMLFilterImpl {
     private static final String SEARCH_NS = "http://marklogic.com/appservices/search";
-    private HashMap<String, String> nsmap = new HashMap<String, String> ();
+    private Map<String, String> nsmap = new HashMap<> ();
 
     public QueryOptionsTransformExtractNS() {
     }
@@ -65,8 +66,8 @@ public class QueryOptionsTransformExtractNS extends XMLFilterImpl {
     }
 
     private static class BindingAttributes implements Attributes {
-        private Vector<String> names = new Vector<String> ();
-        private Vector<String> values = new Vector<String> ();
+        private Vector<String> names = new Vector<> ();
+        private Vector<String> values = new Vector<> ();
 
         public BindingAttributes() {
         }

--- a/src/main/java/com/marklogic/client/impl/QueryOptionsTransformInjectNS.java
+++ b/src/main/java/com/marklogic/client/impl/QueryOptionsTransformInjectNS.java
@@ -21,12 +21,13 @@ import org.xml.sax.helpers.XMLFilterImpl;
 
 import javax.xml.XMLConstants;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Vector;
 
 public class QueryOptionsTransformInjectNS extends XMLFilterImpl {
     private static final String SEARCH_NS = "http://marklogic.com/appservices/search";
     private boolean inBinding = false;
-    private HashMap<String, String> nsmap = new HashMap<String, String> ();
+    private Map<String, String> nsmap = new HashMap<> ();
 
     public QueryOptionsTransformInjectNS() {
     }
@@ -88,9 +89,9 @@ public class QueryOptionsTransformInjectNS extends XMLFilterImpl {
     }
 
     private static class BindingAttributes implements Attributes {
-        private Vector<String> names = new Vector<String> ();
-        private Vector<String> values = new Vector<String> ();
-        private Vector<String> nsuris = new Vector<String> ();
+        private Vector<String> names = new Vector<> ();
+        private Vector<String> values = new Vector<> ();
+        private Vector<String> nsuris = new Vector<> ();
 
         @SuppressWarnings("unused")
         public BindingAttributes() {

--- a/src/main/java/com/marklogic/client/impl/RowManagerImpl.java
+++ b/src/main/java/com/marklogic/client/impl/RowManagerImpl.java
@@ -209,7 +209,7 @@ and not the content
 		RESTServiceResultIterator iter = 
 				services.postIteratedResource(requestLogger, "rows", transaction, params, astHandle);
 
-		return new RowSetImpl<T>(rowFormat, rowHandle, iter);
+		return new RowSetImpl<>(rowFormat, rowHandle, iter);
 	}
 	private PlanBuilderBase.RequestPlan checkPlan(Plan plan) {
 		if (plan == null) {
@@ -310,7 +310,7 @@ and not the content
 				break;
 			case "sparql-xml":
 				try {
-					List<String> cols = new ArrayList<String>();
+					List<String> cols = new ArrayList<>();
 					XMLStreamReader headerReader = headerRow.getContent(new XMLStreamReaderHandle()).get();
 					while (headerReader.hasNext()) {
 						switch(headerReader.next()) {
@@ -377,8 +377,8 @@ and not the content
 			try {
 				RowRecordImpl rowRecord = (RowRecordImpl) rowHandle;
 				
-				Map<String, String> kinds     = new HashMap<String, String>();
-				Map<String, String> datatypes = new HashMap<String, String>();
+				Map<String, String> kinds     = new HashMap<>();
+				Map<String, String> datatypes = new HashMap<>();
 
 				// TODO: replace Jackson mapper with binding-sensitive mapper?
 				@SuppressWarnings("unchecked")
@@ -482,7 +482,7 @@ and not the content
 		new HashMap<Class<? extends XsAnyAtomicTypeVal>, Function<String,? extends XsAnyAtomicTypeVal>>();
 
 		private static final Map<Class<? extends XsAnyAtomicTypeVal>,Constructor<?>> constructors =
-				new HashMap<Class<? extends XsAnyAtomicTypeVal>,Constructor<?>>();
+				new HashMap<>();
 
 		private Map<String, String> kinds     = null;
 		private Map<String, String> datatypes = null;
@@ -901,7 +901,7 @@ and not the content
 	    		throw new IllegalArgumentException("cannot set value with unknown implementation");
 	    	}
 	    	if (params == null) {
-	    		params = new HashMap<PlanBuilderBase.PlanParamBase,XsValueImpl.AnyAtomicTypeValImpl>();
+	    		params = new HashMap<>();
 	    	}
 	    	params.put((PlanBuilderBase.PlanParamBase) param, (XsValueImpl.AnyAtomicTypeValImpl) literal);
 // TODO: return clone with param for immutability

--- a/src/main/java/com/marklogic/client/impl/SPARQLBindingsImpl.java
+++ b/src/main/java/com/marklogic/client/impl/SPARQLBindingsImpl.java
@@ -51,7 +51,7 @@ public class SPARQLBindingsImpl extends TreeMap<String, List<SPARQLBinding>> imp
     private void add(SPARQLBinding binding) {
         String name = binding.getName();
         List<SPARQLBinding> bindings = this.get(name);
-        if ( bindings == null ) bindings = new ArrayList<SPARQLBinding>();
+        if ( bindings == null ) bindings = new ArrayList<>();
         bindings.add(binding);
         this.put(name, bindings);
     }

--- a/src/main/java/com/marklogic/client/impl/ServerEvaluationCallImpl.java
+++ b/src/main/java/com/marklogic/client/impl/ServerEvaluationCallImpl.java
@@ -28,6 +28,7 @@ import com.marklogic.client.io.marker.AbstractWriteHandle;
 import com.marklogic.client.io.marker.ContentHandle;
 import com.marklogic.client.io.marker.TextWriteHandle;
 import com.marklogic.client.util.EditableNamespaceContext;
+import java.util.Map;
 
 public class ServerEvaluationCallImpl 
     extends AbstractLoggingManager
@@ -41,7 +42,7 @@ public class ServerEvaluationCallImpl
     private String                   modulePath;
     private Context                  evalContext;
     private Transaction              transaction;
-    private HashMap<String, Object>  vars = new HashMap<String, Object>();
+    private Map<String, Object>  vars = new HashMap<>();
     private EditableNamespaceContext namespaceContext;
 
     public ServerEvaluationCallImpl(RESTServices services, HandleFactoryRegistry handleRegistry) {

--- a/src/main/java/com/marklogic/client/impl/TransactionImpl.java
+++ b/src/main/java/com/marklogic/client/impl/TransactionImpl.java
@@ -33,7 +33,7 @@ class TransactionImpl implements Transaction {
 	private String          hostId;
 	// we keep cookies scoped with each tranasaction to work with load balancers
 	// that need to keep requests for one transaction on a specific MarkLogic Server host
-	private List<NewCookie> cookies = new ArrayList<NewCookie>();
+	private List<NewCookie> cookies = new ArrayList<>();
 	private Calendar        created = Calendar.getInstance();
 
 	TransactionImpl(RESTServices services, String transactionId, List<NewCookie> cookies) {

--- a/src/main/java/com/marklogic/client/impl/TuplesBuilder.java
+++ b/src/main/java/com/marklogic/client/impl/TuplesBuilder.java
@@ -48,7 +48,7 @@ public final class TuplesBuilder {
         private List<Tuple> tuples;
 
         @XmlElement(namespace = Tuples.TUPLES_NS, name = "aggregate-result")
-        private ArrayList<AggregateResult> aggregateResults;
+        private List<AggregateResult> aggregateResults;
 
         @XmlElement(namespace = Tuples.TUPLES_NS, name = "metrics")
         private ValuesMetricsImpl metrics;
@@ -58,8 +58,8 @@ public final class TuplesBuilder {
         }
 
         public Tuples() {
-            tuples = new ArrayList<Tuple>();
-            aggregateResults = new ArrayList<AggregateResult>();
+            tuples = new ArrayList<>();
+            aggregateResults = new ArrayList<>();
         }
 
         public Tuple[] getTuples() {

--- a/src/main/java/com/marklogic/client/impl/Utilities.java
+++ b/src/main/java/com/marklogic/client/impl/Utilities.java
@@ -221,7 +221,7 @@ public final class Utilities {
 				return null;
 			}
 
-			List<XMLEvent> events = new ArrayList<XMLEvent>();
+			List<XMLEvent> events = new ArrayList<>();
 			while (reader.hasNext()) {
 				XMLEvent event = reader.nextEvent();
 				switch (event.getEventType()) {

--- a/src/main/java/com/marklogic/client/impl/ValuesBuilder.java
+++ b/src/main/java/com/marklogic/client/impl/ValuesBuilder.java
@@ -26,6 +26,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import com.marklogic.client.query.AggregateResult;
 import com.marklogic.client.query.CountedDistinctValue;
 import com.marklogic.client.query.ValuesMetrics;
+import java.util.List;
 
 /**
  * A ValuesBuilder parses a set of value results.
@@ -47,17 +48,17 @@ public final class ValuesBuilder {
         private String type;
 
         @XmlElement(namespace = Values.VALUES_NS, name = "distinct-value")
-        private ArrayList<CountedDistinctValue> distinctValues;
+        private List<CountedDistinctValue> distinctValues;
 
         @XmlElement(namespace = Values.VALUES_NS, name = "aggregate-result")
-        private ArrayList<AggregateResult> aggregateResults;
+        private List<AggregateResult> aggregateResults;
 
         @XmlElement(namespace = Values.VALUES_NS, name = "metrics")
         private ValuesMetricsImpl metrics;
 
         public Values() {
-            distinctValues = new ArrayList<CountedDistinctValue>();
-            aggregateResults = new ArrayList<AggregateResult>();
+            distinctValues = new ArrayList<>();
+            aggregateResults = new ArrayList<>();
         }
 
         public String getName() {

--- a/src/main/java/com/marklogic/client/impl/ValuesListBuilder.java
+++ b/src/main/java/com/marklogic/client/impl/ValuesListBuilder.java
@@ -17,6 +17,8 @@ package com.marklogic.client.impl;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -37,14 +39,14 @@ public final class ValuesListBuilder {
         public static final String VALUES_LIST_NS = "http://marklogic.com/rest-api";
 
         @XmlElement(namespace = ValuesList.VALUES_LIST_NS, name = "values")
-        private ArrayList<Values> values;
+        private List<Values> values;
 
         public ValuesList() {
-            values = new ArrayList<Values>();
+            values = new ArrayList<>();
         }
 
-        public HashMap<String, String> getValuesMap() {
-            HashMap<String,String> map = new HashMap<String, String>();
+        public Map<String, String> getValuesMap() {
+            Map<String,String> map = new HashMap<>();
             for (Values value : values) {
                 map.put(value.getName(), value.getUri());
             }

--- a/src/main/java/com/marklogic/client/impl/XsValueImpl.java
+++ b/src/main/java/com/marklogic/client/impl/XsValueImpl.java
@@ -528,10 +528,10 @@ public class XsValueImpl implements XsValue {
 	}
 
 	static XsAnySimpleTypeSeqVal anySimpleTypes(XsAnySimpleTypeVal... items) {
-		return new AnySimpleTypeSeqValImpl<AnySimpleTypeValImpl>(BaseTypeImpl.convertList(items, AnySimpleTypeValImpl.class));
+		return new AnySimpleTypeSeqValImpl<>(BaseTypeImpl.convertList(items, AnySimpleTypeValImpl.class));
 	}
 	static XsAnyAtomicTypeSeqVal anyAtomicTypes(XsAnyAtomicTypeVal... items) {
-		return new AnyAtomicTypeSeqValImpl<AnyAtomicTypeValImpl>(BaseTypeImpl.convertList(items, AnyAtomicTypeValImpl.class));
+		return new AnyAtomicTypeSeqValImpl<>(BaseTypeImpl.convertList(items, AnyAtomicTypeValImpl.class));
 	}
 
 	static class AnySimpleTypeSeqValImpl<T extends AnySimpleTypeValImpl>

--- a/src/main/java/com/marklogic/client/io/DocumentMetadataHandle.java
+++ b/src/main/java/com/marklogic/client/io/DocumentMetadataHandle.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
-import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -117,7 +116,7 @@ public class DocumentMetadataHandle
 			if (capabilities == null || capabilities.length < 1)
 				return;
 
-			HashSet<Capability> caps = new HashSet<Capability>(capabilities.length);
+			Set<Capability> caps = new HashSet<>(capabilities.length);
 			for (Capability capability: capabilities)
 				caps.add(capability);
 
@@ -128,7 +127,7 @@ public class DocumentMetadataHandle
 			if (containsKey(role)) {
 				get(role).add(capability);
 			} else {
-				HashSet<Capability> caps = new HashSet<Capability>();
+				Set<Capability> caps = new HashSet<>();
 				caps.add(capability);
 				put(role, caps );
 			}
@@ -625,7 +624,7 @@ public class DocumentMetadataHandle
 		NodeList permissionsIn = document.getElementsByTagNameNS(REST_API_NS, "permission");
 		for (int i=0; i < permissionsIn.getLength(); i++) {
 			String roleName = null;
-			HashSet<Capability> caps = new HashSet<Capability>();
+			Set<Capability> caps = new HashSet<>();
 
 			NodeList children = permissionsIn.item(i).getChildNodes();
 			for (int j=0; j < children.getLength(); j++) {

--- a/src/main/java/com/marklogic/client/io/JAXBHandle.java
+++ b/src/main/java/com/marklogic/client/io/JAXBHandle.java
@@ -326,7 +326,7 @@ public class JAXBHandle<C>
 			super();
 			this.pojoClasses    = pojoClasses;
 			this.factoryContext = factoryContext;
-			this.classSet       = new HashSet<Class<?>>(Arrays.asList(pojoClasses));
+			this.classSet       = new HashSet<>(Arrays.asList(pojoClasses));
 		}
 
 		@Override
@@ -340,7 +340,7 @@ public class JAXBHandle<C>
 		@Override
 		public <C> ContentHandle<C> newHandle(Class<C> type) {
 			ContentHandle<C> handle = isHandled(type) ?
-					(ContentHandle<C>) new JAXBHandle<C>(factoryContext) : null;
+					(ContentHandle<C>) new JAXBHandle<>(factoryContext) : null;
 			return handle;
 		}
 	}

--- a/src/main/java/com/marklogic/client/io/JacksonDatabindHandle.java
+++ b/src/main/java/com/marklogic/client/io/JacksonDatabindHandle.java
@@ -207,7 +207,7 @@ public class JacksonDatabindHandle<T>
             super();
             this.contentClasses = contentClasses;
             this.mapper = mapper;
-            this.classSet = new HashSet<Class<?>>(Arrays.asList(contentClasses));
+            this.classSet = new HashSet<>(Arrays.asList(contentClasses));
         }
 
         @Override
@@ -221,7 +221,7 @@ public class JacksonDatabindHandle<T>
         @Override
         public <C> ContentHandle<C> newHandle(Class<C> type) {
             if ( ! isHandled(type) ) return null;
-            JacksonDatabindHandle<C> handle = new JacksonDatabindHandle<C>(type);
+            JacksonDatabindHandle<C> handle = new JacksonDatabindHandle<>(type);
             if ( mapper != null ) handle.setMapper(mapper);
             return handle;
         }

--- a/src/main/java/com/marklogic/client/io/QueryOptionsHandle.java
+++ b/src/main/java/com/marklogic/client/io/QueryOptionsHandle.java
@@ -78,6 +78,7 @@ import com.marklogic.client.impl.QueryOptionsTransformInjectNS;
 import com.marklogic.client.io.marker.BufferableHandle;
 import com.marklogic.client.io.marker.QueryOptionsReadHandle;
 import com.marklogic.client.io.marker.QueryOptionsWriteHandle;
+import javax.xml.transform.Source;
 
 /**
  * @deprecated Use a JSON or XML 
@@ -907,7 +908,7 @@ public final class QueryOptionsHandle
 	public void write(OutputStream out) throws IOException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
-		JAXBElement<QueryOptions> jaxbElement = new JAXBElement<QueryOptions>(
+		JAXBElement<QueryOptions> jaxbElement = new JAXBElement<>(
 				new QName("http://marklogic.com/appservices/search", "options"),
 				QueryOptions.class, optionsHolder);
 		try {
@@ -933,7 +934,7 @@ public final class QueryOptionsHandle
 
             StreamResult result = new StreamResult(out);
 
-            SAXSource saxSource = new SAXSource(itransform, source);
+            Source saxSource = new SAXSource(itransform, source);
             transformer.transform(saxSource, result);
             logger.debug("End write of QueryOptionsHandle");       
         } catch (JAXBException e) {
@@ -1018,7 +1019,7 @@ public final class QueryOptionsHandle
             StringWriter sw = new StringWriter();
             StreamResult result = new StreamResult(sw);
             InputSource source = new InputSource(content);
-            SAXSource saxSource = new SAXSource(transform, source);
+            Source saxSource = new SAXSource(transform, source);
             transformer.transform(saxSource, result);
             String xmlResult = sw.toString();
             InputStream in = new ByteArrayInputStream(xmlResult.getBytes("UTF-8"));

--- a/src/main/java/com/marklogic/client/io/QueryOptionsListHandle.java
+++ b/src/main/java/com/marklogic/client/io/QueryOptionsListHandle.java
@@ -18,7 +18,7 @@ package com.marklogic.client.io;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
-import java.util.HashMap;
+import java.util.Map;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
@@ -113,14 +113,14 @@ public class QueryOptionsListHandle
     }
 
     /**
-     * Returns a HashMap of the named query options from the server.
+     * Returns a Map of the named query options from the server.
      *
      * The keys are the names of the query options, the values are the corresponding URIs on the server.
      *
      * @return The map of names to URIs.
      */
     @Override
-    public HashMap<String, String> getValuesMap() {
+    public Map<String, String> getValuesMap() {
     	if (optionsHolder == null ) return null;
     	else return optionsHolder.getOptionsMap();
     }

--- a/src/main/java/com/marklogic/client/io/SearchHandle.java
+++ b/src/main/java/com/marklogic/client/io/SearchHandle.java
@@ -42,7 +42,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marklogic.client.DatabaseClientFactory;
@@ -66,6 +65,7 @@ import com.marklogic.client.query.MatchSnippet;
 import com.marklogic.client.query.QueryDefinition;
 import com.marklogic.client.query.SearchMetrics;
 import com.marklogic.client.query.SearchResults;
+import java.util.Map;
 
 /**
  * A SearchHandle represents a set of search results returned by the server.
@@ -93,11 +93,11 @@ public class SearchHandle
 
     private MatchDocumentSummary[] summary;
     private SearchMetrics          metrics;
-    private ArrayList<Warning>     warnings;
-    private ArrayList<Report>      reports;
+    private List<Warning>     warnings;
+    private List<Report>      reports;
 
-    private LinkedHashMap<String, FacetResult> facets;
-    private LinkedHashMap<String, EventRange>  constraints;
+    private Map<String, FacetResult> facets;
+    private Map<String, EventRange>  constraints;
 
     private EventRange     planEvents;
     private List<XMLEvent> events;
@@ -383,9 +383,9 @@ public class SearchHandle
     	}
 
     	List<EventRange> constraintList =
-    		new ArrayList<EventRange>(constraints.values());
+    		new ArrayList<>(constraints.values());
 
-        return new EventIterator<T>(events, constraintList, handle);
+        return new EventIterator<>(events, constraintList, handle);
     }
 
     /**
@@ -438,7 +438,7 @@ public class SearchHandle
     		return new Document[0];
     	}
 
-    	ArrayList<Document> documents = new ArrayList<Document>();
+    	List<Document> documents = new ArrayList<>();
 
     	DOMHandle handle = new DOMHandle();
     	for (int i=0; i < rangeList.size(); i++) {
@@ -526,15 +526,15 @@ public class SearchHandle
         private double conf = -1;
         private double fit = -1;
         private String path = null;
-        private ArrayList<MatchLocation> locations = new ArrayList<MatchLocation>();
+        private List<MatchLocation> locations = new ArrayList<>();
         private String mimeType = null;
         private Format format = null;
 
-        private ArrayList<EventRange> snippetEvents;
+        private List<EventRange> snippetEvents;
         private EventRange            extractedEvents;
         private EventRange            metadataEvents;
     	private EventRange            relevanceEvents;
-    	private ArrayList<String>     similarUris;
+    	private List<String>     similarUris;
         private String                extractSelected;
 
         public MatchDocumentSummaryImpl(String uri, int score, double confidence, double fitness, String path, String mimeType, Format format, String extractSelected) {
@@ -615,7 +615,7 @@ public class SearchHandle
                     String json = event.asCharacters().getData();
                     try {
                         JsonNode jsonArray = new ObjectMapper().readTree(json);
-                        ArrayList<String> items = new ArrayList<String>(jsonArray.size());
+                        List<String> items = new ArrayList<>(jsonArray.size());
                         for ( JsonNode item : jsonArray ) {
                             items.add( item.toString() );
                         }
@@ -631,7 +631,7 @@ public class SearchHandle
                             getPath() + "--content should be characters");
                     }
                     String text = event.asCharacters().getData();
-                    ArrayList<String> items = new ArrayList<String>(1);
+                    List<String> items = new ArrayList<>(1);
                     items.add( event.asCharacters().getData() );
                     result.setItems( items );
                 }
@@ -639,9 +639,9 @@ public class SearchHandle
         }
 
         private List<String> populateExtractedItems(List<XMLEvent> events) {
-            List<String> items = new ArrayList<String>();
-            List<XMLEvent> itemEvents = new ArrayList<XMLEvent>();
-            List<QName> startNames = new ArrayList<QName>();
+            List<String> items = new ArrayList<>();
+            List<XMLEvent> itemEvents = new ArrayList<>();
+            List<QName> startNames = new ArrayList<>();
             for ( XMLEvent event : events ) {
                 itemEvents.add(event);
                 switch (event.getEventType()) {
@@ -654,7 +654,7 @@ public class SearchHandle
                         if (startNames.size() == 0 ) {
                             if ( startName.equals(event.asEndElement().getName())) {
                                 items.add(Utilities.eventsToString(itemEvents));
-                                itemEvents = new ArrayList<XMLEvent>();
+                                itemEvents = new ArrayList<>();
                             } else {
                                 throw new IllegalStateException("Error parsing xml \"" +
                                     Utilities.eventsToString(itemEvents) + "\", element " + startName +
@@ -787,7 +787,7 @@ public class SearchHandle
 
     static private class MatchLocationImpl implements MatchLocation {
         private String path = null;
-        private ArrayList<MatchSnippet> matchEvents = new ArrayList<MatchSnippet>();
+        private List<MatchSnippet> matchEvents = new ArrayList<>();
 
         public MatchLocationImpl(String path) {
             this.path = path;
@@ -1068,11 +1068,11 @@ public class SearchHandle
     }
 
 	private class SearchResponseImpl {
-	    private ArrayList<MatchDocumentSummary> tempSummary;
+	    private List<MatchDocumentSummary> tempSummary;
 	    private MatchDocumentSummaryImpl currSummary;
 
-	    private ArrayList<Warning> tempWarnings;
-	    private ArrayList<Report>  tempReports;
+	    private List<Warning> tempWarnings;
+	    private List<Report>  tempReports;
 
 	    private SearchMetrics          tempMetrics;
 	    private EventRange             tempPlanEvents;
@@ -1082,12 +1082,12 @@ public class SearchHandle
 	    private long tempStart        = -1;
 	    private int  tempPageLength   = 0;
 
-	    private LinkedHashMap<String, FacetResult> tempFacets;
-	    private LinkedHashMap<String, EventRange>  tempConstraints;
+	    private Map<String, FacetResult> tempFacets;
+	    private Map<String, EventRange>  tempConstraints;
 
 	    private String tempSnippetType;
 	    private String tempExtractSelected;
-	    private ArrayList<String>      qtextList;
+	    private List<String>      qtextList;
 
 	    private EventRange tempQueryEvents;
 
@@ -1096,7 +1096,7 @@ public class SearchHandle
 		}
 
 		private void parse(XMLEventReader reader) throws XMLStreamException {
-			tempEvents = new ArrayList<XMLEvent>();
+			tempEvents = new ArrayList<>();
 
 			while (reader.hasNext()) {
 				XMLEvent event = reader.nextEvent();
@@ -1204,7 +1204,7 @@ public class SearchHandle
 				ruri, score, confidence, fitness, path, mimeType, format, tempExtractSelected);
 
 	        if (tempSummary == null) {
-	        	tempSummary = new ArrayList<MatchDocumentSummary>();
+	        	tempSummary = new ArrayList<>();
 	        }
 	        tempSummary.add(currSummary);
 
@@ -1219,7 +1219,7 @@ public class SearchHandle
 	    	QName similarName       = new QName(SEARCH_NS, "similar");
 	    	QName relevanceInfoName = new QName(QUERY_NS,  "relevance-info");
 
-	    	ArrayList<XMLEvent> eventBuf = new ArrayList<XMLEvent>();
+	    	List<XMLEvent> eventBuf = new ArrayList<>();
 
 	    	QName resultName = element.getName();
 	    	events: while (reader.hasNext()) {
@@ -1285,7 +1285,7 @@ public class SearchHandle
 	    private void handleSimilar(XMLEventReader reader, StartElement element)
 	    throws XMLStreamException {
 	    	if (currSummary.similarUris == null) {
-	    		currSummary.similarUris = new ArrayList<String>();
+	    		currSummary.similarUris = new ArrayList<>();
 	    	}
 	    	currSummary.similarUris.add(reader.getElementText());
 	    }
@@ -1334,7 +1334,7 @@ public class SearchHandle
 	    }
 	    private void addSnippet(EventRange snippetRange) {
 	    	if (currSummary.snippetEvents == null) {
-	    		currSummary.snippetEvents = new ArrayList<EventRange>();
+	    		currSummary.snippetEvents = new ArrayList<>();
 	    	}
 	    	currSummary.snippetEvents.add(snippetRange);
 	    }
@@ -1394,12 +1394,12 @@ public class SearchHandle
 	    private void handleFacet(XMLEventReader reader, StartElement element)
 	    throws XMLStreamException {
 	        if (tempFacets == null) {
-	        	tempFacets = new LinkedHashMap<String, FacetResult>();
+	        	tempFacets = new LinkedHashMap<>();
 	        }
 
 	        String facetName = getAttribute(element, "name");
 
-	        List<FacetValue> values = new ArrayList<FacetValue>();
+	        List<FacetValue> values = new ArrayList<>();
 
             QName facetValuesName = new QName(SEARCH_NS, "facet-value");
 
@@ -1441,12 +1441,12 @@ public class SearchHandle
 	    private void handleGeoFacet(XMLEventReader reader, StartElement element)
 	    throws XMLStreamException {
 	        if (tempFacets == null) {
-	        	tempFacets = new LinkedHashMap<String, FacetResult>();
+	        	tempFacets = new LinkedHashMap<>();
 	        }
 
 	        String facetName = getAttribute(element, "name");
 
-            List<FacetValue> values = new ArrayList<FacetValue>();
+            List<FacetValue> values = new ArrayList<>();
 
             QName boxName = new QName(SEARCH_NS, "box");
 
@@ -1489,7 +1489,7 @@ public class SearchHandle
 	    private void handleQText(XMLEventReader reader, StartElement element)
 	    throws XMLStreamException {
 	    	if (qtextList == null) {
-	    		qtextList = new ArrayList<String>();
+	    		qtextList = new ArrayList<>();
 	    	}
 	    	qtextList.add(reader.getElementText());
 	    }
@@ -1560,7 +1560,7 @@ public class SearchHandle
 	    private void handleConstraint(XMLEventReader reader, StartElement element)
 	    throws XMLStreamException {
 	        if (tempConstraints == null) {
-	        	tempConstraints = new LinkedHashMap<String, EventRange>();
+	        	tempConstraints = new LinkedHashMap<>();
 	        }
 
 	        String constraintName = getAttribute(element, "name");
@@ -1570,7 +1570,7 @@ public class SearchHandle
 	    private void handleWarning(XMLEventReader reader, StartElement element)
 	    throws XMLStreamException {
 	        if (tempWarnings == null) {
-	            tempWarnings = new ArrayList<Warning>();
+	            tempWarnings = new ArrayList<>();
 	        }
 
 	        Warning warning = new Warning();
@@ -1581,7 +1581,7 @@ public class SearchHandle
 	    private void handleReport(XMLEventReader reader, StartElement element)
 	    throws XMLStreamException {
 	        if (tempReports == null) {
-	            tempReports = new ArrayList<Report>();
+	            tempReports = new ArrayList<>();
 	        }
 
 	        Report report = new Report();
@@ -1666,7 +1666,7 @@ public class SearchHandle
         private void setItems(List<String> itemStrings) {
             if ( itemStrings == null ) return;
             this.itemStrings = itemStrings;
-            items = new ArrayList<ExtractedItem>(itemStrings.size());
+            items = new ArrayList<>(itemStrings.size());
             for ( String itemString : itemStrings ) {
                 items.add( new ExtractedItemImpl(itemString) );
             }

--- a/src/main/java/com/marklogic/client/io/TuplesHandle.java
+++ b/src/main/java/com/marklogic/client/io/TuplesHandle.java
@@ -38,6 +38,7 @@ import com.marklogic.client.query.Tuple;
 import com.marklogic.client.query.TuplesResults;
 import com.marklogic.client.query.ValuesDefinition;
 import com.marklogic.client.query.ValuesMetrics;
+import java.util.Map;
 
 /**
  * A TuplesHandle represents a set of tuples returned by a query on the server.
@@ -52,7 +53,7 @@ public class TuplesHandle
     private Unmarshaller unmarshaller;
 
     private ValuesDefinition valdef = null;
-    private HashMap<String, AggregateResult> hashedAggregates = null;
+    private Map<String, AggregateResult> hashedAggregates = null;
 
     public TuplesHandle() {
     	super();
@@ -158,7 +159,7 @@ public class TuplesHandle
     @Override
     public AggregateResult getAggregate(String name) {
         if (hashedAggregates == null) {
-            hashedAggregates = new HashMap<String, AggregateResult>();
+            hashedAggregates = new HashMap<>();
             for (AggregateResult aggregate : tuplesHolder.getAggregates()) {
                 hashedAggregates.put(aggregate.getName(), aggregate);
             }

--- a/src/main/java/com/marklogic/client/io/ValuesHandle.java
+++ b/src/main/java/com/marklogic/client/io/ValuesHandle.java
@@ -38,6 +38,7 @@ import com.marklogic.client.query.CountedDistinctValue;
 import com.marklogic.client.query.ValuesDefinition;
 import com.marklogic.client.query.ValuesMetrics;
 import com.marklogic.client.query.ValuesResults;
+import java.util.Map;
 
 /**
  * A ValuesHandle represents a list of values or of tuples
@@ -52,7 +53,7 @@ public class ValuesHandle
 
     private ValuesBuilder.Values valuesHolder;
     private Unmarshaller unmarshaller;
-    private HashMap<String, AggregateResult> hashedAggregates = null;
+    private Map<String, AggregateResult> hashedAggregates = null;
 
     private ValuesDefinition valuesdef = null;
 
@@ -164,7 +165,7 @@ public class ValuesHandle
     @Override
     public AggregateResult getAggregate(String name) {
         if (hashedAggregates == null) {
-            hashedAggregates = new HashMap<String, AggregateResult> ();
+            hashedAggregates = new HashMap<> ();
             for (AggregateResult aggregate : valuesHolder.getAggregates()) {
                 hashedAggregates.put(aggregate.getName(), aggregate);
             }

--- a/src/main/java/com/marklogic/client/io/ValuesListHandle.java
+++ b/src/main/java/com/marklogic/client/io/ValuesListHandle.java
@@ -19,7 +19,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
-import java.util.HashMap;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
@@ -34,6 +33,7 @@ import com.marklogic.client.impl.ValuesListBuilder;
 import com.marklogic.client.io.marker.OperationNotSupported;
 import com.marklogic.client.io.marker.ValuesListReadHandle;
 import com.marklogic.client.query.ValuesListResults;
+import java.util.Map;
 
 /**
  * A ValuesListHandle represents a list of available named lexicon configurations
@@ -140,14 +140,14 @@ public class ValuesListHandle
     }
 
     /**
-     * Returns a HashMap of the named lexicon configurations.
+     * Returns a Map of the named lexicon configurations.
      *
      * The keys are the names of the lexicons, the values are the corresponding URIs on the server.
      *
      * @return The map of names to URIs.
      */
     @Override
-    public HashMap<String, String> getValuesMap() {
+    public Map<String, String> getValuesMap() {
         return valuesHolder.getValuesMap();
     }
 

--- a/src/main/java/com/marklogic/client/pojo/util/GenerateIndexConfig.java
+++ b/src/main/java/com/marklogic/client/pojo/util/GenerateIndexConfig.java
@@ -124,9 +124,9 @@ public class GenerateIndexConfig {
     private static void generateConfig(String[] classes, ObjectMapper mapper, Writer out) 
         throws ClassNotFoundException, IOException 
     {
-        ArrayList<PathIndexFound> paths = new ArrayList<PathIndexFound>();
-        ArrayList<GeoPathIndexFound> geoPaths = new ArrayList<GeoPathIndexFound>();
-        ArrayList<GeoPairFound> geoPairs = new ArrayList<GeoPairFound>();
+        List<PathIndexFound> paths = new ArrayList<>();
+        List<GeoPathIndexFound> geoPaths = new ArrayList<>();
+        List<GeoPairFound> geoPairs = new ArrayList<>();
         for ( String className : classes ) {
             Class<?> clazz = ClassUtil.findClass(className);
             SerializationConfig serializationConfig = new ObjectMapper().getSerializationConfig();
@@ -271,7 +271,7 @@ public class GenerateIndexConfig {
             AnnotatedParameter parameter = property.getConstructorParameter();
             T constructorAnnotation = parameter.getAnnotation(annotation);
             if ( constructorAnnotation != null ) {
-                AnnotationFound<T> found = new AnnotationFound<T>();
+                AnnotationFound<T> found = new AnnotationFound<>();
                 found.annotation = constructorAnnotation;
                 found.foundMessage = annotationName + " on constructor parameter '" + 
                     parameter.getRawType().getName() + " " + parameter.getName() + "'";
@@ -281,7 +281,7 @@ public class GenerateIndexConfig {
         if ( property.hasField() ) {
             T fieldAnnotation = property.getField().getAnnotation(annotation);
             if ( fieldAnnotation != null ) {
-                AnnotationFound<T> found = new AnnotationFound<T>();
+                AnnotationFound<T> found = new AnnotationFound<>();
                 found.annotation = fieldAnnotation;
                 found.foundMessage = annotationName + " on field '" + property.getField().getName() + "'";
                 return found;
@@ -291,7 +291,7 @@ public class GenerateIndexConfig {
             // I have to use getMember because Jackson returns annotation whether it's on the getter or setter
             T getterAnnotation = property.getGetter().getMember().getAnnotation(annotation);
             if ( getterAnnotation != null ) {
-                AnnotationFound<T> found = new AnnotationFound<T>();
+                AnnotationFound<T> found = new AnnotationFound<>();
                 found.annotation = getterAnnotation;
                 found.foundMessage = annotationName + " on method '" + property.getGetter().getName() + "'";
                 return found;
@@ -301,7 +301,7 @@ public class GenerateIndexConfig {
             // I have to use getMember because Jackson returns annotation whether it's on the getter or setter
             T setterAnnotation = property.getSetter().getMember().getAnnotation(annotation);
             if ( setterAnnotation != null ) {
-                AnnotationFound<T> found = new AnnotationFound<T>();
+                AnnotationFound<T> found = new AnnotationFound<>();
                 found.annotation = setterAnnotation;
                 found.foundMessage = annotationName + " on method '" + property.getSetter().getName() + "'";
                 return found;

--- a/src/main/java/com/marklogic/client/query/QueryOptionsListBuilder.java
+++ b/src/main/java/com/marklogic/client/query/QueryOptionsListBuilder.java
@@ -21,6 +21,8 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * This is an implementation class used to read the list of named query options from
@@ -37,14 +39,14 @@ public final class QueryOptionsListBuilder {
         public static final String OPTIONS_LIST_NS = "http://marklogic.com/rest-api";
 
         @XmlElement(namespace = OptionsList.OPTIONS_LIST_NS, name = "options")
-        private ArrayList<Options> options;
+        private List<Options> options;
 
         public OptionsList() {
-            options = new ArrayList<Options>();
+            options = new ArrayList<>();
         }
 
-        public HashMap<String, String> getOptionsMap() {
-            HashMap<String,String> map = new HashMap<String, String>();
+        public Map<String, String> getOptionsMap() {
+            Map<String,String> map = new HashMap<>();
             for (Options opt : options) {
                 map.put(opt.getName(), opt.getUri());
             }

--- a/src/main/java/com/marklogic/client/query/QueryOptionsListResults.java
+++ b/src/main/java/com/marklogic/client/query/QueryOptionsListResults.java
@@ -15,20 +15,20 @@
  */
 package com.marklogic.client.query;
 
-import java.util.HashMap;
+import java.util.Map;
 
 /**
  * This interface supports access to the list of named query options provided by the server.
  */
 public interface QueryOptionsListResults {
     /**
-     * Returns a HashMap of the named query options from the server.
+     * Returns a Map of the named query options from the server.
      *
      * The keys are the names of the query options, the values are the corresponding URIs on the server.
      *
      * @return The map of names to URIs.
      */
-    public HashMap<String, String> getValuesMap();
+    public Map<String, String> getValuesMap();
 }
 
 

--- a/src/main/java/com/marklogic/client/query/StructuredQueryBuilder.java
+++ b/src/main/java/com/marklogic/client/query/StructuredQueryBuilder.java
@@ -65,7 +65,7 @@ public class StructuredQueryBuilder {
 	/*
 	 * This map is used to prevent reuse of reserved prefixes in path expressions.
 	 */
-	final static private Map<String,String> reserved = new HashMap<String,String>();
+	final static private Map<String,String> reserved = new HashMap<>();
 	static {
 		reserved.put("search", SEARCH_API_NS);
 		reserved.put("xsi",  XMLConstants.W3C_XML_SCHEMA_INSTANCE_NS_URI);

--- a/src/main/java/com/marklogic/client/query/Tuple.java
+++ b/src/main/java/com/marklogic/client/query/Tuple.java
@@ -33,7 +33,7 @@ public class Tuple {
     private List<TypedDistinctValue> distinctValues;
 
     public Tuple() {
-        distinctValues = new ArrayList<TypedDistinctValue>();
+        distinctValues = new ArrayList<>();
     }
 
     /**

--- a/src/main/java/com/marklogic/client/query/ValuesListResults.java
+++ b/src/main/java/com/marklogic/client/query/ValuesListResults.java
@@ -15,7 +15,7 @@
  */
 package com.marklogic.client.query;
 
-import java.util.HashMap;
+import java.util.Map;
 
 /**
  * A ValuesListResults represents the results of a values query.
@@ -25,7 +25,7 @@ public interface ValuesListResults {
      * Returns the map of value results.
      * @return The map.
      */
-    public HashMap<String, String> getValuesMap();
+    public Map<String, String> getValuesMap();
 }
 
 

--- a/src/main/java/com/marklogic/client/util/EditableNamespaceContext.java
+++ b/src/main/java/com/marklogic/client/util/EditableNamespaceContext.java
@@ -34,7 +34,7 @@ public class EditableNamespaceContext
     implements IterableNamespaceContext, Map<String, String>
 {
 	// key is prefix, value is namespace URI
-	private HashMap<String, String> bindings = new HashMap<String, String>();
+	private Map<String, String> bindings = new HashMap<>();
 
 	/**
 	 * Constructs a NamespaceContext.
@@ -134,7 +134,7 @@ public class EditableNamespaceContext
     	if (namespaceURI == null)
 			throw new IllegalArgumentException("Cannot find prefix for null namespace URI");
 
-    	List<String> list = new ArrayList<String>();
+    	List<String> list = new ArrayList<>();
     	if (XMLConstants.XML_NS_URI.equals(namespaceURI))
     		list.add(XMLConstants.XML_NS_PREFIX);
     	else if (XMLConstants.XMLNS_ATTRIBUTE_NS_URI.equals(namespaceURI))

--- a/src/main/java/com/marklogic/client/util/RequestParameters.java
+++ b/src/main/java/com/marklogic/client/util/RequestParameters.java
@@ -46,7 +46,7 @@ public class RequestParameters
 	 * @param value	the value of the parameter
 	 */
 	public void put(String name, String value) {
-		List<String> list = new ArrayList<String>();
+		List<String> list = new ArrayList<>();
 		list.add(value);
 		getMap().put(name, list);
 	}

--- a/src/test/java/com/marklogic/client/test/BufferableHandleTest.java
+++ b/src/test/java/com/marklogic/client/test/BufferableHandleTest.java
@@ -51,6 +51,7 @@ import com.marklogic.client.io.XMLEventReaderHandle;
 import com.marklogic.client.io.XMLStreamReaderHandle;
 import com.marklogic.client.test.util.Referred;
 import com.marklogic.client.test.util.Refers;
+import java.util.Map;
 
 public class BufferableHandleTest {
 	static private XpathEngine xpather;
@@ -65,7 +66,7 @@ public class BufferableHandleTest {
         XMLUnit.setNormalizeWhitespace(true);
         XMLUnit.setIgnoreDiffBetweenTextAndCDATA(true);
 
-        HashMap<String,String> namespaces = new HashMap<String, String>();
+        Map<String,String> namespaces = new HashMap<>();
         namespaces.put("rapi", "http://marklogic.com/rest-api");
         namespaces.put("prop", "http://marklogic.com/xdmp/property");
         namespaces.put("xs",   "http://www.w3.org/2001/XMLSchema");

--- a/src/test/java/com/marklogic/client/test/BulkReadWriteTest.java
+++ b/src/test/java/com/marklogic/client/test/BulkReadWriteTest.java
@@ -124,7 +124,7 @@ public class BulkReadWriteTest {
     static void loadCities(CityWriter cityWriter) throws Exception {
         // load all the countries into a HashMap (this isn't the big data set)
         // we'll attach country info to each city (that's the big data set)
-        Map<String, Country> countries = new HashMap<String, Country>();
+        Map<String, Country> countries = new HashMap<>();
         System.out.println("Reading countries:" + BulkReadWriteTest.class.getClassLoader().getResourceAsStream(COUNTRIES_FILE));
         BufferedReader countryReader = new BufferedReader(Common.testFileToReader(COUNTRIES_FILE, "UTF-8"));
         String line;
@@ -573,7 +573,7 @@ public class BulkReadWriteTest {
             queryMgr.delete(deleteQuery);
 
             XMLDocumentManager docMgr = client.newXMLDocumentManager();
-            HashMap<String,String> map= new HashMap<String,String>();
+            Map<String,String> map= new HashMap<>();
             DocumentWriteSet writeset =docMgr.newWriteSet();
             for(int i =0;i<2;i++) {
                 String contents = "<xml>test" + i + "</xml>";

--- a/src/test/java/com/marklogic/client/test/ClosingHandlesTest.java
+++ b/src/test/java/com/marklogic/client/test/ClosingHandlesTest.java
@@ -82,10 +82,10 @@ public class ClosingHandlesTest {
         validateClosingHandleClosesUnderlyingStream(new InputStreamHandle(), "testing");
         validateClosingHandleClosesUnderlyingStream(new JacksonHandle(), "null");
         validateClosingHandleClosesUnderlyingStream(
-            new JacksonDatabindHandle<Object>(Object.class), "null");
+            new JacksonDatabindHandle<>(Object.class), "null");
         validateClosingHandleClosesUnderlyingStream(new JacksonParserHandle(), "null");
         validateClosingHandleClosesUnderlyingStream(
-            new JAXBHandle<Object>(context), "<city><population>0</population></city>");
+            new JAXBHandle<>(context), "<city><population>0</population></city>");
         validateClosingHandleClosesUnderlyingStream(new JDOMHandle(), "<xml/>");
         validateClosingHandleClosesUnderlyingStream(
             new QueryOptionsHandle(), "<options xmlns='http://marklogic.com/appservices/search'/>");

--- a/src/test/java/com/marklogic/client/test/DocumentMetadataHandleTest.java
+++ b/src/test/java/com/marklogic/client/test/DocumentMetadataHandleTest.java
@@ -43,6 +43,7 @@ import com.marklogic.client.io.DocumentMetadataHandle.DocumentMetadataValues;
 import com.marklogic.client.io.DocumentMetadataHandle.DocumentPermissions;
 import com.marklogic.client.io.DocumentMetadataHandle.DocumentProperties;
 import com.marklogic.client.io.StringHandle;
+import java.util.List;
 
 public class DocumentMetadataHandleTest {
 	@BeforeClass
@@ -155,7 +156,7 @@ public class DocumentMetadataHandleTest {
 			Object thirdValue = properties.get("third");
 			assertTrue("Third property with wrong class for value", thirdValue instanceof NodeList);
 			NodeList thirdNodes = (NodeList) thirdValue;
-			ArrayList<Element> thirdElements = new ArrayList<Element>(); 
+			List<Element> thirdElements = new ArrayList<>(); 
 			for (int i=0; i < thirdNodes.getLength(); i++) {
 				Node thirdNode = thirdNodes.item(i);
 				if (thirdNode.getNodeType() != Node.ELEMENT_NODE)

--- a/src/test/java/com/marklogic/client/test/EvalTest.java
+++ b/src/test/java/com/marklogic/client/test/EvalTest.java
@@ -61,6 +61,7 @@ import com.marklogic.client.io.ReaderHandle;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.query.DeleteQueryDefinition;
 import com.marklogic.client.query.QueryManager;
+import java.util.Map;
 
 
 public class EvalTest {
@@ -414,7 +415,7 @@ public class EvalTest {
             queryMgr.delete(deleteQuery);
  
             XMLDocumentManager docMgr = client.newXMLDocumentManager();
-            HashMap<String,String> map= new HashMap<String,String>();
+            Map<String,String> map= new HashMap<>();
             DocumentWriteSet writeset =docMgr.newWriteSet();
             for(int i =0;i<2;i++) {
                 String contents = "<xml>test" + i + "</xml>";

--- a/src/test/java/com/marklogic/client/test/HandleAsTest.java
+++ b/src/test/java/com/marklogic/client/test/HandleAsTest.java
@@ -237,7 +237,7 @@ public class HandleAsTest {
 		Product[] products = {product1, product2};
 
 		// setup
-		Set<String> prodNames = new HashSet<String>(products.length);
+		Set<String> prodNames = new HashSet<>(products.length);
 		for (Product product: products) {
 			String prodName = product.getName();
 			prodNames.add(prodName);

--- a/src/test/java/com/marklogic/client/test/JAXBHandleTest.java
+++ b/src/test/java/com/marklogic/client/test/JAXBHandleTest.java
@@ -33,6 +33,7 @@ import com.marklogic.client.document.XMLDocumentManager;
 import com.marklogic.client.io.JAXBHandle;
 import com.marklogic.client.test.util.Referred;
 import com.marklogic.client.test.util.Refers;
+import java.util.Map;
 
 public class JAXBHandleTest {
 	@BeforeClass
@@ -49,11 +50,11 @@ public class JAXBHandleTest {
 	public void testReadWriteJAXB() throws JAXBException {
 		String docId = "/test/jaxbWrite1.xml";
 
-		HashMap<String,Integer> map = new HashMap<String,Integer>();
+		Map<String,Integer> map = new HashMap<>();
 		map.put("alpha", 1);
 		map.put("beta",  2);
 		map.put("gamma", 3);
-		List<String> list = new ArrayList<String>(3);
+		List<String> list = new ArrayList<>(3);
 		list.add("apple");
 		list.add("banana");
 		list.add("cactus");
@@ -83,7 +84,7 @@ public class JAXBHandleTest {
 		assertEquals("JAXB document with different list", refers.list.size(), refers2.list.size());
 
 		// Again with a specified generic -- useful for convenience and strong typing
-		JAXBHandle<Refers> objectHandle2 = new JAXBHandle<Refers>(context);
+		JAXBHandle<Refers> objectHandle2 = new JAXBHandle<>(context);
 
 		docMgr.write(docId, objectHandle2.with(refers));
 

--- a/src/test/java/com/marklogic/client/test/JacksonStreamTest.java
+++ b/src/test/java/com/marklogic/client/test/JacksonStreamTest.java
@@ -40,6 +40,7 @@ import com.marklogic.client.document.JSONDocumentManager;
 import com.marklogic.client.io.JacksonParserHandle;
 import com.marklogic.client.io.ReaderHandle;
 import com.marklogic.client.test.Common;
+import java.util.List;
 
 public class JacksonStreamTest {
     private static final String ORDER_FILE = "sampleOrder.json";
@@ -101,7 +102,7 @@ public class JacksonStreamTest {
         if (jp.nextToken() != JsonToken.START_OBJECT) {
             throw new IOException("Expected data to start with an Object");
         }
-        ArrayList<OrderItem> orderItems = getOrderItems(jp);
+        List<OrderItem> orderItems = getOrderItems(jp);
         assertEquals("orderItems array length is wrong", 4, orderItems.size());
         assertEquals("OrderItem 1 productId is wrong", "widget",   orderItems.get(0).getProductId());
         assertEquals("OrderItem 2 productId is wrong", "cog",      orderItems.get(1).getProductId());
@@ -117,8 +118,8 @@ public class JacksonStreamTest {
         assertEquals("OrderItem 4 itemCostUSD is wrong", 1.99,  orderItems.get(3).getItemCostUSD(), 0.001);
     }
 
-    private ArrayList<OrderItem> getOrderItems(JsonParser parser) throws IOException {
-        ArrayList<OrderItem> orderItems = new ArrayList<OrderItem>();
+    private List<OrderItem> getOrderItems(JsonParser parser) throws IOException {
+        List<OrderItem> orderItems = new ArrayList<>();
         while ( parser.nextValue() != null ) {
             if ( parser.getCurrentToken() == JsonToken.START_ARRAY &&
                  "orderItems".equals(parser.getCurrentName()) )

--- a/src/test/java/com/marklogic/client/test/PageTest.java
+++ b/src/test/java/com/marklogic/client/test/PageTest.java
@@ -35,7 +35,7 @@ public class PageTest {
     }
     @Test
     public void testTestPage() {
-        Iterator<Object> iterator = new HashSet<Object>().iterator();
+        Iterator<Object> iterator = new HashSet<>().iterator();
 
         Page<Object> page = new TestPage(iterator, 1, 10, 100);
         assertEquals("Unexpected size", 10, page.size());

--- a/src/test/java/com/marklogic/client/test/QOPathIndexTest.java
+++ b/src/test/java/com/marklogic/client/test/QOPathIndexTest.java
@@ -44,6 +44,7 @@ import com.marklogic.client.admin.config.QueryOptionsBuilder;
 import com.marklogic.client.impl.HandleAccessor;
 import com.marklogic.client.io.QueryOptionsHandle;
 import com.marklogic.client.util.EditableNamespaceContext;
+import java.util.Map;
 
 @SuppressWarnings("deprecation")
 public class QOPathIndexTest {
@@ -59,7 +60,7 @@ public class QOPathIndexTest {
         Common.connectAdmin();
         builder = new QueryOptionsBuilder();
 
-        HashMap<String,String> xpathNS = new HashMap<String, String>();
+        Map<String,String> xpathNS = new HashMap<>();
         xpathNS.put("search", "http://marklogic.com/appservices/search");
         xpathNS.put("foo", "testing");
         xpathNS.put("x", "ab'c'");

--- a/src/test/java/com/marklogic/client/test/QueryOptionsBuilderTest.java
+++ b/src/test/java/com/marklogic/client/test/QueryOptionsBuilderTest.java
@@ -75,6 +75,7 @@ import com.marklogic.client.admin.config.QueryOptions.QueryWord;
 import com.marklogic.client.admin.config.QueryOptionsBuilder;
 import com.marklogic.client.impl.Utilities;
 import com.marklogic.client.io.QueryOptionsHandle;
+import java.util.Map;
 
 /* 
  * This test targets the QueryOptionsBuilder.
@@ -95,7 +96,7 @@ public class QueryOptionsBuilderTest {
 	@Before
 	public void before() {
 		builder = new QueryOptionsBuilder();
-		HashMap<String, String> xpathNS = new HashMap<String, String>();
+		Map<String, String> xpathNS = new HashMap<>();
 		xpathNS.put("search", "http://marklogic.com/appservices/search");
 		SimpleNamespaceContext xpathNsContext = new SimpleNamespaceContext(
 				xpathNS);

--- a/src/test/java/com/marklogic/client/test/QueryOptionsHandleTest.java
+++ b/src/test/java/com/marklogic/client/test/QueryOptionsHandleTest.java
@@ -82,6 +82,7 @@ import com.marklogic.client.impl.Utilities;
 import com.marklogic.client.io.FileHandle;
 import com.marklogic.client.io.QueryOptionsHandle;
 import com.marklogic.client.io.StringHandle;
+import java.util.Map;
 
 @SuppressWarnings("deprecation")
 public class QueryOptionsHandleTest {
@@ -126,7 +127,7 @@ public class QueryOptionsHandleTest {
 
 		mgr = Common.client.newServerConfigManager().newQueryOptionsManager();
 	
-		optionsPOJOs = new ArrayList<QueryOptionsHandle>();
+		optionsPOJOs = new ArrayList<>();
 
 		for (String option : testOptionsCorpus) {
 			FileHandle f = new FileHandle(new File("src/test/resources/"
@@ -144,7 +145,7 @@ public class QueryOptionsHandleTest {
 
 		builder = new QueryOptionsBuilder();
 
-        HashMap<String,String> xpathNS = new HashMap<String, String>();
+        Map<String,String> xpathNS = new HashMap<>();
         xpathNS.put("search", "http://marklogic.com/appservices/search");
         SimpleNamespaceContext xpathNsContext = new SimpleNamespaceContext(xpathNS);
 

--- a/src/test/java/com/marklogic/client/test/QueryOptionsListHandleTest.java
+++ b/src/test/java/com/marklogic/client/test/QueryOptionsListHandleTest.java
@@ -39,6 +39,7 @@ import com.marklogic.client.admin.QueryOptionsManager;
 import com.marklogic.client.io.QueryOptionsListHandle;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.query.QueryManager;
+import java.util.Map;
 
 public class QueryOptionsListHandleTest {
 	@SuppressWarnings("unused")
@@ -63,7 +64,7 @@ public class QueryOptionsListHandleTest {
         MyQueryOptionsListHandle v = new MyQueryOptionsListHandle();
 
         v.parseTestData(is);
-        HashMap<String,String> map = v.getValuesMap();
+        Map<String,String> map = v.getValuesMap();
         assertEquals("Map should contain two keys", map.size(), 2);
         assertEquals("photos should have this uri", map.get("photos"), "/v1/config/query/photos");
     }
@@ -74,7 +75,7 @@ public class QueryOptionsListHandleTest {
 
         QueryOptionsListHandle results = queryMgr.optionsList(new QueryOptionsListHandle());
         assertNotNull(results);
-        HashMap<String,String> map = results.getValuesMap();
+        Map<String,String> map = results.getValuesMap();
         assertEquals("Map should contain two keys", map.size(), 2);
         assertEquals("photos should have this uri", map.get("photos"), "/v1/config/query/photos");
     }

--- a/src/test/java/com/marklogic/client/test/ResourceExtensionsTest.java
+++ b/src/test/java/com/marklogic/client/test/ResourceExtensionsTest.java
@@ -37,6 +37,7 @@ import com.marklogic.client.admin.ResourceExtensionsManager;
 import com.marklogic.client.admin.ResourceExtensionsManager.MethodParameters;
 import com.marklogic.client.io.Format;
 import com.marklogic.client.io.StringHandle;
+import java.util.Map;
 
 public class ResourceExtensionsTest {
 	final static String RESOURCE_NAME = "testresource";
@@ -56,7 +57,7 @@ public class ResourceExtensionsTest {
         XMLUnit.setNormalizeWhitespace(true);
         XMLUnit.setIgnoreDiffBetweenTextAndCDATA(true);
 
-        HashMap<String,String> namespaces = new HashMap<String, String>();
+        Map<String,String> namespaces = new HashMap<>();
         namespaces.put("rapi", "http://marklogic.com/rest-api");
 
         SimpleNamespaceContext namespaceContext = new SimpleNamespaceContext(namespaces);

--- a/src/test/java/com/marklogic/client/test/ResourceServicesTest.java
+++ b/src/test/java/com/marklogic/client/test/ResourceServicesTest.java
@@ -35,6 +35,7 @@ import com.marklogic.client.extensions.ResourceServices;
 import com.marklogic.client.extensions.ResourceServices.ServiceResultIterator;
 import com.marklogic.client.io.DOMHandle;
 import com.marklogic.client.io.StringHandle;
+import java.util.List;
 
 public class ResourceServicesTest {
 	static private String resourceServices;
@@ -76,7 +77,7 @@ public class ResourceServicesTest {
 
 		ServiceResultIterator resultItr = resourceMgr.getResourceServices().get(params, mimetypes);
 
-		ArrayList<Document> resultDocuments = new ArrayList<Document>();
+		List<Document> resultDocuments = new ArrayList<>();
 		DOMHandle readHandle = new DOMHandle();
 		while (resultItr.hasNext()) {
 			resultDocuments.add(
@@ -120,7 +121,7 @@ public class ResourceServicesTest {
 
 		resultItr = resourceMgr.getResourceServices().post(params, writeHandles, mimetypes);
 
-		resultDocuments = new ArrayList<Document>();
+		resultDocuments = new ArrayList<>();
 		readHandle = new DOMHandle();
 		while (resultItr.hasNext()) {
 			resultDocuments.add(

--- a/src/test/java/com/marklogic/client/test/RowManagerTest.java
+++ b/src/test/java/com/marklogic/client/test/RowManagerTest.java
@@ -81,21 +81,21 @@ public class RowManagerTest {
 
 		litRows = new Map[3];
 
-		Map<String,Object>   row  = new HashMap<String,Object>();
+		Map<String,Object>   row  = new HashMap<>();
 		row.put("rowNum", 1);
 		row.put("city",   "New York");
 		row.put("temp",   "82");
 		row.put("uri",    uris[0]);
 		litRows[0] = row;
 
-		row = new HashMap<String,Object>();
+		row = new HashMap<>();
 		row.put("rowNum", 2);
 		row.put("city",   "Seattle");
 		row.put("temp",   "72");
 		row.put("uri",    uris[1]);
 		litRows[1] = row;
 
-		row = new HashMap<String,Object>();
+		row = new HashMap<>();
 		row.put("rowNum", 3);
 		row.put("city",   "Phoenix");
 		row.put("temp",   "92");
@@ -344,7 +344,7 @@ public class RowManagerTest {
 
 		PlanBuilder p = rowMgr.newPlanBuilder();
 
-		Map<String, CtsReferenceExpr> lexicons = new HashMap<String, CtsReferenceExpr>();
+		Map<String, CtsReferenceExpr> lexicons = new HashMap<>();
 		lexicons.put("uri", p.cts.uriReference());
 		lexicons.put("int", p.cts.elementReference(p.xs.qname("int")));
 

--- a/src/test/java/com/marklogic/client/test/StructuredQueryBuilderTest.java
+++ b/src/test/java/com/marklogic/client/test/StructuredQueryBuilderTest.java
@@ -46,6 +46,7 @@ import com.marklogic.client.query.StructuredQueryBuilder.FragmentScope;
 import com.marklogic.client.query.StructuredQueryBuilder.Operator;
 import com.marklogic.client.query.StructuredQueryDefinition;
 import com.marklogic.client.util.EditableNamespaceContext;
+import java.util.Map;
 
 public class StructuredQueryBuilderTest {
 	static private XpathEngine xpather;
@@ -58,7 +59,7 @@ public class StructuredQueryBuilderTest {
         XMLUnit.setNormalizeWhitespace(true);
         XMLUnit.setIgnoreDiffBetweenTextAndCDATA(true);
 
-        HashMap<String,String> namespaces = new HashMap<String, String>();
+        Map<String,String> namespaces = new HashMap<>();
         namespaces.put("rapi", "http://marklogic.com/rest-api");
         namespaces.put("prop", "http://marklogic.com/xdmp/property");
         namespaces.put("xs",   "http://www.w3.org/2001/XMLSchema");

--- a/src/test/java/com/marklogic/client/test/TransformExtensionsTest.java
+++ b/src/test/java/com/marklogic/client/test/TransformExtensionsTest.java
@@ -39,6 +39,7 @@ import com.marklogic.client.ResourceNotResendableException;
 import com.marklogic.client.io.Format;
 import com.marklogic.client.admin.TransformExtensionsManager;
 import com.marklogic.client.io.StringHandle;
+import java.util.Map;
 
 public class TransformExtensionsTest {
 	final static String XQUERY_NAME = "testxqy";
@@ -60,7 +61,7 @@ public class TransformExtensionsTest {
         XMLUnit.setNormalizeWhitespace(true);
         XMLUnit.setIgnoreDiffBetweenTextAndCDATA(true);
 
-		HashMap<String,String> namespaces = new HashMap<String, String>();
+		Map<String,String> namespaces = new HashMap<>();
 		namespaces.put("xsl",  "http://www.w3.org/1999/XSL/Transform");
 		namespaces.put("rapi", "http://marklogic.com/rest-api");
 

--- a/src/test/java/com/marklogic/client/test/ValuesHandleTest.java
+++ b/src/test/java/com/marklogic/client/test/ValuesHandleTest.java
@@ -51,6 +51,7 @@ import com.marklogic.client.query.StructuredQueryDefinition;
 import com.marklogic.client.query.ValueQueryDefinition;
 import com.marklogic.client.query.ValuesDefinition;
 import com.marklogic.client.query.ValuesListDefinition;
+import java.util.Map;
 
 public class ValuesHandleTest {
 
@@ -162,7 +163,7 @@ public class ValuesHandleTest {
         MyValuesListHandle v = new MyValuesListHandle();
 
         v.parseTestData(is);
-        HashMap<String,String> map = v.getValuesMap();
+        Map<String,String> map = v.getValuesMap();
         assertEquals("Map should contain two keys", map.size(), 2);
         assertEquals("Size should have this uri", map.get("size"), "/v1/values/size?options=photos");
     }
@@ -199,7 +200,7 @@ public class ValuesHandleTest {
 
         ValuesListHandle results = queryMgr.valuesList(vdef, new ValuesListHandle());
         assertNotNull(results);
-        HashMap<String,String> map = results.getValuesMap();
+        Map<String,String> map = results.getValuesMap();
         assertEquals("Map should contain two keys", map.size(), 2);
         assertEquals("Size should have this uri", map.get("size"), "/v1/values/size?options=photos");
         

--- a/src/test/java/com/marklogic/client/test/XMLDocumentTest.java
+++ b/src/test/java/com/marklogic/client/test/XMLDocumentTest.java
@@ -65,6 +65,7 @@ import com.marklogic.client.io.XMLEventReaderHandle;
 import com.marklogic.client.io.XMLStreamReaderHandle;
 import com.marklogic.client.io.marker.DocumentPatchHandle;
 import com.marklogic.client.util.EditableNamespaceContext;
+import java.util.Map;
 
 public class XMLDocumentTest {
 	@BeforeClass
@@ -120,7 +121,7 @@ public class XMLDocumentTest {
 		assertNotNull("Read null document for SAX writer",docText);
 		assertXMLEqual("Failed to read XML document as DOM",domString,docText);
 
-		final HashMap<String,Integer> counter = new HashMap<String,Integer>(); 
+		final Map<String,Integer> counter = new HashMap<>(); 
 		counter.put("elementCount",0);
 		counter.put("attributeCount",0);
 		DefaultHandler handler = new DefaultHandler() {

--- a/test-complete/src/test/java/com/marklogic/client/functionaltest/BasicJavaClientREST.java
+++ b/test-complete/src/test/java/com/marklogic/client/functionaltest/BasicJavaClientREST.java
@@ -1672,7 +1672,7 @@ return readContent;
 	 */
 	public String convertInputSourceToString(InputSource fileRead) throws IOException, TransformerException
 	{
-		SAXSource saxsrc = new SAXSource(fileRead);
+		Source saxsrc = new SAXSource(fileRead);
 		TransformerFactory tf = TransformerFactory.newInstance();
 		Transformer transformer = tf.newTransformer();
 		transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");

--- a/test-complete/src/test/java/com/marklogic/client/functionaltest/ConnectedRESTQA.java
+++ b/test-complete/src/test/java/com/marklogic/client/functionaltest/ConnectedRESTQA.java
@@ -751,7 +751,7 @@ public abstract class ConnectedRESTQA {
 
 			HttpPost post = new HttpPost("http://localhost:8002"+ "/manage/v2/forests/"+fName);
 			//			
-			List<NameValuePair> urlParameters = new ArrayList<NameValuePair>();
+			List<NameValuePair> urlParameters = new ArrayList<>();
 			urlParameters.add(new BasicNameValuePair("state", "detach"));
 			urlParameters.add(new BasicNameValuePair("database", dbName));
 

--- a/test-complete/src/test/java/com/marklogic/client/functionaltest/TestBiTemporal.java
+++ b/test-complete/src/test/java/com/marklogic/client/functionaltest/TestBiTemporal.java
@@ -261,7 +261,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
         record.getContent(recordHandle);
         System.out.println("Content = " + recordHandle.toString());
       } else {
-        JacksonDatabindHandle<ObjectNode> recordHandle = new JacksonDatabindHandle<ObjectNode>(
+        JacksonDatabindHandle<ObjectNode> recordHandle = new JacksonDatabindHandle<>(
             ObjectNode.class);
         record.getContent(recordHandle);
         System.out.println("Content = " + recordHandle.toString());
@@ -271,11 +271,11 @@ public class TestBiTemporal extends BasicJavaClientREST {
         TypeReference<HashMap<String, Object>> typeRef = new TypeReference<HashMap<String, Object>>() {
         };
 
-        HashMap<String, Object> docObject = mapper.readValue(
+        Map<String, Object> docObject = mapper.readValue(
             recordHandle.toString(), typeRef);
 
         @SuppressWarnings("unchecked")
-        HashMap<String, Object> systemNode = (HashMap<String, Object>) (docObject
+        Map<String, Object> systemNode = (HashMap<String, Object>) (docObject
             .get(systemNodeName));
 
         String systemStartDate = (String) systemNode.get(systemStartERIName);
@@ -284,7 +284,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
         System.out.println("systemEndDate = " + systemEndDate);
 
         @SuppressWarnings("unchecked")
-        HashMap<String, Object> validNode = (HashMap<String, Object>) (docObject
+        Map<String, Object> validNode = (HashMap<String, Object>) (docObject
             .get(validNodeName));
 
         String validStartDate = (String) validNode.get(validStartERIName);
@@ -633,7 +633,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
 
     System.out.println(rootNode.toString());
 
-    JacksonDatabindHandle<ObjectNode> handle = new JacksonDatabindHandle<ObjectNode>(
+    JacksonDatabindHandle<ObjectNode> handle = new JacksonDatabindHandle<>(
         ObjectNode.class).withFormat(Format.JSON);
     handle.set(rootNode);
 
@@ -1044,7 +1044,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
 
     // Check if properties have been set. User XML DOcument Manager since
     // properties are written as XML
-    JacksonDatabindHandle<ObjectNode> contentHandle = new JacksonDatabindHandle<ObjectNode>(
+    JacksonDatabindHandle<ObjectNode> contentHandle = new JacksonDatabindHandle<>(
         ObjectNode.class);
     DocumentMetadataHandle metadataHandle = new DocumentMetadataHandle();
     docMgr.read(docId, metadataHandle, contentHandle);
@@ -1152,7 +1152,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
       if (record.getFormat() != Format.JSON) {
         assertFalse("Format is not JSON: " + Format.JSON, true);
       } else {
-        JacksonDatabindHandle<ObjectNode> recordHandle = new JacksonDatabindHandle<ObjectNode>(
+        JacksonDatabindHandle<ObjectNode> recordHandle = new JacksonDatabindHandle<>(
             ObjectNode.class);
         record.getContent(recordHandle);
         System.out.println("Content = " + recordHandle.toString());
@@ -1235,7 +1235,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
 
     // Verify that the document was inserted
     JSONDocumentManager docMgr = readerClient.newJSONDocumentManager();
-    JacksonDatabindHandle<ObjectNode> recordHandle = new JacksonDatabindHandle<ObjectNode>(
+    JacksonDatabindHandle<ObjectNode> recordHandle = new JacksonDatabindHandle<>(
         ObjectNode.class);
     DocumentMetadataHandle metadataHandle = new DocumentMetadataHandle();
     docMgr.read(docId, metadataHandle, recordHandle);
@@ -1258,11 +1258,11 @@ public class TestBiTemporal extends BasicJavaClientREST {
       TypeReference<HashMap<String, Object>> typeRef = new TypeReference<HashMap<String, Object>>() {
       };
 
-      HashMap<String, Object> docObject = mapper.readValue(
+      Map<String, Object> docObject = mapper.readValue(
           recordHandle.toString(), typeRef);
 
       @SuppressWarnings("unchecked")
-      HashMap<String, Object> validNode = (HashMap<String, Object>) (docObject
+      Map<String, Object> validNode = (HashMap<String, Object>) (docObject
           .get(systemNodeName));
 
       String systemStartDate = (String) validNode.get(systemStartERIName);
@@ -1406,7 +1406,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
         assertFalse("Format is not JSON: " + Format.JSON, true);
       } else {
         // Make sure that system and valid times are what is expected
-        recordHandle = new JacksonDatabindHandle<ObjectNode>(ObjectNode.class);
+        recordHandle = new JacksonDatabindHandle<>(ObjectNode.class);
         record.getContent(recordHandle);
         System.out.println("Content = " + recordHandle.toString());
 
@@ -1415,11 +1415,11 @@ public class TestBiTemporal extends BasicJavaClientREST {
         TypeReference<HashMap<String, Object>> typeRef = new TypeReference<HashMap<String, Object>>() {
         };
 
-        HashMap<String, Object> docObject = mapper.readValue(
+        Map<String, Object> docObject = mapper.readValue(
             recordHandle.toString(), typeRef);
 
         @SuppressWarnings("unchecked")
-        HashMap<String, Object> systemNode = (HashMap<String, Object>) (docObject
+        Map<String, Object> systemNode = (HashMap<String, Object>) (docObject
             .get(systemNodeName));
 
         String systemStartDate = (String) systemNode.get(systemStartERIName);
@@ -1428,7 +1428,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
         System.out.println("systemEndDate = " + systemEndDate);
 
         @SuppressWarnings("unchecked")
-        HashMap<String, Object> validNode = (HashMap<String, Object>) (docObject
+        Map<String, Object> validNode = (HashMap<String, Object>) (docObject
             .get(validNodeName));
 
         String validStartDate = (String) validNode.get(validStartERIName);
@@ -1716,7 +1716,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
         assertFalse("Format is not JSON: " + Format.JSON, true);
       } else {
         // Make sure that system and valid times are what is expected
-        recordHandle = new JacksonDatabindHandle<ObjectNode>(ObjectNode.class);
+        recordHandle = new JacksonDatabindHandle<>(ObjectNode.class);
         record.getContent(recordHandle);
         System.out.println("Content = " + recordHandle.toString());
 
@@ -1725,11 +1725,11 @@ public class TestBiTemporal extends BasicJavaClientREST {
         TypeReference<HashMap<String, Object>> typeRef = new TypeReference<HashMap<String, Object>>() {
         };
 
-        HashMap<String, Object> docObject = mapper.readValue(
+        Map<String, Object> docObject = mapper.readValue(
             recordHandle.toString(), typeRef);
 
         @SuppressWarnings("unchecked")
-        HashMap<String, Object> systemNode = (HashMap<String, Object>) (docObject
+        Map<String, Object> systemNode = (HashMap<String, Object>) (docObject
             .get(systemNodeName));
 
         String systemStartDate = (String) systemNode.get(systemStartERIName);
@@ -1738,7 +1738,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
         System.out.println("systemEndDate = " + systemEndDate);
 
         @SuppressWarnings("unchecked")
-        HashMap<String, Object> validNode = (HashMap<String, Object>) (docObject
+        Map<String, Object> validNode = (HashMap<String, Object>) (docObject
             .get(validNodeName));
 
         String validStartDate = (String) validNode.get(validStartERIName);
@@ -2084,7 +2084,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
       // Make sure document is not visible to any other transaction
       boolean exceptionThrown = false;
       try {
-        JacksonDatabindHandle<ObjectNode> contentHandle = new JacksonDatabindHandle<ObjectNode>(
+        JacksonDatabindHandle<ObjectNode> contentHandle = new JacksonDatabindHandle<>(
             ObjectNode.class);
         DocumentMetadataHandle metadataHandle = new DocumentMetadataHandle();
         docMgr.read(docId, metadataHandle, contentHandle);        
@@ -2278,7 +2278,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
 		// Verify that the document is not there after rollback
 		boolean exceptionThrown = false;
 		try {
-		  JacksonDatabindHandle<ObjectNode> contentHandle = new JacksonDatabindHandle<ObjectNode>(
+		  JacksonDatabindHandle<ObjectNode> contentHandle = new JacksonDatabindHandle<>(
 		      ObjectNode.class);
 		  DocumentMetadataHandle metadataHandle = new DocumentMetadataHandle();
 		  docMgr.read(docId, metadataHandle, contentHandle);
@@ -2437,7 +2437,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
         record.getContent(recordHandle);
         System.out.println("Content = " + recordHandle.toString());
       } else {
-        JacksonDatabindHandle<ObjectNode> recordHandle = new JacksonDatabindHandle<ObjectNode>(
+        JacksonDatabindHandle<ObjectNode> recordHandle = new JacksonDatabindHandle<>(
             ObjectNode.class);
         record.getContent(recordHandle);
         System.out.println("Content = " + recordHandle.toString());
@@ -2447,11 +2447,11 @@ public class TestBiTemporal extends BasicJavaClientREST {
         TypeReference<HashMap<String, Object>> typeRef = new TypeReference<HashMap<String, Object>>() {
         };
 
-        HashMap<String, Object> docObject = mapper.readValue(
+        Map<String, Object> docObject = mapper.readValue(
             recordHandle.toString(), typeRef);
 
         @SuppressWarnings("unchecked")
-        HashMap<String, Object> systemNode = (HashMap<String, Object>) (docObject
+        Map<String, Object> systemNode = (HashMap<String, Object>) (docObject
             .get(systemNodeName));
 
         String systemStartDate = (String) systemNode.get(systemStartERIName);
@@ -2460,7 +2460,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
         System.out.println("systemEndDate = " + systemEndDate);
 
         @SuppressWarnings("unchecked")
-        HashMap<String, Object> validNode = (HashMap<String, Object>) (docObject
+        Map<String, Object> validNode = (HashMap<String, Object>) (docObject
             .get(validNodeName));
 
         String validStartDate = (String) validNode.get(validStartERIName);
@@ -2546,7 +2546,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
       if (record.getFormat() != Format.JSON) {
         assertFalse("Invalid document format: " + record.getFormat(), true);
       } else {
-        JacksonDatabindHandle<ObjectNode> recordHandle = new JacksonDatabindHandle<ObjectNode>(
+        JacksonDatabindHandle<ObjectNode> recordHandle = new JacksonDatabindHandle<>(
             ObjectNode.class);
         record.getContent(recordHandle);
         System.out.println("Content = " + recordHandle.toString());
@@ -2556,11 +2556,11 @@ public class TestBiTemporal extends BasicJavaClientREST {
         TypeReference<HashMap<String, Object>> typeRef = new TypeReference<HashMap<String, Object>>() {
         };
 
-        HashMap<String, Object> docObject = mapper.readValue(
+        Map<String, Object> docObject = mapper.readValue(
             recordHandle.toString(), typeRef);
 
         @SuppressWarnings("unchecked")
-        HashMap<String, Object> validNode = (HashMap<String, Object>) (docObject
+        Map<String, Object> validNode = (HashMap<String, Object>) (docObject
             .get(validNodeName));
 
         String validStartDate = (String) validNode.get(validStartERIName);
@@ -2640,7 +2640,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
         record.getContent(recordHandle);
         System.out.println("Content = " + recordHandle.toString());
       } else {
-        JacksonDatabindHandle<ObjectNode> recordHandle = new JacksonDatabindHandle<ObjectNode>(
+        JacksonDatabindHandle<ObjectNode> recordHandle = new JacksonDatabindHandle<>(
             ObjectNode.class);
         record.getContent(recordHandle);
         System.out.println("Content = " + recordHandle.toString());
@@ -2650,11 +2650,11 @@ public class TestBiTemporal extends BasicJavaClientREST {
         TypeReference<HashMap<String, Object>> typeRef = new TypeReference<HashMap<String, Object>>() {
         };
 
-        HashMap<String, Object> docObject = mapper.readValue(
+        Map<String, Object> docObject = mapper.readValue(
             recordHandle.toString(), typeRef);
 
         @SuppressWarnings("unchecked")
-        HashMap<String, Object> systemNode = (HashMap<String, Object>) (docObject
+        Map<String, Object> systemNode = (HashMap<String, Object>) (docObject
             .get(systemNodeName));
 
         String systemStartDate = (String) systemNode.get(systemStartERIName);
@@ -2663,7 +2663,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
         System.out.println("systemEndDate = " + systemEndDate);
 
         @SuppressWarnings("unchecked")
-        HashMap<String, Object> validNode = (HashMap<String, Object>) (docObject
+        Map<String, Object> validNode = (HashMap<String, Object>) (docObject
             .get(validNodeName));
 
         String validStartDate = (String) validNode.get(validStartERIName);

--- a/test-complete/src/test/java/com/marklogic/client/functionaltest/TestBug18026.java
+++ b/test-complete/src/test/java/com/marklogic/client/functionaltest/TestBug18026.java
@@ -45,6 +45,7 @@ import com.marklogic.client.document.JSONDocumentManager;
 import com.marklogic.client.document.XMLDocumentManager;
 import com.marklogic.client.io.DOMHandle;
 import com.marklogic.client.io.InputStreamHandle;
+import java.util.Map;
 public class TestBug18026 extends BasicJavaClientREST {
 	
 	private static String dbName = "Bug18026DB";
@@ -76,7 +77,7 @@ public class TestBug18026 extends BasicJavaClientREST {
         XMLUnit.setNormalizeWhitespace(true);
         XMLUnit.setIgnoreDiffBetweenTextAndCDATA(true);
 
-        HashMap<String,String> namespaces = new HashMap<String, String>();
+        Map<String,String> namespaces = new HashMap<>();
         namespaces.put("rapi", "http://marklogic.com/rest-api");
         namespaces.put("prop", "http://marklogic.com/xdmp/property");
         namespaces.put("xs",   "http://www.w3.org/2001/XMLSchema");
@@ -135,7 +136,7 @@ public class TestBug18026 extends BasicJavaClientREST {
         XMLUnit.setNormalizeWhitespace(true);
         XMLUnit.setIgnoreDiffBetweenTextAndCDATA(true);
 
-        HashMap<String,String> namespaces = new HashMap<String, String>();
+        Map<String,String> namespaces = new HashMap<>();
         namespaces.put("rapi", "http://marklogic.com/rest-api");
         namespaces.put("prop", "http://marklogic.com/xdmp/property");
         namespaces.put("xs",   "http://www.w3.org/2001/XMLSchema");

--- a/test-complete/src/test/java/com/marklogic/client/functionaltest/TestBug18736.java
+++ b/test-complete/src/test/java/com/marklogic/client/functionaltest/TestBug18736.java
@@ -63,7 +63,7 @@ public class TestBug18736 extends BasicJavaClientREST {
 		String docId = "/content/without-xml-ext";
 		//XpathEngine xpathEngine;
 		
-		/*HashMap<String,String> xpathNS = new HashMap<String, String>();
+		/*Map<String,String> xpathNS = new HashMap<>();
 		xpathNS.put("", "http://purl.org/dc/elements/1.1/");
 		SimpleNamespaceContext xpathNsContext = new SimpleNamespaceContext(xpathNS);
 

--- a/test-complete/src/test/java/com/marklogic/client/functionaltest/TestBulkReadSample1.java
+++ b/test-complete/src/test/java/com/marklogic/client/functionaltest/TestBulkReadSample1.java
@@ -50,6 +50,7 @@ import com.marklogic.client.io.FileHandle;
 import com.marklogic.client.io.Format;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.StringHandle;
+import java.util.Map;
 
 /*
  * This test is designed to to test simple bulk reads with different types of Managers and different content type like JSON,text,binary,XMl by passing set of uris
@@ -141,7 +142,7 @@ public class TestBulkReadSample1 extends BasicJavaClientREST  {
 	  {
 		int count=1;
 	    XMLDocumentManager docMgr = client.newXMLDocumentManager();
-	    HashMap<String,String> map= new HashMap<String,String>();
+	    Map<String,String> map= new HashMap<>();
 	    DocumentWriteSet writeset =docMgr.newWriteSet();
 	    for(int i =0;i<102;i++){
 	    	
@@ -240,7 +241,7 @@ public class TestBulkReadSample1 extends BasicJavaClientREST  {
  		 JSONDocumentManager docMgr = client.newJSONDocumentManager();
 		 DocumentWriteSet writeset =docMgr.newWriteSet();
 		 
-		 HashMap<String,String> map= new HashMap<String,String>();
+		 Map<String,String> map= new HashMap<>();
 		 
 		 for(int i =0;i<102;i++){
 		 JsonNode jn = new ObjectMapper().readTree("{\"animal"+i+"\":\"dog"+i+"\", \"says\":\"woof\"}");
@@ -335,7 +336,7 @@ public void test6CloseMethodforReadMultipleDoc() throws KeyManagementException, 
 	 JSONDocumentManager docMgr = client.newJSONDocumentManager();
 	 DocumentWriteSet writeset =docMgr.newWriteSet();
 	 
-	 HashMap<String,String> map= new HashMap<String,String>();
+	 Map<String,String> map= new HashMap<>();
 	for(int j=0;j<102;j++){ 
 	 for(int i =0;i<10;i++){
 	 JsonNode jn = new ObjectMapper().readTree("{\"animal"+i+"\":\"dog"+i+"\", \"says\":\"woof\"}");

--- a/test-complete/src/test/java/com/marklogic/client/functionaltest/TestBulkReadWriteWithJacksonDataBind.java
+++ b/test-complete/src/test/java/com/marklogic/client/functionaltest/TestBulkReadWriteWithJacksonDataBind.java
@@ -404,9 +404,9 @@ public class TestBulkReadWriteWithJacksonDataBind extends
 		DocumentMetadataHandle mh = setMetadata();
 		writeset.addDefault(mh);
 		
-		JacksonDatabindHandle<String> handle1 = new JacksonDatabindHandle<String>(String.class);
+		JacksonDatabindHandle<String> handle1 = new JacksonDatabindHandle<>(String.class);
 
-		Map<String, String> jsonMap = new HashMap<String, String>();
+		Map<String, String> jsonMap = new HashMap<>();
 		String[] uris = new String[150];
 				
 		String dir = new String("/");
@@ -471,9 +471,9 @@ public class TestBulkReadWriteWithJacksonDataBind extends
 		DocumentMetadataHandle mh = setMetadata();
 		writeset.addDefault(mh);
 		
-		JacksonDatabindHandle<String> handle1 = new JacksonDatabindHandle<String>(String.class);
+		JacksonDatabindHandle<String> handle1 = new JacksonDatabindHandle<>(String.class);
 
-		Map<String, String> jsonMap = new HashMap<String, String>();
+		Map<String, String> jsonMap = new HashMap<>();
 		String[] uris = new String[150];
 				
 		String dir = new String("/");

--- a/test-complete/src/test/java/com/marklogic/client/functionaltest/TestBulkSearchEWithQBE.java
+++ b/test-complete/src/test/java/com/marklogic/client/functionaltest/TestBulkSearchEWithQBE.java
@@ -62,6 +62,7 @@ import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.query.QueryManager.QueryView;
 import com.marklogic.client.query.RawCombinedQueryDefinition;
 import com.marklogic.client.query.RawQueryByExampleDefinition;
+import java.util.Map;
 
 public class TestBulkSearchEWithQBE extends BasicJavaClientREST{
 	private static final int BATCH_SIZE=100;
@@ -155,7 +156,7 @@ public class TestBulkSearchEWithQBE extends BasicJavaClientREST{
 		JSONDocumentManager docMgr = client.newJSONDocumentManager();
 		DocumentWriteSet writeset =docMgr.newWriteSet();
 
-		HashMap<String,String> map= new HashMap<String,String>();
+		Map<String,String> map= new HashMap<>();
 
 		for(int i =0;i<102;i++){
 			JsonNode jn = new ObjectMapper().readTree("{\"animal\":\"dog "+i+"\", \"says\":\"woof\"}");

--- a/test-complete/src/test/java/com/marklogic/client/functionaltest/TestBulkSearchWithKeyValQueryDef.java
+++ b/test-complete/src/test/java/com/marklogic/client/functionaltest/TestBulkSearchWithKeyValQueryDef.java
@@ -61,7 +61,7 @@ public class TestBulkSearchWithKeyValQueryDef extends BasicJavaClientREST {
 		JSONDocumentManager docMgr = client.newJSONDocumentManager();
 		DocumentWriteSet writeset =docMgr.newWriteSet();
 
-		HashMap<String,String> map= new HashMap<String,String>();
+		Map<String,String> map= new HashMap<>();
 
 		for(int i =0;i<102;i++){
 			JsonNode jn = new ObjectMapper().readTree("{\"animal\":\"dog"+i+"\", \"says\":\"woof\"}");

--- a/test-complete/src/test/java/com/marklogic/client/functionaltest/TestBulkSearchWithStringQueryDef.java
+++ b/test-complete/src/test/java/com/marklogic/client/functionaltest/TestBulkSearchWithStringQueryDef.java
@@ -61,6 +61,7 @@ import com.marklogic.client.query.MatchLocation;
 import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.query.QueryManager.QueryView;
 import com.marklogic.client.query.StringQueryDefinition;
+import java.util.Map;
 
 public class TestBulkSearchWithStringQueryDef extends BasicJavaClientREST{
 	private static final int BATCH_SIZE=100;
@@ -104,7 +105,7 @@ public class TestBulkSearchWithStringQueryDef extends BasicJavaClientREST{
 		JSONDocumentManager docMgr = client.newJSONDocumentManager();
 		DocumentWriteSet writeset =docMgr.newWriteSet();
 
-		HashMap<String,String> map= new HashMap<String,String>();
+		Map<String,String> map= new HashMap<>();
 
 		for(int i =0;i<102;i++){
 			JsonNode jn = new ObjectMapper().readTree("{\"animal\":\"dog"+i+"\", \"says\":\"woof\"}");

--- a/test-complete/src/test/java/com/marklogic/client/functionaltest/TestBulkSearchWithStrucQueryDef.java
+++ b/test-complete/src/test/java/com/marklogic/client/functionaltest/TestBulkSearchWithStrucQueryDef.java
@@ -74,6 +74,7 @@ import com.marklogic.client.query.RawCombinedQueryDefinition;
 import com.marklogic.client.query.RawStructuredQueryDefinition;
 import com.marklogic.client.query.StructuredQueryBuilder;
 import com.marklogic.client.query.StructuredQueryDefinition;
+import java.util.Map;
 
 public class TestBulkSearchWithStrucQueryDef extends BasicJavaClientREST{
 
@@ -118,7 +119,7 @@ public class TestBulkSearchWithStrucQueryDef extends BasicJavaClientREST{
 		JSONDocumentManager docMgr = client.newJSONDocumentManager();
 		DocumentWriteSet writeset =docMgr.newWriteSet();
 
-		HashMap<String,String> map= new HashMap<String,String>();
+		Map<String,String> map= new HashMap<>();
 
 		for(int i =0;i<102;i++){
 			JsonNode jn = new ObjectMapper().readTree("{\"animal\":\"dog"+i+"\", \"says\":\"woof\"}");

--- a/test-complete/src/test/java/com/marklogic/client/functionaltest/TestBulkWriteMetadata1.java
+++ b/test-complete/src/test/java/com/marklogic/client/functionaltest/TestBulkWriteMetadata1.java
@@ -63,6 +63,7 @@ import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.ReaderHandle;
 import com.marklogic.client.io.SourceHandle;
 import com.marklogic.client.io.StringHandle;
+import javax.xml.transform.Source;
 
 /**
  * @author skottam
@@ -329,7 +330,7 @@ public class TestBulkWriteMetadata1  extends BasicJavaClientREST {
 
 		writeset.add("/generic/foo1.txt",bh);
 
-		DOMSource ds = new DOMSource(getDocumentContent("This is so foo1"));
+		Source ds = new DOMSource(getDocumentContent("This is so foo1"));
 		SourceHandle sh = new SourceHandle();
 		sh.set(ds);
 		sh.setFormat(Format.XML);

--- a/test-complete/src/test/java/com/marklogic/client/functionaltest/TestBulkWriteMetadata2.java
+++ b/test-complete/src/test/java/com/marklogic/client/functionaltest/TestBulkWriteMetadata2.java
@@ -62,6 +62,7 @@ import com.marklogic.client.io.InputStreamHandle;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.SourceHandle;
 import com.marklogic.client.io.StringHandle;
+import javax.xml.transform.Source;
 
 /**
  * @author skottam
@@ -553,7 +554,7 @@ public class TestBulkWriteMetadata2 extends  BasicJavaClientREST{
 
 		writeset.add("/generic/foo1.txt",bh);
 
-		DOMSource ds = new DOMSource(getDocumentContent("This is so foo1"));
+		Source ds = new DOMSource(getDocumentContent("This is so foo1"));
 		SourceHandle sh = new SourceHandle();
 		sh.set(ds);
 		sh.setFormat(Format.XML);

--- a/test-complete/src/test/java/com/marklogic/client/functionaltest/TestBulkWriteMetadatawithRawXML.java
+++ b/test-complete/src/test/java/com/marklogic/client/functionaltest/TestBulkWriteMetadatawithRawXML.java
@@ -61,6 +61,7 @@ import com.marklogic.client.io.InputStreamHandle;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.SourceHandle;
 import com.marklogic.client.io.StringHandle;
+import javax.xml.transform.Source;
 /**
  * @author skottam
  * This test is test the DocumentWriteSet function 
@@ -357,7 +358,7 @@ public class TestBulkWriteMetadatawithRawXML extends  BasicJavaClientREST{
         
        ObjectMapper mapper = new ObjectMapper();
        JacksonHandle defaultMetadata1 = new JacksonHandle();
-       Map<String,String> p = new HashMap<String,String>();
+       Map<String,String> p = new HashMap<>();
        p.put("myString", "json");
        p.put("myInt", "9");
        defaultMetadata1.with(constructJSONPropertiesMetadata(p));
@@ -448,7 +449,7 @@ public class TestBulkWriteMetadatawithRawXML extends  BasicJavaClientREST{
 		 // put metadata
 		ObjectMapper mapper = new ObjectMapper();
 	       JacksonHandle mh = new JacksonHandle();
-	       Map<String,String> p = new HashMap<String,String>();
+	       Map<String,String> p = new HashMap<>();
 	       p.put("myString", "Generic JSON");
 	       p.put("myInt", "19");
 	       mh.with(constructJSONPropertiesMetadata(p));
@@ -477,7 +478,7 @@ public class TestBulkWriteMetadatawithRawXML extends  BasicJavaClientREST{
 	     
 	     writeset.add("/generic/foo1.txt",bh);
 	     
-	     DOMSource ds = new DOMSource(getDocumentContent("This is so foo1"));
+	     Source ds = new DOMSource(getDocumentContent("This is so foo1"));
 	     SourceHandle sh = new SourceHandle();
 	     sh.set(ds);
 	     sh.setFormat(Format.XML);

--- a/test-complete/src/test/java/com/marklogic/client/functionaltest/TestBulkWriteSample1.java
+++ b/test-complete/src/test/java/com/marklogic/client/functionaltest/TestBulkWriteSample1.java
@@ -59,6 +59,7 @@ import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.ReaderHandle;
 import com.marklogic.client.io.SourceHandle;
 import com.marklogic.client.io.StringHandle;
+import javax.xml.transform.Source;
 
 /*
  * This test is designed to to test simple bulk writes with different types of Managers and different content type like JSON,text,binary,XMl
@@ -337,7 +338,7 @@ public class TestBulkWriteSample1 extends BasicJavaClientREST  {
 
 		writeset.add("/generic/foo1.txt",bh);
 
-		DOMSource ds = new DOMSource(getDocumentContent("This is so foo1"));
+		Source ds = new DOMSource(getDocumentContent("This is so foo1"));
 		SourceHandle sh = new SourceHandle();
 		sh.set(ds);
 		sh.setFormat(Format.XML);

--- a/test-complete/src/test/java/com/marklogic/client/functionaltest/TestBulkWriteWithTransactions.java
+++ b/test-complete/src/test/java/com/marklogic/client/functionaltest/TestBulkWriteWithTransactions.java
@@ -49,6 +49,7 @@ import com.marklogic.client.io.DocumentMetadataHandle.DocumentPermissions;
 import com.marklogic.client.io.DocumentMetadataHandle.DocumentProperties;
 import com.marklogic.client.io.FileHandle;
 import com.marklogic.client.io.Format;
+import java.util.Map;
 
 public class TestBulkWriteWithTransactions extends BasicJavaClientREST {
 
@@ -174,7 +175,7 @@ public void testBulkWritewithTransactionCommit() throws KeyManagementException, 
 		int count=1;
 		Transaction t= client.openTransaction();
 		XMLDocumentManager docMgr = client.newXMLDocumentManager();
-		HashMap<String,String> map= new HashMap<String,String>();
+		Map<String,String> map= new HashMap<>();
 		DocumentWriteSet writeset =docMgr.newWriteSet();
 		for(int i =0;i<102;i++){
 			writeset.add(DIRECTORY+"first"+i+".xml", new DOMHandle(getDocumentContent("This is so first"+i)));
@@ -217,7 +218,7 @@ public void testBulkWritewithTransactionsNoCommit() throws KeyManagementExceptio
 		Transaction t1 = client.openTransaction();
 		try{ 
 			XMLDocumentManager docMgr = client.newXMLDocumentManager();
-			HashMap<String,String> map= new HashMap<String,String>();
+			Map<String,String> map= new HashMap<>();
 			DocumentWriteSet writeset =docMgr.newWriteSet();
 			for(int i =0;i<102;i++){
 				writeset.add(DIRECTORY+"bar"+i+".xml", new DOMHandle(getDocumentContent("This is so foo"+i)));
@@ -280,7 +281,7 @@ public void testBulkWritewithTransactionsNoCommit() throws KeyManagementExceptio
 		Transaction t1 = client.openTransaction();
 		try{ 
 		XMLDocumentManager docMgr = client.newXMLDocumentManager();
-		HashMap<String,String> map= new HashMap<String,String>();
+		Map<String,String> map= new HashMap<>();
 		DocumentWriteSet writeset =docMgr.newWriteSet();
 		for(int i =0;i<102;i++){
 			writeset.add(DIRECTORY+"sec"+i+".xml", new DOMHandle(getDocumentContent("This is so sec"+i)));
@@ -295,7 +296,7 @@ public void testBulkWritewithTransactionsNoCommit() throws KeyManagementExceptio
 			docMgr.write(writeset);
 		}
 		count=1;
-		HashMap<String,String> map2= new HashMap<String,String>();
+		Map<String,String> map2= new HashMap<>();
 		DocumentMetadataHandle mh = setMetadata();
 		for(int i =0;i<102;i++){
 			writeset.add(DIRECTORY+"sec"+i+".xml",mh, new DOMHandle(getDocumentContent("This is with metadata"+i)));
@@ -364,7 +365,7 @@ public void testBulkWritewithTransactionsNoCommit() throws KeyManagementExceptio
 	Transaction t1 = client.openTransaction();
 	try{ 
 	XMLDocumentManager docMgr = client.newXMLDocumentManager();
-	HashMap<String,String> map= new HashMap<String,String>();
+	Map<String,String> map= new HashMap<>();
 	DocumentWriteSet writeset =docMgr.newWriteSet();
 	DocumentMetadataHandle mh = setMetadata();
 	for(int i =0;i<102;i++){
@@ -470,7 +471,7 @@ public void testBulkWritewithTransactionCommitTimeOut() throws KeyManagementExce
 		Transaction t1 = client.openTransaction();
 		try {
 			XMLDocumentManager docMgr = client.newXMLDocumentManager();
-			HashMap<String, String> map = new HashMap<String, String>();
+			Map<String, String> map = new HashMap<>();
 			DocumentWriteSet writeset = docMgr.newWriteSet();
 			for (int i = 0; i < 102; i++) {
 				writeset.add(DIRECTORY + "bar" + i + ".xml", new DOMHandle(

--- a/test-complete/src/test/java/com/marklogic/client/functionaltest/TestBulkWriteWithTransformations.java
+++ b/test-complete/src/test/java/com/marklogic/client/functionaltest/TestBulkWriteWithTransformations.java
@@ -50,6 +50,7 @@ import com.marklogic.client.document.XMLDocumentManager;
 import com.marklogic.client.io.DOMHandle;
 import com.marklogic.client.io.FileHandle;
 import com.marklogic.client.io.SourceHandle;
+import java.util.Map;
 
 public class TestBulkWriteWithTransformations extends BasicJavaClientREST{
 	private static final int BATCH_SIZE=100;
@@ -155,7 +156,7 @@ public class TestBulkWriteWithTransformations extends BasicJavaClientREST{
 		transform.put("value", "English");
 		int count=1;
 		XMLDocumentManager docMgr = client.newXMLDocumentManager();
-		HashMap<String,String> map= new HashMap<String,String>();
+		Map<String,String> map= new HashMap<>();
 		DocumentWriteSet writeset =docMgr.newWriteSet();
 		for(int i =0;i<102;i++){
 
@@ -214,7 +215,7 @@ public class TestBulkWriteWithTransformations extends BasicJavaClientREST{
 		transform.put("value", "testBulkXQYTransformWithTrans");
 		int count=1;
 		XMLDocumentManager docMgr = client.newXMLDocumentManager();
-		HashMap<String,String> map= new HashMap<String,String>();
+		Map<String,String> map= new HashMap<>();
 		DocumentWriteSet writesetRollback = docMgr.newWriteSet();
 		// Verify rollback with a smaller number of documents.
 		for(int i = 0;i<12;i++){
@@ -296,7 +297,7 @@ public class TestBulkWriteWithTransformations extends BasicJavaClientREST{
 		transform.put("value", "English");
 		int count=1;
 		XMLDocumentManager docMgr = client.newXMLDocumentManager();
-		HashMap<String,String> map= new HashMap<String,String>();
+		Map<String,String> map= new HashMap<>();
 		DocumentWriteSet writeset =docMgr.newWriteSet();
 		for(int i =0;i<102;i++){
 

--- a/test-complete/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientConnection.java
+++ b/test-complete/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientConnection.java
@@ -67,6 +67,7 @@ import com.marklogic.client.query.StringQueryDefinition;
 import com.marklogic.client.query.SuggestDefinition;
 import com.marklogic.client.query.ValuesDefinition;
 import com.marklogic.client.query.ValuesListDefinition;
+import java.util.Map;
 
 public class TestDatabaseClientConnection extends BasicJavaClientREST{
 	
@@ -420,8 +421,8 @@ public class TestDatabaseClientConnection extends BasicJavaClientREST{
         ValuesListDefinition vdef = queryMgr.newValuesListDefinition("aggregatesOpt.xml");
         ValuesListHandle results = queryMgr.valuesList(vdef, new ValuesListHandle());
         // Get the Map of lexicons sorted.
-        HashMap<String,String> lexiconMap = results.getValuesMap();
-        TreeMap<String, String> treeMap = new TreeMap<String,String>(lexiconMap);
+        Map<String,String> lexiconMap = results.getValuesMap();
+        TreeMap<String, String> treeMap = new TreeMap<>(lexiconMap);
         assertEquals("Map should contain three keys", treeMap.size(), 3);
         assertEquals("First key incorrect",treeMap.firstKey(), "pop-aggr");
         assertEquals("Last key incorrect",treeMap.lastKey(), "score-aggr");

--- a/test-complete/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientWithKerberos.java
+++ b/test-complete/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientWithKerberos.java
@@ -106,6 +106,7 @@ import com.marklogic.client.query.StringQueryDefinition;
 import com.marklogic.client.query.StructuredQueryBuilder;
 import com.marklogic.client.query.StructuredQueryDefinition;
 import com.marklogic.client.util.RequestLogger;
+import java.util.Map;
 
 public class TestDatabaseClientWithKerberos extends BasicJavaClientREST {
 
@@ -826,7 +827,7 @@ public class TestDatabaseClientWithKerberos extends BasicJavaClientREST {
 		transform.put("value", "testBulkXQYTransformWithTrans");
 		int count=1;
 		XMLDocumentManager docMgr = client.newXMLDocumentManager();
-		HashMap<String,String> map= new HashMap<String,String>();
+		Map<String,String> map= new HashMap<>();
 		DocumentWriteSet writesetRollback = docMgr.newWriteSet();
 		// Verify rollback with a smaller number of documents.
 		for(int i = 0;i<12;i++) {

--- a/test-complete/src/test/java/com/marklogic/client/functionaltest/TestDocumentEncoding.java
+++ b/test-complete/src/test/java/com/marklogic/client/functionaltest/TestDocumentEncoding.java
@@ -45,6 +45,7 @@ import com.marklogic.client.DatabaseClientFactory.Authentication;
 import com.marklogic.client.document.XMLDocumentManager;
 import com.marklogic.client.io.BytesHandle;
 import com.marklogic.client.io.StringHandle;
+import javax.xml.transform.Source;
 
 public class TestDocumentEncoding extends BasicJavaClientREST
 {
@@ -78,7 +79,7 @@ public class TestDocumentEncoding extends BasicJavaClientREST
         e2.appendChild(text);
 
         // transform the Document into a String
-        DOMSource domSource = new DOMSource(doc);
+        Source domSource = new DOMSource(doc);
         TransformerFactory tf = TransformerFactory.newInstance();
         Transformer transformer = tf.newTransformer();
         transformer.setOutputProperty(OutputKeys.METHOD, "xml");
@@ -116,7 +117,7 @@ public class TestDocumentEncoding extends BasicJavaClientREST
         Text text2 = doc2.createTextNode("漢字");
         x2.appendChild(text2);
         
-        DOMSource domSource2 = new DOMSource(doc2);
+        Source domSource2 = new DOMSource(doc2);
         TransformerFactory tf2 = TransformerFactory.newInstance();
         Transformer transformer2 = tf2.newTransformer();
         transformer2.setOutputProperty(OutputKeys.METHOD, "xml");

--- a/test-complete/src/test/java/com/marklogic/client/functionaltest/TestEvalwithRunTimeDBnTransactions.java
+++ b/test-complete/src/test/java/com/marklogic/client/functionaltest/TestEvalwithRunTimeDBnTransactions.java
@@ -48,6 +48,7 @@ import com.marklogic.client.io.DOMHandle;
 import com.marklogic.client.io.FileHandle;
 import com.marklogic.client.io.Format;
 import com.marklogic.client.io.InputStreamHandle;
+import java.util.Map;
 /*
  * This test is intended for 
  * looping eval query for more than 100 times
@@ -137,7 +138,7 @@ public class TestEvalwithRunTimeDBnTransactions extends BasicJavaClientREST {
 		Transaction t1 = client.openTransaction();
 		try { 
 		XMLDocumentManager docMgr = client.newXMLDocumentManager();
-		HashMap<String,String> map= new HashMap<String,String>();
+		Map<String,String> map= new HashMap<>();
 		DocumentWriteSet writeset =docMgr.newWriteSet();
 		for(int i =0;i<102;i++) {
 			writeset.add("/sec"+i+".xml", new DOMHandle(getDocumentContent("This is so sec"+i)));
@@ -186,7 +187,7 @@ public class TestEvalwithRunTimeDBnTransactions extends BasicJavaClientREST {
 			Transaction t1 = client2.openTransaction();
 			try { 
 			XMLDocumentManager docMgr = client2.newXMLDocumentManager();
-			HashMap<String,String> map= new HashMap<String,String>();
+			Map<String,String> map= new HashMap<>();
 			DocumentWriteSet writeset =docMgr.newWriteSet();
 			for(int i =0;i<102;i++){
 				writeset.add("/sec"+i+".xml", new DOMHandle(getDocumentContent("This is so sec"+i)));

--- a/test-complete/src/test/java/com/marklogic/client/functionaltest/TestJSResourceExtensions.java
+++ b/test-complete/src/test/java/com/marklogic/client/functionaltest/TestJSResourceExtensions.java
@@ -86,7 +86,7 @@ public class TestJSResourceExtensions extends BasicJavaClientREST {
 			ServiceResultIterator resultItr = getServices().get(params, mimetypes);
 
 			// iterate over the results
-			List<String> responses = new ArrayList<String>();
+			List<String> responses = new ArrayList<>();
 			StringHandle readHandle = new StringHandle();
 			while (resultItr.hasNext()) {
 				ServiceResult result = resultItr.next();
@@ -111,7 +111,7 @@ public class TestJSResourceExtensions extends BasicJavaClientREST {
 			// call the service
 			ServiceResultIterator resultItr= getServices().post(params, new StringHandle(input).withFormat(Format.JSON), mimetypes);
 			// iterate over the results
-			List<String> responses = new ArrayList<String>();
+			List<String> responses = new ArrayList<>();
 			StringHandle readHandle = new StringHandle();
 			while (resultItr.hasNext()) {
 				ServiceResult result = resultItr.next();

--- a/test-complete/src/test/java/com/marklogic/client/functionaltest/TestQueryOptionBuilderSearchOptions.java
+++ b/test-complete/src/test/java/com/marklogic/client/functionaltest/TestQueryOptionBuilderSearchOptions.java
@@ -81,7 +81,7 @@ public class TestQueryOptionBuilderSearchOptions extends BasicJavaClientREST {
 		// create query options handle
 		QueryOptionsHandle handle = new QueryOptionsHandle();
 
-		List<String> listOfSearchOptions = new ArrayList<String> ();
+		List<String> listOfSearchOptions = new ArrayList<> ();
 		listOfSearchOptions.add("checked");
 		listOfSearchOptions.add("filtered");
 		listOfSearchOptions.add("score-simple");
@@ -152,7 +152,7 @@ public class TestQueryOptionBuilderSearchOptions extends BasicJavaClientREST {
 		// create query options handle
 		QueryOptionsHandle handle = new QueryOptionsHandle();
 
-		List<String> listOfSearchOptions = new ArrayList<String> ();
+		List<String> listOfSearchOptions = new ArrayList<> ();
 		listOfSearchOptions.add("unchecked");
 		listOfSearchOptions.add("unfiltered");
 		listOfSearchOptions.add("score-logtfidf");

--- a/test-complete/src/test/java/com/marklogic/client/functionaltest/TestQueryOptionsListHandle.java
+++ b/test-complete/src/test/java/com/marklogic/client/functionaltest/TestQueryOptionsListHandle.java
@@ -31,6 +31,7 @@ import org.xml.sax.SAXException;
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.DatabaseClientFactory.Authentication;
 import com.marklogic.client.io.QueryOptionsListHandle;
+import java.util.Map;
 
 public class TestQueryOptionsListHandle extends BasicJavaClientREST {
 
@@ -55,7 +56,7 @@ public class TestQueryOptionsListHandle extends BasicJavaClientREST {
 
 		QueryOptionsListHandle handle = new QueryOptionsListHandle();
 
-		HashMap map = handle.getValuesMap();
+		Map map = handle.getValuesMap();
 
 		// release client
 		client.release();


### PR DESCRIPTION

- Declare objects using the interface, rather than an implementation.
- Eliminate redundant type arguments. Use the diamond operator for the
right hand side of the object assignment.