### PR TITLE
Efficiencies: avoid constructing new Objects, auto boxing, etc.

### DIFF
--- a/src/main/java/com/marklogic/client/alerting/RuleDefinitionList.java
+++ b/src/main/java/com/marklogic/client/alerting/RuleDefinitionList.java
@@ -70,7 +70,8 @@ implements Iterable<RuleDefinition>, RuleListReadHandle {
 		HandleAccessor.receiveContent(domHandle, content);
 		Document document = domHandle.get();
 		NodeList ruleNodes = document.getElementsByTagNameNS(RequestConstants.RESTAPI_NS, "rule");
-		for (int i=0; i < ruleNodes.getLength(); i++) {
+        int ruleNodesLength = ruleNodes.getLength();
+		for (int i=0; i < ruleNodesLength; i++) {
 			Element ruleElement = (Element) ruleNodes.item(i);
 			RuleDefinition ruleDefinition = new RuleDefinition();
 			ruleDefinition.receiveElement(ruleElement);

--- a/src/main/java/com/marklogic/client/impl/GraphManagerImpl.java
+++ b/src/main/java/com/marklogic/client/impl/GraphManagerImpl.java
@@ -38,6 +38,7 @@ import com.marklogic.client.io.marker.TriplesWriteHandle;
 import com.marklogic.client.semantics.Capability;
 import com.marklogic.client.semantics.GraphManager;
 import com.marklogic.client.semantics.GraphPermissions;
+import java.util.Map;
 
 public class GraphManagerImpl<R extends TriplesReadHandle, W extends TriplesWriteHandle>
     extends AbstractLoggingManager
@@ -142,11 +143,11 @@ public class GraphManagerImpl<R extends TriplesReadHandle, W extends TriplesWrit
         ObjectNode payload = mapper.createObjectNode();
         ArrayNode permissionsNode = mapper.createArrayNode();
         payload.set("permissions", permissionsNode);
-        for ( String role : permissions.keySet() ) {
+        for ( Map.Entry<String,Set<Capability>> entry : permissions.entrySet() ) {
             ObjectNode permissionNode = mapper.createObjectNode();
-            permissionNode.put("role-name", role);
+            permissionNode.put("role-name", entry.getKey());
             ArrayNode capabilitiesNode = mapper.createArrayNode();
-            for ( Capability capability : permissions.get(role) ) {
+            for ( Capability capability : entry.getValue() ) {
                 capabilitiesNode.add(capability.toString().toLowerCase());
             }
             permissionNode.set("capabilities", capabilitiesNode);

--- a/src/main/java/com/marklogic/client/impl/HTTPKerberosAuthFilter.java
+++ b/src/main/java/com/marklogic/client/impl/HTTPKerberosAuthFilter.java
@@ -248,7 +248,7 @@ class HTTPKerberosAuthFilter extends ClientFilter {
 
         // Add the whole Authorization line to the header
         try {
-            String authLine = new String("Negotiate "+ getAuthorizationHeader("HTTP/" + host));
+            String authLine = "Negotiate "+ getAuthorizationHeader("HTTP/" + host);
             request.getHeaders().add(HttpHeaders.AUTHORIZATION, authLine);
         } catch (Exception e) {
             throw new FailedRequestException(e.getMessage(), e);

--- a/src/main/java/com/marklogic/client/impl/JerseyServices.java
+++ b/src/main/java/com/marklogic/client/impl/JerseyServices.java
@@ -505,7 +505,7 @@ public class JerseyServices implements RESTServices {
 		response.close();
 
 		String retryAfterRaw = responseHeaders.getFirst("Retry-After");
-		int retryAfter = (retryAfterRaw != null) ? Integer.valueOf(retryAfterRaw) : -1;
+		int retryAfter = (retryAfterRaw != null) ? Integer.parseInt(retryAfterRaw) : -1;
 		return Math.max(retryAfter, calculateDelay(randRetry, retry));
 	}
 
@@ -652,7 +652,7 @@ public class JerseyServices implements RESTServices {
 	private int getRetryAfterTime(ClientResponse response) {
 		MultivaluedMap<String, String> responseHeaders = response.getHeaders();
 		String retryAfterRaw = responseHeaders.getFirst("Retry-After");
-		return (retryAfterRaw != null) ? Integer.valueOf(retryAfterRaw) : -1;
+		return (retryAfterRaw != null) ? Integer.parseInt(retryAfterRaw) : -1;
 	}
 
 	private ClientResponse makeRequest(Builder builder, Function<Builder, ClientResponse> doFunction, Consumer<Boolean> resendableConsumer) {
@@ -1341,7 +1341,7 @@ public class JerseyServices implements RESTServices {
 						 ((uri != null) ? uri : "new document"));
 			}
 
-			int retryAfter = (retryAfterRaw != null) ? Integer.valueOf(retryAfterRaw) : -1;
+			int retryAfter = (retryAfterRaw != null) ? Integer.parseInt(retryAfterRaw) : -1;
 			nextDelay = Math.max(retryAfter, calculateDelay(randRetry, retry));
 		}
 		if (status == ClientResponse.Status.SERVICE_UNAVAILABLE) {
@@ -1485,7 +1485,7 @@ public class JerseyServices implements RESTServices {
 						((uri != null) ? uri : "new document"));
 			}
 
-			int retryAfter = (retryAfterRaw != null) ? Integer.valueOf(retryAfterRaw) : -1;
+			int retryAfter = (retryAfterRaw != null) ? Integer.parseInt(retryAfterRaw) : -1;
 			nextDelay = Math.max(retryAfter, calculateDelay(randRetry, retry));
 		}
 		if (status == ClientResponse.Status.SERVICE_UNAVAILABLE) {
@@ -1880,7 +1880,7 @@ public class JerseyServices implements RESTServices {
 		if (values != null) {
 			String timestamp = values.get(0);
 			if (timestamp != null && timestamp.length() > 0) {
-				return Long.valueOf(timestamp);
+				return Long.parseLong(timestamp);
 			}
 		}
 		return -1;
@@ -1898,7 +1898,7 @@ public class JerseyServices implements RESTServices {
 		if (headers.containsKey(HttpHeaders.CONTENT_LENGTH)) {
 			List<String> values = headers.get(HttpHeaders.CONTENT_LENGTH);
 			if (values != null) {
-				return Long.valueOf(values.get(0));
+				return Long.parseLong(values.get(0));
 			}
 		}
 		return ContentDescriptor.UNKNOWN_LENGTH;
@@ -1920,7 +1920,7 @@ public class JerseyServices implements RESTServices {
 			if (values != null) {
 				// trim the double quotes
 				String value = values.get(0);
-				version = Long.valueOf(value.substring(1, value.length() - 1));
+				version = Long.parseLong(value.substring(1, value.length() - 1));
 			}
 		}
 		descriptor.setVersion(version);
@@ -2195,7 +2195,7 @@ public class JerseyServices implements RESTServices {
 
                 MultivaluedMap<String, String> responseHeaders = response.getHeaders();
                 String retryAfterRaw = responseHeaders.getFirst("Retry-After");
-                int retryAfter = (retryAfterRaw != null) ? Integer.valueOf(retryAfterRaw) : -1;
+                int retryAfter = (retryAfterRaw != null) ? Integer.parseInt(retryAfterRaw) : -1;
 
                 response.close();
 
@@ -2736,7 +2736,7 @@ public class JerseyServices implements RESTServices {
 						"Cannot retry request for " + connectPath);
 			}
 
-			int retryAfter = (retryAfterRaw != null) ? Integer.valueOf(retryAfterRaw) : -1;
+			int retryAfter = (retryAfterRaw != null) ? Integer.parseInt(retryAfterRaw) : -1;
 			nextDelay = Math.max(retryAfter, calculateDelay(randRetry, retry));
 		}
 		if (status == ClientResponse.Status.SERVICE_UNAVAILABLE) {
@@ -3050,7 +3050,7 @@ public class JerseyServices implements RESTServices {
 						"Cannot retry request for " + path);
 			}
 
-			int retryAfter = (retryAfterRaw != null) ? Integer.valueOf(retryAfterRaw) : -1;
+			int retryAfter = (retryAfterRaw != null) ? Integer.parseInt(retryAfterRaw) : -1;
 			nextDelay = Math.max(retryAfter, calculateDelay(randRetry, retry));
 		}
 		if (status == ClientResponse.Status.SERVICE_UNAVAILABLE) {
@@ -3201,7 +3201,7 @@ public class JerseyServices implements RESTServices {
 						"Cannot retry request for " + path);
 			}
 
-			int retryAfter = (retryAfterRaw != null) ? Integer.valueOf(retryAfterRaw) : -1;
+			int retryAfter = (retryAfterRaw != null) ? Integer.parseInt(retryAfterRaw) : -1;
 			nextDelay = Math.max(retryAfter, calculateDelay(randRetry, retry));
 		}
 		if (status == ClientResponse.Status.SERVICE_UNAVAILABLE) {
@@ -3472,16 +3472,16 @@ public class JerseyServices implements RESTServices {
 		@Override
 		public Number getNumber() {
 			if      ( getType() == EvalResult.Type.DECIMAL ) return new BigDecimal(getString());
-			else if ( getType() == EvalResult.Type.DOUBLE )  return new Double(getString());
-			else if ( getType() == EvalResult.Type.FLOAT )   return new Float(getString());
+			else if ( getType() == EvalResult.Type.DOUBLE )  return Double.valueOf(getString());
+			else if ( getType() == EvalResult.Type.FLOAT )   return Float.valueOf(getString());
 			// MarkLogic integers can be much larger than Java integers, so we'll use Long instead
-			else if ( getType() == EvalResult.Type.INTEGER ) return new Long(getString());
+			else if ( getType() == EvalResult.Type.INTEGER ) return Long.valueOf(getString());
 			else return new BigDecimal(getString());
 		}
 
 		@Override
 		public Boolean getBoolean() {
-			return new Boolean(getString());
+			return Boolean.valueOf(getString());
 		}
 
 	}
@@ -3727,7 +3727,7 @@ public class JerseyServices implements RESTServices {
 						"Cannot retry request for " + path);
 			}
 
-			int retryAfter = (retryAfterRaw != null) ? Integer.valueOf(retryAfterRaw) : -1;
+			int retryAfter = (retryAfterRaw != null) ? Integer.parseInt(retryAfterRaw) : -1;
 			nextDelay = Math.max(retryAfter, calculateDelay(randRetry, retry));
 		}
 		if (status == ClientResponse.Status.SERVICE_UNAVAILABLE) {
@@ -4456,7 +4456,7 @@ public class JerseyServices implements RESTServices {
         }
 
         public JerseyResultIterator<T> setSize(long size) {
-            this.size = new Long(size);
+            this.size = size;
             return this;
         }
 
@@ -4789,7 +4789,7 @@ public class JerseyServices implements RESTServices {
 
 			MultivaluedMap<String, String> responseHeaders = response.getHeaders();
 			String retryAfterRaw = responseHeaders.getFirst("Retry-After");
-			int retryAfter = (retryAfterRaw != null) ? Integer.valueOf(retryAfterRaw) : -1;
+			int retryAfter = (retryAfterRaw != null) ? Integer.parseInt(retryAfterRaw) : -1;
 
 			response.close();
 
@@ -4868,10 +4868,10 @@ public class JerseyServices implements RESTServices {
 
 	private void addPermsParams(RequestParameters params, GraphPermissions permissions) {
 		if ( permissions != null ) {
-			for ( String role : permissions.keySet() ) {
-				if ( permissions.get(role) != null ) {
-					for ( Capability capability : permissions.get(role) ) {
-						params.add("perm:" + role, capability.toString().toLowerCase());
+			for ( Map.Entry<String,Set<Capability>> entry : permissions.entrySet() ) {
+				if ( entry.getValue() != null ) {
+					for ( Capability capability : entry.getValue() ) {
+						params.add("perm:" + entry.getKey(), capability.toString().toLowerCase());
 					}
 				}
 			}
@@ -5026,10 +5026,10 @@ public class JerseyServices implements RESTServices {
 		addPermsParams(params, qdef.getUpdatePermissions());
 		String sparql = qdef.getSparql();
 		SPARQLBindings bindings = qdef.getBindings();
-		for ( String bindingName : bindings.keySet() ) {
-			String paramName = "bind:" + bindingName;
+		for ( Map.Entry<String,List<SPARQLBinding>> entry : bindings.entrySet() ) {
+			String paramName = "bind:" + entry.getKey();
 			String typeOrLang = "";
-			for ( SPARQLBinding binding : bindings.get(bindingName) ) {
+			for ( SPARQLBinding binding : entry.getValue() ) {
 				if ( binding.getDatatype() != null ) {
 					typeOrLang = ":" + binding.getDatatype();
 				} else if ( binding.getLanguageTag() != null ) {

--- a/src/main/java/com/marklogic/client/impl/QueryOptionsTransformExtractNS.java
+++ b/src/main/java/com/marklogic/client/impl/QueryOptionsTransformExtractNS.java
@@ -20,6 +20,7 @@ import org.xml.sax.SAXException;
 import org.xml.sax.helpers.XMLFilterImpl;
 
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Vector;
 
 public class QueryOptionsTransformExtractNS extends XMLFilterImpl {
@@ -50,10 +51,10 @@ public class QueryOptionsTransformExtractNS extends XMLFilterImpl {
             }
 
             super.startElement(SEARCH_NS, ename, ename, null);
-            for (String pfx : nsmap.keySet()) {
+            for (Map.Entry<String,String> entry : nsmap.entrySet()) {
                 BindingAttributes attrs = new BindingAttributes();
-                attrs.addAttribute("prefix", pfx);
-                attrs.addAttribute("namespace-uri", nsmap.get(pfx));
+                attrs.addAttribute("prefix", entry.getKey());
+                attrs.addAttribute("namespace-uri", entry.getValue());
                 super.startElement(SEARCH_NS, "binding", "binding", attrs);
                 super.endElement(SEARCH_NS, "binding", "binding");
             }

--- a/src/main/java/com/marklogic/client/impl/QueryOptionsTransformInjectNS.java
+++ b/src/main/java/com/marklogic/client/impl/QueryOptionsTransformInjectNS.java
@@ -21,6 +21,7 @@ import org.xml.sax.helpers.XMLFilterImpl;
 
 import javax.xml.XMLConstants;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Vector;
 
 public class QueryOptionsTransformInjectNS extends XMLFilterImpl {
@@ -50,12 +51,12 @@ public class QueryOptionsTransformInjectNS extends XMLFilterImpl {
             BindingAttributes attrs = new BindingAttributes(attributes);
             if ("path-index".equals(localName) || "searchable-expression".equals(localName)) {
                 String xmlns = null;
-                for (String pfx : nsmap.keySet()) {
+                for (Map.Entry<String,String> entry : nsmap.entrySet()) {
                     xmlns = "xmlns";
-                    if (!"".equals(pfx)) {
-                        xmlns += ":" + pfx;
+                    if (!"".equals(entry.getKey())) {
+                        xmlns += ":" + entry.getKey();
                     }
-                    attrs.addAttribute(XMLConstants.XMLNS_ATTRIBUTE_NS_URI, xmlns, nsmap.get(pfx));
+                    attrs.addAttribute(XMLConstants.XMLNS_ATTRIBUTE_NS_URI, xmlns, entry.getValue());
                 }
             }
 

--- a/src/main/java/com/marklogic/client/io/DocumentMetadataHandle.java
+++ b/src/main/java/com/marklogic/client/io/DocumentMetadataHandle.java
@@ -576,7 +576,8 @@ public class DocumentMetadataHandle
 			return;
 
 		NodeList valuesIn = document.getElementsByTagNameNS(REST_API_NS, "metadata-values");
-		for (int i = 0; i < valuesIn.getLength(); i++) {
+        int valuesInLength = valuesIn.getLength();
+		for (int i = 0; i < valuesInLength; i++) {
 			String key = null;
 			String value = null;
 
@@ -611,7 +612,8 @@ public class DocumentMetadataHandle
 			return;
 		
 		NodeList collectionsIn = document.getElementsByTagNameNS(REST_API_NS, "collection");
-		for (int i=0; i < collectionsIn.getLength(); i++) {
+        int collectionsInLength = collectionsIn.getLength();
+		for (int i=0; i < collectionsInLength; i++) {
 			collections.add(collectionsIn.item(i).getTextContent());
 		}
 	}
@@ -623,7 +625,8 @@ public class DocumentMetadataHandle
 			return;
 
 		NodeList permissionsIn = document.getElementsByTagNameNS(REST_API_NS, "permission");
-		for (int i=0; i < permissionsIn.getLength(); i++) {
+        int permissionsInLength = permissionsIn.getLength();
+		for (int i=0; i < permissionsInLength; i++) {
 			String roleName = null;
 			HashSet<Capability> caps = new HashSet<Capability>();
 

--- a/src/test/java/com/marklogic/client/test/GraphsTest.java
+++ b/src/test/java/com/marklogic/client/test/GraphsTest.java
@@ -156,7 +156,7 @@ public class GraphsTest {
         gmgr.write(tripleGraphUri, new StringHandle(ntriple5 + "\n" + ntriple6)
             );
         String triples5and6 = gmgr.readAs(tripleGraphUri, String.class);
-        String expected = new String(ntriple5 + "\n" + ntriple6);
+        String expected = ntriple5 + "\n" + ntriple6;
         assertEquals(expected, triples5and6);
 
         gmgr.merge(tripleGraphUri, new StringHandle(ntriple7));


### PR DESCRIPTION
- Use static methods to produce Numbers, rather than constructors.
- Avoid auto boxing. If primitives are needed, use Obj.parseXXX()
- Do not recalculate NodeList.getLength() inside of a loop. It is not
cached and is re-calculated on every invocation. Set value outside of
the loop.
- Avoid constructing new String() objects when not necessary.
- Use entrySet iterator, rather than Map.get()