### PR TITLE
fix #125 - breakout WriteHostBatcher.flush to flushAsync and flushAndWait

### DIFF
--- a/src/main/java/com/marklogic/client/datamovement/WriteHostBatcher.java
+++ b/src/main/java/com/marklogic/client/datamovement/WriteHostBatcher.java
@@ -32,8 +32,8 @@ import com.marklogic.client.io.marker.DocumentMetadataWriteHandle;
  * time enough documents are added to make a batch, the batch is added to an
  * internal queue where the first available internal thread will pick it up and
  * write it to the server.  Since batches are not written until they are full,
- * you should always call {@link #flush} when no more documents will be written to
- * ensure that any partial batch is written.
+ * you should always call {@link #flushAsync} or {@link #flushAndWait} when no
+ * more documents will be written to ensure that any partial batch is written.
  *
  * Sample Usage:
  *
@@ -48,7 +48,7 @@ import com.marklogic.client.io.marker.DocumentMetadataWriteHandle;
  *     whb.add  ("doc1.txt", new StringHandle("doc1 contents"));
  *     whb.addAs("doc2.txt", "doc2 contents");
  *
- *     whb.flush(); // send the two docs even though they're not a full batch
+ *     whb.flushAndWait(); // send the two docs even though they're not a full batch
  *     dataMovementManager.stopJob(ticket);
  *
  * Note: All Closeable content or metadata handles passed to {@link #add add}
@@ -64,7 +64,7 @@ import com.marklogic.client.io.marker.DocumentMetadataWriteHandle;
 public interface WriteHostBatcher extends HostBatcher {
   /**
    * Add a document to be batched then written to the server when a batch is full
-   * or {@link #flush} is called.
+   * or {@link #flushAsync} or {@link #flushAndWait} is called.
    *
    * #####See Also:
    *   [the Java Guide](http://docs.marklogic.com/guide/java/document-operations) for more on using handles
@@ -77,7 +77,7 @@ public interface WriteHostBatcher extends HostBatcher {
 
   /**
    * Add a document to be batched then written to the server when a batch is full
-   * or {@link #flush} is called.
+   * or {@link #flushAsync} or {@link #flushAndWait} is called.
    *
    * #####See Also:
    *   [IO Shortcut in MarkLogic Java Client API](http://www.marklogic.com/blog/io-shortcut-marklogic-java-client-api/)
@@ -91,7 +91,7 @@ public interface WriteHostBatcher extends HostBatcher {
 
   /**
    * Add a document to be batched then written to the server when a batch is full
-   * or {@link #flush} is called.
+   * or {@link #flushAsync} or {@link #flushAndWait} is called.
    *
    * #####See Also:
    *   [the Java Guide](http://docs.marklogic.com/guide/java/document-operations) for more on using handles
@@ -106,7 +106,7 @@ public interface WriteHostBatcher extends HostBatcher {
 
   /**
    * Add a document to be batched then written to the server when a batch is full
-   * or {@link #flush} is called.
+   * or {@link #flushAsync} or {@link #flushAndWait} is called.
    *
    * #####See Also:
    *   [IO Shortcut in MarkLogic Java Client API](http://www.marklogic.com/blog/io-shortcut-marklogic-java-client-api/)
@@ -230,10 +230,15 @@ public interface WriteHostBatcher extends HostBatcher {
   @Override
   WriteHostBatcher withThreadCount(int threadCount);
 
+  /** Create a batch from any unbatched documents and write that batch
+   * asynchronously.
+   */
+  void flushAsync();
+
   /** Create a batch from any unbatched documents and write that batch, then
    * wait for all batches to complete (the same as awaitCompletion().
    */
-  void flush();
+  void flushAndWait();
 
   /**
    * Blocks until the job has no batches queued for writing.

--- a/src/main/java/com/marklogic/client/datamovement/impl/QueryHostBatcherImpl.java
+++ b/src/main/java/com/marklogic/client/datamovement/impl/QueryHostBatcherImpl.java
@@ -64,7 +64,7 @@ public class QueryHostBatcherImpl extends HostBatcherImpl implements QueryHostBa
   private Map<Forest,AtomicBoolean> forestIsDone = new HashMap<>();
   private final AtomicBoolean stopped = new AtomicBoolean(false);
 
-  public QueryHostBatcherImpl(QueryDefinition query, DataMovementManager moveMger, ForestConfiguration forestConfig) {
+  public QueryHostBatcherImpl(QueryDefinition query, DataMovementManager moveMgr, ForestConfiguration forestConfig) {
     super();
     this.moveMgr = moveMgr;
     this.query = query;

--- a/src/main/java/com/marklogic/client/datamovement/package-info.java
+++ b/src/main/java/com/marklogic/client/datamovement/package-info.java
@@ -105,7 +105,7 @@
  *     whb.add  ("doc1.txt", new StringHandle("doc1 contents"));
  *     whb.addAs("doc2.txt", "doc2 contents");
  *
- *     whb.flush(); // send the two docs even though they're not a full batch
+ *     whb.flushAndWait(); // send the two docs even though they're not a full batch
  *     dataMovementManager.stopJob(ticket);
  * ```
  * [mlcp]: https://developer.marklogic.com/products/mlcp

--- a/src/test/java/com/marklogic/client/test/datamovement/ApplyTransformTest.java
+++ b/src/test/java/com/marklogic/client/test/datamovement/ApplyTransformTest.java
@@ -131,7 +131,7 @@ public class ApplyTransformTest {
     for ( int i=0; i < numDocs; i++) {
       batcher1.addAs(collection + "/test_doc_" + i + ".json", meta, "{ \"testProperty\": \"test3\" }");
     }
-    batcher1.flush();
+    batcher1.flushAndWait();
     moveMgr.stopJob(ticket1);
 
 

--- a/src/test/java/com/marklogic/client/test/datamovement/DeleteListenerTest.java
+++ b/src/test/java/com/marklogic/client/test/datamovement/DeleteListenerTest.java
@@ -56,7 +56,7 @@ public class DeleteListenerTest {
       uris[i] = "doc" + i + ".txt";
       writeBatcher.addAs(uris[i], meta, docContents);
     }
-    writeBatcher.flush();
+    writeBatcher.flushAndWait();
 
     // verify that the files made it to the db
     assertEquals( "There should be 100 documents in the db",

--- a/src/test/java/com/marklogic/client/test/datamovement/ExportToWriterListenerTest.java
+++ b/src/test/java/com/marklogic/client/test/datamovement/ExportToWriterListenerTest.java
@@ -67,7 +67,7 @@ public class ExportToWriterListenerTest {
       uris[i] = "/" + collection + "/doc" + i + ".txt";
       batcher.addAs(uris[i], meta, docContents);
     }
-    batcher.flush();
+    batcher.flushAndWait();
 
     // verify that the files made it to the db
     assertEquals( "There should be 100 documents in the db",

--- a/src/test/java/com/marklogic/client/test/datamovement/PointInTimeQueryTest.java
+++ b/src/test/java/com/marklogic/client/test/datamovement/PointInTimeQueryTest.java
@@ -83,7 +83,7 @@ public class PointInTimeQueryTest {
     for ( int i=1; i <= numDocs; i++ ) {
       writeBatcher.addAs(collection + "/doc_" + i + ".txt", meta, "test contents");
     }
-    writeBatcher.flush();
+    writeBatcher.flushAsync();
     writeBatcher.awaitCompletion();
     if ( failures.length() > 0 ) fail(failures.toString());
     logger.info("Successfully wrote {} docs to collection {}", numDocs, collection);

--- a/src/test/java/com/marklogic/client/test/datamovement/QueryHostBatcherIteratorTest.java
+++ b/src/test/java/com/marklogic/client/test/datamovement/QueryHostBatcherIteratorTest.java
@@ -85,7 +85,7 @@ public class QueryHostBatcherIteratorTest {
       writeBatcher.addAs(collection + "/doc_" + i + ".json", meta,
           new StringHandle("{name:\"John Doe\",dept:\"HR\"}").withFormat(JSON));
     }
-    writeBatcher.flush();
+    writeBatcher.flushAsync();
     writeBatcher.awaitCompletion();
   }
 

--- a/src/test/java/com/marklogic/client/test/datamovement/QueryHostBatcherTest.java
+++ b/src/test/java/com/marklogic/client/test/datamovement/QueryHostBatcherTest.java
@@ -89,7 +89,7 @@ public class QueryHostBatcherTest {
     writeBatcher.addAs(uri2, meta, new StringHandle("{name:\"Jane Doe\",dept:\"HR\"}").withFormat(JSON));
     writeBatcher.addAs(uri3, meta, new StringHandle("{name:\"John Smith\",dept:\"HR\"}").withFormat(JSON));
     writeBatcher.addAs(uri4, meta, new StringHandle("{name:\"John Lennon\",dept:\"HR\"}").withFormat(JSON));
-    writeBatcher.flush();
+    writeBatcher.flushAsync();
     writeBatcher.awaitCompletion();
   }
 

--- a/src/test/java/com/marklogic/client/test/datamovement/WriteHostBatcherTest.java
+++ b/src/test/java/com/marklogic/client/test/datamovement/WriteHostBatcherTest.java
@@ -127,7 +127,7 @@ public class WriteHostBatcherTest {
       .add("/doc/dom", new DomHandle);
       */
 
-    ihb1.flush();
+    ihb1.flushAndWait();
   }
   @Test
   public void testWrites() throws Exception {
@@ -178,7 +178,7 @@ public class WriteHostBatcherTest {
     batcher.addAs(uri2, meta, doc2);
     batcher.add(uri3, meta, doc3);
     batcher.add(uri4, meta, new JacksonHandle(doc4));
-    batcher.flush();
+    batcher.flushAndWait();
     assertEquals("The success listener should have run", "true", successListenerWasRun.toString());
     assertEquals("The failure listener should have run", "true", failListenerWasRun.toString());
 
@@ -255,7 +255,7 @@ public class WriteHostBatcherTest {
     batcher.add  (whbTestCollection + "doc_7.json", meta, doc7);
     StringHandle doc8 = new StringHandle("{ \"testProperty8\": \"test8\" }").withFormat(Format.JSON);
     batcher.add  (whbTestCollection + "doc_8.json", meta, doc8);
-    batcher.flush();
+    batcher.flushAndWait();
     moveMgr.stopJob(ticket);
 
     if ( failures.length() > 0 ) fail(failures.toString());
@@ -390,14 +390,14 @@ public class WriteHostBatcherTest {
     for ( Thread thread : externalThreads ) {
       try { thread.join(); } catch (Exception e) {}
     }
-    batcher.flush();
+    batcher.flushAndWait();
     int leftover = (totalDocCount % docsPerExternalThread);
     // write any leftovers
     for (int j =0; j < leftover; j++) {
       String uri = "/" + collection + "/"+ Thread.currentThread().getName() + "/" + j + ".txt";
       batcher.add(uri, meta, new StringHandle("test").withFormat(Format.TEXT));
     }
-    batcher.flush();
+    batcher.flushAndWait();
     moveMgr.stopJob(ticket);
 
     if ( failures.length() > 0 ) fail(failures.toString());
@@ -456,7 +456,7 @@ public class WriteHostBatcherTest {
 
 
           }
-          batcher.flush();
+          batcher.flushAndWait();
         }  
 
     } 
@@ -515,7 +515,7 @@ public class WriteHostBatcherTest {
 
 
           }
-          batcher.flush();
+          batcher.flushAndWait();
         } 
 
     }
@@ -560,7 +560,7 @@ public class WriteHostBatcherTest {
 
     String docContents = "{a:{b1:{c:\"jsonValue1\"}, b2:[\"b2 val1\", \"b2 val2\"]}}";
     batcher.add("/doc/string", meta, new StringHandle(docContents));
-    batcher.flush();
+    batcher.flushAndWait();
     moveMgr.stopJob(ticket);
 
     BytesHandle readContents = client.newDocumentManager().read("/doc/string", new BytesHandle());
@@ -596,8 +596,8 @@ public class WriteHostBatcherTest {
 
     batcher.add("test.xml", meta, new InputStreamHandle(fileStream));
 
-    // when we call flush, the WriteHostBatcher should write the batch the close all the handles
-    batcher.flush();
+    // when we call flushAndWait, the WriteHostBatcher should write the batch the close all the handles
+    batcher.flushAndWait();
     assertEquals(true, closed.get());
 
     moveMgr.stopJob(ticket);
@@ -643,7 +643,7 @@ public class WriteHostBatcherTest {
           System.out.println("Thread name: "+Thread.currentThread().getName()+"  URI:"+ uri);
           ihbMT.add(uri, meta, new StringHandle("test"));
           if(j ==80){
-            ihbMT.flush();
+            ihbMT.flushAndWait();
             moveMgr.stopJob(writeTicket);
           }
 

--- a/src/test/java/com/marklogic/client/test/datamovement/javadocExamples/PackageExamples.java
+++ b/src/test/java/com/marklogic/client/test/datamovement/javadocExamples/PackageExamples.java
@@ -118,7 +118,7 @@ public class PackageExamples {
     whb.add  ("doc1.txt", new StringHandle("doc1 contents"));
     whb.addAs("doc2.txt", "doc2 contents");
 
-    whb.flush(); // send the two docs even though they're not a full batch
+    whb.flushAndWait(); // send the two docs even though they're not a full batch
     dataMovementManager.stopJob(ticket);
     // end copy from "Using WriteHostBatcher" in src/main/java/com/marklogic/datamovement/package-info.java
 

--- a/test-complete/src/test/java/com/marklogic/client/datamovement/functionaltests/ApplyTransformTest.java
+++ b/test-complete/src/test/java/com/marklogic/client/datamovement/functionaltests/ApplyTransformTest.java
@@ -83,6 +83,9 @@ public class ApplyTransformTest extends  DmsdkJavaClientREST {
 	private static String[] hostNames ;
 
 
+	/**
+	 * @throws Exception
+	 */
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception {
 		hostNames = getHosts();	    
@@ -173,7 +176,7 @@ public class ApplyTransformTest extends  DmsdkJavaClientREST {
 			ihb2.add(uri, meta1, fileHandle);
 		}
 
-		ihb2.flush();
+		ihb2.flushAndWait();
 		Assert.assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 2000);
 
 		for (int j =0 ;j < 2000; j++){
@@ -181,22 +184,22 @@ public class ApplyTransformTest extends  DmsdkJavaClientREST {
 			ihb2.add(uri, meta2, stringHandle);
 		}
 
-		ihb2.flush();
+		ihb2.flushAndWait();
 		Assert.assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 4000);
 
 		ihb2.add("/local/quality", meta3, jacksonHandle);
-		ihb2.flush();
+		ihb2.flushAndWait();
 		Assert.assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 4001);
 
 		ihb2.add("/local/nomatch", meta4, jacksonHandle1);
-		ihb2.flush();
+		ihb2.flushAndWait();
 		Assert.assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 4002);
 
 		for (int j =0 ;j < 100; j++){
 			String uri ="/local/snapshot-"+ j;
 			ihb2.add(uri, meta5, fileHandle);
 		}
-		ihb2.flush();
+		ihb2.flushAndWait();
 		Assert.assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 4102);
 
 		for (int j =0 ;j < 2000; j++){
@@ -204,17 +207,17 @@ public class ApplyTransformTest extends  DmsdkJavaClientREST {
 			ihb2.add(uri, meta6, stringHandle);
 		}
 
-		ihb2.flush();
+		ihb2.flushAndWait();
 		Assert.assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 6102);
 
 		String uri ="/local/failed";
 		ihb2.add(uri, meta7, stringHandle);
 		ihb2.add("/local/failed-1", meta7, jacksonHandle);
-		ihb2.flush();
+		ihb2.flushAndWait();
 		Assert.assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 6104);
 
 		ihb2.add("/local/nonexistent-1", stringHandle);
-		ihb2.flush();
+		ihb2.flushAndWait();
 		Assert.assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 6105);
 	}
 

--- a/test-complete/src/test/java/com/marklogic/client/datamovement/functionaltests/DeleteListenerTest.java
+++ b/test-complete/src/test/java/com/marklogic/client/datamovement/functionaltests/DeleteListenerTest.java
@@ -147,7 +147,7 @@ public class DeleteListenerTest extends  DmsdkJavaClientREST{
 			ihb2.add(uri, meta, jacksonHandle);
 		}
 	
-		ihb2.flush();
+		ihb2.flushAndWait();
 		Assert.assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 2000);
 
 	}

--- a/test-complete/src/test/java/com/marklogic/client/datamovement/functionaltests/ExportListenerTest.java
+++ b/test-complete/src/test/java/com/marklogic/client/datamovement/functionaltests/ExportListenerTest.java
@@ -155,7 +155,7 @@ public class ExportListenerTest extends  DmsdkJavaClientREST {
 			ihb2.add(uri, meta, jacksonHandle);
 		}
 	
-		ihb2.flush();
+		ihb2.flushAndWait();
 		Assert.assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 2000);
 	}
 	

--- a/test-complete/src/test/java/com/marklogic/client/datamovement/functionaltests/ExportToWriterListenerTest.java
+++ b/test-complete/src/test/java/com/marklogic/client/datamovement/functionaltests/ExportToWriterListenerTest.java
@@ -133,7 +133,7 @@ public class ExportToWriterListenerTest extends com.marklogic.client.datamovemen
 			ihb2.addAs(uri, meta3, stringHandle);
 		}
 		
-		ihb2.flush();
+		ihb2.flushAndWait();
 		Assert.assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 30);
 	}
 

--- a/test-complete/src/test/java/com/marklogic/client/datamovement/functionaltests/StringQueryHostBatcherTest.java
+++ b/test-complete/src/test/java/com/marklogic/client/datamovement/functionaltests/StringQueryHostBatcherTest.java
@@ -218,7 +218,7 @@ public class StringQueryHostBatcherTest extends  DmsdkJavaClientREST {
 
 			// Verify if the batch flushes when batch size is reached.
 			// Flush
-			batcher.flush();
+			batcher.flushAndWait();
 			// Hold for asserting the callbacks batch contents, since callback are on different threads than the main JUnit thread.
 			// JUnit can not assert on different threads; other than the main one. 
 			StringBuilder batchResults = new StringBuilder();
@@ -327,7 +327,7 @@ public class StringQueryHostBatcherTest extends  DmsdkJavaClientREST {
 
 			// Verify if the batch flushes when batch size is reached.
 			// Flush
-			batcher.flush();
+			batcher.flushAndWait();
 			// Hold for asserting the callbacks batch contents, since callback are on different threads than the main JUnit thread.
 			// JUnit can not assert on different threads; other than the main one. 
 			StringBuilder batchResults = new StringBuilder();
@@ -413,7 +413,7 @@ public class StringQueryHostBatcherTest extends  DmsdkJavaClientREST {
 		batcher.add("/batcher-contraints5.json", contentHandle5);
 		
 		// Flush
-		batcher.flush();
+		batcher.flushAndWait();
 
 		StringBuilder querybatchResults = new StringBuilder();
 		StringBuilder querybatchFailResults = new StringBuilder();
@@ -501,7 +501,7 @@ public class StringQueryHostBatcherTest extends  DmsdkJavaClientREST {
 		batcher.add("/fail-contraints5.xml", contentHandle5);
 
 		// Flush
-		batcher.flush();
+		batcher.flushAndWait();
 		StringBuilder batchResults = new StringBuilder();
 		StringBuilder batchFailResults = new StringBuilder();
 		// create query def
@@ -598,7 +598,7 @@ public class StringQueryHostBatcherTest extends  DmsdkJavaClientREST {
 		batcher.add("contraints1.json", contentHandle1);
 			
 		// Flush
-		batcher.flush();
+		batcher.flushAndWait();
 		StringBuffer batchFailResults  = new StringBuffer();
 		String expectedStr = "Vannevar Bush wrote an article for The Atlantic Monthly";
 		
@@ -734,7 +734,7 @@ public class StringQueryHostBatcherTest extends  DmsdkJavaClientREST {
 		}
 
 		// Flush
-		batcher.flush();
+		batcher.flushAndWait();
 		StringBuffer batchResults  = new StringBuffer();
 		StringBuffer batchFailResults  = new StringBuffer();
 			
@@ -848,7 +848,7 @@ public class StringQueryHostBatcherTest extends  DmsdkJavaClientREST {
 		}
 		
 		// Flush
-		batcher.flush();
+		batcher.flushAndWait();
 		StringBuilder batchResults = new StringBuilder();
 		StringBuilder batchFailResults = new StringBuilder();
 
@@ -946,7 +946,7 @@ public class StringQueryHostBatcherTest extends  DmsdkJavaClientREST {
 			batcher.add(uri, handleBar);
 		}
 		// Flush
-		batcher.flush();
+		batcher.flushAndWait();
 		
 		StringBuffer batchResults  = new StringBuffer();
 		StringBuffer batchFailResults  = new StringBuffer();
@@ -1039,7 +1039,7 @@ public class StringQueryHostBatcherTest extends  DmsdkJavaClientREST {
 			}
 
 			// Flush
-			batcher.flush();
+			batcher.flushAndWait();
 			StringBuffer batchResults  = new StringBuffer();
 			StringBuffer batchFailResults  = new StringBuffer();
 
@@ -1202,7 +1202,7 @@ public class StringQueryHostBatcherTest extends  DmsdkJavaClientREST {
 			}
 
 			// Flush
-			batcher.flush();
+			batcher.flushAndWait();
 			StringBuilder batchResults = new StringBuilder();
 			StringBuffer batchFailResults = new StringBuffer();
 			StringBuilder ccBuf = new StringBuilder();
@@ -1308,7 +1308,7 @@ public class StringQueryHostBatcherTest extends  DmsdkJavaClientREST {
 		batcher.add("/batcher-contraints5.json", contentHandle5);
 
 		// Flush
-		batcher.flush();
+		batcher.flushAndWait();
 
 		StringBuffer querybatchResults = new StringBuffer();
 		StringBuilder querybatchFailResults = new StringBuilder();
@@ -1358,7 +1358,7 @@ public class StringQueryHostBatcherTest extends  DmsdkJavaClientREST {
 		// Update contents to same doc uri.
 		batcherTwo.withBatchSize(1);
 		batcherTwo.add("/batcher-contraints11.json", handle);
-		batcherTwo.flush();
+		batcherTwo.flushAndWait();
 		
 		JobTicket jobTicketWriteTwo = moveMgr.startJob(batcherTwo);
 		
@@ -1431,7 +1431,7 @@ public class StringQueryHostBatcherTest extends  DmsdkJavaClientREST {
 			batcher.add("/abs-range-constraint/batcher-contraints5.xml", contentHandle5);
 
 			// Flush
-			batcher.flush();
+			batcher.flushAndWait();
 
 			StringBuilder batchResults = new StringBuilder();
 			StringBuilder batchDetails = new StringBuilder();
@@ -1584,7 +1584,7 @@ public class StringQueryHostBatcherTest extends  DmsdkJavaClientREST {
 			batcher.add("/abs-range-constraint/batcher-contraints5.xml", contentHandle5);
 
 			// Flush
-			batcher.flush();
+			batcher.flushAndWait();
 
 			StringBuilder batchWordResults = new StringBuilder();
 			StringBuilder batchWordFailResults = new StringBuilder();

--- a/test-complete/src/test/java/com/marklogic/client/datamovement/functionaltests/WriteHostBatcherTest.java
+++ b/test-complete/src/test/java/com/marklogic/client/datamovement/functionaltests/WriteHostBatcherTest.java
@@ -327,7 +327,7 @@ public class WriteHostBatcherTest extends  DmsdkJavaClientREST {
 		.add("/doc/os_wrongjson", docMeta2, osHandle).add("/doc/bytes", docMeta1, bytesHandle).add("/doc/dom", domHandle);
 		
 		
-		ihb1.flush();
+		ihb1.flushAndWait();
 		
 		   	
 		System.out.println("Success URI's: "+successBatch.toString());
@@ -381,7 +381,7 @@ public class WriteHostBatcherTest extends  DmsdkJavaClientREST {
 		.add("/doc/os_wrongjson", docMeta2, osHandle).add("/doc/bytes", docMeta1, bytesHandle).add("/doc/dom", domHandle);
 		
 		
-		ihb2.flush();
+		ihb2.flushAndWait();
     	Assert.assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue()==0);
      	Assert.assertTrue(uriExists(failureBatch.toString(),"/doc/reader_wrongxml"));
     	
@@ -418,7 +418,7 @@ public class WriteHostBatcherTest extends  DmsdkJavaClientREST {
 		.add("/doc/os_json",  osHandle1).add("/doc/bytes",  bytesHandle).add("/doc/dom", docMeta1, domHandle);
 		
 		
-		ihb3.flush();
+		ihb3.flushAndWait();
 		
 		System.out.println("Size is "+dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue());
     	Assert.assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue()==8);
@@ -467,10 +467,10 @@ public class WriteHostBatcherTest extends  DmsdkJavaClientREST {
 		dmManager.startJob(ihb4);
 		
 		ihb4.add("/doc/jackson", docMeta2, jacksonHandle).add("/doc/reader_wrongxml",docMeta1, readerHandle).add("/doc/string", stringHandle).add("/doc/file",  fileHandle);
-		ihb4.flush();
+		ihb4.flushAndWait();
 		
 		ihb4.add("/doc/is", docMeta2,isHandle).add("/doc/os_wrongjson",  osHandle).add("/doc/bytes",  bytesHandle).add("/doc/dom", docMeta1, domHandle);
-		ihb4.flush();
+		ihb4.flushAndWait();
 		
 		
 		Assert.assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue()==0);
@@ -516,7 +516,7 @@ public class WriteHostBatcherTest extends  DmsdkJavaClientREST {
 		ihb3.addAs("/doc/jackson", docMeta2, jsonNode).addAs("/doc/reader_xml",docMeta1, docStream1).addAs("/doc/string", stringTriple).addAs("/doc/dom", docMeta1, docContent);
 		
 		
-		ihb3.flush();
+		ihb3.flushAndWait();
 		System.out.println("Size is "+dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue());
     	Assert.assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue()==4);
     	
@@ -573,7 +573,7 @@ public class WriteHostBatcherTest extends  DmsdkJavaClientREST {
 		.add("/doc/os_wrongjson", docMeta2, osHandle).add("/doc/bytes", docMeta1, bytesHandle).addAs("/doc/dom", domHandle);
 		
 		
-		ihb1.flush();
+		ihb1.flushAndWait();
 		
     
     	Assert.assertTrue(uriExists(failureBatch.toString(),"/doc/os_wrongjson"));
@@ -623,7 +623,7 @@ public class WriteHostBatcherTest extends  DmsdkJavaClientREST {
 		.add("/doc/os_wrongjson", docMeta2, osHandle).addAs("/doc/bytes", docMeta1, bytesJson).addAs("/doc/dom", domHandle);
 		
 		
-		ihb2.flush();
+		ihb2.flushAndWait();
     	Assert.assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue()==0);
      	Assert.assertTrue(uriExists(failureBatch.toString(),"/doc/reader_wrongxml"));
     	
@@ -660,7 +660,7 @@ public class WriteHostBatcherTest extends  DmsdkJavaClientREST {
 		.add("/doc/os_json",  osHandle1).add("/doc/bytes",  bytesHandle).addAs("/doc/dom", docMeta1, docContent);
 		
 		
-		ihb3.flush();
+		ihb3.flushAndWait();
 		System.out.println("Size is "+dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue());
     	Assert.assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue()==8);
     	
@@ -707,10 +707,10 @@ public class WriteHostBatcherTest extends  DmsdkJavaClientREST {
 		dmManager.startJob(ihb4);
 		
 		ihb4.addAs("/doc/jackson", docMeta2, jsonNode).add("/doc/reader_wrongxml",docMeta1, readerHandle).add("/doc/string", stringHandle).addAs("/doc/file",  fileJson);
-		ihb4.flush();
+		ihb4.flushAndWait();
 		
 		ihb4.add("/doc/is", docMeta2,isHandle).add("/doc/os_wrongjson",  osHandle).add("/doc/bytes",  bytesHandle).addAs("/doc/dom", docMeta1, docContent);
-		ihb4.flush();
+		ihb4.flushAndWait();
 		
 		
 		Assert.assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue()==0);
@@ -755,7 +755,7 @@ public class WriteHostBatcherTest extends  DmsdkJavaClientREST {
 		
 		
 		
-		ihb.flush();
+		ihb.flushAndWait();
 		
 	}
 	
@@ -786,7 +786,7 @@ public class WriteHostBatcherTest extends  DmsdkJavaClientREST {
 			ihb1.add(uri, jacksonHandle);
 		}
 	
-		ihb1.flush();
+		ihb1.flushAndWait();
 		Assert.assertTrue(state.booleanValue());
 		System.out.println(numberOfSuccessFulBatches.intValue());
 		Assert.assertTrue(numberOfSuccessFulBatches.intValue()==21);
@@ -837,7 +837,7 @@ public class WriteHostBatcherTest extends  DmsdkJavaClientREST {
 		for (int i =0 ; i < 5; i++){
 			ihb1.add("", stringHandle);
 		}
-		ihb1.flush();
+		ihb1.flushAndWait();
 
 		
 		System.out.println(successUser.toString());
@@ -909,7 +909,7 @@ public class WriteHostBatcherTest extends  DmsdkJavaClientREST {
 		for (int i =0 ;i < 5; i++){
 			ihb1.add("", stringHandle);
 		}
-		ihb1.flush();
+		ihb1.flushAndWait();
 		dmManager.stopJob(jt);
 		
 		System.out.println(successBatchNum.toString());
@@ -1027,7 +1027,7 @@ public class WriteHostBatcherTest extends  DmsdkJavaClientREST {
 			ihb2.addAs(uri, stringHandle);
 		}
 	
-		ihb2.flush();
+		ihb2.flushAndWait();
 		
 		properties.put("updates-allowed", "all");
 		for (int i =0 ; i < clusterInfo.size(); i++)
@@ -1066,7 +1066,7 @@ public class WriteHostBatcherTest extends  DmsdkJavaClientREST {
 			ihb1.add(uri, stringHandle);
 		}
 	
-		ihb1.flush();
+		ihb1.flushAndWait();
 		
 	 	Number response = dbClient.newServerEval().xquery(query1).eval().next().getNumber();
     	Assert.assertTrue(response.intValue()==20);
@@ -1098,7 +1098,7 @@ public class WriteHostBatcherTest extends  DmsdkJavaClientREST {
 			ihb2.add(uri, stringHandle);
 		}
 
-		ihb2.flush();
+		ihb2.flushAndWait();
 		
 		properties.put("updates-allowed", "all");
 		for (int i =0 ; i < clusterInfo.size(); i++)
@@ -1151,7 +1151,7 @@ public class WriteHostBatcherTest extends  DmsdkJavaClientREST {
 
 		changeProperty(properties,"/manage/v2/databases/"+dbName+"/properties");
 		
-		ihb2.flush();
+		ihb2.flushAndWait();
 		
 		properties.put("enabled", "true");
 		changeProperty(properties,"/manage/v2/databases/"+dbName+"/properties");
@@ -1231,7 +1231,7 @@ public class WriteHostBatcherTest extends  DmsdkJavaClientREST {
                   ihb1.addAs(uri1, handleFoo).addAs(uri2, handleBar);
            }
            // Flush
-           ihb1.flush();
+           ihb1.flushAndWait();
    		   Assert.assertFalse(failState.booleanValue());
    		   Assert.assertTrue(successCount.intValue()==8);
            Assert.assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue()==8);
@@ -1299,7 +1299,7 @@ public class WriteHostBatcherTest extends  DmsdkJavaClientREST {
                   ihb1.add(uri1, handleFoo).add(uri2, handleBar);;
            }
            // Flush
-           ihb1.flush();
+           ihb1.flushAndWait();
            Assert.assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue()==4);
    		   Assert.assertTrue(failState.booleanValue());
    		   Assert.assertTrue(successCount.intValue()==4);
@@ -1333,7 +1333,7 @@ public class WriteHostBatcherTest extends  DmsdkJavaClientREST {
                ihb2.add(uri1, handleFoo);
         }
         // Flush
-        ihb2.flush();
+        ihb2.flushAndWait();
         Assert.assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue()==0);
 	    Assert.assertTrue(failState.booleanValue());
 	    Assert.assertTrue(successCount.intValue()==0);
@@ -1383,7 +1383,7 @@ public class WriteHostBatcherTest extends  DmsdkJavaClientREST {
     				
     				
     			}
-           		ihbMT.flush();
+           		ihbMT.flushAndWait();
        	  }  
            		
        	} 
@@ -1438,7 +1438,7 @@ public class WriteHostBatcherTest extends  DmsdkJavaClientREST {
     				//System.out.println("Thread name: "+Thread.currentThread().getName()+"  URI:"+ uri);
     				ihbMT.add(uri, fileHandle);
     			}
-           		ihbMT.flush();
+           		ihbMT.flushAndWait();
        	  }  
            		
        	} 
@@ -1507,7 +1507,7 @@ public class WriteHostBatcherTest extends  DmsdkJavaClientREST {
     				
     				
     			}
-           		ihbMT.flush();
+           		ihbMT.flushAndWait();
        	  }  
            		
        	} 
@@ -1608,7 +1608,7 @@ public class WriteHostBatcherTest extends  DmsdkJavaClientREST {
     				
     				
     			}
-           		ihbMT.flush();
+           		ihbMT.flushAndWait();
        	  }  
            		
        	} 
@@ -1704,7 +1704,7 @@ public class WriteHostBatcherTest extends  DmsdkJavaClientREST {
     				
     				
     			}
-           		ihbMT.flush();
+           		ihbMT.flushAndWait();
        	  }  
            		
        	} 
@@ -1802,7 +1802,7 @@ public class WriteHostBatcherTest extends  DmsdkJavaClientREST {
 			}
 		
 			
-		    ihb2.flush();
+		    ihb2.flushAndWait();
 		    
 	    	System.out.println("Fail : "+failCount.intValue());
 	    	System.out.println("Success : "+successCount.intValue());
@@ -1905,7 +1905,7 @@ public class WriteHostBatcherTest extends  DmsdkJavaClientREST {
 			}
 		
 			
-		    ihb2.flush();
+		    ihb2.flushAndWait();
 		    t1.join();
 		    
 	    	System.out.println("Fail : "+failCount.intValue());
@@ -1986,7 +1986,7 @@ public class WriteHostBatcherTest extends  DmsdkJavaClientREST {
 		          }
 		);
 		try{
-			ihb2.flush();
+			ihb2.flushAndWait();
 			Assert.assertFalse("Exception was not thrown, when it should have been", 1<2);
 		}
 		catch(Exception e){
@@ -2031,7 +2031,7 @@ public class WriteHostBatcherTest extends  DmsdkJavaClientREST {
     				System.out.println("Thread name: "+Thread.currentThread().getName()+"  URI:"+ uri);
     				ihbMT.add(uri, fileHandle);
     				if(j ==80){
-    					ihbMT.flush();
+    					ihbMT.flushAndWait();
     					dmManager.stopJob(writeTicket);
     				}
     					
@@ -2094,10 +2094,10 @@ public class WriteHostBatcherTest extends  DmsdkJavaClientREST {
     				ihbMT.add(uri, fileHandle);
     				if(j ==80){
     					dmManager.startJob(ihbMT);
-    					ihbMT.flush();
+    					ihbMT.flushAndWait();
     				}
     			}
-           		ihbMT.flush();
+           		ihbMT.flushAndWait();
 				
 		 }  
            		
@@ -2158,7 +2158,7 @@ public class WriteHostBatcherTest extends  DmsdkJavaClientREST {
 		properties.put("enabled", "false");
 		changeProperty(properties,"/manage/v2/servers/"+server+"/properties");
 		Thread.currentThread().sleep(1000L);
-		ihb2.flush();
+		ihb2.flushAndWait();
 		
 		properties.put("enabled", "true");
 		changeProperty(properties,"/manage/v2/servers/"+server+"/properties");
@@ -2206,7 +2206,7 @@ public class WriteHostBatcherTest extends  DmsdkJavaClientREST {
 			ihb2.add(uri, fileHandle);
 		}
 				
-		ihb2.flush();
+		ihb2.flushAndWait();
 		t1.join();
     	
     	
@@ -2275,7 +2275,7 @@ public class WriteHostBatcherTest extends  DmsdkJavaClientREST {
 			ihb2.add(uri, fileHandle);
 		}
 				
-		ihb2.flush();
+		ihb2.flushAndWait();
 		t1.join();
 		properties.put("enabled", "true");
 		changeProperty(properties,"/manage/v2/databases/"+dbName+"/properties");
@@ -2370,7 +2370,7 @@ public class WriteHostBatcherTest extends  DmsdkJavaClientREST {
 			ihb2.add(uri, fileHandle);
 		}
 				
-		ihb2.flush();
+		ihb2.flushAndWait();
 		t1.join();
 		
 				


### PR DESCRIPTION
This fixes https://github.com/marklogic/data-movement/issues/125

Some early feedback with WriteHostBatcher was that sometimes one might want to flush without blocking for everything to complete.  Some were unsure whether to expect flush to block or not.  We decided to  remove flush and replace it with flushAndWait and flushAsync.  The method names hopefully illustrate what they do.  We discussed this in feature team meeting, but it's been a *long* time back.  Let me know if this raises any concerns.

Charles, can you merge this into entity services, then change any of your calls to writeHostBatcher.flush() to be flushAndWait() instead?  

Ajit, can you do the same and merge in this pull request when you've updated the functional tests to not use flush() any longer?