### PR TITLE
update slf4j-api to the latest 1.7.25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -276,7 +276,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.7.4</version>
+			<version>1.7.25</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
The pom has an explicit dependency on slf4j-api 1.7.4 and there is a transitive dependency on 1.7.6 through logback-classic. 

Update the explicit dependency to the latest, 1.7.25