### PR TITLE
update provided dependencies jdom2, gson, and htmlcleaner to the latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -316,7 +316,7 @@
 		<dependency>
 			<groupId>org.jdom</groupId>
 			<artifactId>jdom2</artifactId>
-			<version>2.0.5</version>
+			<version>2.0.6</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -334,13 +334,13 @@
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
-			<version>2.2.2</version>
+			<version>2.8.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>net.sourceforge.htmlcleaner</groupId>
 			<artifactId>htmlcleaner</artifactId>
-			<version>2.4</version>
+			<version>2.19</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Update the build to reference the latest versions available for the following provided dependencies

|Dependency	|Resolved	|Newest	|
|---|---|---|
|jdom2	|2.0.5	| 2.0.6	|
|gson	|2.2.2	| 2.8.0	|
|htmlcleaner|	2.4	| 2.19|