### PR TITLE
issue #747: Fix some typos in the javadoc

### DIFF
--- a/src/main/java/com/marklogic/client/io/XMLEventReaderHandle.java
+++ b/src/main/java/com/marklogic/client/io/XMLEventReaderHandle.java
@@ -125,7 +125,7 @@ public class XMLEventReaderHandle
   }
 
   /**
-   * Returns an XML Event Reader for for reading a resource from the database
+   * Returns an XML Event Reader reading a resource from the database
    * as a series of StAX events.
    *
    * When finished with the event reader, close the event reader to release

--- a/src/main/java/com/marklogic/client/io/XMLStreamReaderHandle.java
+++ b/src/main/java/com/marklogic/client/io/XMLStreamReaderHandle.java
@@ -126,7 +126,7 @@ public class XMLStreamReaderHandle
   }
 
   /**
-   * Returns an XML Stream Reader for for reading a resource from the database
+   * Returns an XML Stream Reader for reading a resource from the database
    * as a StAX pull stream.
    *
    * When finished with the stream reader, call {@link #close} to release

--- a/src/main/java/com/marklogic/client/query/StructuredQueryBuilder.java
+++ b/src/main/java/com/marklogic/client/query/StructuredQueryBuilder.java
@@ -2823,7 +2823,7 @@ public class StructuredQueryBuilder {
    * Matches documents with LSQT prior to timestamp
    * @param temporalCollection the temporal collection to query
    * @param time documents with lsqt equal to or prior to this timestamp will match
-   * @param weight the weight for for this query
+   * @param weight the weight for this query
    * @param options string options from the list for
    *     <a href="http://docs.marklogic.com/cts:lsqt-query">cts:lsqt-query calls</a>
    * @return a query to filter by lsqt
@@ -2843,7 +2843,7 @@ public class StructuredQueryBuilder {
    * @param temporalCollection the temporal collection to query
    * @param timestamp timestamp in ISO 8601 format - documents with lsqt equal to or
    *        prior to this timestamp will match
-   * @param weight the weight for for this query
+   * @param weight the weight for this query
    * @param options string options from the list for
    *     <a href="http://docs.marklogic.com/cts:lsqt-query">cts:lsqt-query calls</a>
    * @return a query to filter by lsqt


### PR DESCRIPTION
See #747 - removed dup occurrences of "for" in the javadoc.