### PR TITLE
fix #867--make getString work like getContentAs(name,String.class)

### DIFF
--- a/src/main/java/com/marklogic/client/impl/RowManagerImpl.java
+++ b/src/main/java/com/marklogic/client/impl/RowManagerImpl.java
@@ -1095,7 +1095,11 @@ public class RowManagerImpl
     }
     @Override
     public String getString(String columnName) {
-      return asString(get(columnName));
+      try {
+        return asString(get(columnName));
+      } catch(NodeNotAStringException e) {
+        throw new IllegalArgumentException("value for column \""+columnName+"\" not a string");
+      }
     }
 
     private boolean asBoolean(String columnName, Object value) {
@@ -1140,12 +1144,21 @@ public class RowManagerImpl
       }
       throw new IllegalStateException("column "+columnName+" does not have a short value");
     }
-    private String asString(Object value) {
+    /**
+     * @throws NodeNotAStringException when the value is a node but not a single text node
+     *   (with content-type "text/plain")
+     */
+    private String asString(Object value) throws NodeNotAStringException {
       if (value == null || value instanceof String) {
         return (String) value;
       }
       if (value instanceof RESTServiceResult) {
-        return ((RESTServiceResult) value).getContent(new StringHandle()).get();
+        RESTServiceResult result = (RESTServiceResult) value;
+        if ( result.getMimetype() != null && result.getMimetype().startsWith("text/plain") ) {
+          return result.getContent(new StringHandle()).get();
+        } else {
+          throw new NodeNotAStringException();
+        }
       }
       return value.toString();
     }
@@ -1180,27 +1193,27 @@ public class RowManagerImpl
 			}
 			*/
 
-      String valueStr = asString(value);
-
-      Function<String,? extends XsAnyAtomicTypeVal> factory = getFactory(as);
-      if (factory != null) {
-        return as.cast(factory.apply(valueStr));
-      }
-
-      // fallback
-      @SuppressWarnings("unchecked")
-      Constructor<T> constructor = (Constructor<T>) constructors.get(as);
-      if (constructor == null) {
-        try {
-          constructor = as.getConstructor(String.class);
-        } catch(NoSuchMethodException e) {
-          throw new IllegalArgumentException("cannot construct "+columnName+" value as class: "+as.getName());
-        }
-        constructors.put(as, constructor);
-      }
-
       try {
+        String valueStr = asString(value);
+
+        Function<String,? extends XsAnyAtomicTypeVal> factory = getFactory(as);
+        if (factory != null) {
+          return as.cast(factory.apply(valueStr));
+        }
+
+        // fallback
+        @SuppressWarnings("unchecked")
+        Constructor<T> constructor = (Constructor<T>) constructors.get(as);
+        if (constructor == null) {
+          constructor = as.getConstructor(String.class);
+          constructors.put(as, constructor);
+        }
+
         return constructor.newInstance(valueStr);
+      } catch(NodeNotAStringException e) {
+        throw new IllegalArgumentException("column \""+columnName+"\" is a node, not an atomic");
+      } catch(NoSuchMethodException e) {
+        throw new IllegalArgumentException("cannot construct "+columnName+" value as class: "+as.getName());
       } catch (InstantiationException e) {
         throw new MarkLogicBindingException("could not construct value as class: "+as.getName(), e);
       } catch (IllegalAccessException e) {
@@ -1535,5 +1548,8 @@ public class RowManagerImpl
       setHandle(handle);
       return this;
     }
+  }
+
+  private static class NodeNotAStringException extends Exception {
   }
 }

--- a/src/main/java/com/marklogic/client/impl/RowManagerImpl.java
+++ b/src/main/java/com/marklogic/client/impl/RowManagerImpl.java
@@ -50,6 +50,7 @@ import com.marklogic.client.impl.RESTServices.RESTServiceResultIterator;
 import com.marklogic.client.io.BaseHandle;
 import com.marklogic.client.io.Format;
 import com.marklogic.client.io.InputStreamHandle;
+import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.io.XMLStreamReaderHandle;
 import com.marklogic.client.io.marker.AbstractReadHandle;
 import com.marklogic.client.io.marker.AbstractWriteHandle;
@@ -1142,6 +1143,9 @@ public class RowManagerImpl
     private String asString(Object value) {
       if (value == null || value instanceof String) {
         return (String) value;
+      }
+      if (value instanceof RESTServiceResult) {
+        return ((RESTServiceResult) value).getContent(new StringHandle()).get();
       }
       return value.toString();
     }

--- a/src/test/java/com/marklogic/client/test/RowManagerTest.java
+++ b/src/test/java/com/marklogic/client/test/RowManagerTest.java
@@ -455,7 +455,7 @@ public class RowManagerTest {
       assertEquals("unexpected lastName value in row record "+rowNum,  lastName[rowNum],  row.getString("lastName"));
       assertEquals("unexpected firstName value in row record "+rowNum, firstName[rowNum], row.getString("firstName"));
 
-      String instruments = row.getContent("instruments", new StringHandle()).get();
+      String instruments = row.getString("instruments");
       assertNotNull("null instrucments value in row record "+rowNum,    instruments);
       assertTrue("unexpected instrucments value in row record "+rowNum, instruments.contains("trumpet"));
       rowNum++;

--- a/src/test/java/com/marklogic/client/test/RowManagerTest.java
+++ b/src/test/java/com/marklogic/client/test/RowManagerTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.io.LineNumberReader;
@@ -451,14 +452,24 @@ public class RowManagerTest {
     String[] firstName = {"Louis",      "Miles"};
 
     int rowNum = 0;
+    boolean didARowFail = false;
     for (RowRecord row: rowMgr.resultRows(builtPlan)) {
       assertEquals("unexpected lastName value in row record "+rowNum,  lastName[rowNum],  row.getString("lastName"));
       assertEquals("unexpected firstName value in row record "+rowNum, firstName[rowNum], row.getString("firstName"));
 
-      String instruments = row.getString("instruments");
+      String instruments;
+      try {
+        instruments = row.getString("instruments");
+      } catch (IllegalArgumentException e ) {
+        didARowFail = true;
+        instruments = row.getContentAs("instruments", String.class);
+      }
       assertNotNull("null instrucments value in row record "+rowNum,    instruments);
       assertTrue("unexpected instrucments value in row record "+rowNum, instruments.contains("trumpet"));
       rowNum++;
+    }
+    if ( didARowFail == false ) {
+      fail("getString(\"instruments\") should throw an exception since some rows return an array");
     }
     assertEquals("unexpected count of result records", 2, rowNum);
   }


### PR DESCRIPTION
fixes #867.  Targets upcoming version 4.0.4.  Tested against ML Server 9.0-3.1 on RH7 and java 1.8.0_151-b12 on Windows 10 Home.
