### PR TITLE
change EvalResultIterator interface to extend Closeable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ test-complete/build/
 .classpath
 .project
 .settings/
+.idea

--- a/src/main/java/com/marklogic/client/eval/EvalResultIterator.java
+++ b/src/main/java/com/marklogic/client/eval/EvalResultIterator.java
@@ -15,12 +15,13 @@
  */
 package com.marklogic.client.eval;
 
+import java.io.Closeable;
 import java.util.Iterator;
 
 /** An Iterator to walk through all results returned from calls to
  * {@link ServerEvaluationCall#eval()}.
  */
-public interface EvalResultIterator extends Iterable<EvalResult>, Iterator<EvalResult> {
+public interface EvalResultIterator extends Iterable<EvalResult>, Iterator<EvalResult>, Closeable {
   @Override
   Iterator<EvalResult> iterator();
   @Override


### PR DESCRIPTION
- added Closeable to EvalResultIterator
- added an explicit test to verify that close() is invoked when try-with-resources is used
- changed EvalTest methods to utilize try-with-resources and remove the finally
blocks explicitly closing

resolves issue #874 