### PR TITLE
Fix XML serialization in DOMWriter

### DIFF
--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/DOMWriter.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/DOMWriter.java
@@ -18,9 +18,6 @@ package com.marklogic.client.impl;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import org.w3c.dom.Attr;
 import org.w3c.dom.CDATASection;
 import org.w3c.dom.Comment;
@@ -35,7 +32,6 @@ import org.w3c.dom.Text;
 import com.marklogic.client.MarkLogicInternalException;
 
 public class DOMWriter {
-  final static private Logger logger = LoggerFactory.getLogger(DOMWriter.class);
   private XMLStreamWriter serializer;
 
   public DOMWriter() {

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/DOMWriter.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/DOMWriter.java
@@ -18,6 +18,9 @@ package com.marklogic.client.impl;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.w3c.dom.Attr;
 import org.w3c.dom.CDATASection;
 import org.w3c.dom.Comment;
@@ -32,6 +35,7 @@ import org.w3c.dom.Text;
 import com.marklogic.client.MarkLogicInternalException;
 
 public class DOMWriter {
+  final static private Logger logger = LoggerFactory.getLogger(DOMWriter.class);
   private XMLStreamWriter serializer;
 
   public DOMWriter() {
@@ -74,6 +78,7 @@ public class DOMWriter {
     }
   }
   public void serializeDocument(Document document) throws XMLStreamException {
+	  
     String encoding = document.getInputEncoding();
     String version  = document.getXmlVersion();
     if (encoding != null) {
@@ -94,7 +99,7 @@ public class DOMWriter {
       if (prefix != null) {
         serializer.writeStartElement(prefix, localName, namespaceURI);
       } else if (namespaceURI != null) {
-        serializer.writeStartElement(localName, namespaceURI);
+        serializer.writeStartElement("", localName, namespaceURI);
       } else {
         serializer.writeStartElement(localName);
       }
@@ -107,7 +112,7 @@ public class DOMWriter {
       if (prefix != null) {
         serializer.writeEmptyElement(prefix, localName, namespaceURI);
       } else if (namespaceURI != null) {
-        serializer.writeEmptyElement(localName, namespaceURI);
+        serializer.writeEmptyElement("", localName, namespaceURI);
       } else {
         serializer.writeEmptyElement(localName);
       }
@@ -123,10 +128,12 @@ public class DOMWriter {
       String prefix       = (namespaceURI != null) ? attribute.getPrefix() : null;
       String localName    = (namespaceURI != null) ? attribute.getLocalName() : attribute.getName();
       String value        = attribute.getValue();
-      if (prefix != null) {
-        serializer.writeAttribute(prefix, localName, namespaceURI, value);
+      if ("http://www.w3.org/2000/xmlns/".equals(namespaceURI)) {
+        //TODO: Seems there should be a better way to prevent redundant namespaces.
+      } else if (prefix != null) {
+        serializer.writeAttribute(prefix, namespaceURI, localName, value);
       } else if (namespaceURI != null) {
-        serializer.writeAttribute(localName, namespaceURI, value);
+        serializer.writeAttribute(namespaceURI, localName, value);
       } else {
         serializer.writeAttribute(localName, value);
       }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/DocumentMetadataHandleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/DocumentMetadataHandleTest.java
@@ -21,8 +21,10 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.util.ArrayList;
 
+import javax.xml.namespace.QName;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
@@ -30,6 +32,8 @@ import org.custommonkey.xmlunit.exceptions.XpathException;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -38,6 +42,7 @@ import org.xml.sax.SAXException;
 
 import com.marklogic.client.Transaction;
 import com.marklogic.client.document.DocumentManager.Metadata;
+import com.marklogic.client.document.BinaryDocumentManager;
 import com.marklogic.client.document.XMLDocumentManager;
 import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.DocumentMetadataHandle.Capability;
@@ -51,6 +56,7 @@ import com.marklogic.client.io.StringHandle;
 import java.util.List;
 
 public class DocumentMetadataHandleTest {
+  final static private Logger logger = LoggerFactory.getLogger(DocumentMetadataHandleTest.class);
   @BeforeClass
   public static void beforeClass() {
     Common.connect();
@@ -190,6 +196,42 @@ public class DocumentMetadataHandleTest {
     assertEquals(Capability.NODE_UPDATE, Capability.getValueOf("node-Update"));
     assertEquals(Capability.NODE_UPDATE, Capability.getValueOf("NODE_UPDATE"));
   }
+  
+  @Test
+  public void testMetadataPropertiesExtraction() {
+	String docId = "/test.bin";
+	// Make a document manager to work with binary files 
+    BinaryDocumentManager docMgr = Common.client.newBinaryDocumentManager();
+    DocumentMetadataHandle metadataHandle = new DocumentMetadataHandle();
+    docMgr.setMetadataExtraction(BinaryDocumentManager.MetadataExtraction.PROPERTIES);
+    // read binary from resources
+    ClassLoader classLoader = getClass().getClassLoader();
+    File file = null;
+    FileInputStream docStream = null;
+    try {
+    	file = new File(classLoader.getResource("test.bin").getFile());
+    	docStream = new FileInputStream(file);
+    } catch (Exception e) {
+    	assertTrue(false);
+    }
+
+    // Create a handle to hold string content.
+    InputStreamHandle handle = new InputStreamHandle(docStream);
+    docMgr.write(docId, metadataHandle, handle);
+    
+    DocumentMetadataHandle readMetadataHandle = new DocumentMetadataHandle();
+    //read only the metadata into a handle
+    docMgr.readMetadata(docId, readMetadataHandle);
+    QName qn = new QName("", "testId");
+    readMetadataHandle.getProperties().put(qn, "123456");
+    docMgr.writeMetadata(docId, readMetadataHandle);
+    
+    readMetadataHandle = new DocumentMetadataHandle();
+    
+    docMgr.readMetadata(docId, readMetadataHandle);
+    assertEquals("123456", readMetadataHandle.getProperties().get(qn));
+  }
+
 
   // testing https://github.com/marklogic/java-client-api/issues/783
   @Test

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/DocumentMetadataHandleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/DocumentMetadataHandleTest.java
@@ -32,8 +32,6 @@ import org.custommonkey.xmlunit.exceptions.XpathException;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -56,7 +54,6 @@ import com.marklogic.client.io.StringHandle;
 import java.util.List;
 
 public class DocumentMetadataHandleTest {
-  final static private Logger logger = LoggerFactory.getLogger(DocumentMetadataHandleTest.class);
   @BeforeClass
   public static void beforeClass() {
     Common.connect();

--- a/marklogic-client-api/src/test/resources/test.bin
+++ b/marklogic-client-api/src/test/resources/test.bin
@@ -1,0 +1,1 @@
+my test binary document


### PR DESCRIPTION
* What issue are you addressing with this pull request?
Complex XML with namespaces were getting serialized incorrectly in the properties. This was found out by trying to write back properties that had extracted text. The root cause seemed to be parameters passed in the wrong order to a few functions. 
* Are you modifying the correct branch? (See CONTRIBUTING.md)
I believe so. This needs to be fixed in both the 3.x and 4.x releases.
* Have you run unit tests? (See CONTRIBUTING.md)
Yes and I've added a unit test to cover this case. I did see some failures, but it appeared to be the same number of failures as before my changes.
* Version of MarkLogic Java Client API (see Readme.txt)
4.0.4 and 3.0.8
* Version of MarkLogic Server (see admin gui on port 8001)
MarkLogic 9.0-6 and 8.0-6
* Java version (`java -version`)
1.8.0_77
* OS and version
MacOS 10.13.6 
* What Changed: What happened before this change? What happens without this change?
XML serialization for the metadata would create invalid XML like below:
    ```xml
    <rapi:metadata xmlns:rapi="http://marklogic.com/rest-api" xmlns:prop="http://marklogic.com/xdmp/property" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema">
      <rapi:permissions>
        <rapi:permission>
          <rapi:role-name>rest-writer</rapi:role-name>
          <rapi:capability>update</rapi:capability>
        </rapi:permission>
        <rapi:permission>
          <rapi:role-name>rest-reader</rapi:role-name>
          <rapi:capability>read</rapi:capability>
        </rapi:permission>
      </rapi:permissions>
      <prop:properties>
        <filter:text xmlns:filter="http://marklogic.com/filter">
          <zdef-1006346975:http://www.w3.org/1999/xhtml xmlns:zdef-1593109095="xmlns" xmlns:zdef-1006346975="body" zdef-1593109095:http://www.w3.org/2000/xmlns/="http://www.w3.org/1999/xhtml">
            <zdef-1303289172:http://www.w3.org/1999/xhtml xmlns:zdef-1303289172="p">
              This is a test!</zdef-1303289172:http://www.w3.org/1999/xhtml>
          </zdef-1006346975:http://www.w3.org/1999/xhtml>
        </filter:text>
        <content-type xmlns="http://marklogic.com/filter" xsi:type="xs:string">text/plain</content-type>
        <testId xsi:type="xs:string">123456</testId>
        <size xmlns="http://marklogic.com/filter" xsi:type="xs:string">15</size>
        <filter-capabilities xmlns="http://marklogic.com/filter" xsi:type="xs:string">text</filter-capabilities>
      </prop:properties>
      <rapi:quality>0</rapi:quality>
    </rapi:metadata>
    ```