### PR TITLE
Adding support for constructing a DatabaseClient via configuration

### DIFF
--- a/marklogic-client-api/src/main/java/com/marklogic/client/config/ConfiguredDatabaseClientFactory.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/config/ConfiguredDatabaseClientFactory.java
@@ -1,0 +1,14 @@
+package com.marklogic.client.config;
+
+import com.marklogic.client.DatabaseClient;
+
+/**
+ * Hides how a DatabaseClient is constructed based on the inputs in a DatabaseClientConfig object. The intent is that a
+ * client can populate any set of properties on the DatabaseClientConfig, and an implementation of this interface will
+ * determine how to construct a new DatabaseClient based on those properties.
+ */
+public interface ConfiguredDatabaseClientFactory {
+
+	DatabaseClient newDatabaseClient(DatabaseClientConfig databaseClientConfig);
+
+}

--- a/marklogic-client-api/src/main/java/com/marklogic/client/config/DatabaseClientConfig.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/config/DatabaseClientConfig.java
@@ -1,0 +1,146 @@
+package com.marklogic.client.config;
+
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.DatabaseClientFactory.SSLHostnameVerifier;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.X509TrustManager;
+
+/**
+ * Captures all the possible inputs used to construct an instance of DatabaseClient.
+ */
+public class DatabaseClientConfig {
+
+	private SecurityContextType securityContextType = SecurityContextType.DIGEST;
+	private String host;
+	private int port;
+	private String username;
+	private String password;
+	private String database;
+	private SSLContext sslContext;
+	private SSLHostnameVerifier sslHostnameVerifier;
+	private String certFile;
+	private String certPassword;
+	private String externalName;
+	private X509TrustManager trustManager;
+	private DatabaseClient.ConnectionType connectionType;
+
+	public DatabaseClientConfig() {
+	}
+
+	public DatabaseClientConfig(String host, int port) {
+		this.host = host;
+		this.port = port;
+	}
+
+	public DatabaseClientConfig(String host, int port, String username, String password) {
+		this.host = host;
+		this.port = port;
+		this.username = username;
+		this.password = password;
+	}
+
+	public String getHost() {
+		return host;
+	}
+
+	public int getPort() {
+		return port;
+	}
+
+	public String getUsername() {
+		return username;
+	}
+
+	public String getPassword() {
+		return password;
+	}
+
+	public void setHost(String host) {
+		this.host = host;
+	}
+
+	public void setPort(int port) {
+		this.port = port;
+	}
+
+	public void setUsername(String username) {
+		this.username = username;
+	}
+
+	public void setPassword(String password) {
+		this.password = password;
+	}
+
+	public SSLContext getSslContext() {
+		return sslContext;
+	}
+
+	public void setSslContext(SSLContext sslContext) {
+		this.sslContext = sslContext;
+	}
+
+	public SSLHostnameVerifier getSslHostnameVerifier() {
+		return sslHostnameVerifier;
+	}
+
+	public void setSslHostnameVerifier(SSLHostnameVerifier sslHostnameVerifier) {
+		this.sslHostnameVerifier = sslHostnameVerifier;
+	}
+
+	public String getDatabase() {
+		return database;
+	}
+
+	public void setDatabase(String database) {
+		this.database = database;
+	}
+
+	public SecurityContextType getSecurityContextType() {
+		return securityContextType;
+	}
+
+	public void setSecurityContextType(SecurityContextType securityContextType) {
+		this.securityContextType = securityContextType;
+	}
+
+	public String getCertFile() {
+		return certFile;
+	}
+
+	public void setCertFile(String certFile) {
+		this.certFile = certFile;
+	}
+
+	public String getCertPassword() {
+		return certPassword;
+	}
+
+	public void setCertPassword(String certPassword) {
+		this.certPassword = certPassword;
+	}
+
+	public String getExternalName() {
+		return externalName;
+	}
+
+	public void setExternalName(String externalName) {
+		this.externalName = externalName;
+	}
+
+	public X509TrustManager getTrustManager() {
+		return trustManager;
+	}
+
+	public void setTrustManager(X509TrustManager trustManager) {
+		this.trustManager = trustManager;
+	}
+
+	public DatabaseClient.ConnectionType getConnectionType() {
+		return connectionType;
+	}
+
+	public void setConnectionType(DatabaseClient.ConnectionType connectionType) {
+		this.connectionType = connectionType;
+	}
+}

--- a/marklogic-client-api/src/main/java/com/marklogic/client/config/DefaultConfiguredDatabaseClientFactory.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/config/DefaultConfiguredDatabaseClientFactory.java
@@ -1,0 +1,131 @@
+package com.marklogic.client.config;
+
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.DatabaseClientFactory;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.X509TrustManager;
+
+/**
+ * Default implementation for constructing a new instance of DatabaseClient based on the inputs in an instance of
+ * DatabaseClientConfig.
+ */
+public class DefaultConfiguredDatabaseClientFactory implements ConfiguredDatabaseClientFactory {
+
+	/**
+	 * @param config
+	 * @return
+	 */
+	@Override
+	public DatabaseClient newDatabaseClient(DatabaseClientConfig config) {
+		DatabaseClientFactory.SecurityContext securityContext = buildSecurityContext(config);
+		securityContext = applySslConfig(config, securityContext);
+		return createClient(config, securityContext);
+	}
+
+	/**
+	 * @param config
+	 * @param securityContext
+	 * @return
+	 */
+	protected DatabaseClient createClient(DatabaseClientConfig config, DatabaseClientFactory.SecurityContext securityContext) {
+		final String host = config.getHost();
+		final int port = config.getPort();
+		final String database = config.getDatabase();
+		final DatabaseClient.ConnectionType connectionType = config.getConnectionType();
+
+		if (connectionType == null) {
+			if (securityContext == null) {
+				if (database == null) {
+					return DatabaseClientFactory.newClient(host, port);
+				}
+				return DatabaseClientFactory.newClient(host, port, database);
+			}
+			if (database == null) {
+				return DatabaseClientFactory.newClient(host, port, securityContext);
+			}
+			return DatabaseClientFactory.newClient(host, port, database, securityContext);
+		} else {
+			if (securityContext == null) {
+				if (database == null) {
+					return DatabaseClientFactory.newClient(host, port, null, connectionType);
+				}
+				return DatabaseClientFactory.newClient(host, port, database, null, connectionType);
+			}
+			if (database == null) {
+				return DatabaseClientFactory.newClient(host, port, securityContext, connectionType);
+			}
+			return DatabaseClientFactory.newClient(host, port, database, securityContext, connectionType);
+		}
+	}
+
+	/**
+	 * @param config
+	 * @return
+	 */
+	protected DatabaseClientFactory.SecurityContext buildSecurityContext(DatabaseClientConfig config) {
+		SecurityContextType securityContextType = config.getSecurityContextType();
+		if (SecurityContextType.BASIC.equals(securityContextType)) {
+			return new DatabaseClientFactory.BasicAuthContext(config.getUsername(), config.getPassword());
+		} else if (SecurityContextType.CERTIFICATE.equals(securityContextType)) {
+			return buildCertificateAuthContent(config);
+		} else if (SecurityContextType.DIGEST.equals(securityContextType)) {
+			return new DatabaseClientFactory.DigestAuthContext(config.getUsername(), config.getPassword());
+		} else if (SecurityContextType.KERBEROS.equals(securityContextType)) {
+			return new DatabaseClientFactory.KerberosAuthContext(config.getExternalName());
+		} else if (SecurityContextType.NONE.equals(securityContextType)) {
+			return null;
+		} else {
+			throw new IllegalArgumentException("Unsupported SecurityContextType: " + securityContextType);
+		}
+	}
+
+	/**
+	 * Uses the certificate-related properties in the config object to construct a new CertificateAuthContext.
+	 *
+	 * @param config
+	 * @return
+	 */
+	protected DatabaseClientFactory.SecurityContext buildCertificateAuthContent(DatabaseClientConfig config) {
+		X509TrustManager trustManager = config.getTrustManager();
+
+		String certFile = config.getCertFile();
+		if (certFile != null) {
+			try {
+				if (config.getCertPassword() != null) {
+					return new DatabaseClientFactory.CertificateAuthContext(certFile, config.getCertPassword(), trustManager);
+				}
+				return new DatabaseClientFactory.CertificateAuthContext(certFile, trustManager);
+			} catch (Exception ex) {
+				throw new RuntimeException("Unable to build CertificateAuthContext: " + ex.getMessage(), ex);
+			}
+		}
+
+		DatabaseClientFactory.SSLHostnameVerifier verifier = config.getSslHostnameVerifier();
+		if (verifier != null) {
+			return new DatabaseClientFactory.CertificateAuthContext(config.getSslContext(), verifier, trustManager);
+		}
+		return new DatabaseClientFactory.CertificateAuthContext(config.getSslContext(), trustManager);
+	}
+
+	/**
+	 * Applies an SSLContext and SSLHostnameVerifier if they've been set on the config object.
+	 *
+	 * @param config
+	 * @param securityContext
+	 * @return
+	 */
+	protected DatabaseClientFactory.SecurityContext applySslConfig(DatabaseClientConfig config, DatabaseClientFactory.SecurityContext securityContext) {
+		if (securityContext != null) {
+			SSLContext sslContext = config.getSslContext();
+			DatabaseClientFactory.SSLHostnameVerifier verifier = config.getSslHostnameVerifier();
+			if (sslContext != null) {
+				securityContext = securityContext.withSSLContext(sslContext, config.getTrustManager());
+			}
+			if (verifier != null) {
+				securityContext = securityContext.withSSLHostnameVerifier(verifier);
+			}
+		}
+		return securityContext;
+	}
+}

--- a/marklogic-client-api/src/main/java/com/marklogic/client/config/SecurityContextType.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/config/SecurityContextType.java
@@ -1,0 +1,14 @@
+package com.marklogic.client.config;
+
+/**
+ * The Authentication enum in marklogic-client-api was deprecated in 4.0.1, but this enum is useful in
+ * DatabaseClientConfig as a way of referencing a particular SecurityContext implementation to use.
+ */
+public enum SecurityContextType {
+
+	BASIC,
+	CERTIFICATE,
+	DIGEST,
+	KERBEROS,
+	NONE
+}

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/Common.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/Common.java
@@ -29,6 +29,9 @@ import java.net.URISyntaxException;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
+import com.marklogic.client.config.ConfiguredDatabaseClientFactory;
+import com.marklogic.client.config.DatabaseClientConfig;
+import com.marklogic.client.config.DefaultConfiguredDatabaseClientFactory;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
 import org.w3c.dom.ls.DOMImplementationLS;
@@ -37,8 +40,6 @@ import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 import com.marklogic.client.DatabaseClient;
-import com.marklogic.client.DatabaseClientFactory;
-import com.marklogic.client.DatabaseClientFactory.DigestAuthContext;
 
 public class Common {
   final public static String USER= "rest-writer";
@@ -74,6 +75,8 @@ public class Common {
   public static DatabaseClient evalClient;
   public static DatabaseClient readOnlyClient;
 
+  private static ConfiguredDatabaseClientFactory configuredDatabaseClientFactory = new DefaultConfiguredDatabaseClientFactory();
+
   public static DatabaseClient connect() {
     if (client != null) return client;
     client = newClient();
@@ -103,32 +106,33 @@ public class Common {
     return newClient(null);
   }
   public static DatabaseClient newClient(String databaseName) {
-    return DatabaseClientFactory.newClient(Common.HOST, Common.PORT, databaseName,
-      new DatabaseClientFactory.DigestAuthContext(Common.USER, Common.PASS),
-          CONNECTION_TYPE);
+    DatabaseClientConfig config = new DatabaseClientConfig(HOST, PORT, USER, PASS);
+    config.setDatabase(databaseName);
+    config.setConnectionType(CONNECTION_TYPE);
+    return configuredDatabaseClientFactory.newDatabaseClient(config);
   }
   public static DatabaseClient newAdminClient() {
-    return DatabaseClientFactory.newClient(
-      Common.HOST, Common.PORT, new DigestAuthContext(Common.REST_ADMIN_USER, Common.REST_ADMIN_PASS),
-          CONNECTION_TYPE);
+    DatabaseClientConfig config = new DatabaseClientConfig(HOST, PORT, REST_ADMIN_USER, REST_ADMIN_PASS);
+    config.setConnectionType(CONNECTION_TYPE);
+    return configuredDatabaseClientFactory.newDatabaseClient(config);
   }
   public static DatabaseClient newServerAdminClient() {
-    return DatabaseClientFactory.newClient(
-      Common.HOST, Common.PORT, new DigestAuthContext(Common.SERVER_ADMIN_USER, Common.SERVER_ADMIN_PASS),
-          CONNECTION_TYPE);
+    DatabaseClientConfig config = new DatabaseClientConfig(HOST, PORT, SERVER_ADMIN_USER, SERVER_ADMIN_PASS);
+    config.setConnectionType(CONNECTION_TYPE);
+    return configuredDatabaseClientFactory.newDatabaseClient(config);
   }
   public static DatabaseClient newEvalClient() {
     return newEvalClient(null);
   }
   public static DatabaseClient newEvalClient(String databaseName) {
-    return DatabaseClientFactory.newClient(
-      Common.HOST, Common.PORT, databaseName, new DigestAuthContext(Common.EVAL_USER, Common.EVAL_PASS),
-          CONNECTION_TYPE);
+    DatabaseClientConfig config = new DatabaseClientConfig(HOST, PORT, EVAL_USER, EVAL_PASS);
+    config.setConnectionType(CONNECTION_TYPE);
+    return configuredDatabaseClientFactory.newDatabaseClient(config);
   }
   public static DatabaseClient newReadOnlyClient() {
-    return DatabaseClientFactory.newClient(
-      Common.HOST, Common.PORT, new DigestAuthContext(Common.READ_ONLY_USER, Common.READ_ONLY_PASS),
-          CONNECTION_TYPE);
+    DatabaseClientConfig config = new DatabaseClientConfig(HOST, PORT, READ_ONLY_USER, READ_ONLY_PASS);
+    config.setConnectionType(CONNECTION_TYPE);
+    return configuredDatabaseClientFactory.newDatabaseClient(config);
   }
 
   public static byte[] streamToBytes(InputStream is) throws IOException {


### PR DESCRIPTION
* What issue are you addressing with this pull request?

This copies classes from the ml-javaclient-util into java-client-api so that they can be more easily kept in sync with `DatabaseClientFactory`. These classes are used in several places (ml-gradle, DHF, NiFi) for constructing a `DatabaseClient` by calling setters on `DatabaseClientConfig`.

* Are you modifying the correct branch? 

The only branch I can really push this to right now is `4.0-master`, because the develop branch does not yet have the `ConnectionType` addition in `DatabaseClient`. Once `develop` is updated with that addition, this PR should point to `develop`. 

* Have you run unit tests?

Where'd CONTRIBUTING.md go?

* Version of MarkLogic Java Client API (see Readme.txt)

4.1.1 was just released, so I think this would go into 4.2?

* Version of MarkLogic Server (see admin gui on port 8001)

N/A

* Java version (`java -version`)

N/A

* OS and version

N/A

* What Changed: What happened before this change? What happens without this change?

See above. 