### PR TITLE
Removing the import as ConnectionResult is moved from OkHttpServices to

### DIFF
--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/DatabaseClientImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/DatabaseClientImpl.java
@@ -35,7 +35,6 @@ import com.marklogic.client.semantics.SPARQLQueryManager;
 import com.marklogic.client.util.RequestLogger;
 import com.marklogic.client.eval.ServerEvaluationCall;
 import com.marklogic.client.extensions.ResourceManager;
-import com.marklogic.client.impl.OkHttpServices.ConnectionResult;
 import com.marklogic.client.DatabaseClientFactory.HandleFactoryRegistry;
 import com.marklogic.client.admin.ServerConfigurationManager;
 import com.marklogic.client.alerting.RuleManager;


### PR DESCRIPTION
DatabseClient.

So we can incorporate your pull request, please share the following:
* What issue are you addressing with this pull request?
* Are you modifying the correct branch? (See CONTRIBUTING.md)
* Have you run unit tests? (See CONTRIBUTING.md)
* Version of MarkLogic Java Client API (see Readme.txt)
* Version of MarkLogic Server (see admin gui on port 8001)
* Java version (`java -version`)
* OS and version
* What Changed: What happened before this change? What happens without this change?
