### PR TITLE
updating copyright to 2020

### DIFF
--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/StringQueryHostBatcherTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/StringQueryHostBatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/document/DocumentWriteOperation.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/document/DocumentWriteOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright 2012-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/DocumentWriteOperationImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/DocumentWriteOperationImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright 2012-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/DocumentWriteSetImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/DocumentWriteSetImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright 2012-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/WriteBatcherTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/WriteBatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright 2015-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
So we can incorporate your pull request, please share the following:
* What issue are you addressing with this pull request?
Copyright upgrade
* Are you modifying the correct branch? (See CONTRIBUTING.md)
Yes
* Have you run unit tests? (See CONTRIBUTING.md)
No
* Version of MarkLogic Java Client API (see Readme.txt)
5.1.0
* Version of MarkLogic Server (see admin gui on port 8001)
NA
* Java version (`java -version`)
NA
* OS and version
* What Changed: What happened before this change? What happens without this change?
