### PR TITLE
test cleanup - forest count in cluster environment,  #1196

### DIFF
--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/document/DocumentWriteOperationTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/document/DocumentWriteOperationTest.java
@@ -15,6 +15,8 @@
  */
 package com.marklogic.client.test.document;
 
+import com.marklogic.client.datamovement.DataMovementManager;
+import com.marklogic.client.datamovement.ForestConfiguration;
 import com.marklogic.client.document.*;
 import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.Format;
@@ -322,7 +324,11 @@ public class DocumentWriteOperationTest {
         textDocumentManager.write(batch);
         StructuredQueryDefinition query = new StructuredQueryBuilder().collection(collectionName);
 
-        int forestCount = 3;
+        int forestCount;
+        DataMovementManager moveMgr = Common.client.newDataMovementManager();
+        ForestConfiguration forest = moveMgr.readForestConfig();
+        forestCount = forest.listForests().length;
+
         DocumentPage[] documents = new DocumentPage[forestCount];
         ArrayList<Set<String>> sets = new ArrayList<Set<String>>();
 


### PR DESCRIPTION
So we can incorporate your pull request, please share the following:
* What issue are you addressing with this pull request? forestCount in cluster envrionment
* Are you modifying the correct branch? (See CONTRIBUTING.md) yes, develop
* Have you run unit tests? (See CONTRIBUTING.md) Yes
* Version of MarkLogic Java Client API (see Readme.txt) 5.2
* Version of MarkLogic Server (see admin gui on port 8001) 10.0 nightly
* Java version (`java -version`) 11
* OS and version Mac
* What Changed: What happened before this change? What happens without this change?
