### PR TITLE
Updating copyright string

### DIFF
--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/ApplyTransformTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/ApplyTransformTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/DeleteListenerTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/DeleteListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/ExportListenerTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/ExportListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/ExportToWriterListenerTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/ExportToWriterListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/QBFailover.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/QBFailover.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/QueryBatcherJobReportTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/QueryBatcherJobReportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/StringQueryHostBatcherTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/StringQueryHostBatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2020 MarkLogic Corporation
+ * Copyright (c) 2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/UrisToWriterListenerFuncTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/UrisToWriterListenerFuncTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/WBFailover.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/WBFailover.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2014-2019 MarkLogic Corporation
+* Copyright (c) 2019 MarkLogic Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/WriteBatcherJobReportTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/WriteBatcherJobReportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/WriteHostBatcherTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/WriteHostBatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2020 MarkLogic Corporation
+ * Copyright (c) 2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/Artifact.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/Artifact.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactIndexedOnCalendar.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactIndexedOnCalendar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactIndexedOnDateTime.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactIndexedOnDateTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactIndexedOnFloat.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactIndexedOnFloat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactIndexedOnInt.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactIndexedOnInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactIndexedOnIntAsString.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactIndexedOnIntAsString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactIndexedOnInteger.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactIndexedOnInteger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactIndexedOnMultipleFields.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactIndexedOnMultipleFields.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactIndexedOnString.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactIndexedOnString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactIndexedOnStringSub.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactIndexedOnStringSub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactIndexedOnUri.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactIndexedOnUri.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactIndexedUnSupportedDataType.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactIndexedUnSupportedDataType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactMultipleIndexedOnInt.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactMultipleIndexedOnInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/BasicJavaClientREST.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/BasicJavaClientREST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/Company.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/Company.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ConnectedRESTQA.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ConnectedRESTQA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/GeoCompany.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/GeoCompany.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/GeoSpecialArtifact.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/GeoSpecialArtifact.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/JavaApiBatchSuite.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/JavaApiBatchSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ import org.junit.runner.notification.Failure;
 public class JavaApiBatchSuite {
 
   /*
-   * Copyright 2003-2013 MarkLogic Corporation. All Rights Reserved.
+   * Copyright (c) 2019 MarkLogic Corporation
    */
 
   private static final Class<?>[] testClasses = { TestAggregates.class,

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/Product.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/Product.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/SpecialGeoArtifact.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/SpecialGeoArtifact.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestAggregates.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestAggregates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestAppServicesAbsRangeConstraint.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestAppServicesAbsRangeConstraint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestAppServicesCollectionConstraint.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestAppServicesCollectionConstraint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestAppServicesConstraintCombination.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestAppServicesConstraintCombination.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestAppServicesFieldConstraint.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestAppServicesFieldConstraint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestAppServicesGeoAttrPairConstraint.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestAppServicesGeoAttrPairConstraint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestAppServicesGeoElemPairConstraint.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestAppServicesGeoElemPairConstraint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestAppServicesGeoElementChildConstraint.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestAppServicesGeoElementChildConstraint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestAppServicesGeoElementConstraint.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestAppServicesGeoElementConstraint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestAppServicesRangeConstraint.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestAppServicesRangeConstraint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestAppServicesRangePathIndexConstraint.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestAppServicesRangePathIndexConstraint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestAppServicesValueConstraint.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestAppServicesValueConstraint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestAppServicesWordConstraint.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestAppServicesWordConstraint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestAutomatedPathRangeIndex.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestAutomatedPathRangeIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBiTempMetaValues.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBiTempMetaValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBiTemporal.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBiTemporal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBug18026.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBug18026.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBug18736.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBug18736.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBug18920.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBug18920.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBug18993.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBug18993.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBug21159.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBug21159.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBug26248.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBug26248.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBulkReadSample1.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBulkReadSample1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBulkReadWriteMetaDataChange.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBulkReadWriteMetaDataChange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBulkReadWriteWithJacksonDataBind.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBulkReadWriteWithJacksonDataBind.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBulkReadWriteWithJacksonHandle.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBulkReadWriteWithJacksonHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBulkReadWriteWithJacksonParserHandle.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBulkReadWriteWithJacksonParserHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBulkSearchEWithQBE.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBulkSearchEWithQBE.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBulkSearchWithKeyValQueryDef.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBulkSearchWithKeyValQueryDef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBulkSearchWithStringQueryDef.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBulkSearchWithStringQueryDef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBulkSearchWithStrucQueryDef.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBulkSearchWithStrucQueryDef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBulkWriteMetadata1.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBulkWriteMetadata1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBulkWriteMetadata2.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBulkWriteMetadata2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBulkWriteMetadatawithRawXML.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBulkWriteMetadatawithRawXML.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBulkWriteOptimisticLocking.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBulkWriteOptimisticLocking.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBulkWriteSample1.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBulkWriteSample1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBulkWriteWithTransactions.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBulkWriteWithTransactions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBulkWriteWithTransformations.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBulkWriteWithTransformations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBytesHandle.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBytesHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestCRUDModulesDb.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestCRUDModulesDb.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -199,7 +199,7 @@ public class TestCRUDModulesDb extends BasicJavaClientREST {
 
     // read it back
     String xqueryModuleAsString = libsMgr.read(Path, new StringHandle()).get();
-    assertTrue("module read and read back", xqueryModuleAsString.startsWith("Copyright 2017 MarkLogic Corporation"));
+    assertTrue("module read and read back", xqueryModuleAsString.startsWith("Copyright (c) 2019 MarkLogic Corporation"));
 
     // get the list of descriptors
     ExtensionLibraryDescriptor[] descriptors = libsMgr.list();

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestConstraintCombination.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestConstraintCombination.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDOMHandle.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDOMHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDatabaseAuthentication.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDatabaseAuthentication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientConnection.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientKerberosFromFile.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientKerberosFromFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientWithCertBasedAuth.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientWithCertBasedAuth.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientWithKerberos.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientWithKerberos.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDocumentEncoding.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDocumentEncoding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDocumentFormat.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDocumentFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDocumentMimetype.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDocumentMimetype.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDoublePrecisionGeoOps.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDoublePrecisionGeoOps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestEvalJavaScript.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestEvalJavaScript.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2020 MarkLogic Corporation
+ * Copyright (c) 2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestEvalXquery.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestEvalXquery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestEvalwithRunTimeDBnTransactions.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestEvalwithRunTimeDBnTransactions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestFieldConstraint.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestFieldConstraint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestFileHandle.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestFileHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestInputSourceHandle.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestInputSourceHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestInputStreamHandle.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestInputStreamHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestJSResourceExtensions.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestJSResourceExtensions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestJacksonAnnotationsTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestJacksonAnnotationsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestJacksonDateTimeFormat.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestJacksonDateTimeFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestLinkResultDocuments.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestLinkResultDocuments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestMetadata.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestMetadataXML.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestMetadataXML.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestMultithreading.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestMultithreading.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestNamespaces.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestNamespaces.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestOpticOnCtsQuery.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestOpticOnCtsQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestOpticOnFromSparql.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestOpticOnFromSparql.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestOpticOnLexicons.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestOpticOnLexicons.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestOpticOnLiterals.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestOpticOnLiterals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestOpticOnMixedViews.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestOpticOnMixedViews.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestOpticOnTriples.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestOpticOnTriples.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestOpticOnViews.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestOpticOnViews.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestOptimisticLocking.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestOptimisticLocking.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestOutputStreamHandle.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestOutputStreamHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestPOJOBasicSearch.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestPOJOBasicSearch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestPOJOMissingIdGetSetMethod.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestPOJOMissingIdGetSetMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestPOJOQueryBuilderContainerQuery.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestPOJOQueryBuilderContainerQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestPOJOQueryBuilderGeoQueries.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestPOJOQueryBuilderGeoQueries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestPOJOQueryBuilderValueQuery.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestPOJOQueryBuilderValueQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestPOJOReadWrite1.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestPOJOReadWrite1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestPOJOReadWriteWithTransactions.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestPOJOReadWriteWithTransactions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestPOJOSpecialCharRead.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestPOJOSpecialCharRead.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestPOJOWithDocsStoredByOthers.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestPOJOWithDocsStoredByOthers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestPOJOWithStringQD.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestPOJOWithStringQD.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestPOJOWithStrucQD.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestPOJOWithStrucQD.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestPOJOwithQBEQueryDef.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestPOJOwithQBEQueryDef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestPartialUpdate.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestPartialUpdate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestPatchCardinality.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestPatchCardinality.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestPointInTimeQuery.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestPointInTimeQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestQueryByExample.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestQueryByExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestQueryOptionBuilder.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestQueryOptionBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestQueryOptionBuilderGrammar.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestQueryOptionBuilderGrammar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestQueryOptionBuilderSearchOptions.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestQueryOptionBuilderSearchOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestQueryOptionBuilderSearchableExpression.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestQueryOptionBuilderSearchableExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestQueryOptionBuilderSortOrder.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestQueryOptionBuilderSortOrder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestQueryOptionBuilderTransformResults.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestQueryOptionBuilderTransformResults.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestQueryOptionsHandle.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestQueryOptionsHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestQueryOptionsListHandle.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestQueryOptionsListHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestRangeConstraint.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestRangeConstraint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestRangeConstraintAbsoluteBucket.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestRangeConstraintAbsoluteBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestRangeConstraintRelativeBucket.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestRangeConstraintRelativeBucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestRawAlert.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestRawAlert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestRawCombinedQuery.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestRawCombinedQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestRawCombinedQueryGeo.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestRawCombinedQueryGeo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestRawCtsQueryDefinition.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestRawCtsQueryDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestRawStructuredQuery.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestRawStructuredQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestReaderHandle.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestReaderHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestRequestLogger.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestRequestLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestResponseTransform.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestResponseTransform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestRollbackTransaction.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestRollbackTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestRuntimeDBselection.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestRuntimeDBselection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestSSLConnection.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestSSLConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestSandBox.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestSandBox.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestSearchMultibyte.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestSearchMultibyte.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestSearchMultipleForests.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestSearchMultipleForests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestSearchOnJSON.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestSearchOnJSON.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestSearchOnProperties.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestSearchOnProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestSearchOptions.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestSearchOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestSearchSuggestion.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestSearchSuggestion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestSemanticsGraphManager.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestSemanticsGraphManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestServerAssignedDocumentURI.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestServerAssignedDocumentURI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestSourceHandle.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestSourceHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestSparqlQueryManager.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestSparqlQueryManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestStandaloneGeoQuery.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestStandaloneGeoQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestStandaloneQuery.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestStandaloneQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestStringHandle.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestStringHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestStructuredQuery.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestStructuredQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestStructuredQueryMildNot.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestStructuredQueryMildNot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestStructuredSearchGeo.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestStructuredSearchGeo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestTransformXMLWithXSLT.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestTransformXMLWithXSLT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestValueConstraint.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestValueConstraint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestWordConstraint.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestWordConstraint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestWriteTextDoc.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestWriteTextDoc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestXMLDocumentRepair.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestXMLDocumentRepair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestXMLEventReaderHandle.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestXMLEventReaderHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestXMLMultiByte.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestXMLMultiByte.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestXMLStreamReaderHandle.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestXMLStreamReaderHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ThreadClass.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ThreadClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ThreadSearch.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ThreadSearch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ThreadWrite.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ThreadWrite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/data/JSResource.js
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/data/JSResource.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 MarkLogic Corporation
+ * Copyright (c) 2018 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/data/OpticsTestJSResource.js
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/data/OpticsTestJSResource.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 MarkLogic Corporation
+ * Copyright (c) 2018 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/data/custom-lib.xqy
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/data/custom-lib.xqy
@@ -1,5 +1,5 @@
 (:
-  Copyright 2014-2017 MarkLogic Corporation
+  Copyright (c) 2018 MarkLogic Corporation
  
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/data/javascriptQueries.sjs
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/data/javascriptQueries.sjs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 MarkLogic Corporation
+ * Copyright (c) 2018 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/data/module.xqy
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/data/module.xqy
@@ -1,6 +1,6 @@
 xquery version "1.0-ml";
 (:
-  Copyright 2014-2017 MarkLogic Corporation
+  Copyright (c) 2018 MarkLogic Corporation
  
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/data/result-decorator-test.xqy
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/data/result-decorator-test.xqy
@@ -1,5 +1,5 @@
 (:
-  Copyright 2014-2017 MarkLogic Corporation
+  Copyright (c) 2018 MarkLogic Corporation
  
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/data/xquery-modules-with-diff-variable-types.xqy
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/data/xquery-modules-with-diff-variable-types.xqy
@@ -1,5 +1,5 @@
 (:
-  Copyright 2014-2017 MarkLogic Corporation
+  Copyright (c) 2018 MarkLogic Corporation
  
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/rules/rule-transform.xqy
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/rules/rule-transform.xqy
@@ -1,5 +1,5 @@
 (:
-  Copyright 2014-2017 MarkLogic Corporation
+  Copyright (c) 2018 MarkLogic Corporation
  
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/transforms/add-attr-xquery-transform.xqy
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/transforms/add-attr-xquery-transform.xqy
@@ -1,5 +1,5 @@
 (:
-  Copyright 2014-2017 MarkLogic Corporation
+  Copyright (c) 2018 MarkLogic Corporation
  
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/transforms/add-element-xquery-invalid-bitemp-transform.xqy
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/transforms/add-element-xquery-invalid-bitemp-transform.xqy
@@ -1,5 +1,5 @@
 (:
-  Copyright 2014-2017 MarkLogic Corporation
+  Copyright (c) 2018 MarkLogic Corporation
  
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/transforms/add-element-xquery-transform.xqy
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/transforms/add-element-xquery-transform.xqy
@@ -1,5 +1,5 @@
 (:
-  Copyright 2014-2017 MarkLogic Corporation
+  Copyright (c) 2018 MarkLogic Corporation
  
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/transforms/timestampTransform.js
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/transforms/timestampTransform.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 MarkLogic Corporation
+ * Copyright (c) 2018 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/resources/WriteHostBatcher-testdata/add-attr-xquery-transform.xqy
+++ b/marklogic-client-api-functionaltests/src/test/resources/WriteHostBatcher-testdata/add-attr-xquery-transform.xqy
@@ -1,5 +1,5 @@
 (:
-  Copyright 2014-2017 MarkLogic Corporation
+  Copyright (c) 2018 MarkLogic Corporation
  
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClient.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClientFactory.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/FailedRequestException.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/FailedRequestException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/FailedRetryException.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/FailedRetryException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/ForbiddenUserException.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/ForbiddenUserException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/MarkLogicBindingException.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/MarkLogicBindingException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/MarkLogicIOException.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/MarkLogicIOException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/MarkLogicInternalException.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/MarkLogicInternalException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/MarkLogicServerException.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/MarkLogicServerException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/Page.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/Page.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/RequestConstants.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/RequestConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/ResourceNotFoundException.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/ResourceNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/ResourceNotResendableException.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/ResourceNotResendableException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/SessionState.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/SessionState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/Transaction.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/Transaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/UnauthorizedUserException.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/UnauthorizedUserException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/admin/ExtensionLibrariesManager.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/admin/ExtensionLibrariesManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/admin/ExtensionLibraryDescriptor.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/admin/ExtensionLibraryDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/admin/ExtensionMetadata.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/admin/ExtensionMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/admin/MethodType.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/admin/MethodType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/admin/NamespacesManager.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/admin/NamespacesManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/admin/QueryOptionsManager.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/admin/QueryOptionsManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/admin/ResourceExtensionsManager.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/admin/ResourceExtensionsManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/admin/ServerConfigurationManager.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/admin/ServerConfigurationManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/admin/TransformExtensionsManager.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/admin/TransformExtensionsManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/admin/package-info.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/admin/package-info.java
@@ -7,7 +7,7 @@
  * capabilities of the REST server.
  */
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/alerting/RuleDefinition.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/alerting/RuleDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 MarkLogic Corporation
+ * Copyright (c) 2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/alerting/RuleDefinitionList.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/alerting/RuleDefinitionList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/alerting/RuleManager.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/alerting/RuleManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/alerting/package-info.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/alerting/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/bitemporal/TemporalDescriptor.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/bitemporal/TemporalDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/bitemporal/TemporalDocumentManager.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/bitemporal/TemporalDocumentManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/ApplyTransformListener.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/ApplyTransformListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/Batch.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/Batch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/BatchEvent.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/BatchEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/BatchFailureListener.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/BatchFailureListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/BatchListener.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/BatchListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/Batcher.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/Batcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/DataMovementException.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/DataMovementException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/DataMovementManager.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/DataMovementManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/DeleteListener.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/DeleteListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/ExportListener.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/ExportListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/ExportToWriterListener.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/ExportToWriterListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/ExtractRowsViaTemplateListener.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/ExtractRowsViaTemplateListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/FailureListener.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/FailureListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/FilteredForestConfiguration.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/FilteredForestConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/Forest.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/Forest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/ForestConfiguration.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/ForestConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/HostAvailabilityListener.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/HostAvailabilityListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/JacksonCSVSplitter.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/JacksonCSVSplitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/JobReport.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/JobReport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/JobTicket.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/JobTicket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/LineSplitter.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/LineSplitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/NodeOperation.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/NodeOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 MarkLogic Corporation
+ * Copyright (c) 2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/PeekingIterator.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/PeekingIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/ProgressListener.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/ProgressListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/QueryBatch.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/QueryBatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/QueryBatchException.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/QueryBatchException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/QueryBatchListener.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/QueryBatchListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/QueryBatcher.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/QueryBatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/QueryEvent.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/QueryEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/QueryFailureListener.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/QueryFailureListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/Splitter.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/Splitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/TypedRow.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/TypedRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/UrisToWriterListener.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/UrisToWriterListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/WriteBatch.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/WriteBatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/WriteBatchListener.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/WriteBatchListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/WriteBatcher.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/WriteBatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/WriteEvent.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/WriteEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/WriteFailureListener.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/WriteFailureListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/XMLSplitter.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/XMLSplitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 MarkLogic Corporation
+ * Copyright (c) 2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/ZipSplitter.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/ZipSplitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/BatchEventImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/BatchEventImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/BatchImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/BatchImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/BatchWriteSet.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/BatchWriteSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/BatcherImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/BatcherImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/DataMovementEventImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/DataMovementEventImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/DataMovementInternalError.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/DataMovementInternalError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/DataMovementManagerImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/DataMovementManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/DataMovementServices.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/DataMovementServices.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/ForestConfigurationImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/ForestConfigurationImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/ForestImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/ForestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/JobReportImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/JobReportImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/JobReportListener.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/JobReportListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/JobTicketImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/JobTicketImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/QueryBatchImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/QueryBatchImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/QueryBatcherImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/QueryBatcherImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/QueryJobReportListener.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/QueryJobReportListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/WriteBatchImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/WriteBatchImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/WriteBatcherImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/WriteBatcherImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/WriteEventImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/WriteEventImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/WriteJobReportListener.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/WriteJobReportListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/package-info.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/package-info.java
@@ -228,7 +228,7 @@
  * <br><br><br><br><br><br><br><br><br><br><br><br><br><br>
  */
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/dataservices/ExecEndpoint.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/dataservices/ExecEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/dataservices/IOEndpoint.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/dataservices/IOEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/dataservices/InputEndpoint.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/dataservices/InputEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/dataservices/InputOutputEndpoint.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/dataservices/InputOutputEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/dataservices/OutputEndpoint.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/dataservices/OutputEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/dataservices/impl/BaseCallerImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/dataservices/impl/BaseCallerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/dataservices/impl/ExecCallerImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/dataservices/impl/ExecCallerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/dataservices/impl/ExecEndpointImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/dataservices/impl/ExecEndpointImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/dataservices/impl/IOCallerImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/dataservices/impl/IOCallerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 MarkLogic Corporation
+ * Copyright (c) 2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/dataservices/impl/IOEndpointImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/dataservices/impl/IOEndpointImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/dataservices/impl/InputCallerImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/dataservices/impl/InputCallerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/dataservices/impl/InputEndpointImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/dataservices/impl/InputEndpointImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/dataservices/impl/InputOutputCallerImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/dataservices/impl/InputOutputCallerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/dataservices/impl/InputOutputEndpointImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/dataservices/impl/InputOutputEndpointImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/dataservices/impl/OutputCallerImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/dataservices/impl/OutputCallerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/dataservices/impl/OutputEndpointImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/dataservices/impl/OutputEndpointImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/document/BinaryDocumentManager.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/document/BinaryDocumentManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/document/ContentDescriptor.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/document/ContentDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/document/DocumentDescriptor.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/document/DocumentDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/document/DocumentManager.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/document/DocumentManager.java
@@ -1,4 +1,4 @@
-/* * Copyright 2012-2019 MarkLogic Corporation
+/* * Copyright (c) 2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/document/DocumentMetadataPatchBuilder.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/document/DocumentMetadataPatchBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/document/DocumentPage.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/document/DocumentPage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/document/DocumentPatchBuilder.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/document/DocumentPatchBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/document/DocumentRecord.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/document/DocumentRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/document/DocumentUriTemplate.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/document/DocumentUriTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/document/DocumentWriteOperation.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/document/DocumentWriteOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 MarkLogic Corporation
+ * Copyright (c) 2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/document/DocumentWriteSet.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/document/DocumentWriteSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/document/GenericDocumentManager.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/document/GenericDocumentManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/document/JSONDocumentManager.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/document/JSONDocumentManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/document/ServerTransform.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/document/ServerTransform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/document/TextDocumentManager.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/document/TextDocumentManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/document/XMLDocumentManager.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/document/XMLDocumentManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/document/package-info.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/document/package-info.java
@@ -5,7 +5,7 @@
  * in different formats.
  */
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/eval/EvalResult.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/eval/EvalResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/eval/EvalResultIterator.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/eval/EvalResultIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/eval/ServerEvaluationCall.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/eval/ServerEvaluationCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/AllCookbookExamples.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/AllCookbookExamples.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/ClientCreator.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/ClientCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/DocumentDelete.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/DocumentDelete.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/DocumentFormats.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/DocumentFormats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/DocumentMetadataRead.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/DocumentMetadataRead.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/DocumentMetadataWrite.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/DocumentMetadataWrite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/DocumentOutputStream.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/DocumentOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/DocumentRead.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/DocumentRead.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/DocumentReadTransform.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/DocumentReadTransform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/DocumentWrite.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/DocumentWrite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/DocumentWriteServerURI.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/DocumentWriteServerURI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/DocumentWriteTransform.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/DocumentWriteTransform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/JAXBDocument.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/JAXBDocument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/JavascriptResourceExtension.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/JavascriptResourceExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/KerberosClientCreator.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/KerberosClientCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/KerberosSSLClientCreator.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/KerberosSSLClientCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/MultiStatementTransaction.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/MultiStatementTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/OptimisticLocking.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/OptimisticLocking.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/QueryOptions.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/QueryOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/RawClientAlert.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/RawClientAlert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/RawCombinedSearch.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/RawCombinedSearch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/ResourceExtension.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/ResourceExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/SSLClientCreator.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/SSLClientCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/SearchResponseTransform.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/SearchResponseTransform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/StringSearch.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/StringSearch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/StructuredSearch.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/StructuredSearch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/Suggest.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/Suggest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/Util.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/Util.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/datamovement/BulkExportServices.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/datamovement/BulkExportServices.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 MarkLogic Corporation
+ * Copyright (c) 2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/datamovement/BulkExportToJdbc.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/datamovement/BulkExportToJdbc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/datamovement/BulkExportWithDataService.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/datamovement/BulkExportWithDataService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 MarkLogic Corporation
+ * Copyright (c) 2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/datamovement/BulkLoadFromJdbcRaw.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/datamovement/BulkLoadFromJdbcRaw.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/datamovement/BulkLoadFromJdbcWithJoins.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/datamovement/BulkLoadFromJdbcWithJoins.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/datamovement/BulkLoadFromJdbcWithSimpleJoins.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/datamovement/BulkLoadFromJdbcWithSimpleJoins.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/datamovement/DatabaseClientSingleton.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/datamovement/DatabaseClientSingleton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/datamovement/Employee.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/datamovement/Employee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/datamovement/ExtractRowsViaTemplate.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/datamovement/ExtractRowsViaTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/datamovement/IncrementalLoadFromJdbc.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/datamovement/IncrementalLoadFromJdbc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/datamovement/LoadDetail.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/datamovement/LoadDetail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/datamovement/WriteandReadPOJOs.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/datamovement/WriteandReadPOJOs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/package-info.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/package-info.java
@@ -6,7 +6,7 @@
  * order for viewing the examples
  */
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/extension/BatchManager.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/extension/BatchManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/extension/BatchManagerExample.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/extension/BatchManagerExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/extension/DocumentSplitter.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/extension/DocumentSplitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/extension/GraphSPARQLExample.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/extension/GraphSPARQLExample.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/extension/NameConverter.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/extension/NameConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/extension/OpenCSVBatcher.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/extension/OpenCSVBatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/extension/OpenCSVBatcherExample.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/extension/OpenCSVBatcherExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/extension/SearchCollector.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/extension/SearchCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/extension/SearchCollectorExample.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/extension/SearchCollectorExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/extension/package-info.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/extension/package-info.java
@@ -3,7 +3,7 @@
  * of database documents.
  */
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/handle/DOM4JHandleExample.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/handle/DOM4JHandleExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/handle/GSONHandleExample.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/handle/GSONHandleExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/handle/HTMLCleanerHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/handle/HTMLCleanerHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/handle/HTMLCleanerHandleExample.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/handle/HTMLCleanerHandleExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/handle/JDOMHandleExample.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/handle/JDOMHandleExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/handle/JacksonHandleExample.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/handle/JacksonHandleExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/handle/URIHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/handle/URIHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/handle/URIHandleExample.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/handle/URIHandleExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/handle/package-info.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/handle/package-info.java
@@ -5,7 +5,7 @@
  * XML documents using the Open Source JDOM library.
  */
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/util/Bootstrapper.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/util/Bootstrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/util/BootstrapperExample.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/util/BootstrapperExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/util/package-info.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/util/package-info.java
@@ -2,7 +2,7 @@
  * The package provides utilities for bootstrapping and tearing down a MarkLogic REST instance.
  */
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/expression/CtsExpr.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/expression/CtsExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/expression/FnExpr.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/expression/FnExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/expression/JsonExpr.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/expression/JsonExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/expression/MapExpr.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/expression/MapExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/expression/MathExpr.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/expression/MathExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/expression/PlanBuilder.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/expression/PlanBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/expression/PlanBuilderBase.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/expression/PlanBuilderBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/expression/RdfExpr.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/expression/RdfExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/expression/RdfValue.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/expression/RdfValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/expression/SemExpr.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/expression/SemExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/expression/SemValue.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/expression/SemValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/expression/SpellExpr.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/expression/SpellExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/expression/SqlExpr.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/expression/SqlExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/expression/XdmpExpr.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/expression/XdmpExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/expression/XsExpr.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/expression/XsExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/expression/XsValue.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/expression/XsValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/expression/package-info.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/expression/package-info.java
@@ -17,7 +17,7 @@
  * </p>
  */
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/extensions/ResourceManager.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/extensions/ResourceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/extensions/ResourceServices.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/extensions/ResourceServices.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/extensions/package-info.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/extensions/package-info.java
@@ -8,7 +8,7 @@
  * for an example.
  */
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/extra/dom4j/DOM4JHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/extra/dom4j/DOM4JHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/extra/dom4j/package-info.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/extra/dom4j/package-info.java
@@ -4,7 +4,7 @@
  * data structures.  You must install the dom4j library to use this package.
  */
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/extra/gson/GSONHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/extra/gson/GSONHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/extra/gson/package-info.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/extra/gson/package-info.java
@@ -4,7 +4,7 @@
  * input and output.  You must install the GSON library to use this package.
  */
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/extra/httpclient/HttpClientConfigurator.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/extra/httpclient/HttpClientConfigurator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/extra/httpclient/package-info.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/extra/httpclient/package-info.java
@@ -6,7 +6,7 @@
  * HTTP configuration. 
  */
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/extra/jdom/JDOMHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/extra/jdom/JDOMHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/extra/jdom/package-info.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/extra/jdom/package-info.java
@@ -4,7 +4,7 @@
  * data structures.  You must install the JDOM library to use this package.
  */
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/extra/okhttpclient/OkHttpClientConfigurator.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/extra/okhttpclient/OkHttpClientConfigurator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2016 MarkLogic Corporation
+ * Copyright (c) 2018 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/AbstractLoggingManager.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/AbstractLoggingManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/AbstractQueryDefinition.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/AbstractQueryDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/BaseProxy.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/BaseProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/BaseTypeImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/BaseTypeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/BasicPage.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/BasicPage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/BinaryDocumentImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/BinaryDocumentImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/ClientCookie.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/ClientCookie.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/ClientPropertiesImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/ClientPropertiesImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/CombinedQueryBuilder.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/CombinedQueryBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/CombinedQueryBuilderImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/CombinedQueryBuilderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/CombinedQueryDefinition.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/CombinedQueryDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/CtsExprImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/CtsExprImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/DOMWriter.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/DOMWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/DatabaseClientImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/DatabaseClientImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/DeleteQueryDefinitionImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/DeleteQueryDefinitionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/DocumentDescriptorImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/DocumentDescriptorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/DocumentManagerImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/DocumentManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/DocumentMetadataPatchBuilderImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/DocumentMetadataPatchBuilderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 MarkLogic Corporation
+ * Copyright (c) 2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/DocumentPatchBuilderImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/DocumentPatchBuilderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 MarkLogic Corporation
+ * Copyright (c) 2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/DocumentUriTemplateImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/DocumentUriTemplateImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/DocumentWriteOperationImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/DocumentWriteOperationImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 MarkLogic Corporation
+ * Copyright (c) 2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/DocumentWriteSetImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/DocumentWriteSetImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 MarkLogic Corporation
+ * Copyright (c) 2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/ExtensionLibrariesManagerImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/ExtensionLibrariesManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/FailedRequest.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/FailedRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/FailedRequestParser.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/FailedRequestParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/FnExprImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/FnExprImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/GenericDocumentImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/GenericDocumentImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/GraphManagerImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/GraphManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/GraphPermissionsImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/GraphPermissionsImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/HTTPBasicAuthInterceptor.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/HTTPBasicAuthInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/HTTPKerberosAuthInterceptor.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/HTTPKerberosAuthInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/HTTPSamlAuthInterceptor.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/HTTPSamlAuthInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/HandleAccessor.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/HandleAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/HandleFactoryRegistryImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/HandleFactoryRegistryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/HandleImplementation.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/HandleImplementation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/InputStreamTee.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/InputStreamTee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/JSONDocumentImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/JSONDocumentImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/JSONStringWriter.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/JSONStringWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/JacksonBaseHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/JacksonBaseHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/JsonExprImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/JsonExprImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/MapExprImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/MapExprImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/MathExprImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/MathExprImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/NameMapBase.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/NameMapBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/NamespacesManagerImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/NamespacesManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/NodeConverter.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/NodeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/OkHttpServices.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/OkHttpServices.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 MarkLogic Corporation
+ * Copyright (c) 2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/OutputStreamTee.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/OutputStreamTee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/PlanBuilderBaseImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/PlanBuilderBaseImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/PlanBuilderImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/PlanBuilderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/PlanBuilderSubImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/PlanBuilderSubImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/PojoPageImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/PojoPageImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/PojoQueryBuilderImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/PojoQueryBuilderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/PojoRepositoryImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/PojoRepositoryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/QueryManagerImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/QueryManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/QueryOptionsManagerImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/QueryOptionsManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/QueryOptionsTransformInjectNS.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/QueryOptionsTransformInjectNS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/RESTServices.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/RESTServices.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/RawQueryDefinitionImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/RawQueryDefinitionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/RdfExprImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/RdfExprImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/RdfValueImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/RdfValueImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/ReaderTee.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/ReaderTee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/RequestLoggerImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/RequestLoggerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/RequestParametersImplementation.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/RequestParametersImplementation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/ResourceExtensionsImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/ResourceExtensionsImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/ResourceManagerImplementation.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/ResourceManagerImplementation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/ResourceServicesImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/ResourceServicesImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/RowManagerImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/RowManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/RuleManagerImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/RuleManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/SPARQLBindingImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/SPARQLBindingImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/SPARQLBindingsImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/SPARQLBindingsImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/SPARQLQueryDefinitionImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/SPARQLQueryDefinitionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/SPARQLQueryManagerImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/SPARQLQueryManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/SemExprImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/SemExprImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/SemValueImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/SemValueImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/ServerConfigurationManagerImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/ServerConfigurationManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/ServerEvaluationCallImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/ServerEvaluationCallImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/SessionStateImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/SessionStateImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/SpellExprImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/SpellExprImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/SqlExprImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/SqlExprImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/StreamingOutputImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/StreamingOutputImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/StringQueryDefinitionImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/StringQueryDefinitionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/SuggestDefinitionImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/SuggestDefinitionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/TextDocumentImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/TextDocumentImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/TransactionImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/TransactionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/TransformExtensionsImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/TransformExtensionsImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/TuplesBuilder.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/TuplesBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/UrisHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/UrisHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/UrisReadHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/UrisReadHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/Utilities.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/Utilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/ValueConverter.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/ValueConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/ValuesBuilder.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/ValuesBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/ValuesDefinitionImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/ValuesDefinitionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/ValuesListBuilder.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/ValuesListBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/ValuesListDefinitionImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/ValuesListDefinitionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/ValuesMetricImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/ValuesMetricImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/ValuesMetricsImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/ValuesMetricsImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/XMLDocumentImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/XMLDocumentImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/XdmpExprImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/XdmpExprImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/XmlFactories.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/XmlFactories.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/XsExprImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/XsExprImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/XsValueImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/XsValueImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/BaseHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/BaseHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/BytesHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/BytesHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/DOMHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/DOMHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/DocumentMetadataHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/DocumentMetadataHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/FileHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/FileHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/Format.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/Format.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/InputSourceHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/InputSourceHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/InputStreamHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/InputStreamHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/JAXBHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/JAXBHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/JSONErrorParser.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/JSONErrorParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/JacksonDatabindHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/JacksonDatabindHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/JacksonHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/JacksonHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/JacksonParserHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/JacksonParserHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/OutputStreamHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/OutputStreamHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/OutputStreamSender.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/OutputStreamSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/QueryOptionsListHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/QueryOptionsListHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/ReaderHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/ReaderHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/SearchHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/SearchHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/SourceHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/SourceHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/StringHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/StringHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/TuplesHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/TuplesHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/ValuesHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/ValuesHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/ValuesListHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/ValuesListHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/XMLEventReaderHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/XMLEventReaderHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/XMLStreamReaderHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/XMLStreamReaderHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/AbstractReadHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/AbstractReadHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/AbstractWriteHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/AbstractWriteHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/BinaryReadHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/BinaryReadHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/BinaryWriteHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/BinaryWriteHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/BufferableHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/BufferableHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/ContentHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/ContentHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/ContentHandleFactory.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/ContentHandleFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/CtsQueryWriteHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/CtsQueryWriteHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/DocumentMetadataReadHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/DocumentMetadataReadHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/DocumentMetadataWriteHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/DocumentMetadataWriteHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/DocumentPatchHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/DocumentPatchHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/GenericReadHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/GenericReadHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/GenericWriteHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/GenericWriteHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/JSONReadHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/JSONReadHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/JSONWriteHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/JSONWriteHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/OperationNotSupported.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/OperationNotSupported.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/QuadsWriteHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/QuadsWriteHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/QueryOptionsListReadHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/QueryOptionsListReadHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/QueryOptionsReadHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/QueryOptionsReadHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/QueryOptionsWriteHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/QueryOptionsWriteHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/RuleListReadHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/RuleListReadHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/RuleReadHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/RuleReadHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/RuleWriteHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/RuleWriteHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/SPARQLResultsReadHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/SPARQLResultsReadHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/SearchReadHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/SearchReadHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/StructureReadHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/StructureReadHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/StructureWriteHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/StructureWriteHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/TextReadHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/TextReadHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/TextWriteHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/TextWriteHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/TriplesReadHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/TriplesReadHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/TriplesWriteHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/TriplesWriteHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/TuplesReadHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/TuplesReadHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/ValuesListReadHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/ValuesListReadHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/ValuesReadHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/ValuesReadHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/XMLReadHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/XMLReadHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/XMLWriteHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/XMLWriteHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/package-info.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/marker/package-info.java
@@ -5,7 +5,7 @@
  * content when writing documents implement the {com.marklogic.client.io.marker.XMLWriteHandle} interface.
  */
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/package-info.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/package-info.java
@@ -6,7 +6,7 @@
  * some handles to read or write document metadata or query options or to read search results.
  */
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/package-info.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/package-info.java
@@ -9,7 +9,7 @@
  * exceptions in this package enumerate the ways in which a REST server request can go wrong.
  */
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/pojo/PojoPage.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/pojo/PojoPage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/pojo/PojoQueryBuilder.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/pojo/PojoQueryBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/pojo/PojoQueryDefinition.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/pojo/PojoQueryDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/pojo/PojoRepository.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/pojo/PojoRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/pojo/annotation/GeospatialLatitude.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/pojo/annotation/GeospatialLatitude.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/pojo/annotation/GeospatialPathIndexProperty.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/pojo/annotation/GeospatialPathIndexProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/pojo/annotation/Id.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/pojo/annotation/Id.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/pojo/annotation/PathIndexProperty.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/pojo/annotation/PathIndexProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/pojo/package-info.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/pojo/package-info.java
@@ -7,7 +7,7 @@
  * objects persisted using PojoRepository.
  */
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/pojo/util/GenerateIndexConfig.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/pojo/util/GenerateIndexConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/AggregateResult.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/AggregateResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/CountedDistinctValue.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/CountedDistinctValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/DeleteQueryDefinition.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/DeleteQueryDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/ExtractedItem.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/ExtractedItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/ExtractedResult.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/ExtractedResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/FacetHeatmapValue.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/FacetHeatmapValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/FacetResult.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/FacetResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/FacetValue.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/FacetValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/MatchDocumentSummary.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/MatchDocumentSummary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/MatchLocation.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/MatchLocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/MatchSnippet.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/MatchSnippet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/QueryDefinition.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/QueryDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/QueryManager.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/QueryManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/QueryOptionsListBuilder.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/QueryOptionsListBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/QueryOptionsListResults.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/QueryOptionsListResults.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/RawCombinedQueryDefinition.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/RawCombinedQueryDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/RawCtsQueryDefinition.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/RawCtsQueryDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/RawQueryByExampleDefinition.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/RawQueryByExampleDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/RawQueryDefinition.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/RawQueryDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/RawStructuredQueryDefinition.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/RawStructuredQueryDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/SearchMetrics.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/SearchMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/SearchResults.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/SearchResults.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/StringQueryDefinition.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/StringQueryDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/StructuredQueryBuilder.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/StructuredQueryBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/StructuredQueryDefinition.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/StructuredQueryDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/SuggestDefinition.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/SuggestDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/Tuple.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/Tuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/TuplesResults.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/TuplesResults.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/TypedDistinctValue.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/TypedDistinctValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/ValueQueryDefinition.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/ValueQueryDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/ValuesDefinition.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/ValuesDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/ValuesListDefinition.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/ValuesListDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/ValuesListResults.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/ValuesListResults.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/ValuesMetrics.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/ValuesMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/ValuesResults.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/ValuesResults.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/package-info.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/package-info.java
@@ -5,7 +5,7 @@
  * for different ways of querying the database.
  */
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/row/RawPlanDefinition.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/row/RawPlanDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/row/RowManager.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/row/RowManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/row/RowRecord.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/row/RowRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/row/RowSet.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/row/RowSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/row/package-info.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/row/package-info.java
@@ -6,7 +6,7 @@
  * to build plan requests.
  */
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/semantics/Capability.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/semantics/Capability.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/semantics/GraphManager.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/semantics/GraphManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/semantics/GraphPermissions.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/semantics/GraphPermissions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/semantics/RDFMimeTypes.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/semantics/RDFMimeTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/semantics/RDFTypes.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/semantics/RDFTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/semantics/SPARQLBinding.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/semantics/SPARQLBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/semantics/SPARQLBindings.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/semantics/SPARQLBindings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/semantics/SPARQLMimeTypes.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/semantics/SPARQLMimeTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/semantics/SPARQLQueryDefinition.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/semantics/SPARQLQueryDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/semantics/SPARQLQueryManager.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/semantics/SPARQLQueryManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/semantics/SPARQLRuleset.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/semantics/SPARQLRuleset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/CtsBoxExpr.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/CtsBoxExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/CtsBoxSeqExpr.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/CtsBoxSeqExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/CtsCircleExpr.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/CtsCircleExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/CtsCircleSeqExpr.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/CtsCircleSeqExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/CtsPeriodExpr.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/CtsPeriodExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/CtsPeriodSeqExpr.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/CtsPeriodSeqExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/CtsPointExpr.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/CtsPointExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/CtsPointSeqExpr.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/CtsPointSeqExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/CtsPolygonExpr.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/CtsPolygonExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/CtsPolygonSeqExpr.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/CtsPolygonSeqExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/CtsQueryExpr.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/CtsQueryExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/CtsQuerySeqExpr.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/CtsQuerySeqExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/CtsReferenceExpr.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/CtsReferenceExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/CtsReferenceSeqExpr.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/CtsReferenceSeqExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/CtsRegionExpr.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/CtsRegionExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/CtsRegionSeqExpr.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/CtsRegionSeqExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/ItemSeqVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/ItemSeqVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/ItemVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/ItemVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanAggregateCol.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanAggregateCol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanAggregateColSeq.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanAggregateColSeq.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanCase.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanCaseSeq.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanCaseSeq.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanColumn.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanColumn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanColumnSeq.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanColumnSeq.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanCondition.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanCondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanConditionSeq.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanConditionSeq.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanExprCol.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanExprCol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanExprColSeq.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanExprColSeq.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanFunction.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanFunctionSeq.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanFunctionSeq.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanGroupConcatOption.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanGroupConcatOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanGroupConcatOptionSeq.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanGroupConcatOptionSeq.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanJoinKey.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanJoinKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanJoinKeySeq.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanJoinKeySeq.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanJsonProperty.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanJsonProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanJsonPropertySeq.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanJsonPropertySeq.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanParamBindingSeqVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanParamBindingSeqVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanParamBindingVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanParamBindingVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanParamExpr.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanParamExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanParamSeqExpr.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanParamSeqExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanPrefixer.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanPrefixer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanPrefixerSeq.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanPrefixerSeq.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanSortKey.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanSortKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanSortKeySeq.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanSortKeySeq.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanSystemColumn.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanSystemColumn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanSystemColumnSeq.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanSystemColumnSeq.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanTripleOption.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanTripleOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanTriplePattern.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanTriplePattern.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanTriplePatternSeq.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanTriplePatternSeq.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanTriplePosition.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanTriplePosition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanTriplePositionSeq.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanTriplePositionSeq.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanValueOption.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanValueOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanValueOptionSeq.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanValueOptionSeq.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/RdfLangStringSeqVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/RdfLangStringSeqVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/RdfLangStringVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/RdfLangStringVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/SemIriSeqVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/SemIriSeqVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/SemIriVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/SemIriVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/SemStoreExpr.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/SemStoreExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/SemStoreSeqExpr.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/SemStoreSeqExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/ServerExpression.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/ServerExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsAnyAtomicTypeSeqVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsAnyAtomicTypeSeqVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsAnyAtomicTypeVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsAnyAtomicTypeVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsAnySimpleTypeSeqVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsAnySimpleTypeSeqVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsAnySimpleTypeVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsAnySimpleTypeVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsAnyURISeqVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsAnyURISeqVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsAnyURIVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsAnyURIVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsBase64BinarySeqVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsBase64BinarySeqVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsBase64BinaryVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsBase64BinaryVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsBooleanSeqVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsBooleanSeqVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsBooleanVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsBooleanVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsByteSeqVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsByteSeqVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsByteVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsByteVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsDateSeqVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsDateSeqVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsDateTimeSeqVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsDateTimeSeqVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsDateTimeVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsDateTimeVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsDateVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsDateVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsDayTimeDurationSeqVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsDayTimeDurationSeqVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsDayTimeDurationVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsDayTimeDurationVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsDecimalSeqVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsDecimalSeqVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsDecimalVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsDecimalVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsDoubleSeqVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsDoubleSeqVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsDoubleVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsDoubleVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsDurationSeqVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsDurationSeqVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsDurationVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsDurationVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsFloatSeqVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsFloatSeqVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsFloatVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsFloatVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsGDaySeqVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsGDaySeqVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsGDayVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsGDayVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsGMonthDaySeqVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsGMonthDaySeqVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsGMonthDayVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsGMonthDayVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsGMonthSeqVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsGMonthSeqVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsGMonthVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsGMonthVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsGYearMonthSeqVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsGYearMonthSeqVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsGYearMonthVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsGYearMonthVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsGYearSeqVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsGYearSeqVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsGYearVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsGYearVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsHexBinarySeqVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsHexBinarySeqVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsHexBinaryVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsHexBinaryVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsIntSeqVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsIntSeqVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsIntVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsIntVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsIntegerSeqVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsIntegerSeqVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsIntegerVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsIntegerVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsLongSeqVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsLongSeqVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsLongVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsLongVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsNonNegativeIntegerSeqVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsNonNegativeIntegerSeqVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsNonNegativeIntegerVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsNonNegativeIntegerVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsNumericSeqVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsNumericSeqVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsNumericVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsNumericVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsQNameSeqVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsQNameSeqVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsQNameVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsQNameVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsShortSeqVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsShortSeqVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsShortVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsShortVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsStringSeqVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsStringSeqVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsStringVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsStringVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsTimeSeqVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsTimeSeqVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsTimeVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsTimeVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsUnsignedByteSeqVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsUnsignedByteSeqVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsUnsignedByteVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsUnsignedByteVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsUnsignedIntSeqVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsUnsignedIntSeqVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsUnsignedIntVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsUnsignedIntVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsUnsignedLongSeqVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsUnsignedLongSeqVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsUnsignedLongVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsUnsignedLongVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsUnsignedShortSeqVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsUnsignedShortSeqVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsUnsignedShortVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsUnsignedShortVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsUntypedAtomicSeqVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsUntypedAtomicSeqVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsUntypedAtomicVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsUntypedAtomicVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsYearMonthDurationSeqVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsYearMonthDurationSeqVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/XsYearMonthDurationVal.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/XsYearMonthDurationVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/package-info.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/package-info.java
@@ -4,7 +4,7 @@
  * or returned from a {@link com.marklogic.client.row.RowRecord} method.
  */
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/util/EditableNamespaceContext.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/util/EditableNamespaceContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/util/IterableNamespaceContext.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/util/IterableNamespaceContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/util/NameMap.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/util/NameMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/util/RequestLogger.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/util/RequestLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/util/RequestParameters.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/util/RequestParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/util/package-info.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/util/package-info.java
@@ -3,7 +3,7 @@
  * shared across other packages.
  */
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/resources/property.xsd
+++ b/marklogic-client-api/src/main/resources/property.xsd
@@ -1,4 +1,4 @@
-<!-- Copyright 2002-2019 MarkLogic Corporation.  All Rights Reserved. -->
+<!-- Copyright (c) 2019 MarkLogic Corporation -->
 <xs:schema targetNamespace="http://marklogic.com/xdmp/property"
  xsi:schemaLocation="http://www.w3.org/2001/XMLSchema XMLSchema.xsd
                      http://marklogic.com/xdmp/security security.xsd"

--- a/marklogic-client-api/src/main/resources/scripts/dictionary.xqy
+++ b/marklogic-client-api/src/main/resources/scripts/dictionary.xqy
@@ -1,6 +1,6 @@
 xquery version "1.0-ml";
 
-(: Copyright 2011-2019 MarkLogic Corporation.  All Rights Reserved. :)
+(: Copyright (c) 2019 MarkLogic Corporation :)
 
 module namespace dictionary = "http://marklogic.com/rest-api/resource/dictionary";
 

--- a/marklogic-client-api/src/main/resources/scripts/docbatch.xqy
+++ b/marklogic-client-api/src/main/resources/scripts/docbatch.xqy
@@ -1,6 +1,6 @@
 xquery version "1.0-ml";
 
-(: Copyright 2011-2019 MarkLogic Corporation.  All Rights Reserved. :)
+(: Copyright (c) 2019 MarkLogic Corporation :)
 
 module namespace docbatch = "http://marklogic.com/rest-api/resource/docbatch";
 

--- a/marklogic-client-api/src/main/resources/scripts/docsplit.xqy
+++ b/marklogic-client-api/src/main/resources/scripts/docsplit.xqy
@@ -1,6 +1,6 @@
 xquery version "1.0-ml";
 
-(: Copyright 2011-2019 MarkLogic Corporation.  All Rights Reserved. :)
+(: Copyright (c) 2019 MarkLogic Corporation :)
 
 module namespace docsplit = "http://marklogic.com/rest-api/resource/docsplit";
 

--- a/marklogic-client-api/src/main/resources/scripts/html2xhtml.xqy
+++ b/marklogic-client-api/src/main/resources/scripts/html2xhtml.xqy
@@ -1,6 +1,6 @@
 xquery version "1.0-ml";
 
-(: Copyright 2011-2019 MarkLogic Corporation.  All Rights Reserved. :)
+(: Copyright (c) 2019 MarkLogic Corporation :)
 
 (: An XQuery transform must follow some conventions rigorously:
    *  The transform must be an XQuery library module

--- a/marklogic-client-api/src/main/resources/scripts/searchcollect.xqy
+++ b/marklogic-client-api/src/main/resources/scripts/searchcollect.xqy
@@ -1,6 +1,6 @@
 xquery version "1.0-ml";
 
-(: Copyright 2011-2019 MarkLogic Corporation.  All Rights Reserved. :)
+(: Copyright (c) 2019 MarkLogic Corporation :)
 
 module namespace searchcollect = "http://marklogic.com/rest-api/resource/searchcollect";
 

--- a/marklogic-client-api/src/main/resources/search.xsd
+++ b/marklogic-client-api/src/main/resources/search.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright 2002-2019 MarkLogic Corporation.  All Rights Reserved. -->
+<!-- Copyright (c) 2019 MarkLogic Corporation -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://marklogic.com/appservices/search" xmlns:search="http://marklogic.com/appservices/search">
   <!--
     Notice: The *.rnc are the normative human-edited versions

--- a/marklogic-client-api/src/main/resources/security.xsd
+++ b/marklogic-client-api/src/main/resources/security.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright 2002-2019 MarkLogic Corporation.  All Rights Reserved. -->
+<!-- Copyright (c) 2019 MarkLogic Corporation -->
 <xs:schema targetNamespace="http://marklogic.com/xdmp/security"
  xsi:schemaLocation="http://www.w3.org/2001/XMLSchema XMLSchema.xsd
                      http://www.w3.org/1999/xhtml xhtml-inlstyle-1.xsd"

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/AlertingTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/AlertingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/BinaryDocumentTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/BinaryDocumentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/BitemporalFeaturesTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/BitemporalFeaturesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/BitemporalTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/BitemporalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/BufferableHandleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/BufferableHandleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/BulkReadWriteTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/BulkReadWriteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/City.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/City.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/ClosingHandlesTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/ClosingHandlesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/CombinedQueryBuilderTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/CombinedQueryBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/Common.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/Common.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/ConditionalDocumentTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/ConditionalDocumentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/Country.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/Country.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/DOMSearchResultTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/DOMSearchResultTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/DatabaseClientFactoryTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/DatabaseClientFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/DatabaseClientTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/DatabaseClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/DeleteSearchTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/DeleteSearchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/DocumentMetadataHandleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/DocumentMetadataHandleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/EvalTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/EvalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/ExtensionLibrariesTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/ExtensionLibrariesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/FailedRequestTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/FailedRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/GenericDocumentTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/GenericDocumentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/GeospatialRegionQueriesTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/GeospatialRegionQueriesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/GraphsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/GraphsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/HandleAccessorTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/HandleAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/HandleAsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/HandleAsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/InvalidUserTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/InvalidUserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/JAXBHandleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/JAXBHandleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/JSONDocumentTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/JSONDocumentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/JacksonDatabindTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/JacksonDatabindTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/JacksonHandleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/JacksonHandleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/JacksonStreamTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/JacksonStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/NamespacesManagerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/NamespacesManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/PageTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/PageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/PlanGeneratedBase.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/PlanGeneratedBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/PlanGeneratedTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/PlanGeneratedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/PojoFacadeTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/PojoFacadeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/QueryByExampleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/QueryByExampleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/QueryOptionsListHandleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/QueryOptionsListHandleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/QueryOptionsManagerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/QueryOptionsManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/RawCtsQueryDefinitionTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/RawCtsQueryDefinitionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/RawQueryDefinitionTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/RawQueryDefinitionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/RequestLoggerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/RequestLoggerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/ResourceExtensionsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/ResourceExtensionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/ResourceServicesTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/ResourceServicesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/RowManagerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/RowManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/RowRecordTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/RowRecordTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/SPARQLManagerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/SPARQLManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/SPARQLQueryDefinitionTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/SPARQLQueryDefinitionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/SPARQLQueryManagerImplTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/SPARQLQueryManagerImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/SSLTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/SSLTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/SearchFacetTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/SearchFacetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/SemanticsPermissionsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/SemanticsPermissionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/ServerConfigurationManagerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/ServerConfigurationManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/StringSearchTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/StringSearchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/StructuredQueryBuilderTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/StructuredQueryBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/StructuredSearchTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/StructuredSearchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/SuggestTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/SuggestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/TextDocumentTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/TextDocumentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/TimeTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/TimeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/TransformExtensionsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/TransformExtensionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/TransformTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/TransformTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/TuplesHandleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/TuplesHandleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/ValueConverterTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/ValueConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/ValuesHandleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/ValuesHandleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/XMLDocumentTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/XMLDocumentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/ApplyTransformTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/ApplyTransformTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/DeleteListenerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/DeleteListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/ExportToWriterListenerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/ExportToWriterListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/FilteredForestConfigTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/FilteredForestConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/ForestConfigTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/ForestConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/JacksonCSVSplitterTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/JacksonCSVSplitterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/LegalHoldsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/LegalHoldsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/PointInTimeQueryTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/PointInTimeQueryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/ProgressListenerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/ProgressListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/QueryBatcherImplTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/QueryBatcherImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/QueryBatcherIteratorTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/QueryBatcherIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/QueryBatcherTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/QueryBatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/ScenariosTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/ScenariosTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/WriteBatcherTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/WriteBatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 MarkLogic Corporation
+ * Copyright (c) 2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/XMLSplitterTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/XMLSplitterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 MarkLogic Corporation
+ * Copyright (c) 2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/javadocExamples/PackageExamplesTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/javadocExamples/PackageExamplesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/javadocExamples/UrisToWriterListenerExamplesTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/javadocExamples/UrisToWriterListenerExamplesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/BulkIOEndpointTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/BulkIOEndpointTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/BulkInputCallerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/BulkInputCallerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/BulkOutputCallerNext.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/BulkOutputCallerNext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/BulkOutputCallerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/BulkOutputCallerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/IOCallerImplTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/IOCallerImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/IOTestUtil.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/IOTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/InputEndpointImplTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/InputEndpointImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/OutputEndpointImplTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/OutputEndpointImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/document/DocumentWriteOperationTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/document/DocumentWriteOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 MarkLogic Corporation
+ * Copyright (c) 2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/ClientCreatorTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/ClientCreatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentDeleteTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentDeleteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentFormatsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentFormatsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentMetadataReadTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentMetadataReadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentMetadataWriteTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentMetadataWriteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentOutputStreamTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentOutputStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentReadTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentReadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentReadTransformTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentReadTransformTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentWriteServerURITest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentWriteServerURITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentWriteTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentWriteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentWriteTransformTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentWriteTransformTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/ExtractRowsViaTemplateTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/ExtractRowsViaTemplateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/JAXBDocumentTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/JAXBDocumentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/JavascriptExtensionTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/JavascriptExtensionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/MultiStatementTransactionTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/MultiStatementTransactionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/OptimisticLockingTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/OptimisticLockingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/QueryOptionsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/QueryOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/RawClientAlertTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/RawClientAlertTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/RawCombinedSearchTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/RawCombinedSearchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/ResourceExtensionTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/ResourceExtensionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/SearchResponseTransformTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/SearchResponseTransformTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/StringSearchTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/StringSearchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/StructuredSearchTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/StructuredSearchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/WriteandReadPOJOsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/WriteandReadPOJOsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/extension/BatchManagerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/extension/BatchManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/extension/GraphSPARQLExampleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/extension/GraphSPARQLExampleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/extension/OpenCSVBatcherTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/extension/OpenCSVBatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/extension/SearchCollectorTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/extension/SearchCollectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/handle/HTMLCleanerHandleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/handle/HTMLCleanerHandleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/handle/URIHandleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/handle/URIHandleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/extra/DOM4JHandleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/extra/DOM4JHandleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/extra/GSONHandleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/extra/GSONHandleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/extra/JDOMHandleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/extra/JDOMHandleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/util/Referred.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/util/Referred.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/util/Refers.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/util/Refers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/util/TestServerBootstrapper.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/util/TestServerBootstrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/resources/bootstrap.xqy
+++ b/marklogic-client-api/src/test/resources/bootstrap.xqy
@@ -1,7 +1,7 @@
 xquery version "1.0-ml";
 
 module namespace bootstrap = "http://marklogic.com/rest-api/resource/bootstrap";
-(: Copyright 2002-2018 Mark Logic Corporation.  All Rights Reserved. :)
+(: Copyright (c) 2018 MarkLogic Corporation :)
 
 import module namespace admin = "http://marklogic.com/xdmp/admin" at "/MarkLogic/admin.xqy";
 import module namespace temporal = "http://marklogic.com/xdmp/temporal" at "/MarkLogic/temporal.xqy";

--- a/marklogic-client-api/src/test/resources/data/people.xml
+++ b/marklogic-client-api/src/test/resources/data/people.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- Copyright 2020 MarkLogic Corporation
+ Copyright (c) 2020 MarkLogic Corporation
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/resources/search.xsd
+++ b/marklogic-client-api/src/test/resources/search.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright 2002-2019 MarkLogic Corporation.  All Rights Reserved. -->
+<!-- Copyright (c) 2019 MarkLogic Corporation -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://marklogic.com/appservices/search" xmlns:search="http://marklogic.com/appservices/search">
   <!-- Root element -->
   <xs:complexType name="OptionsType">

--- a/ml-development-tools/src/main/kotlin/com/marklogic/client/tools/fnclassgen.kt
+++ b/ml-development-tools/src/main/kotlin/com/marklogic/client/tools/fnclassgen.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 MarkLogic Corporation
+ * Copyright (c) 2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ml-development-tools/src/main/kotlin/com/marklogic/client/tools/fnmodinit.kt
+++ b/ml-development-tools/src/main/kotlin/com/marklogic/client/tools/fnmodinit.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 MarkLogic Corporation
+ * Copyright (c) 2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ml-development-tools/src/main/kotlin/com/marklogic/client/tools/gradle/EndpointProxiesConfig.kt
+++ b/ml-development-tools/src/main/kotlin/com/marklogic/client/tools/gradle/EndpointProxiesConfig.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ml-development-tools/src/main/kotlin/com/marklogic/client/tools/gradle/EndpointProxiesGenTask.kt
+++ b/ml-development-tools/src/main/kotlin/com/marklogic/client/tools/gradle/EndpointProxiesGenTask.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ml-development-tools/src/main/kotlin/com/marklogic/client/tools/gradle/ModuleInitTask.kt
+++ b/ml-development-tools/src/main/kotlin/com/marklogic/client/tools/gradle/ModuleInitTask.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ml-development-tools/src/main/kotlin/com/marklogic/client/tools/gradle/ServiceCompareTask.kt
+++ b/ml-development-tools/src/main/kotlin/com/marklogic/client/tools/gradle/ServiceCompareTask.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ml-development-tools/src/main/kotlin/com/marklogic/client/tools/gradle/ToolsPlugin.kt
+++ b/ml-development-tools/src/main/kotlin/com/marklogic/client/tools/gradle/ToolsPlugin.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ml-development-tools/src/main/kotlin/com/marklogic/client/tools/proxy/Generator.kt
+++ b/ml-development-tools/src/main/kotlin/com/marklogic/client/tools/proxy/Generator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ml-development-tools/src/main/resources/META-INF/gradle-plugins/com.marklogic.ml-development-tools.properties
+++ b/ml-development-tools/src/main/resources/META-INF/gradle-plugins/com.marklogic.ml-development-tools.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2019 MarkLogic Corporation
+# Copyright (c) 2019 MarkLogic Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ml-development-tools/src/test/java/com/marklogic/client/test/dbfunction/positive/DecoratorBaseBundleTest.java
+++ b/ml-development-tools/src/test/java/com/marklogic/client/test/dbfunction/positive/DecoratorBaseBundleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ml-development-tools/src/test/java/com/marklogic/client/test/dbfunction/positive/DecoratorCustomBundleTest.java
+++ b/ml-development-tools/src/test/java/com/marklogic/client/test/dbfunction/positive/DecoratorCustomBundleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ml-development-tools/src/test/java/com/marklogic/client/test/dbfunction/positive/DescribedBundleTest.java
+++ b/ml-development-tools/src/test/java/com/marklogic/client/test/dbfunction/positive/DescribedBundleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ml-development-tools/src/test/java/com/marklogic/client/test/dbfunction/positive/MimetypeBundleTest.java
+++ b/ml-development-tools/src/test/java/com/marklogic/client/test/dbfunction/positive/MimetypeBundleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ml-development-tools/src/test/java/com/marklogic/client/test/dbfunction/positive/SessionsBundleTest.java
+++ b/ml-development-tools/src/test/java/com/marklogic/client/test/dbfunction/positive/SessionsBundleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ml-development-tools/src/test/java/com/marklogic/client/test/gradle/EndpointProxiesGenTaskTest.java
+++ b/ml-development-tools/src/test/java/com/marklogic/client/test/gradle/EndpointProxiesGenTaskTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ml-development-tools/src/test/java/com/marklogic/client/test/gradle/GradleTestUtil.java
+++ b/ml-development-tools/src/test/java/com/marklogic/client/test/gradle/GradleTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ml-development-tools/src/test/java/com/marklogic/client/test/gradle/ModuleInitTaskTest.java
+++ b/ml-development-tools/src/test/java/com/marklogic/client/test/gradle/ModuleInitTaskTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ml-development-tools/src/test/java/com/marklogic/client/test/gradle/ServiceCompareTaskTest.java
+++ b/ml-development-tools/src/test/java/com/marklogic/client/test/gradle/ServiceCompareTaskTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ml-development-tools/src/test/kotlin/com/marklogic/client/test/dbfunction/fntestconf.kt
+++ b/ml-development-tools/src/test/kotlin/com/marklogic/client/test/dbfunction/fntestconf.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 MarkLogic Corporation
+ * Copyright (c) 2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ml-development-tools/src/test/kotlin/com/marklogic/client/test/dbfunction/fntestgen.kt
+++ b/ml-development-tools/src/test/kotlin/com/marklogic/client/test/dbfunction/fntestgen.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 MarkLogic Corporation
+ * Copyright (c) 2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ml-development-tools/src/test/resources/testInspector.sjs
+++ b/ml-development-tools/src/test/resources/testInspector.sjs
@@ -1,6 +1,6 @@
 'use strict';
 /*
- * Copyright 2018-2019 MarkLogic Corporation
+ * Copyright (c) 2019 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
So we can incorporate your pull request, please share the following:
* What issue are you addressing with this pull request?
Copyright update to standard string
* Are you modifying the correct branch? (See CONTRIBUTING.md)
Yes
* Have you run unit tests? (See CONTRIBUTING.md)
NA
* Version of MarkLogic Java Client API (see Readme.txt)
NA
* Version of MarkLogic Server (see admin gui on port 8001)
NA
* Java version (`java -version`)
NA
* OS and version
NA
* What Changed: What happened before this change? What happens without this change?
Its just a copyright update. Few years did not have correct copyright year, whereas most of the files copyright string was updated with the standard string.