### PR TITLE
bumping up the plugin-publish plugin due to security vulnerability

### DIFF
--- a/ml-development-tools/build.gradle
+++ b/ml-development-tools/build.gradle
@@ -14,7 +14,7 @@ plugins {
     id 'java'
     id 'java-gradle-plugin'
     id 'maven-publish'
-    id 'com.gradle.plugin-publish' version '0.10.0'
+    id 'com.gradle.plugin-publish' version '0.11.0'
     id 'org.jetbrains.kotlin.jvm'  version '1.3.61'
 }
 


### PR DESCRIPTION
So we can incorporate your pull request, please share the following:
* What issue are you addressing with this pull request?
Unable to publish to gradle plugin site
* Are you modifying the correct branch? (See CONTRIBUTING.md)
develop
* Have you run unit tests? (See CONTRIBUTING.md)
Yes, tested while releasing 5.2.0
* Version of MarkLogic Java Client API (see Readme.txt)
5.2.0
* Version of MarkLogic Server (see admin gui on port 8001)
10.0-4
* Java version (`java -version`)
open JDK 9
* OS and version
NA
* What Changed: What happened before this change? What happens without this change?
Unable to publish to gradle plugin site. The version upgrade has been enforced.