### PR TITLE
JavaDoc change for JobReport as now it's count uris processed not que…

### DIFF
--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/JobReport.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/JobReport.java
@@ -25,25 +25,25 @@ import java.util.Calendar;
 public interface JobReport {
   /**
    * {@link WriteBatcher} : gets the number of documents written to the database<br>
-   * {@link QueryBatcher} : gets the number of uris read from the database 
+   * {@link QueryBatcher} : gets the number of uris processed from the database
    * @return the number of events that succeeded
    */
   long getSuccessEventsCount();
   /**
    * {@link WriteBatcher} : gets the number of documents that were sent but failed to write<br>
-   * {@link QueryBatcher} : gets the number of query attempts that failed (same as getFailureBatchesCount)
+   * {@link QueryBatcher} : gets the number of batches that failed to process (same as getFailureBatchesCount)
    * @return the number of events that failed
    */
   long getFailureEventsCount();
   /**
    * {@link WriteBatcher} : gets the number of batches written to the database<br>
-   * {@link QueryBatcher} : gets the number of batches of URIs read from the database
+   * {@link QueryBatcher} : gets the number of batches processed from the database
    * @return the number of batches that succeeded
    */
   long getSuccessBatchesCount();
   /**
    * {@link WriteBatcher} : gets the number of batches that the job failed to write<br>
-   * {@link QueryBatcher} : gets the number of query attempts that failed (same as getFailureEventsCount)
+   * {@link QueryBatcher} : gets the number of batches that failed to process (same as getFailureEventsCount)
    * @return the number of batches that failed
    */
   long getFailureBatchesCount();

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/QueryBatchListener.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/QueryBatchListener.java
@@ -30,8 +30,7 @@ public interface QueryBatchListener extends BatchListener<QueryBatch> {
    *
    * <pre>{@code
    *     QueryBatcher qhb = dataMovementManager.newQueryBatcher(query)
-   *         .withBatchSize(1000)
-   *         .withThreadCount(20)
+   *         .withBatchSize(1000, 20)
    *         .onUrisReady(batch -> {
    *             for ( String uri : batch.getItems() ) {
    *                 if ( uri.endsWith(".txt") ) {


### PR DESCRIPTION
…ried. Another change if example of QueryBatchListener. Promoting using of docToUriRatio in withBatchSize method instead of using withTreadCount method.

So we can incorporate your pull request, please share the following:
* What issue are you addressing with this pull request?
* Are you modifying the correct branch? (See CONTRIBUTING.md)
* Have you run unit tests? (See CONTRIBUTING.md)
* Version of MarkLogic Java Client API (see Readme.txt)
* Version of MarkLogic Server (see admin gui on port 8001)
* Java version (`java -version`)
* OS and version
* What Changed: What happened before this change? What happens without this change?
