### PR TITLE
Removed threadThrottleFactor related methods. In the next release, we…

### DIFF
--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/QueryBatcher.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/QueryBatcher.java
@@ -292,7 +292,7 @@ public interface QueryBatcher extends Batcher {
    */
   public QueryBatcher withBatchSize(int docBatchSize, int docToUriBatchRatio);
 
-  /**
+  /*
    * Sets the number of documents processed in a batch, the ratio of the document processing batch to the document uri
    * collection batch and threadThrottleFactor. For example, if docBatchSize is 100 and docToUriBatchRatio is 5, the
    * document processing batch size is 100 and the document URI collection batch is 500. Ordinarily, QueryBatcher starts
@@ -318,7 +318,7 @@ public interface QueryBatcher extends Batcher {
    */
   public int getDocToUriBatchRatio();
 
-  /**
+  /*
    * Returns threadThrottleFactor set to the QueryBatcher
    * @return threadThrottleFactor
    */

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/QueryBatcher.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/QueryBatcher.java
@@ -310,7 +310,7 @@ public interface QueryBatcher extends Batcher {
    *                             0 explicitly uses the maximum number of threads
    * @return this instance for method chaining
    */
-  public QueryBatcher withBatchSize(int docBatchSize, int docToUriBatchRatio, int threadThrottleFactor);
+  //public QueryBatcher withBatchSize(int docBatchSize, int docToUriBatchRatio, int threadThrottleFactor);
 
   /**
    * Returns docToUriBatchRatio set to the QueryBatcher
@@ -322,7 +322,7 @@ public interface QueryBatcher extends Batcher {
    * Returns threadThrottleFactor set to the QueryBatcher
    * @return threadThrottleFactor
    */
-  public int getThreadThrottleFactor();
+  //public int getThreadThrottleFactor();
 
   /**
    * Returns defaultDocBatchSize, which is calculated according to server status

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/QueryBatcherImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/QueryBatcherImpl.java
@@ -344,7 +344,7 @@ public class QueryBatcherImpl extends BatcherImpl implements QueryBatcher {
     return this;
   }
 
-  @Override
+/*  @Override
   public QueryBatcher withBatchSize(int docBatchSize, int docToUriBatchRatio, int threadThrottleFactor) {
     if (threadThrottleFactor < 0 || threadThrottleFactor > this.maxDocToUriBatchRatio) {
       throw new IllegalArgumentException("threadThrottleFactor is less than 0 or " +
@@ -356,14 +356,14 @@ public class QueryBatcherImpl extends BatcherImpl implements QueryBatcher {
     withBatchSize(docBatchSize, docToUriBatchRatio);
     this.threadThrottleFactor = threadThrottleFactor;
     return this;
-  }
+  }*/
 
   @Override
   public int getDocToUriBatchRatio() {
     return this.docToUriBatchRatio;
   }
 
-  @Override
+//  @Override
   public int getThreadThrottleFactor() {
     return this.threadThrottleFactor;
   }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/ConcurrencyTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/ConcurrencyTest.java
@@ -55,7 +55,7 @@ public class ConcurrencyTest {
         int batchSize = 20;
         int docToUriBatchRatio = 5;
         int totalCount = 1000;
-        int threadThrottleFactor = 4;
+        //int threadThrottleFactor = 4;
 
         DocumentMetadataHandle documentMetadata = new DocumentMetadataHandle().withCollections("ConcurrencyTest");
         WriteBatcher batcher = moveMgr.newWriteBatcher().withDefaultMetadata(documentMetadata);
@@ -93,7 +93,7 @@ public class ConcurrencyTest {
 
         assertTrue("Output list does not contain all number of outputs", outputUris.size() == totalCount);
 
-        QueryBatcher queryBatcherAfter = dmManager.newQueryBatcher(new StructuredQueryBuilder().collection("ConcurrencyTest"));
+/*        QueryBatcher queryBatcherAfter = dmManager.newQueryBatcher(new StructuredQueryBuilder().collection("ConcurrencyTest"));
         AtomicInteger minAfter = new AtomicInteger(Integer.MAX_VALUE);
         AtomicInteger maxAfter = new AtomicInteger(0);
         queryBatcherAfter.withBatchSize(batchSize, docToUriBatchRatio, threadThrottleFactor)
@@ -113,10 +113,10 @@ public class ConcurrencyTest {
 
         dmManager.startJob(queryBatcherAfter);
         queryBatcherAfter.awaitCompletion();
-        dmManager.stopJob(queryBatcherAfter);
+        dmManager.stopJob(queryBatcherAfter);*/
 
         assertTrue(max.get() <= forest_count * docToUriBatchRatio);
-        assertTrue(maxAfter.get() <= forest_count * (docToUriBatchRatio - threadThrottleFactor));
+        //assertTrue(maxAfter.get() <= forest_count * (docToUriBatchRatio - threadThrottleFactor));
     }
 
     static void changeAssignmentPolicy(String value) throws IOException {


### PR DESCRIPTION
…'ll have autoscaling. It has similar functionality of threadThrottleFactor. We are removing this, otherwise, it will confuse users.

So we can incorporate your pull request, please share the following:
* What issue are you addressing with this pull request? Removing threadThrottleFactor related methods and unit test
* Are you modifying the correct branch? (See CONTRIBUTING.md) develop branch
* Have you run unit tests? (See CONTRIBUTING.md) cocurrency.java test
* Version of MarkLogic Java Client API (see Readme.txt) currenct
* Version of MarkLogic Server (see admin gui on port 8001)  10
* Java version (`java -version`) 8
* OS and version Mac
* What Changed: What happened before this change? What happens without this change?
