### PR TITLE
#1294 client interface for generate view and redaction on rows

### DIFF
--- a/marklogic-client-api/src/main/java/com/marklogic/client/expression/PlanBuilder.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/expression/PlanBuilder.java
@@ -26,7 +26,7 @@ import java.util.Map;
  */
 public abstract class PlanBuilder implements PlanBuilderBase {
   protected PlanBuilder(
-    CtsExpr cts, FnExpr fn, GeoExpr geo, JsonExpr json, MapExpr map, MathExpr math, RdfExpr rdf, SemExpr sem, SpellExpr spell, SqlExpr sql, XdmpExpr xdmp, XsExpr xs
+    CtsExpr cts, FnExpr fn, GeoExpr geo, JsonExpr json, MapExpr map, MathExpr math, RdfExpr rdf, SemExpr sem, SpellExpr spell, SqlExpr sql, XdmpExpr xdmp, XsExpr xs, RdtExpr rdt
     ) {
     this.cts = cts;
      this.fn = fn;
@@ -40,7 +40,7 @@ public abstract class PlanBuilder implements PlanBuilderBase {
      this.sql = sql;
      this.xdmp = xdmp;
      this.xs = xs;
-
+     this.rdt = rdt;
   }
 /**
   * Builds expressions with cts server functions.
@@ -90,7 +90,8 @@ public abstract class PlanBuilder implements PlanBuilderBase {
   * Builds expressions with xs server functions.
   */
   public final XsExpr xs;
-/**
+  public final RdtExpr rdt;
+  /**
   * This function returns the sum of the specified numeric expressions. In expressions, the call should pass the result from an op:col function to identify a column. 
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/op:add" target="mlserverdoc">op:add</a> server function.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/expression/RdtExpr.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/expression/RdtExpr.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2021 MarkLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.marklogic.client.expression;
+
+import com.marklogic.client.type.PlanColumn;
+import com.marklogic.client.type.PlanExprCol;
+import com.marklogic.client.type.ServerExpression;
+
+import java.util.Map;
+
+/**
+ * The RdtExpr instance provides functions that build expressions
+ * for redacting the values of a column.
+ * <p>In addition to using the provided functions,
+ * you can redact any column by using {@link PlanBuilder#as(PlanColumn, ServerExpression)}
+ * to rebind the column to an expression that replaces the existing value
+ * with an altered or randomly generated value.
+ * You can also hide a column by binding the column to the null value
+ * or by projecting other columns.
+ * </p>
+ */
+public interface RdtExpr {
+    /**
+     * Redacts a column with string values by replacing each value with deterministic masking text.
+     * That is, a specific value generates the same masked value every time the value is redacted.
+     * <p>Provides a client interface to the
+     * <a href="http://docs.marklogic.com/ordt:mask-deterministic" target="mlserverdoc">ordt:mask-deterministic</a>
+     * server function.</p>
+     * @param column  the column to be redacted
+     * @return  a PlanExprCol object
+     */
+    PlanExprCol maskDeterministic(PlanColumn column);
+    /**
+     * Redacts a column with string values by replacing each value with deterministic masking text.
+     * That is, a specific value generates the same masked value every time the value is redacted.
+     * <p>Provides a client interface to the
+     * <a href="http://docs.marklogic.com/ordt:mask-deterministic" target="mlserverdoc">ordt:mask-deterministic</a>
+     * server function.</p>
+     * @param column  the column to be redacted
+     * @param options  the options for redacting the column
+     * @return  a PlanExprCol object
+     */
+    PlanExprCol maskDeterministic(PlanColumn column, Map<String,?> options);
+    /**
+     * Redacts a column with string values by replacing each value with random masking text.
+     * The same value may produce a different masked value every time the value is redacted.
+     * <p>Provides a client interface to the
+     * <a href="http://docs.marklogic.com/ordt:mask-random" target="mlserverdoc">ordt:mask-random</a>
+     * server function.</p>
+     * @param column  the column to be redacted
+     * @return  a PlanExprCol object for the redacted column
+     */
+    PlanExprCol maskRandom(PlanColumn column);
+    /**
+     * Redacts a column with string values by replacing each value with random masking text.
+     * The same value may produce a different masked value every time the value is redacted.
+     * <p>Provides a client interface to the
+     * <a href="http://docs.marklogic.com/ordt:mask-random" target="mlserverdoc">ordt:mask-random</a>
+     * server function.</p>
+     * @param column  the column to be redacted
+     * @param options  the options for redacting the column
+     * @return  a PlanExprCol object for the redacted column
+     */
+    PlanExprCol maskRandom(PlanColumn column, Map<String,?> options);
+    /**
+     * Redacts a column with date or datetime values either by masking part
+     * of the existing value or by generating a random value.
+     * <p>Provides a client interface to the
+     * <a href="http://docs.marklogic.com/ordt:redact-datetime" target="mlserverdoc">ordt:redact-datetime</a>
+     * server function.</p>
+     * @param column  the column to be redacted
+     * @param options  the options for redacting the column
+     * @return  a PlanExprCol object for the redacted column
+     */
+    PlanExprCol redactDatetime(PlanColumn column, Map<String,?> options);
+    /**
+     * Redacts a column with email address string
+     * that conforms to the pattern <code>name@domain</code>.
+     * <p>Provides a client interface to the
+     * <a href="http://docs.marklogic.com/ordt:redact-email" target="mlserverdoc">ordt:redact-email</a>
+     * server function.</p>
+     * @param column  the column to be redacted
+     * @return  a PlanExprCol object for the redacted column
+     */
+    PlanExprCol redactEmail(PlanColumn column);
+    /**
+     * Redacts a column with email address string
+     * that conforms to the pattern <code>name@domain</code>.
+     * <p>Provides a client interface to the
+     * <a href="http://docs.marklogic.com/ordt:redact-email" target="mlserverdoc">ordt:redact-email</a>
+     * server function.</p>
+     * @param column  the column to be redacted
+     * @param options  the options for redacting the column
+     * @return  a PlanExprCol object for the redacted column
+     */
+    PlanExprCol redactEmail(PlanColumn column, Map<String,?> options);
+    /**
+     * Redacts a column with IPv4 address string that conforms to a pattern with
+     * four blocks of 1-3 decimal digits separated by period (.) where the value of each block
+     * of digits is less than or equal to 255 as in <code>123.201.098.112</code> and
+     * <code>123.45.678.0</code>.
+     * <p>Provides a client interface to the
+     * <a href="http://docs.marklogic.com/ordt:redact-ipv4" target="mlserverdoc">ordt:redact-ipv4</a>
+     * server function.</p>
+     * @param column  the column to be redacted
+     * @return  a PlanExprCol object for the redacted column
+     */
+    PlanExprCol redactIpv4(PlanColumn column);
+    /**
+     * Redacts a column with IPv4 address string that conforms to a pattern with
+     * four blocks of 1-3 decimal digits separated by period (.) where the value of each block
+     * of digits is less than or equal to 255 as in <code>123.201.098.112</code> and
+     * <code>123.45.678.0</code>.
+     * <p>Provides a client interface to the
+     * <a href="http://docs.marklogic.com/ordt:redact-ipv4" target="mlserverdoc">ordt:redact-ipv4</a>
+     * server function.</p>
+     * @param column  the column to be redacted
+     * @param options  the options for redacting the column
+     * @return  a PlanExprCol object for the redacted column
+     */
+    PlanExprCol redactIpv4(PlanColumn column, Map<String,?> options);
+    /**
+     * Redacts a column by generating a random number within a configurable range
+     * either as a numeric data type or as a formatted string.
+     * <p>Provides a client interface to the
+     * <a href="http://docs.marklogic.com/ordt:redact-number" target="mlserverdoc">ordt:redact-number</a>
+     * server function.</p>
+     * @param column  the column to be redacted
+     * @return  a PlanExprCol object for the redacted column
+     */
+    PlanExprCol redactNumber(PlanColumn column);
+    /**
+     * Redacts a column by generating a random number within a configurable range
+     * either as a numeric data type or as a formatted string.
+     * <p>Provides a client interface to the
+     * <a href="http://docs.marklogic.com/ordt:redact-number" target="mlserverdoc">ordt:redact-number</a>
+     * server function.</p>
+     * @param column  the column to be redacted
+     * @param options  the options for redacting the column
+     * @return  a PlanExprCol object for the redacted column
+     */
+    PlanExprCol redactNumber(PlanColumn column, Map<String,?> options);
+    /**
+     * Redacts a string column by applying a regular expression.
+     * <p>Provides a client interface to the
+     * <a href="http://docs.marklogic.com/ordt:redact-regex" target="mlserverdoc">ordt:redact-regex</a>
+     * server function.</p>
+     * @param column  the column to be redacted
+     * @param options  the options for redacting the column
+     * @return  a PlanExprCol object for the redacted column
+     */
+    PlanExprCol redactRegex(PlanColumn column, Map<String,?> options);
+    /**
+     * Redacts a column with a 10-digit US phone number string
+     * by generating random numbers or replacing numbers with a masking character.
+     * <p>Provides a client interface to the
+     * <a href="http://docs.marklogic.com/ordt:redact-us-phone" target="mlserverdoc">ordt:redact-us-phone</a>
+     * server function.</p>
+     * @param column  the column to be redacted
+     * @return  a PlanExprCol object for the redacted column
+     */
+    PlanExprCol redactUsPhone(PlanColumn column);
+    /**
+     * Redacts a column with a 10-digit US phone number string
+     * by generating random numbers or replacing numbers with a masking character.
+     * <p>Provides a client interface to the
+     * <a href="http://docs.marklogic.com/ordt:redact-us-phone" target="mlserverdoc">ordt:redact-us-phone</a>
+     * server function.</p>
+     * @param column  the column to be redacted
+     * @param options  the options for redacting the column
+     * @return  a PlanExprCol object for the redacted column
+     */
+    PlanExprCol redactUsPhone(PlanColumn column, Map<String,?> options);
+    /**
+     * Redacts a column with a 9-digit US SSN (Social Security Number) string
+     * by generating random numbers or replacing numbers with a masking character.
+     * <p>Provides a client interface to the
+     * <a href="http://docs.marklogic.com/ordt:redact-us-ssn" target="mlserverdoc">ordt:redact-us-ssn</a>
+     * server function.</p>
+     * @param column  the column to be redacted
+     * @return  a PlanExprCol object for the redacted column
+     */
+    PlanExprCol redactUsSsn(PlanColumn column);
+    /**
+     * Redacts a column with a 9-digit US SSN (Social Security Number) string
+     * by generating random numbers or replacing numbers with a masking character.
+     * <p>Provides a client interface to the
+     * <a href="http://docs.marklogic.com/ordt:redact-us-ssn" target="mlserverdoc">ordt:redact-us-ssn</a>
+     * server function.</p>
+     * @param column  the column to be redacted
+     * @param options  the options for redacting the column
+     * @return  a PlanExprCol object for the redacted column
+     */
+    PlanExprCol redactUsSsn(PlanColumn column, Map<String,?> options);
+}

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/PlanBuilderBaseImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/PlanBuilderBaseImpl.java
@@ -37,7 +37,7 @@ abstract class PlanBuilderBaseImpl extends PlanBuilder {
     super(
       CtsExprImpl.cts, FnExprImpl.fn, GeoExprImpl.geo, JsonExprImpl.json, MapExprImpl.map,
       MathExprImpl.math, RdfExprImpl.rdf, SemExprImpl.sem, SpellExprImpl.spell,
-      SqlExprImpl.sql, XdmpExprImpl.xdmp, XsExprImpl.xs
+      SqlExprImpl.sql, XdmpExprImpl.xdmp, XsExprImpl.xs, RdtExprImpl.rdt
     );
   }
 

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/RdtExprImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/RdtExprImpl.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2021 MarkLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.marklogic.client.impl;
+
+import com.marklogic.client.expression.RdtExpr;
+import com.marklogic.client.type.PlanColumn;
+import com.marklogic.client.type.PlanExprCol;
+
+import java.util.Map;
+
+public class RdtExprImpl implements RdtExpr {
+    final static RdtExprImpl rdt = new RdtExprImpl();
+
+    @Override
+    public PlanExprCol maskDeterministic(PlanColumn column) {
+        return maskDeterministic(column, null);
+    }
+    @Override
+    public PlanExprCol maskDeterministic(PlanColumn column, Map<String,?> options) {
+        return redactImpl("maskDeterministic", "mask-deterministic", column, options);
+    }
+    @Override
+    public PlanExprCol maskRandom(PlanColumn column) {
+        return maskRandom(column, null);
+    }
+    @Override
+    public PlanExprCol maskRandom(PlanColumn column, Map<String,?> options) {
+        return redactImpl("maskRandom", "mask-random", column, options);
+    }
+    @Override
+    public PlanExprCol redactDatetime(PlanColumn column, Map<String,?> options) {
+        if (column == null) {
+            throw new IllegalArgumentException("must provide options for redactDatetime()");
+        }
+        return redactImpl("redactDatetime", "redact-datetime", column, options);
+    }
+    @Override
+    public PlanExprCol redactEmail(PlanColumn column) {
+        return redactEmail(column, null);
+    }
+    @Override
+    public PlanExprCol redactEmail(PlanColumn column, Map<String,?> options) {
+        return redactImpl("redactEmail", "redact-email", column, options);
+    }
+    @Override
+    public PlanExprCol redactIpv4(PlanColumn column) {
+        return redactIpv4(column, null);
+    }
+    @Override
+    public PlanExprCol redactIpv4(PlanColumn column, Map<String,?> options) {
+        return redactImpl("redactIpv4", "redact-ipv4", column, options);
+    }
+    @Override
+    public PlanExprCol redactNumber(PlanColumn column) {
+        return redactNumber(column, null);
+    }
+    @Override
+    public PlanExprCol redactNumber(PlanColumn column, Map<String,?> options) {
+        return redactImpl("redactNumber", "redact-number", column, options);
+    }
+    @Override
+    public PlanExprCol redactRegex(PlanColumn column, Map<String,?> options) {
+        if (column == null) {
+            throw new IllegalArgumentException("must provide options for redactRegex()");
+        }
+        return redactImpl("redactRegex", "redact-regex", column, options);
+    }
+    @Override
+    public PlanExprCol redactUsPhone(PlanColumn column) {
+        return redactUsPhone(column, null);
+    }
+    @Override
+    public PlanExprCol redactUsPhone(PlanColumn column, Map<String,?> options) {
+        return redactImpl("redactUsPhone", "redact-us-phone", column, options);
+    }
+    @Override
+    public PlanExprCol redactUsSsn(PlanColumn column) {
+        return redactUsSsn(column, null);
+    }
+    @Override
+    public PlanExprCol redactUsSsn(PlanColumn column, Map<String,?> options) {
+        return redactImpl("redactUsSsn", "redact-us-ssn", column, options);
+    }
+    private PlanExprCol redactImpl(String clientFn, String enodeFn, PlanColumn column, Map<String,?> options) {
+        if (column == null) {
+            throw new IllegalArgumentException("must provide column to redact for "+clientFn+"()");
+        }
+        return new RedactCallImpl(enodeFn, new Object[]{column, (options == null) ? null : new BaseTypeImpl.BaseMapImpl(options)});
+    }
+    static class RedactCallImpl extends PlanBuilderSubImpl.ExprColCallImpl {
+        RedactCallImpl(String fnName, Object[] fnArgs) {
+            super("ordt", fnName, fnArgs);
+        }
+    }
+}

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/RowManagerImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/RowManagerImpl.java
@@ -255,6 +255,36 @@ public class RowManagerImpl
     return handle.get();
   }
 
+  @Override
+  public <T extends XMLReadHandle> T generateView(Plan plan, String schema, String view, T resultsHandle) {
+    if (resultsHandle == null) {
+      throw new IllegalArgumentException("Must specify a handle to generate a view for the plan");
+    } else if (schema == null || schema.length() == 0) {
+      throw new IllegalArgumentException("Must specify a schema name to generate a view for the plan");
+    } else if (view == null || view.length() == 0) {
+      throw new IllegalArgumentException("Must specify a view name to generate a view for the plan");
+    }
+
+    PlanBuilderBaseImpl.RequestPlan requestPlan = checkPlan(plan);
+    AbstractWriteHandle astHandle = requestPlan.getHandle();
+
+    RequestParameters params = new RequestParameters();
+    params.add("output",     "generateView");
+    params.add("schemaName", "schema");
+    params.add("viewName",   "view");
+
+    return services.postResource(requestLogger, "rows", null, params, astHandle, resultsHandle);
+  }
+  @Override
+  public <T> T generateViewAs(Plan plan, String schema, String view, Class<T> as) {
+    ContentHandle<T> handle = handleFor(as);
+    if (generateView(plan, schema, view, (XMLReadHandle) handle) == null) {
+      return null;
+    }
+
+    return handle.get();
+  }
+
   private void addDatatypeStyleParam(RequestParameters params, RowSetPart datatypeStyle) {
     if (datatypeStyle != null) {
       switch (datatypeStyle) {

--- a/marklogic-client-api/src/main/java/com/marklogic/client/row/RowManager.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/row/RowManager.java
@@ -21,6 +21,7 @@ import com.marklogic.client.expression.PlanBuilder.Plan;
 import com.marklogic.client.io.marker.JSONWriteHandle;
 import com.marklogic.client.io.marker.StructureReadHandle;
 import com.marklogic.client.io.marker.TextWriteHandle;
+import com.marklogic.client.io.marker.XMLReadHandle;
 
 /**
  * A Row Manager provides database operations on rows projected from documents.
@@ -238,7 +239,7 @@ public interface RowManager {
      * @param plan	the definition of a plan for database rows
      * @param handle	the JSON or XML handle on the explanation for the plan
      * @param <T> the type of the explanation handle
-     * @return	an object of the IO class with the content of the explanation for the plan
+     * @return	the handle with the content of the explanation for the plan
      */
     <T extends StructureReadHandle> T explain(Plan plan, T handle);
     /**
@@ -257,4 +258,40 @@ public interface RowManager {
      * @return	an object of the IO class with the content of the explanation for the plan
      */
     <T> T explainAs(Plan plan, Class<T> as);
+
+    /**
+     * Generates generates a view that encapsulates a plan.
+     *
+     * Insert the generated XML into the schemas database and then use the
+     * {@link PlanBuilder#fromView(String, String)} accessor to query
+     * against the generated view.
+     * @param plan	the definition of a plan for database rows
+     * @param schema  the name of the schema for the new view generated from the plan
+     * @param view  the name of the new view generated from the plan
+     * @param handle	the XML handle on the generated view for the plan
+     * @param <T> the type of the handle for the generated view
+     * @return	the handle with the content of the generated view for the plan
+     */
+    <T extends XMLReadHandle> T generateView(Plan plan, String schema, String view, T handle);
+    /**
+     * Generates generates a view that encapsulates a plan.
+     *
+     * Insert the generated XML into the schemas database and then use the
+     * {@link PlanBuilder#fromView(String, String)} accessor to query
+     * against the generated view.
+     *
+     * The IO class must have been registered before creating the database client.
+     * By default, the provided handles that implement
+     * {@link com.marklogic.client.io.marker.ContentHandle ContentHandle} are registered.
+     *
+     * <a href="../../../../overview-summary.html#ShortcutMethods">Learn more about shortcut methods</a>
+     *
+     * @param plan	the definition of a plan for database rows
+     * @param schema  the name of the schema for the new view generated from the plan
+     * @param view  the name of the new view generated from the plan
+     * @param as	the IO class for reading the generated view for the plan
+     * @param <T> the type of the IO object for reading the generated view
+     * @return	an object of the IO class with the content of the generated view for the plan
+     */
+    <T> T generateViewAs(Plan plan, String schema, String view, Class<T> as);
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/PlanExpressionTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/PlanExpressionTest.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) 2021 MarkLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.marklogic.client.test;
+
+import com.marklogic.client.expression.PlanBuilder;
+import com.marklogic.client.row.RowManager;
+import com.marklogic.client.row.RowRecord;
+import com.marklogic.client.row.RowSet;
+import com.marklogic.client.type.PlanExprCol;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class PlanExpressionTest {
+    protected static RowManager rowMgr = null;
+    protected static PlanBuilder p = null;
+
+    @BeforeClass
+    public static void beforeClass() {
+        Common.connect();
+        rowMgr = Common.client.newRowManager();
+        p      = rowMgr.newPlanBuilder();
+    }
+    @AfterClass
+    public static void afterClass() {
+        p      = null;
+        rowMgr = null;
+   }
+
+   private RowRecord redactTest(String testName, Map<String,Object> testRow, PlanExprCol... cols) {
+       PlanBuilder.ModifyPlan plan =
+               p.fromLiterals(new Map[]{testRow})
+                .bind(p.colSeq(cols));
+
+       RowSet<RowRecord> rowSet = rowMgr.resultRows(plan);
+       Iterator<RowRecord> rowItr = rowSet.iterator();
+       assertTrue("no row to test for "+testName, rowItr.hasNext());
+
+       return rowItr.next();
+   }
+
+   @Test
+   public void testMaskDeterministic() {
+      final String testStr = "What is truth?";
+      final int testLen    = testStr.length();
+
+      Map<String,Object> testRow = new HashMap<>();
+      testRow.put("cDefault",             testStr);
+      testRow.put("cCharMixedCaseMaxLen", testStr);
+
+      Map<String,Object> testOpts = new HashMap<>();
+      testOpts.put("character", "mixedCase");
+      testOpts.put("maxLength", testLen);
+
+      RowRecord resultRow = redactTest("testMaskDeterministic()", testRow,
+              p.rdt.maskDeterministic(p.col("cDefault")),
+              p.rdt.maskDeterministic(p.col("cCharMixedCaseMaxLen"), testOpts)
+      );
+
+      String cDefaultVal = resultRow.getString("cDefault");
+      assertNotNull(cDefaultVal);
+      assertTrue(cDefaultVal.matches("^[A-za-z0-9+=/]+$"));
+
+      String cCharMixedCaseMaxLenVal = resultRow.getString("cCharMixedCaseMaxLen");
+      assertNotNull(cCharMixedCaseMaxLenVal);
+      assertEquals(testLen, cCharMixedCaseMaxLenVal.length());
+      assertTrue(cCharMixedCaseMaxLenVal.matches("^[A-za-z]+$"));
+   }
+   @Test
+   public void testMaskRandom() {
+      final int base64Len  = 26;
+      final String testStr = "What is truth?";
+      final int testLen    = base64Len - 1;
+
+      Map<String,Object> testRow = new HashMap<>();
+      testRow.put("cDefault",                 testStr);
+      testRow.put("cCharLowerCaseNumericLen", testStr);
+
+      Map<String,Object> testOpts = new HashMap<>();
+      testOpts.put("character", "lowerCaseNumeric");
+      testOpts.put("length",    testLen);
+
+      RowRecord resultRow = redactTest("testMaskRandom()", testRow,
+              p.rdt.maskRandom(p.col("cDefault")),
+              p.rdt.maskRandom(p.col("cCharLowerCaseNumericLen"), testOpts)
+      );
+
+      String cDefaultVal = resultRow.getString("cDefault");
+      assertNotNull(cDefaultVal);
+      assertEquals(base64Len, cDefaultVal.length());
+      assertTrue(cDefaultVal.matches("^[A-za-z0-9+=/]+$"));
+
+      String cCharLowerCaseNumericLenVal = resultRow.getString("cCharLowerCaseNumericLen");
+      assertNotNull(cCharLowerCaseNumericLenVal);
+      assertEquals(testLen, cCharLowerCaseNumericLenVal.length());
+      assertTrue(cCharLowerCaseNumericLenVal.matches("^[a-z0-9]+$"));
+   }
+   @Test
+   public void testRedactDatetime() {
+      final String testStr = "12/31/2019";
+
+      Map<String,Object> testRow = new HashMap<>();
+      testRow.put("cParsed", testStr);
+      testRow.put("cRandom", testStr);
+
+      Map<String,Object> parsedOpts = new HashMap<>();
+      parsedOpts.put("level",   "parsed");
+      parsedOpts.put("picture", "[M01]/[D01]/[Y0001]");
+      parsedOpts.put("format",  "xx/xx/[Y01]");
+
+      Map<String,Object> randomOpts = new HashMap<>();
+      randomOpts.put("level", "random");
+      randomOpts.put("range", "2000,2020");
+
+      RowRecord resultRow = redactTest("testRedactDatetime()", testRow,
+              p.rdt.redactDatetime(p.col("cParsed"), parsedOpts),
+              p.rdt.redactDatetime(p.col("cRandom"), randomOpts)
+      );
+
+      String cParsedVal = resultRow.getString("cParsed");
+      assertNotNull(cParsedVal);
+      assertEquals("xx/xx/19", cParsedVal);
+
+      String cRandomVal = resultRow.getString("cRandom");
+      assertNotNull(cRandomVal);
+      assertTrue(cRandomVal.matches("^20\\d{2}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+$"));
+   }
+   @Test
+   public void testRedactEmail() {
+      final String testStr = "thename1@thedomain1.com";
+
+      Map<String,Object> testRow = new HashMap<>();
+      testRow.put("cDefault", testStr);
+      testRow.put("cName",    testStr);
+
+      Map<String,Object> testOpts = new HashMap<>();
+      testOpts.put("level", "name");
+
+      RowRecord resultRow = redactTest("testRedactEmail()", testRow,
+              p.rdt.redactEmail(p.col("cDefault")),
+              p.rdt.redactEmail(p.col("cName"), testOpts)
+      );
+
+      String cDefaultVal = resultRow.getString("cDefault");
+      assertNotNull(cDefaultVal);
+      assertEquals("NAME@DOMAIN", cDefaultVal);
+
+      String cNameVal = resultRow.getString("cName");
+      assertNotNull(cNameVal);
+      assertEquals("NAME@thedomain1.com", cNameVal);
+   }
+   @Test
+   public void testRedactIpv4() {
+      final String testStr = "123.145.167.189";
+
+      Map<String,Object> testRow = new HashMap<>();
+      testRow.put("cDefault", testStr);
+      testRow.put("cChar",    testStr);
+
+      Map<String,Object> testOpts = new HashMap<>();
+      testOpts.put("character", "x");
+
+      RowRecord resultRow = redactTest("testRedactIpv4()", testRow,
+              p.rdt.redactIpv4(p.col("cDefault")),
+              p.rdt.redactIpv4(p.col("cChar"), testOpts)
+      );
+
+      String cDefaultVal = resultRow.getString("cDefault");
+      assertNotNull(cDefaultVal);
+      assertEquals("###.###.###.###", cDefaultVal);
+
+      String cCharVal = resultRow.getString("cChar");
+      assertNotNull(cCharVal);
+      assertEquals("xxx.xxx.xxx.xxx", cCharVal);
+   }
+   @Test
+   public void testRedactNumber() {
+      Map<String,Object> testRow = new HashMap<>();
+      testRow.put("cDefault", 1);
+      testRow.put("cDouble",  1.3);
+
+      Map<String,Object> testOpts = new HashMap<>();
+      testOpts.put("type", "double");
+      testOpts.put("min",  2);
+      testOpts.put("max",  4);
+
+      RowRecord resultRow = redactTest("testRedactNumber()", testRow,
+              p.rdt.redactNumber(p.col("cDefault")),
+              p.rdt.redactNumber(p.col("cDouble"), testOpts)
+      );
+
+      int cDefaultVal = resultRow.getInt("cDefault");
+
+      double cDoubleVal = resultRow.getDouble("cDouble");
+      assertTrue(2 <= cDoubleVal && cDoubleVal <= 4);
+   }
+   @Test
+   public void testRedactRegex() {
+      Map<String,Object> testRow = new HashMap<>();
+      testRow.put("cTarget", "thetargettext");
+
+      Map<String,Object> testOpts = new HashMap<>();
+      testOpts.put("pattern",     "tar([a-z])et");
+      testOpts.put("replacement", "=$1=");
+
+      RowRecord resultRow = redactTest("testRedactRegex()", testRow,
+              p.rdt.redactRegex(p.col("cTarget"), testOpts)
+      );
+
+      String cTargetVal = resultRow.getString("cTarget");
+      assertNotNull(cTargetVal);
+      assertEquals("the=g=text", cTargetVal);
+   }
+   @Test
+   public void testRedactUsPhone() {
+      final String testStr = "123-456-7890";
+
+      Map<String,Object> testRow = new HashMap<>();
+      testRow.put("cDefault",    testStr);
+      testRow.put("cFullRandom", testStr);
+
+      Map<String,Object> testOpts = new HashMap<>();
+      testOpts.put("level", "full-random");
+
+      RowRecord resultRow = redactTest("testRedactUsPhone()", testRow,
+              p.rdt.redactUsPhone(p.col("cDefault")),
+              p.rdt.redactUsPhone(p.col("cFullRandom"), testOpts)
+      );
+
+      String cDefaultVal = resultRow.getString("cDefault");
+      assertNotNull(cDefaultVal);
+      assertEquals("###-###-####", cDefaultVal);
+
+      String cFullRandomVal = resultRow.getString("cFullRandom");
+      assertNotNull(cFullRandomVal);
+      assertEquals(testStr.length(), cFullRandomVal.length());
+      assertTrue(cFullRandomVal.matches("^\\d{3}-\\d{3}-\\d{4}$"));
+   }
+   @Test
+   public void testRedactUsSsn() {
+      final String testStr = "123-45-6789";
+
+      Map<String,Object> testRow = new HashMap<>();
+      testRow.put("cDefault",    testStr);
+      testRow.put("cFullRandom", testStr);
+
+      Map<String,Object> testOpts = new HashMap<>();
+      testOpts.put("level", "full-random");
+
+      RowRecord resultRow = redactTest("testRedactUsSsn()", testRow,
+              p.rdt.redactUsSsn(p.col("cDefault")),
+              p.rdt.redactUsSsn(p.col("cFullRandom"), testOpts)
+      );
+
+      String cDefaultVal = resultRow.getString("cDefault");
+      assertNotNull(cDefaultVal);
+      assertEquals("###-##-####", cDefaultVal);
+
+      String cFullRandomVal = resultRow.getString("cFullRandom");
+      assertNotNull(cFullRandomVal);
+      assertEquals(testStr.length(), cFullRandomVal.length());
+      assertTrue(cFullRandomVal.matches("^\\d{3}-\\d{2}-\\d{4}$"));
+   }
+}

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/RowManagerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/RowManagerTest.java
@@ -1172,6 +1172,27 @@ public class RowManagerTest {
     }
   }
   @Test
+  public void testGenerateView() throws IOException {
+    RowManager rowMgr = Common.client.newRowManager();
+
+    PlanBuilder p = rowMgr.newPlanBuilder();
+
+    PlanBuilder.ExportablePlan builtPlan =
+          p.fromView("opticUnitTest", "musician")
+           .where(
+              p.cts.andQuery(
+                 p.cts.jsonPropertyWordQuery("instrument", "trumpet"),
+                 p.cts.jsonPropertyWordQuery(p.xs.string("lastName"), p.xs.stringSeq("Armstrong", "Davis"))
+                 )
+              )
+           .orderBy(p.col("lastName"));
+
+    Document xmlRoot = rowMgr.generateView(builtPlan, "opticUnitTest", "musicianView", new DOMHandle()).get();
+    assertNotNull(xmlRoot);
+    xmlRoot = rowMgr.generateViewAs(builtPlan, "opticUnitTest", "musicianView", Document.class);
+    assertNotNull(xmlRoot);
+  }
+  @Test
   public void testExplain() throws IOException {
     RowManager rowMgr = Common.client.newRowManager();
 


### PR DESCRIPTION
Implements the following client interfaces with unit tests and JavaDoc:

- RowManager generateView() and generateViewAs() methods
- The methods supporting "Redaction On Rows"

Support for existsJoin() and notExistsJoin() were checked in previously. 

Any concerns?
