### PR TITLE
Change log msg from warn to debug level. Added what maxDocBatchSize is in the msg #1291

### DIFF
--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/QueryBatcherImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/QueryBatcherImpl.java
@@ -313,7 +313,7 @@ public class QueryBatcherImpl extends BatcherImpl implements QueryBatcher {
   @Override
   public QueryBatcher withBatchSize(int docBatchSize) {
     if (docBatchSize > this.maxUriBatchSize) {
-      logger.warn("docBatchSize is beyond maxDocBatchSize");
+      logger.debug("docBatchSize is beyond maxDocBatchSize, which is {}.", this.maxUriBatchSize);
     }
     if (docBatchSize < 1) {
       throw new IllegalArgumentException("docBatchSize cannot be less than 1");


### PR DESCRIPTION
So we can incorporate your pull request, please share the following:
* What issue are you addressing with this pull request? #1291
* Are you modifying the correct branch? (See CONTRIBUTING.md) yes, develop
* Have you run unit tests? (See CONTRIBUTING.md) yes, ran QueryBatcherTest.java. All tests passed.
* Version of MarkLogic Java Client API (see Readme.txt) nightly
* Version of MarkLogic Server (see admin gui on port 8001) 10.0
* Java version (`java -version`) 8
* OS and version Mac
* What Changed: What happened before this change? What happens without this change? - Before the error msg is at warn level, but now at debug level. Also added in the msg what maxDocBatchSize is. Now the logs look like "[Test worker] DEBUG c.m.c.d.impl.QueryBatcherImpl - docBatchSize is beyond maxDocBatchSize, which is 2048."
