### PR TITLE
Throw an exception when constructing a query with empty string as cri

### DIFF
--- a/marklogic-client-api/src/main/java/com/marklogic/client/dataservices/impl/ExecEndpointImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/dataservices/impl/ExecEndpointImpl.java
@@ -254,7 +254,7 @@ public class ExecEndpointImpl<I,O> extends IOEndpointImpl<I,O> implements ExecCa
                     submitTask(this);
                 }
                 else {
-                    if (aliveCallContextCount.decrementAndGet() == 0) {
+                    if (aliveCallContextCount.decrementAndGet() == 0 && getCallerThreadPoolExecutor() != null) {
                         getCallerThreadPoolExecutor().shutdown();
                     }
                 }

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/StringQueryDefinitionImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/StringQueryDefinitionImpl.java
@@ -31,6 +31,9 @@ public class StringQueryDefinitionImpl extends AbstractQueryDefinition implement
 
   @Override
   public void setCriteria(String criteria) {
+    if (criteria.length() == 0) {
+      throw new IllegalArgumentException("Criteria cannot be an empty string.");
+    }
     this.criteria = criteria;
   }
 


### PR DESCRIPTION
…teria #1290

So we can incorporate your pull request, please share the following:
* What issue are you addressing with this pull request? - #1290 
* Are you modifying the correct branch? (See CONTRIBUTING.md) - develop
* Have you run unit tests? (See CONTRIBUTING.md) - yes
* Version of MarkLogic Java Client API (see Readme.txt) - latest
* Version of MarkLogic Server (see admin gui on port 8001) - 10.0
* Java version (`java -version`) - 8
* OS and version - Mac
* What Changed: What happened before this change? What happens without this change? - When constructing a query with an empty string as criteria, it used to throw an exception at the docBatchSize part. Now it will throw an exception complaining about empty string. 
