### PR TITLE
JAVA-252: Fixing failing tests on ML 10 nightly

### DIFF
--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/Common.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/Common.java
@@ -136,6 +136,11 @@ public class Common {
           CONNECTION_TYPE);
   }
 
+  public static MarkLogicVersion getMarkLogicVersion() {
+    String version = newServerAdminClient().newServerEval().javascript("xdmp.version()").evalAs(String.class);
+    return new MarkLogicVersion(version);
+  }
+
   public static byte[] streamToBytes(InputStream is) throws IOException {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     byte[] b = new byte[1000];

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/MarkLogicVersion.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/MarkLogicVersion.java
@@ -1,0 +1,52 @@
+package com.marklogic.client.test;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Parses a MarkLogic version string - i.e. from xdmp.version() - into its major and minor versions. The minor version
+ * contains the patch number and starts with 100 representing minor version 1 with no patch number. This allows for
+ * any combination of minor and patch number to be compared easily.
+ */
+public class MarkLogicVersion {
+
+    private int major;
+    private Integer minor;
+    private boolean nightly;
+
+    private final static String VERSION_WITH_PATCH_PATTERN = "^.*-(.+)\\..*";
+
+    public MarkLogicVersion(String version) {
+        int major = Integer.parseInt(version.replaceAll("([^.]+)\\..*", "$1"));
+        final String nightlyPattern = "[^-]+-(\\d{4})(\\d{2})(\\d{2})";
+        final String majorWithMinorPattern = "^.*-(.+)$";
+        if (version.matches(nightlyPattern)) {
+            this.nightly = true;
+        } else if (version.matches(majorWithMinorPattern)) {
+            this.minor = version.matches(VERSION_WITH_PATCH_PATTERN) ?
+                    parseMinorWithPatch(version) :
+                    Integer.parseInt(version.replaceAll(majorWithMinorPattern, "$1") + "00");
+        }
+        this.major = major;
+    }
+
+    private int parseMinorWithPatch(String version) {
+        final int minorNumber = Integer.parseInt(version.replaceAll(VERSION_WITH_PATCH_PATTERN, "$1"));
+        final int patch = Integer.parseInt(version.replaceAll("^.*-(.+)\\.(.*)", "$2"));
+        final String leftPaddedPatchNumber = patch < 10 ?
+                StringUtils.leftPad(String.valueOf(patch), 2, "0") :
+                String.valueOf(patch);
+        return Integer.parseInt(minorNumber + leftPaddedPatchNumber);
+    }
+
+    public int getMajor() {
+        return major;
+    }
+
+    public Integer getMinor() {
+        return minor;
+    }
+
+    public boolean isNightly() {
+        return nightly;
+    }
+}

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/MarkLogicVersionTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/MarkLogicVersionTest.java
@@ -1,0 +1,65 @@
+package com.marklogic.client.test;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MarkLogicVersionTest extends Assert {
+
+    private MarkLogicVersion version;
+
+    @Test
+    public void elevenNightly() {
+        version = new MarkLogicVersion("11.0-20220915");
+        assertEquals(11, version.getMajor());
+        assertNull(version.getMinor());
+        assertTrue(version.isNightly());
+    }
+
+    @Test
+    public void tenNightly() {
+        version = new MarkLogicVersion("10.0-20220915");
+        assertEquals(10, version.getMajor());
+        assertNull(version.getMinor());
+        assertTrue(version.isNightly());
+    }
+
+    @Test
+    public void tenMinorRelease() {
+        version = new MarkLogicVersion("10.0-9.4");
+        assertEquals(10, version.getMajor());
+        assertEquals(904, version.getMinor().intValue());
+        assertFalse(version.isNightly());
+    }
+
+    @Test
+    public void minorHigherThanNine() {
+        version = new MarkLogicVersion("9.0-13.1");
+        assertEquals(9, version.getMajor());
+        assertEquals(1301, version.getMinor().intValue());
+        assertFalse(version.isNightly());
+    }
+
+    @Test
+    public void noPatchNumber() {
+        version = new MarkLogicVersion("10.0-1");
+        assertEquals(10, version.getMajor());
+        assertEquals(100, version.getMinor().intValue());
+        assertFalse(version.isNightly());
+    }
+
+    @Test
+    public void minorHigherThanNineWithNoPatchNumber() {
+        version = new MarkLogicVersion("9.0-11");
+        assertEquals(9, version.getMajor());
+        assertEquals(1100, version.getMinor().intValue());
+        assertFalse(version.isNightly());
+    }
+
+    @Test
+    public void majorWithNoMinor() {
+        version = new MarkLogicVersion("9.0");
+        assertEquals(9, version.getMajor());
+        assertNull(version.getMinor());
+        assertFalse(version.isNightly());
+    }
+}

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/RowManagerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/RowManagerTest.java
@@ -42,7 +42,6 @@ import javax.xml.xpath.XPathExpressionException;
 import com.marklogic.client.datamovement.DataMovementManager;
 import com.marklogic.client.datamovement.WriteBatcher;
 import com.marklogic.client.io.*;
-import com.marklogic.client.io.marker.JSONReadHandle;
 import com.marklogic.client.query.DeleteQueryDefinition;
 import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.row.*;
@@ -527,6 +526,10 @@ public class RowManagerTest {
 
   @Test
   public void testSQLException() {
+    if (!markLogicIsVersion11OrHigher()) {
+      return;
+    }
+
     RowManager rowMgr = Common.client.newRowManager();
     PlanBuilder p = rowMgr.newPlanBuilder();
     PlanBuilder.ExportablePlan builtPlan =
@@ -1489,11 +1492,14 @@ public class RowManagerTest {
 
   @Test
   public void testFromDocUrisWithWordQuery() {
+    if (!markLogicIsVersion11OrHigher()) {
+      return;
+    }
+
     RowManager rowMgr = Common.client.newRowManager();
     PlanBuilder p = rowMgr.newPlanBuilder();
     PlanBuilder.ExportablePlan builtPlan = p.fromDocUris(p.cts.wordQuery("trumpet"), "");
 
-    RowSet<RowRecord> recordRowSet = rowMgr.resultRows(builtPlan);
     Set<String> uriSet = new HashSet<>();
     uriSet.add("/optic/test/musician4.json");
     uriSet.add("/optic/test/musician1.json");
@@ -1507,7 +1513,10 @@ public class RowManagerTest {
   }
 
   @Test
-  public void testFromDocUrisWithDirectoryQuery() throws Exception {
+  public void testFromDocUrisWithDirectoryQuery() {
+    if (!markLogicIsVersion11OrHigher()) {
+      return;
+    }
     RowManager rowMgr = Common.client.newRowManager();
     PlanBuilder p = rowMgr.newPlanBuilder();
     PlanBuilder.ExportablePlan builtPlan = p.fromDocUris(p.cts.directoryQuery("/testFromDocUrisWithDirectoryQuery/"), "");
@@ -1520,7 +1529,6 @@ public class RowManagerTest {
     batcher.addAs("/testFromDocUrisWithDirectoryQueryNew/doc4.txt", meta, "This is doc4");
     batcher.flushAndWait();
 
-    RowSet<RowRecord> recordRowSet = rowMgr.resultRows(builtPlan);
     Set<String> uriSet = new HashSet<>();
     uriSet.add("/testFromDocUrisWithDirectoryQuery/doc1.txt");
     uriSet.add("/testFromDocUrisWithDirectoryQuery/doc2.txt");
@@ -1753,8 +1761,7 @@ public class RowManagerTest {
     }
     assertEquals("row count for record document join", 3, rowCount);
   }
-  private String nodeToString(Node node)
-    throws TransformerConfigurationException, TransformerException, TransformerFactoryConfigurationError
+  private String nodeToString(Node node) throws TransformerException, TransformerFactoryConfigurationError
   {
     StringWriter sw = new StringWriter();
     Transformer  tf = TransformerFactory.newInstance().newTransformer();
@@ -1763,5 +1770,14 @@ public class RowManagerTest {
       new DOMSource(node), new StreamResult(sw)
     );
     return sw.toString();
+  }
+
+  private boolean markLogicIsVersion11OrHigher() {
+    MarkLogicVersion version = Common.getMarkLogicVersion();
+    boolean val = version.getMajor() >= 11;
+    if (!val) {
+      System.out.println("Will not run test because the MarkLogic server is not at least major version 11");
+    }
+    return val;
   }
 }


### PR DESCRIPTION
I looked for an annotation-based approach, but that's not easily done with JUnit 4. So just putting an `if` statement at the start of each RowManagerTest test that should only run on ML 11 or higher. 