### PR TITLE
ml-development-tools now uses 1.0.0 of publish plugin

### DIFF
--- a/ml-development-tools/build.gradle
+++ b/ml-development-tools/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id "groovy"
     id 'maven-publish'
-    id 'com.gradle.plugin-publish' version '0.12.0'
+    id 'com.gradle.plugin-publish' version '1.0.0'
     id 'java-gradle-plugin'
     id 'org.jetbrains.kotlin.jvm'  version '1.3.72'
 }
@@ -26,6 +26,11 @@ task mlDevelopmentToolsJar(type: Jar, dependsOn: classes) {
     archivesBaseName = 'ml-development-tools'
 }
 
+pluginBundle {
+    website = 'https://github.com/marklogic/java-client-api'
+    vcsUrl = 'git@github.com:marklogic/java-client-api.git'
+    tags = ['marklogic']
+}
 gradlePlugin {
     plugins {
         mlDevelopmentToolsPlugin {
@@ -33,7 +38,6 @@ gradlePlugin {
             implementationClass = 'com.marklogic.client.tools.gradle.ToolsPlugin'
             displayName = 'ml-development-tools MarkLogic Data Service Tools'
             description = 'ml-development-tools plugin for developing data services on MarkLogic'
-            version = project.version
         }
     }
 }
@@ -42,20 +46,6 @@ publishing {
     publications {
         main(MavenPublication) {
             from components.java
-        }
-    }
-}
-
-pluginBundle {
-    website = 'https://github.com/marklogic/java-client-api'
-    vcsUrl = 'git@github.com:marklogic/java-client-api.git'
-    plugins {
-        mlDevelopmentToolsPlugin {
-            id = 'com.marklogic.ml-development-tools'
-            displayName = 'ml-development-tools MarkLogic Data Service Tools'
-            description = 'ml-development-tools plugin for developing data services on MarkLogic'
-            tags = ['marklogic', 'development tools', 'data services']
-            version = project.version
         }
     }
 }


### PR DESCRIPTION
Per the docs at https://docs.gradle.org/current/userguide/publishing_gradle_plugins.html . This should hopefully fix the error we're getting from the Gradle plugins site about hash collisions on javadoc and groovydoc. 