### PR TITLE
JAVA-246: Can now bind attachments when using fromParam

### DIFF
--- a/marklogic-client-api/src/main/java/com/marklogic/client/expression/PlanBuilderBase.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/expression/PlanBuilderBase.java
@@ -15,10 +15,9 @@
  */
 package com.marklogic.client.expression;
 
+import java.util.List;
 import java.util.Map;
 
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.marklogic.client.document.DocumentWriteSet;
 import com.marklogic.client.io.marker.AbstractWriteHandle;
 import com.marklogic.client.io.marker.JSONReadHandle;
 
@@ -590,8 +589,29 @@ public interface PlanBuilderBase {
      * Use AccessPlan as the type for instances of AccessPlan.
      */
     interface AccessPlanBase {
-        PlanBuilder.Plan bindParam(String param, AbstractWriteHandle content);
-        Map<String, AbstractWriteHandle> getContentParams();
+        /**
+         * Specifies a content handle to replace a placeholder parameter during this
+         * execution of the plan in all expressions in which the parameter appears.
+         * <p>Contrary to other `bindParam` methods, this mutates the existence of the plan rather than constructing
+         * a new instance.</p>
+         * @param param the name of a placeholder parameter
+         * @param content the content to replace the parameter
+         * @return the same instance that this was invoked on
+         */
+        PlanBuilder.AccessPlan bindParam(String param, AbstractWriteHandle content);
+
+        /**
+         * Binds attachments to the content parameter identified by {@code param} that had content bound to it via
+         * {@code bindParam(String, AbstractWriteHandle)}.
+         *
+         * @param param the name of the param that was passed to {@code bindParam(String, AbstractWriteHandle)}
+         * @param columnName the name of the column in the plan whose values match the names of attachments
+         * @param attachments a map of attachment names to content handles. When the plan is executed, the attachment
+         *                    name in the column identified by {@code columnName} in each row will be replaced with the
+         *                    associated content handle
+         * @return
+         */
+        PlanBuilder.AccessPlan bindParamAttachments(String param, String columnName, Map<String, AbstractWriteHandle> attachments);
     }
     /**
      * Defines base methods for ExportablePlan. This interface is an implementation detail.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/RESTServices.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/RESTServices.java
@@ -267,7 +267,7 @@ public interface RESTServices {
     FailedRequestException;
   RESTServiceResultIterator postMultipartForm(
           RequestLogger reqlog, String path, Transaction transaction, RequestParameters params,
-          Map<String, AbstractWriteHandle> contentParams)
+          Map<String, AbstractWriteHandle> contentParams, List<PlanBuilderSubImpl.ParamAttachments> contentParamAttachments)
           throws ResourceNotFoundException, ResourceNotResendableException, ForbiddenUserException,
           FailedRequestException;
   <W extends AbstractWriteHandle> RESTServiceResultIterator postIteratedResource(

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/RowManagerImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/RowManagerImpl.java
@@ -378,11 +378,12 @@ public class RowManagerImpl
     addDatatypeStyleParam(params,     datatypeStyle);
     addRowStructureStyleParam(params, rowStructureStyle);
 
-    if (requestPlan instanceof PlanBuilderBase.AccessPlanBase) {
-      Map<String, AbstractWriteHandle> contentParams = ((PlanBuilderBase.AccessPlanBase)requestPlan).getContentParams();
+    if (requestPlan instanceof PlanBuilderSubImpl.AccessPlanSubImpl) {
+      PlanBuilderSubImpl.AccessPlanSubImpl accessPlan = (PlanBuilderSubImpl.AccessPlanSubImpl) requestPlan;
+      Map<String, AbstractWriteHandle> contentParams = accessPlan.getContentParams();
       if (contentParams != null && !contentParams.isEmpty()) {
         contentParams.put("query", astHandle);
-        return services.postMultipartForm(requestLogger, "rows", transaction, params, contentParams);
+        return services.postMultipartForm(requestLogger, "rows", transaction, params, contentParams, accessPlan.getContentParamAttachments());
       }
     }
     return services.postIteratedResource(requestLogger, "rows", transaction, params, astHandle);

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/Common.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/Common.java
@@ -141,6 +141,16 @@ public class Common {
     return new MarkLogicVersion(version);
   }
 
+  public static boolean markLogicIsVersion11OrHigher() {
+    MarkLogicVersion version = getMarkLogicVersion();
+    boolean val = version.getMajor() >= 11;
+    if (!val) {
+      System.out.println("Will not run test because the MarkLogic server is not at least major version 11; " +
+              "major version: " + version.getMajor());
+    }
+    return val;
+  }
+
   public static byte[] streamToBytes(InputStream is) throws IOException {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     byte[] b = new byte[1000];

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/RowManagerFromParamTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/RowManagerFromParamTest.java
@@ -1,0 +1,173 @@
+package com.marklogic.client.test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.marklogic.client.expression.PlanBuilder;
+import com.marklogic.client.io.BytesHandle;
+import com.marklogic.client.io.Format;
+import com.marklogic.client.io.JacksonHandle;
+import com.marklogic.client.io.StringHandle;
+import com.marklogic.client.io.marker.AbstractWriteHandle;
+import com.marklogic.client.row.RowManager;
+import com.marklogic.client.row.RowRecord;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests various scenarios involving the {@code fromParam} accessor and the need to bind a content handle as a parameter
+ * to the plan.
+ */
+public class RowManagerFromParamTest {
+
+    @BeforeClass
+    public static void beforeClass() {
+        Common.connect();
+    }
+
+    @Test
+    public void fromParamWithSimpleJsonArray() {
+        if (!Common.markLogicIsVersion11OrHigher()) {
+            return;
+        }
+
+        RowManager rowMgr = Common.client.newRowManager();
+        PlanBuilder planBuilder = rowMgr.newPlanBuilder();
+
+        PlanBuilder.AccessPlan plan = planBuilder.fromParam("myDocs", "", planBuilder.colTypes(
+                planBuilder.colType("lastName", "string"),
+                planBuilder.colType("firstName", "string", "", "", null)
+        ));
+
+        ArrayNode array = new ObjectMapper().createArrayNode();
+        array.addObject().put("lastName", "Smith").put("firstName", "Jane");
+        array.addObject().put("lastName", "Jones").put("firstName", "Jack");
+        plan.bindParam("myDocs", new JacksonHandle(array));
+
+        List<RowRecord> rows = rowMgr.resultRows(plan).stream().collect(Collectors.toList());
+        assertEquals(2, rows.size());
+        assertEquals("Jane", rows.get(0).getString("firstName"));
+        assertEquals("Smith", rows.get(0).getString("lastName"));
+        assertEquals("Jack", rows.get(1).getString("firstName"));
+        assertEquals("Jones", rows.get(1).getString("lastName"));
+    }
+
+    @Test
+    public void fromParamWithXmlAttachments() {
+        if (!Common.markLogicIsVersion11OrHigher()) {
+            return;
+        }
+
+        RowManager rowMgr = Common.client.newRowManager();
+        PlanBuilder planBuilder = rowMgr.newPlanBuilder();
+
+        PlanBuilder.AccessPlan plan = planBuilder.fromParam("bindingParam", "", planBuilder.colTypes(
+                planBuilder.colType("rowId", "integer"),
+                planBuilder.colType("doc", "none")
+        ));
+
+        ArrayNode array = new ObjectMapper().createArrayNode();
+        array.addObject().put("rowId", 1).put("doc", "doc1.xml");
+        array.addObject().put("rowId", 2).put("doc", "doc2.xml");
+        plan = plan.bindParam("bindingParam", new JacksonHandle(array));
+
+        Map<String, AbstractWriteHandle> attachments = new HashMap<>();
+        attachments.put("doc1.xml", new StringHandle("<doc>1</doc>").withFormat(Format.XML));
+        attachments.put("doc2.xml", new StringHandle("<doc>2</doc>").withFormat(Format.XML));
+        plan = plan.bindParamAttachments("bindingParam", "doc", attachments);
+
+        List<RowRecord> rows = rowMgr.resultRows(plan).stream().collect(Collectors.toList());
+        assertEquals(2, rows.size());
+
+        RowRecord row = rows.get(0);
+        assertEquals(1, row.getInt("rowId"));
+        assertEquals("<doc>1</doc>", getRowContentWithoutXmlDeclaration(row, "doc"));
+
+        row = rows.get(1);
+        assertEquals(2, row.getInt("rowId"));
+        assertEquals("<doc>2</doc>", getRowContentWithoutXmlDeclaration(row, "doc"));
+    }
+
+    @Test
+    public void fromParamWithBinaryAttachments() {
+        if (!Common.markLogicIsVersion11OrHigher()) {
+            return;
+        }
+
+        RowManager rowMgr = Common.client.newRowManager();
+        PlanBuilder planBuilder = rowMgr.newPlanBuilder();
+
+        PlanBuilder.AccessPlan plan = planBuilder.fromParam("bindingParam", "", planBuilder.colTypes(
+                planBuilder.colType("rowId", "integer"),
+                planBuilder.colType("doc", "none")
+        ));
+
+        ArrayNode array = new ObjectMapper().createArrayNode();
+        array.addObject().put("rowId", 1).put("doc", "doc1.bin");
+        array.addObject().put("rowId", 2).put("doc", "doc2.bin");
+        plan = plan.bindParam("bindingParam", new JacksonHandle(array));
+
+        Map<String, AbstractWriteHandle> attachments = new HashMap<>();
+        attachments.put("doc1.bin", new BytesHandle("<doc>1</doc>".getBytes()).withFormat(Format.BINARY));
+        attachments.put("doc2.bin", new BytesHandle("<doc>2</doc>".getBytes()).withFormat(Format.BINARY));
+        plan = plan.bindParamAttachments("bindingParam", "doc", attachments);
+
+        List<RowRecord> rows = rowMgr.resultRows(plan).stream().collect(Collectors.toList());
+        assertEquals(2, rows.size());
+
+        RowRecord row = rows.get(0);
+        assertEquals(1, row.getInt("rowId"));
+        assertEquals("<doc>1</doc>", row.getContentAs("doc", String.class));
+
+        row = rows.get(1);
+        assertEquals(2, row.getInt("rowId"));
+        assertEquals("<doc>2</doc>", row.getContentAs("doc", String.class));
+    }
+
+    @Test
+    public void fromParamWithTextAttachments() {
+        if (!Common.markLogicIsVersion11OrHigher()) {
+            return;
+        }
+
+        RowManager rowMgr = Common.client.newRowManager();
+        PlanBuilder planBuilder = rowMgr.newPlanBuilder();
+
+        PlanBuilder.AccessPlan plan = planBuilder.fromParam("bindingParam", "", planBuilder.colTypes(
+                planBuilder.colType("rowId", "integer"),
+                planBuilder.colType("doc", "none")
+        ));
+
+        ArrayNode array = new ObjectMapper().createArrayNode();
+        array.addObject().put("rowId", 1).put("doc", "doc1.txt");
+        array.addObject().put("rowId", 2).put("doc", "doc2.txt");
+        plan = plan.bindParam("bindingParam", new JacksonHandle(array));
+
+        Map<String, AbstractWriteHandle> attachments = new HashMap<>();
+        attachments.put("doc1.txt", new StringHandle("doc1-text").withFormat(Format.TEXT));
+        attachments.put("doc2.txt", new StringHandle("doc2-text").withFormat(Format.TEXT));
+        plan = plan.bindParamAttachments("bindingParam", "doc", attachments);
+
+        List<RowRecord> rows = rowMgr.resultRows(plan).stream().collect(Collectors.toList());
+        assertEquals(2, rows.size());
+
+        RowRecord row = rows.get(0);
+        assertEquals(1, row.getInt("rowId"));
+        assertEquals("doc1-text", row.getContentAs("doc", String.class));
+
+        row = rows.get(1);
+        assertEquals(2, row.getInt("rowId"));
+        assertEquals("doc2-text", row.getContentAs("doc", String.class));
+    }
+
+    private String getRowContentWithoutXmlDeclaration(RowRecord row, String columnName) {
+        String content = row.getContentAs(columnName, String.class);
+        return content.replace("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n", "");
+    }
+}

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/RowManagerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/RowManagerTest.java
@@ -21,13 +21,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.io.LineNumberReader;
 import java.io.StringWriter;
 import java.util.*;
-import java.util.stream.Collectors;
 
 import javax.xml.namespace.QName;
 import javax.xml.transform.OutputKeys;
@@ -40,7 +38,6 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.xpath.XPathExpressionException;
 
-import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.marklogic.client.datamovement.DataMovementManager;
 import com.marklogic.client.datamovement.WriteBatcher;
 import com.marklogic.client.io.*;
@@ -528,7 +525,7 @@ public class RowManagerTest {
 
   @Test
   public void testSQLException() {
-    if (!markLogicIsVersion11OrHigher()) {
+    if (!Common.markLogicIsVersion11OrHigher()) {
       return;
     }
 
@@ -1494,7 +1491,7 @@ public class RowManagerTest {
 
   @Test
   public void testFromDocUrisWithWordQuery() {
-    if (!markLogicIsVersion11OrHigher()) {
+    if (!Common.markLogicIsVersion11OrHigher()) {
       return;
     }
 
@@ -1516,7 +1513,7 @@ public class RowManagerTest {
 
   @Test
   public void testFromDocUrisWithDirectoryQuery() {
-    if (!markLogicIsVersion11OrHigher()) {
+    if (!Common.markLogicIsVersion11OrHigher()) {
       return;
     }
     RowManager rowMgr = Common.client.newRowManager();
@@ -1543,33 +1540,6 @@ public class RowManagerTest {
       uriSet.remove(temp);
     }
     assertTrue(uriSet.size() == 1 && uriSet.contains("/testFromDocUrisWithDirectoryQueryNew/doc4.txt"));
-  }
-
-  @Test
-  public void testFromParamWithJsonDocs() {
-    if (!markLogicIsVersion11OrHigher()) {
-      return;
-    }
-
-    RowManager rowMgr = Common.client.newRowManager();
-    PlanBuilder planBuilder = rowMgr.newPlanBuilder();
-
-    PlanBuilder.AccessPlan plan = planBuilder.fromParam("myDocs", "", planBuilder.colTypes(
-            planBuilder.colType("lastName", "string"),
-            planBuilder.colType("firstName", "string", "", "", null)
-    ));
-
-    ArrayNode array = new ObjectMapper().createArrayNode();
-    array.addObject().put("lastName", "Smith").put("firstName", "Jane");
-    array.addObject().put("lastName", "Jones").put("firstName", "Jack");
-    PlanBuilder.Plan boundPlan = plan.bindParam("myDocs", new JacksonHandle(array));
-
-    List<RowRecord> rows = rowMgr.resultRows(boundPlan).stream().collect(Collectors.toList());
-    assertEquals(2, rows.size());
-    assertEquals("Jane", rows.get(0).getString("firstName"));
-    assertEquals("Smith", rows.get(0).getString("lastName"));
-    assertEquals("Jack", rows.get(1).getString("firstName"));
-    assertEquals("Jones", rows.get(1).getString("lastName"));
   }
 
   private void checkSingleRow(NodeList row, RowSetPart datatypeStyle) {
@@ -1799,14 +1769,5 @@ public class RowManagerTest {
       new DOMSource(node), new StreamResult(sw)
     );
     return sw.toString();
-  }
-
-  private boolean markLogicIsVersion11OrHigher() {
-    MarkLogicVersion version = Common.getMarkLogicVersion();
-    boolean val = version.getMajor() >= 11;
-    if (!val) {
-      System.out.println("Will not run test because the MarkLogic server is not at least major version 11");
-    }
-    return val;
   }
 }


### PR DESCRIPTION
Additional changes:

- Documented the two new public methods in `PlanBuilderBase`
- Moved all `fromParam` tests into its own simple test class for faster execution and easier understanding of the tests
- Testing JSON, XML, TEXT, and BINARY