### PR TITLE
JAVA-246: RowBatcher and QueryBatcher now provide access to timestamp

### DIFF
--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/QueryBatcher.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/QueryBatcher.java
@@ -419,4 +419,12 @@ public interface QueryBatcher extends Batcher {
    * @return the maximum number of Batches that can be collected.
    */
   long getMaxBatches();
+
+  /**
+   * If {@code withConsistentSnapshot} was used before starting the job, will return the MarkLogic server timestamp
+   * associated with the snapshot. Returns null otherwise.
+   *
+   * @return the timestamp or null
+   */
+  Long getServerTimestamp();
 }

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/RowBatcher.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/RowBatcher.java
@@ -276,4 +276,12 @@ public interface RowBatcher<T> extends Batcher {
      * @return the number of row batches
      */
     long getFailedBatches();
+
+    /**
+     * If {@code withConsistentSnapshot} was used before starting the job, will return the MarkLogic server timestamp
+     * associated with the snapshot. Returns null otherwise.
+     *
+     * @return the timestamp or null
+     */
+    Long getServerTimestamp();
 }

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/QueryBatcherImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/QueryBatcherImpl.java
@@ -381,6 +381,12 @@ public class QueryBatcherImpl extends BatcherImpl implements QueryBatcher {
   }
 
   @Override
+  public Long getServerTimestamp() {
+    long val = this.serverTimestamp.get();
+    return val > -1 ? val : null;
+  }
+
+  @Override
   public boolean awaitCompletion(long timeout, TimeUnit unit) throws InterruptedException {
     requireJobStarted();
     return threadPool.awaitTermination(timeout, unit);

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/RowBatcherImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/RowBatcherImpl.java
@@ -317,6 +317,11 @@ class RowBatcherImpl<T>  extends BatcherImpl implements RowBatcher<T> {
         requireStarted("Must start job before getting ticket");
         return super.getJobTicket();
     }
+    @Override
+    public Long getServerTimestamp() {
+        long val = this.serverTimestamp.get();
+        return val > -1 ? val : null;
+    }
     private void requireNotStarted(String msg) {
         if (this.isStarted()) {
             throw new IllegalStateException(msg);

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/PointInTimeQueryTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/PointInTimeQueryTest.java
@@ -18,9 +18,6 @@ package com.marklogic.client.test.datamovement;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-
 import com.marklogic.client.datamovement.*;
 import org.junit.FixMethodOrder;
 import org.junit.runners.MethodSorters;
@@ -39,6 +36,8 @@ import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.query.StructuredQueryBuilder;
 
 import com.marklogic.client.test.Common;
+
+import static org.junit.Assert.*;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class PointInTimeQueryTest {
@@ -138,6 +137,9 @@ public class PointInTimeQueryTest {
 
     // now that we're done deleting, wait for the exportBatcher to finish
     exportBatcher.awaitCompletion();
+
+    assertNotNull("withConsistentSnapshot was used, so the server timestamp should be available to the client",
+            exportBatcher.getServerTimestamp());
 
     // if we still got all the docs, that means our delete was ignored during the run
     assertEquals(numDocs, successDocs.get());

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/QueryBatcherTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/QueryBatcherTest.java
@@ -15,11 +15,6 @@
  */
 package com.marklogic.client.test.datamovement;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
@@ -74,6 +69,7 @@ import com.marklogic.client.io.SearchHandle;
 import com.marklogic.client.io.StringHandle;
 import static com.marklogic.client.io.Format.JSON;
 import static com.marklogic.client.io.Format.XML;
+import static org.junit.Assert.*;
 
 import com.marklogic.client.datamovement.ApplyTransformListener;
 import com.marklogic.client.datamovement.DataMovementManager;
@@ -848,7 +844,8 @@ public class QueryBatcherTest {
     System.out.println("Failure event: "+moveMgr.getJobReport(queryTicket.get()).getFailureEventsCount());
     System.out.println("Failure batch: "+moveMgr.getJobReport(queryTicket.get()).getFailureBatchesCount());
 
-
+    assertNull("withConsistentSnapshot was not used, so the server timestamp should be null",
+            batcher.getServerTimestamp());
     assertTrue(successCount.get() < 200);
     assertTrue(batchCount.get() == moveMgr.getJobReport(queryTicket.get()).getSuccessBatchesCount());
   }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/RowBatcherTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/RowBatcherTest.java
@@ -52,7 +52,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 public class RowBatcherTest {
     private final static String TEST_DIR = "/test/rowbatch/unit/";
@@ -258,7 +258,7 @@ public class RowBatcherTest {
     }
     private void runJsonRowsTest(
             RowBatcher<JsonNode> rowBatcher, boolean consistentSnapshot, Class<? extends PlanBuilder.Plan> planType
-    ) throws Exception {
+    ) {
         if (consistentSnapshot) {
             rowBatcher.withConsistentSnapshot();
         }
@@ -349,7 +349,16 @@ public class RowBatcherTest {
         // System.out.println("stopped="+rowBatcher.isStopped());
 
         if (consistentSnapshot) {
+            assertNotNull("The RowBatcher should make the timestamp available so that the client can perform " +
+                            "additional operations using that timestamp after the job has completed. For example, " +
+                            "the client may wish to lookup the highest dateTime value in an index at the timestamp " +
+                            "so that a future job can constrain to documents with a dateTime greater than the " +
+                            "looked-up value, thus allowing for a 'Only process new records' feature.",
+                    rowBatcher.getServerTimestamp());
             docMgr.delete(addedDocUri);
+        } else {
+            assertNull("If withConsistentSnapshot is not used, getServerTimestamp() should return null since no " +
+                    "server timestamp would have been captured", rowBatcher.getServerTimestamp());
         }
 
         assertEquals("test execution failed", false, failed.get());


### PR DESCRIPTION
Allows for client to perform subsequent operations using that same timestamp.

Note that QueryBatcher provides access to this via the argument passed to QueryBatchListener, though that of course requires a bit more effort for a user to get than simply calling getServerTimestamp after the job completes. 