### PR TITLE
JAVA-246: Can now execute write() plans

### DIFF
--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/ContentParam.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/ContentParam.java
@@ -1,0 +1,137 @@
+package com.marklogic.client.impl;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.marklogic.client.document.DocumentWriteSet;
+import com.marklogic.client.io.BaseHandle;
+import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.client.io.Format;
+import com.marklogic.client.io.JacksonHandle;
+import com.marklogic.client.io.marker.AbstractWriteHandle;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Defines a content parameter that can be bound to a plan, optionally with a mapping of column names to
+ * attachments.
+ */
+class ContentParam {
+
+    private PlanBuilderBaseImpl.PlanParamBase planParam;
+    private AbstractWriteHandle content;
+    private Map<String, Map<String, AbstractWriteHandle>> columnAttachments;
+
+    public ContentParam(PlanBuilderBaseImpl.PlanParamBase planParam, AbstractWriteHandle content) {
+        this.planParam = planParam;
+        this.content = content;
+    }
+
+    public ContentParam(PlanBuilderBaseImpl.PlanParamBase planParam, AbstractWriteHandle content, Map<String, Map<String, AbstractWriteHandle>> columnAttachments) {
+        this(planParam, content);
+        this.columnAttachments = columnAttachments;
+    }
+
+    public PlanBuilderBaseImpl.PlanParamBase getPlanParam() {
+        return planParam;
+    }
+
+    public AbstractWriteHandle getContent() {
+        return content;
+    }
+
+    public Map<String, Map<String, AbstractWriteHandle>> getColumnAttachments() {
+        return columnAttachments;
+    }
+
+    /**
+     * Convenience method that is less-than-ideally located here as a way of avoiding duplication between the
+     * two classes that must implement {@code bindParam(String, DocumentWriteSet)} - {@code PlanBuilderSubImpl} and
+     * {@code RawPlanImpl}. Those classes do not have a common parent class, and so they both depend on this method
+     * to avoid duplicating the logic in both classes.
+     *
+     * @param param
+     * @param writeSet
+     * @return
+     */
+    public static ContentParam fromDocumentWriteSet(PlanBuilderBaseImpl.PlanParamBase param, DocumentWriteSet writeSet) {
+        ArrayNode contentRows = new ObjectMapper().createArrayNode();
+        Map<String, AbstractWriteHandle> attachments = new HashMap<>();
+
+        writeSet.stream().forEach(writeOp -> {
+            String uri = writeOp.getUri();
+            AbstractWriteHandle content = writeOp.getContent();
+
+            ObjectNode row = contentRows.addObject();
+            row.put("uri", uri);
+
+            JsonNode jsonContent = getJsonNodeFromContent(content);
+            if (jsonContent != null) {
+                // JSON attachments aren't supported yet, so we need to inline it
+                row.set("doc", jsonContent);
+            } else {
+                // For every other content type, make an attachment
+                row.put("doc", "attachment-" + uri);
+                attachments.put("attachment-" + uri, content);
+            }
+
+            if (writeOp.getMetadata() instanceof DocumentMetadataHandle) {
+                DocumentMetadataHandle metadata = (DocumentMetadataHandle) writeOp.getMetadata();
+                row.put("quality", metadata.getQuality());
+
+                if (!metadata.getCollections().isEmpty()) {
+                    ArrayNode collections = row.putArray("collections");
+                    metadata.getCollections().forEach(c -> collections.add(c));
+                }
+
+//          if (!metadata.getPermissions().isEmpty()) {
+//            ArrayNode permissions = row.putArray("permissions");
+//            for (String roleName : metadata.getPermissions().keySet()) {
+//              for (DocumentMetadataHandle.Capability c : metadata.getPermissions().get(roleName)) {
+//                permissions.addObject().put("roleId", "7089338530631756591").put("capability", c.toString().toLowerCase());
+//              }
+//            }
+//          }
+
+                // Hack until the REST endpoint supports a JSON serialization of permissions
+                ArrayNode permissions = row.putArray("permissions");
+                permissions.addObject().put("roleId", "7089338530631756591").put("capability", "read");
+                permissions.addObject().put("roleId", "7089338530631756591").put("capability", "update");
+
+                if (!metadata.getMetadataValues().isEmpty()) {
+                    ObjectNode values = row.putObject("metadata");
+                    for (String key : metadata.getMetadataValues().keySet()) {
+                        values.put(key, metadata.getMetadataValues().get(key));
+                    }
+                }
+            }
+        });
+
+        Map<String, Map<String, AbstractWriteHandle>> columnAttachments = attachments.isEmpty() ? null :
+                Collections.singletonMap("doc", attachments);
+        JacksonHandle content = new JacksonHandle(contentRows);
+        return new ContentParam(param, content, columnAttachments);
+    }
+
+    private static JsonNode getJsonNodeFromContent(AbstractWriteHandle content) {
+        if (content instanceof JacksonHandle) {
+            return ((JacksonHandle) content).get();
+        }
+        if (content instanceof BaseHandle) {
+            BaseHandle h = (BaseHandle) content;
+            if (Format.JSON.equals(h.getFormat())) {
+                String json = HandleAccessor.contentAsString(content);
+                try {
+                    return new ObjectMapper().readTree(json);
+                } catch (JsonProcessingException e) {
+                    throw new RuntimeException("Unable to read content as JSON; cause: " + e.getMessage(), e);
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/PlanBuilderBaseImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/PlanBuilderBaseImpl.java
@@ -16,6 +16,7 @@
 package com.marklogic.client.impl;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import com.marklogic.client.DatabaseClientFactory.HandleFactoryRegistry;
@@ -119,9 +120,10 @@ abstract class PlanBuilderBaseImpl extends PlanBuilder {
     }
   }
 
-  static interface RequestPlan {
-    public Map<PlanParamBase,BaseTypeImpl.ParamBinder> getParams();
-    public AbstractWriteHandle getHandle();
+  interface RequestPlan {
+    Map<PlanParamBase,BaseTypeImpl.ParamBinder> getParams();
+    AbstractWriteHandle getHandle();
+    List<ContentParam> getContentParams();
   }
 
   static abstract class PlanBaseImpl

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/RESTServices.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/RESTServices.java
@@ -266,9 +266,7 @@ public interface RESTServices {
     throws ResourceNotFoundException, ResourceNotResendableException, ForbiddenUserException,
     FailedRequestException;
   RESTServiceResultIterator postMultipartForm(
-          RequestLogger reqlog, String path, Transaction transaction, RequestParameters params,
-          Map<PlanBuilderBaseImpl.PlanParamBase, AbstractWriteHandle> contentParams,
-          List<ParamAttachments> contentParamAttachments)
+          RequestLogger reqlog, String path, Transaction transaction, RequestParameters params, List<ContentParam> contentParams)
           throws ResourceNotFoundException, ResourceNotResendableException, ForbiddenUserException,
           FailedRequestException;
   <W extends AbstractWriteHandle> RESTServiceResultIterator postIteratedResource(

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/RowManagerFromParamTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/RowManagerFromParamTest.java
@@ -15,6 +15,7 @@ import com.marklogic.client.type.PlanParamExpr;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -52,7 +53,7 @@ public class RowManagerFromParamTest {
         ArrayNode array = new ObjectMapper().createArrayNode();
         array.addObject().put("lastName", "Smith").put("firstName", "Jane");
         array.addObject().put("lastName", "Jones").put("firstName", "Jack");
-        plan = plan.bindParam("myDocs", new JacksonHandle(array));
+        plan = plan.bindParam("myDocs", new JacksonHandle(array), null);
 
         List<RowRecord> rows = rowMgr.resultRows(plan).stream().collect(Collectors.toList());
         assertEquals(2, rows.size());
@@ -81,12 +82,10 @@ public class RowManagerFromParamTest {
         ArrayNode array = new ObjectMapper().createArrayNode();
         array.addObject().put("rowId", 1).put("doc", "doc1.xml");
         array.addObject().put("rowId", 2).put("doc", "doc2.xml");
-        plan = plan.bindParam(param, new JacksonHandle(array));
-
         Map<String, AbstractWriteHandle> attachments = new HashMap<>();
         attachments.put("doc1.xml", new StringHandle("<doc>1</doc>").withFormat(Format.XML));
         attachments.put("doc2.xml", new StringHandle("<doc>2</doc>").withFormat(Format.XML));
-        plan = plan.bindParamAttachments(param, "doc", attachments);
+        plan = plan.bindParam(param, new JacksonHandle(array), Collections.singletonMap("doc", attachments));
 
         List<RowRecord> rows = rowMgr.resultRows(plan).stream().collect(Collectors.toList());
         assertEquals(2, rows.size());
@@ -117,12 +116,10 @@ public class RowManagerFromParamTest {
         ArrayNode array = new ObjectMapper().createArrayNode();
         array.addObject().put("rowId", 1).put("doc", "doc1.bin");
         array.addObject().put("rowId", 2).put("doc", "doc2.bin");
-        plan = plan.bindParam("bindingParam", new JacksonHandle(array));
-
         Map<String, AbstractWriteHandle> attachments = new HashMap<>();
         attachments.put("doc1.bin", new BytesHandle("<doc>1</doc>".getBytes()).withFormat(Format.BINARY));
         attachments.put("doc2.bin", new BytesHandle("<doc>2</doc>".getBytes()).withFormat(Format.BINARY));
-        plan = plan.bindParamAttachments("bindingParam", "doc", attachments);
+        plan = plan.bindParam("bindingParam", new JacksonHandle(array), Collections.singletonMap("doc", attachments));
 
         List<RowRecord> rows = rowMgr.resultRows(plan).stream().collect(Collectors.toList());
         assertEquals(2, rows.size());
@@ -153,12 +150,10 @@ public class RowManagerFromParamTest {
         ArrayNode array = new ObjectMapper().createArrayNode();
         array.addObject().put("rowId", 1).put("doc", "doc1.txt");
         array.addObject().put("rowId", 2).put("doc", "doc2.txt");
-        plan = plan.bindParam("bindingParam", new JacksonHandle(array));
-
         Map<String, AbstractWriteHandle> attachments = new HashMap<>();
         attachments.put("doc1.txt", new StringHandle("doc1-text").withFormat(Format.TEXT));
         attachments.put("doc2.txt", new StringHandle("doc2-text").withFormat(Format.TEXT));
-        plan = plan.bindParamAttachments("bindingParam", "doc", attachments);
+        plan = plan.bindParam("bindingParam", new JacksonHandle(array), Collections.singletonMap("doc", attachments));
 
         List<RowRecord> rows = rowMgr.resultRows(plan).stream().collect(Collectors.toList());
         assertEquals(2, rows.size());
@@ -237,12 +232,10 @@ public class RowManagerFromParamTest {
         ArrayNode array = new ObjectMapper().createArrayNode();
         array.addObject().put("rowId", 1).put("doc", "doc1.xml");
         array.addObject().put("rowId", 2).put("doc", "doc2.xml");
-        PlanBuilder.Plan plan = rawPlan.bindParam(param, new JacksonHandle(array));
-
         Map<String, AbstractWriteHandle> attachments = new HashMap<>();
         attachments.put("doc1.xml", new StringHandle("<doc>1</doc>").withFormat(Format.XML));
         attachments.put("doc2.xml", new StringHandle("<doc>2</doc>").withFormat(Format.XML));
-        plan = plan.bindParamAttachments(param, "doc", attachments);
+        PlanBuilder.Plan plan = rawPlan.bindParam(param, new JacksonHandle(array), Collections.singletonMap("doc", attachments));
 
         List<RowRecord> rows = rowMgr.resultRows(plan).stream().collect(Collectors.toList());
         assertEquals(2, rows.size());
@@ -254,6 +247,54 @@ public class RowManagerFromParamTest {
         row = rows.get(1);
         assertEquals(2, row.getInt("rowId"));
         assertEquals("<doc>2</doc>", getRowContentWithoutXmlDeclaration(row, "doc"));
+    }
+
+    /**
+     * Verifies that a user can have multiple columns that are associated with attachments.
+     */
+    @Test
+    public void fromParamWithMultipleAttachmentColumns() {
+        if (!Common.markLogicIsVersion11OrHigher()) {
+            return;
+        }
+
+        RowManager rowMgr = Common.client.newRowManager();
+        PlanBuilder planBuilder = rowMgr.newPlanBuilder();
+
+        PlanBuilder.Plan plan = planBuilder.fromParam("bindingParam", "", planBuilder.colTypes(
+                planBuilder.colType("rowId", "integer"),
+                planBuilder.colType("doc", "none"),
+                planBuilder.colType("otherDoc", "none")
+        ));
+
+        final PlanParamExpr param = planBuilder.param("bindingParam");
+
+        ArrayNode array = new ObjectMapper().createArrayNode();
+        array.addObject().put("rowId", 1).put("doc", "doc1.xml").put("otherDoc", "otherDoc1.xml");
+        array.addObject().put("rowId", 2).put("doc", "doc2.xml").put("otherDoc", "otherDoc2.xml");
+        Map<String, Map<String, AbstractWriteHandle>> columnAttachments = new HashMap<>();
+        Map<String, AbstractWriteHandle> attachments = new HashMap<>();
+        attachments.put("doc1.xml", new StringHandle("<doc>1</doc>").withFormat(Format.XML));
+        attachments.put("doc2.xml", new StringHandle("<doc>2</doc>").withFormat(Format.XML));
+        columnAttachments.put("doc", attachments);
+        attachments = new HashMap<>();
+        attachments.put("otherDoc1.xml", new StringHandle("<otherDoc>1</otherDoc>").withFormat(Format.XML));
+        attachments.put("otherDoc2.xml", new StringHandle("<otherDoc>2</otherDoc>").withFormat(Format.XML));
+        columnAttachments.put("otherDoc", attachments);
+        plan = plan.bindParam(param, new JacksonHandle(array), columnAttachments);
+
+        List<RowRecord> rows = rowMgr.resultRows(plan).stream().collect(Collectors.toList());
+        assertEquals(2, rows.size());
+
+        RowRecord row = rows.get(0);
+        assertEquals(1, row.getInt("rowId"));
+        assertEquals("<doc>1</doc>", getRowContentWithoutXmlDeclaration(row, "doc"));
+        assertEquals("<otherDoc>1</otherDoc>", getRowContentWithoutXmlDeclaration(row, "otherDoc"));
+
+        row = rows.get(1);
+        assertEquals(2, row.getInt("rowId"));
+        assertEquals("<doc>2</doc>", getRowContentWithoutXmlDeclaration(row, "doc"));
+        assertEquals("<otherDoc>2</otherDoc>", getRowContentWithoutXmlDeclaration(row, "otherDoc"));
     }
 
     private String getRowContentWithoutXmlDeclaration(RowRecord row, String columnName) {

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/RowManagerFromParamWriteTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/RowManagerFromParamWriteTest.java
@@ -1,0 +1,183 @@
+package com.marklogic.client.test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marklogic.client.FailedRequestException;
+import com.marklogic.client.document.DocumentWriteSet;
+import com.marklogic.client.document.JSONDocumentManager;
+import com.marklogic.client.expression.PlanBuilder;
+import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.client.io.Format;
+import com.marklogic.client.io.JacksonHandle;
+import com.marklogic.client.io.StringHandle;
+import com.marklogic.client.row.RawPlanDefinition;
+import com.marklogic.client.row.RowManager;
+import com.marklogic.client.row.RowRecord;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.*;
+
+public class RowManagerFromParamWriteTest {
+
+    @BeforeClass
+    public static void beforeClass() {
+        Common.connect();
+        Common.connectServerAdmin().newServerEval()
+                .xquery("cts:uri-match('/fromParam/*') ! xdmp:document-delete(.)")
+                .evalAs(String.class);
+    }
+
+    @Test
+    public void jsonDocumentWithAllMetadata() {
+        if (!Common.markLogicIsVersion11OrHigher()) {
+            return;
+        }
+
+        RowManager rowMgr = Common.client.newRowManager();
+        PlanBuilder planBuilder = rowMgr.newPlanBuilder();
+        PlanBuilder.Plan plan = planBuilder
+                .fromParam("myDocs", "", planBuilder.docColTypes())
+                .write();
+
+        DocumentMetadataHandle metadata = new DocumentMetadataHandle()
+                .withQuality(2)
+//                // TODO Metadata and permissions not supported by server yet
+//                .withMetadataValue("meta1", "value1")
+//                .withMetadataValue("meta2", "value2")
+                .withPermission("rest-reader", DocumentMetadataHandle.Capability.READ, DocumentMetadataHandle.Capability.UPDATE)
+                .withCollections("common-coll", "other-coll-1");
+
+        DocumentWriteSet writeSet = Common.client.newDocumentManager().newWriteSet();
+        writeSet.add("/fromParam/doc1.json", metadata,
+                new JacksonHandle(new ObjectMapper().createObjectNode().put("value", 1)));
+        plan = plan.bindParam("myDocs", writeSet);
+
+        List<RowRecord> rows = rowMgr.resultRows(plan).stream().collect(Collectors.toList());
+        // TODO Is this expected - that we don't get any rows back?
+        assertEquals(0, rows.size());
+
+        JSONDocumentManager mgr = Common.client.newJSONDocumentManager();
+
+        metadata = mgr.readMetadata("/fromParam/doc1.json", new DocumentMetadataHandle());
+        assertEquals(2, metadata.getQuality());
+        assertTrue(metadata.getCollections().contains("common-coll"));
+        assertTrue(metadata.getCollections().contains("other-coll-1"));
+    }
+
+    @Test
+    public void xmlDocumentWriteSet() {
+        if (!Common.markLogicIsVersion11OrHigher()) {
+            return;
+        }
+
+        RowManager rowMgr = Common.client.newRowManager();
+        PlanBuilder planBuilder = rowMgr.newPlanBuilder();
+        PlanBuilder.Plan plan = planBuilder.fromParam("myDocs", "", planBuilder.docColTypes()).write();
+
+        DocumentMetadataHandle metadata = new DocumentMetadataHandle();
+        DocumentWriteSet writeSet = Common.client.newDocumentManager().newWriteSet();
+        writeSet.add("/fromParam/doc1.xml", metadata, new StringHandle("<doc>1</doc>").withFormat(Format.XML));
+        writeSet.add("/fromParam/doc2.xml", metadata, new StringHandle("<doc>2</doc>").withFormat(Format.XML));
+        plan = plan.bindParam("myDocs", writeSet);
+
+        rowMgr.resultRows(plan);
+
+        verifyXmlDoc("/fromParam/doc1.xml", "<doc>1</doc>");
+        verifyXmlDoc("/fromParam/doc2.xml", "<doc>2</doc>");
+    }
+
+    /**
+     * This test is used to document the fact that mixed content cannot be written yet.
+     */
+    @Test
+    public void jsonAndXmlDocumentsInDocumentWriteSet() {
+        if (!Common.markLogicIsVersion11OrHigher()) {
+            return;
+        }
+
+        RowManager rowMgr = Common.client.newRowManager();
+        PlanBuilder planBuilder = rowMgr.newPlanBuilder();
+        PlanBuilder.Plan plan = planBuilder.fromParam("myDocs", "", planBuilder.docColTypes()).write();
+
+        DocumentMetadataHandle metadata = new DocumentMetadataHandle();
+        DocumentWriteSet writeSet = Common.client.newDocumentManager().newWriteSet();
+        writeSet.add("/fromParam/doc1.xml", metadata, new StringHandle("<doc>1</doc>"));
+        writeSet.add("/fromParam/doc2.json", metadata, new StringHandle("{\"doc\":2}").withFormat(Format.JSON));
+        PlanBuilder.Plan finalPlan = plan.bindParam("myDocs", writeSet);
+
+        FailedRequestException ex = assertThrows(FailedRequestException.class, () -> rowMgr.resultRows(finalPlan));
+        assertTrue("Unexpected error: " + ex.getMessage(),
+                ex.getMessage().contains("'binding for '+bindingName+' is not in correct format.'"));
+    }
+
+    /**
+     * Verifies that the path through RawPlanImpl supports binding content params.
+     */
+    @Test
+    public void rawPlanAndDocumentWriteSet() {
+        if (!Common.markLogicIsVersion11OrHigher()) {
+            return;
+        }
+
+        RowManager rowMgr = Common.client.newRowManager();
+
+        RawPlanDefinition rawPlan = rowMgr.newRawPlanDefinition(new StringHandle("{\n" +
+                "    \"$optic\": {\n" +
+                "        \"ns\": \"op\",\n" +
+                "        \"fn\": \"operators\",\n" +
+                "        \"args\": [\n" +
+                "            {\n" +
+                "                \"ns\": \"op\",\n" +
+                "                \"fn\": \"from-param\",\n" +
+                "                \"args\": [\n" +
+                "                    {\n" +
+                "                        \"ns\": \"xs\",\n" +
+                "                        \"fn\": \"string\",\n" +
+                "                        \"args\": [\n" +
+                "                            \"myDocs\"\n" +
+                "                        ]\n" +
+                "                    },\n" +
+                "                    {\n" +
+                "                        \"ns\": \"xs\",\n" +
+                "                        \"fn\": \"string\",\n" +
+                "                        \"args\": [\n" +
+                "                            \"\"\n" +
+                "                        ]\n" +
+                "                    },\n" +
+                "                    {\n" +
+                "                        \"ns\": \"op\",\n" +
+                "                        \"fn\": \"doc-col-types\",\n" +
+                "                        \"args\": []\n" +
+                "                    }\n" +
+                "                ]\n" +
+                "            },\n" +
+                "            {\n" +
+                "                \"ns\": \"op\",\n" +
+                "                \"fn\": \"write\",\n" +
+                "                \"args\": []\n" +
+                "            }\n" +
+                "        ]\n" +
+                "    }\n" +
+                "}"));
+
+        DocumentMetadataHandle metadata = new DocumentMetadataHandle();
+        DocumentWriteSet writeSet = Common.client.newDocumentManager().newWriteSet();
+        writeSet.add("/fromParam/doc1.xml", metadata, new StringHandle("<doc>1</doc>").withFormat(Format.XML));
+        writeSet.add("/fromParam/doc2.xml", metadata, new StringHandle("<doc>2</doc>").withFormat(Format.XML));
+        PlanBuilder.Plan plan = rawPlan.bindParam("myDocs", writeSet);
+
+        rowMgr.resultRows(plan);
+
+        verifyXmlDoc("/fromParam/doc1.xml", "<doc>1</doc>");
+        verifyXmlDoc("/fromParam/doc2.xml", "<doc>2</doc>");
+    }
+
+    private void verifyXmlDoc(String uri, String expectedContent) {
+        StringHandle doc = Common.client.newXMLDocumentManager().read(uri, new StringHandle());
+        assertEquals(Format.XML, doc.getFormat());
+        assertTrue("Unexpected content: " + doc.get(), doc.get().contains(expectedContent));
+    }
+}

--- a/marklogic-client-api/src/test/ml-config/security/roles/rest-delete-graph.json
+++ b/marklogic-client-api/src/test/ml-config/security/roles/rest-delete-graph.json
@@ -1,10 +1,25 @@
 {
   "role-name": "rest-delete-graph",
-  "description": "Addresses a bug found in ML 10.0-8.3 and ML 10.0-9.2 where term-query is needed to delete a graph",
+  "description": "Addresses a bug found in ML 10.0-8.3 and ML 10.0-9.2 where term-query is needed to delete a graph; temporarily adding xdmp:invoke and any-uri until /v1/rows uses an amp to grant these for updates",
   "privilege": [
     {
       "privilege-name": "term-query",
       "action": "http://marklogic.com/xdmp/privileges/term-query",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "xdmp:invoke",
+      "action": "http://marklogic.com/xdmp/privileges/xdmp-invoke",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "any-uri",
+      "action": "http://marklogic.com/xdmp/privileges/any-uri",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "unprotected-collections",
+      "action": "http://marklogic.com/xdmp/privileges/unprotected-collections",
       "kind": "execute"
     }
   ]


### PR DESCRIPTION
This feature is not yet complete as it's waiting on some fixes/enhancements in the REST API. But it's good incremental progress until those fixes occur. 

Summary of changes: 

- Added bindParam(param, DocumentWriteSet)
- Added colType(column, type, nullable) as a convenience
- Combined bindParam(param, AbstractWriteHandle) and bindParamAttachments into a single new method - bindParam(param, AbstractWriteHandle, map of column names to attachments)
- Added ContentParam implementation class to simplifying ferrying around content params and optional attachment maps
