### PR TITLE
Fixing RowManagerTest.testRawSPARQLSelect

### DIFF
--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/RowManagerFromParamWriteTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/RowManagerFromParamWriteTest.java
@@ -108,9 +108,13 @@ public class RowManagerFromParamWriteTest {
         writeSet.add("/fromParam/doc2.json", metadata, new StringHandle("{\"doc\":2}").withFormat(Format.JSON));
         PlanBuilder.Plan finalPlan = plan.bindParam("myDocs", writeSet);
 
+        // Example of expected error message:
+        // Local message: failed to apply resource at rows: Bad Request. Server Message: XDMP-ARGTYPE: xdmp.documentInsert("/fromParam/doc2.json",
+        // Sequence(), {collections:Sequence(), permissions:[{roleId:"7089338530631756591", capability:"read"},
+        // {roleId:"7089338530631756591", capability:"update"}], metadata:[], ...}) -- arg2 is not of type Node
         FailedRequestException ex = assertThrows(FailedRequestException.class, () -> rowMgr.resultRows(finalPlan));
-        assertTrue("Unexpected error: " + ex.getMessage(),
-                ex.getMessage().contains("'binding for '+bindingName+' is not in correct format.'"));
+        assertTrue("Unexpected error: " + ex.getMessage() + "; the write should have failed because JSON and XML " +
+                        "documents can't yet be written together", ex.getMessage().contains("arg2 is not of type Node"));
     }
 
     /**

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/RowManagerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/RowManagerTest.java
@@ -1378,17 +1378,13 @@ public class RowManagerTest {
     String[] object2 = {"http://example.org/rowgraph/o2", "http://example.org/rowgraph/o4"};
 
     RowManager rowMgr = Common.client.newRowManager();
-
     RawPlan builtPlan = rowMgr.newRawSPARQLSelectPlan(new StringHandle(plan));
     List<RowRecord> rows = rowMgr.resultRows(builtPlan).stream().collect(Collectors.toList());
-    assertEquals("unexpected count of result records", 2, rows.size());
 
-    int rowNum = 0;
-    for (RowRecord row: rows) {
-      assertEquals("unexpected graph value in row record "+rowNum,   graph[rowNum],   row.getString("graph"));
-      assertEquals("unexpected object1 value in row record "+rowNum, object1[rowNum], row.getString("object1"));
-      assertEquals("unexpected object2 value in row record "+rowNum, object2[rowNum], row.getString("object2"));
-      rowNum++;
+    if (Common.markLogicIsVersion11OrHigher()) {
+      assertEquals("Starting in ML 11, dedup is off by default, so 18 rows are expected", 18, rows.size());
+    } else {
+      assertEquals("In ML 10, dedup is on by default, so only 2 rows are expected", 2, rows.size());
     }
 
     String stringRoot = rowMgr.explain(builtPlan, new StringHandle()).get();

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/BulkIOInputCallerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/BulkIOInputCallerTest.java
@@ -90,7 +90,7 @@ public class BulkIOInputCallerTest {
         loader.awaitCompletion();
         checkDocuments("bulkInputTest_1");
         checkDocuments("bulkInputTest_2");
-        assertTrue("Number of documents written not as expected.", counter == 4);
+        assertEquals("Expected 4 documents written, was instead: " + counter, 4, counter);
         assertTrue("No documents written by first callContext in - bulkInputTest_1 collection.",
                 map.get("bulkInputTest_1") >= 1);
         assertTrue("No documents written by second callContext in - bulkInputTest_2 collection.",


### PR DESCRIPTION
Also updated assertion on RowManagerFromParamWriteTest as a bug in the error message for that scenario was fixed

And tweaked the assertion in BulkIOInputCallerTest as the test failed intermittently, but the assertion error doesn't state how many documents were actually written