### PR TITLE
Extracted AbstractRowManagerTest

### DIFF
--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/AbstractRowManagerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/AbstractRowManagerTest.java
@@ -1,0 +1,74 @@
+package com.marklogic.client.test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.marklogic.client.expression.PlanBuilder;
+import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.client.io.JacksonHandle;
+import com.marklogic.client.io.StringHandle;
+import com.marklogic.client.row.RawPlanDefinition;
+import com.marklogic.client.row.RowManager;
+import com.marklogic.client.row.RowRecord;
+import org.junit.Before;
+
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+
+public abstract class AbstractRowManagerTest {
+
+    protected RowManager rowManager;
+    protected PlanBuilder op;
+    protected ObjectMapper mapper = new ObjectMapper();
+
+    @Before
+    public void beforeClass() {
+        Common.connect();
+        // Subclasses of this test are expected to only write URIs starting with /fromParam/, so delete all of them
+        // before running the test to ensure a document doesn't already exist.
+        Common.connectServerAdmin().newServerEval()
+                .xquery("cts:uri-match('/fromParam/*') ! xdmp:document-delete(.)")
+                .evalAs(String.class);
+
+        rowManager = Common.client.newRowManager();
+        op = rowManager.newPlanBuilder();
+    }
+
+    protected void verifyExportedPlanReturnsSameRowCount(PlanBuilder.ExportablePlan plan) {
+        verifyExportedPlanReturnsSameRowCount(plan, null);
+    }
+
+    protected final void verifyExportedPlanReturnsSameRowCount(PlanBuilder.ExportablePlan plan,
+                                                               Function<PlanBuilder.Plan, PlanBuilder.Plan> bindingFunction) {
+        PlanBuilder.Plan planToExecute = bindingFunction != null ? bindingFunction.apply(plan) : plan;
+        List<RowRecord> rowsFromPlan = rowManager
+                .resultRows(planToExecute)
+                .stream().collect(Collectors.toList());
+
+        String exportedPlan = plan.exportAs(String.class);
+        RawPlanDefinition rawPlan = rowManager.newRawPlanDefinition(new StringHandle(exportedPlan));
+        PlanBuilder.Plan rawPlanToExecute = bindingFunction != null ? bindingFunction.apply(rawPlan) : rawPlan;
+
+        List<RowRecord> rowsFromExportedPlan = rowManager
+                .resultRows(rawPlanToExecute)
+                .stream().collect(Collectors.toList());
+        assertEquals("The row count from the exported list should match that of the rows from the original plan",
+                rowsFromPlan.size(), rowsFromExportedPlan.size());
+    }
+
+    protected final void verifyJsonDoc(String uri, Consumer<ObjectNode> verifier) {
+        verifier.accept((ObjectNode) Common.client.newJSONDocumentManager().read(uri, new JacksonHandle()).get());
+    }
+
+    protected final void verifyMetadata(String uri, Consumer<DocumentMetadataHandle> verifier) {
+        verifier.accept(Common.client.newJSONDocumentManager().readMetadata(uri, new DocumentMetadataHandle()));
+    }
+
+    protected final String getRowContentWithoutXmlDeclaration(RowRecord row, String columnName) {
+        String content = row.getContentAs(columnName, String.class);
+        return content.replace("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n", "");
+    }
+}

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/RowManagerExportTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/RowManagerExportTest.java
@@ -1,25 +1,17 @@
 package com.marklogic.client.test;
 
 import com.marklogic.client.document.DocumentWriteSet;
-import com.marklogic.client.expression.PlanBuilder;
 import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.Format;
 import com.marklogic.client.io.StringHandle;
-import com.marklogic.client.row.RawPlanDefinition;
-import com.marklogic.client.row.RowManager;
-import com.marklogic.client.row.RowRecord;
 import com.marklogic.client.type.CtsReferenceExpr;
 import com.marklogic.client.type.PlanTripleOption;
-import org.junit.Before;
+
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * Verifies that export/import works for each accessor. This test is critical to ensure that each generated accessor
@@ -28,17 +20,8 @@ import static org.junit.Assert.assertEquals;
  * <p>
  * fromLiterals is not tested here because RowManagerTest already verifies export/import for it.
  */
-public class RowManagerExportTest {
-
-    private RowManager rowManager;
-    private PlanBuilder op;
-
-    @Before
-    public void beforeClass() {
-        Common.connect();
-        rowManager = Common.client.newRowManager();
-        op = rowManager.newPlanBuilder();
-    }
+@Ignore("Causing eventual segfaults, see https://bugtrack.marklogic.com/57916")
+public class RowManagerExportTest extends AbstractRowManagerTest {
 
     @Test
     public void fromDocUris() {
@@ -47,45 +30,44 @@ public class RowManagerExportTest {
         // );
     }
 
-    // @Test
-    // public void fromLexicons() {
-    //     Map<String, CtsReferenceExpr> lexicons = new HashMap<>();
-    //     lexicons.put("uri", op.cts.uriReference());
-    //     lexicons.put("int", op.cts.elementReference(op.xs.QName("int")));
+//     @Test
+//     public void fromLexicons() {
+//         Map<String, CtsReferenceExpr> lexicons = new HashMap<>();
+//         lexicons.put("uri", op.cts.uriReference());
+//         lexicons.put("int", op.cts.elementReference(op.xs.QName("int")));
 
-    //     verifyExportedPlanReturnsSameRowCount(
-    //             op.fromLexicons(lexicons)
-    //     );
-    // }
+//         verifyExportedPlanReturnsSameRowCount(
+//                 op.fromLexicons(lexicons)
+//         );
+//     }
 
-    // @Test
-    // public void fromParam() {
-    //     DocumentMetadataHandle metadata = new DocumentMetadataHandle();
-    //     DocumentWriteSet writeSet = Common.client.newDocumentManager().newWriteSet();
-    //     writeSet.add("/fromParam/doc1.xml", metadata, new StringHandle("<doc>1</doc>").withFormat(Format.XML));
-    //     writeSet.add("/fromParam/doc2.xml", metadata, new StringHandle("<doc>2</doc>").withFormat(Format.XML));
+//     @Test
+//     public void fromParam() {
+//         DocumentMetadataHandle metadata = new DocumentMetadataHandle();
+//         DocumentWriteSet writeSet = Common.client.newDocumentManager().newWriteSet();
+//         writeSet.add("/fromParam/doc1.xml", metadata, new StringHandle("<doc>1</doc>").withFormat(Format.XML));
+//         writeSet.add("/fromParam/doc2.xml", metadata, new StringHandle("<doc>2</doc>").withFormat(Format.XML));
 
-    //     verifyExportedPlanReturnsSameRowCount(
-    //             op.fromParam("myDocs", "", op.docColTypes()),
-    //             plan -> plan.bindParam("myDocs", writeSet)
-    //     );
-    // }
+//         verifyExportedPlanReturnsSameRowCount(
+//                 op.fromParam("myDocs", "", op.docColTypes()),
+//                 plan -> plan.bindParam("myDocs", writeSet)
+//         );
+//     }
 
-    // @Test
-    // public void fromSearch() {
-    //     verifyExportedPlanReturnsSameRowCount(
-    //             op.fromSearch(op.cts.jsonPropertyValueQuery("instrument", "trumpet"))
-    //     );
-    // }
-    
-    // @Test
-    // public void fromSearchDocs() {
-    //     verifyExportedPlanReturnsSameRowCount(
-    //             op.fromSearchDocs(op.cts.wordQuery("trumpet"))
-    //     );
-    // }
+//     @Test
+//     public void fromSearch() {
+//         verifyExportedPlanReturnsSameRowCount(
+//                 op.fromSearch(op.cts.jsonPropertyValueQuery("instrument", "trumpet"))
+//         );
+//     }
 
-    // Ignoring, as running these and then running a fromDocDescriptors or fromParam test is causing a segfault
+//     @Test
+//     public void fromSearchDocs() {
+//         verifyExportedPlanReturnsSameRowCount(
+//                 op.fromSearchDocs(op.cts.wordQuery("trumpet"))
+//         );
+//     }
+
 //     @Test
 //     public void fromSparql() {
 //         String selectStmt = "PREFIX ad: <http://marklogicsparql.com/addressbook#> " +
@@ -106,43 +88,21 @@ public class RowManagerExportTest {
 //         );
 //     }
 
-    // @Test
-    // public void fromTriples() {
-    //     verifyExportedPlanReturnsSameRowCount(
-    //             op.fromTriples(
-    //                     op.pattern(op.col("subject"), op.prefixer("http://example.org/rowgraph").iri("p1"), op.col("object")),
-    //                     null, (String) null, PlanTripleOption.DEDUPLICATED
-    //             )
-    //     );
-    // }
+//     @Test
+//     public void fromTriples() {
+//         verifyExportedPlanReturnsSameRowCount(
+//                 op.fromTriples(
+//                         op.pattern(op.col("subject"), op.prefixer("http://example.org/rowgraph").iri("p1"), op.col("object")),
+//                         null, (String) null, PlanTripleOption.DEDUPLICATED
+//                 )
+//         );
+//     }
 
-    // @Test
-    // public void fromView() {
-    //     verifyExportedPlanReturnsSameRowCount(
-    //             op.fromView("opticUnitTest", "musician"), null
-    //     );
-    // }
+//     @Test
+//     public void fromView() {
+//         verifyExportedPlanReturnsSameRowCount(
+//                 op.fromView("opticUnitTest", "musician"), null
+//         );
+//     }
 
-    private void verifyExportedPlanReturnsSameRowCount(PlanBuilder.ExportablePlan plan) {
-        verifyExportedPlanReturnsSameRowCount(plan, null);
-    }
-
-    private void verifyExportedPlanReturnsSameRowCount(PlanBuilder.ExportablePlan plan,
-                                                       Function<PlanBuilder.Plan, PlanBuilder.Plan> bindingFunction) {
-        PlanBuilder.Plan planToExecute = bindingFunction != null ? bindingFunction.apply(plan) : plan;
-        List<RowRecord> rowsFromPlan = rowManager
-                .resultRows(planToExecute)
-                .stream().collect(Collectors.toList());
-
-        String exportedPlan = plan.exportAs(String.class);
-        RawPlanDefinition rawPlan = rowManager.newRawPlanDefinition(new StringHandle(exportedPlan));
-        PlanBuilder.Plan rawPlanToExecute = bindingFunction != null ? bindingFunction.apply(rawPlan) : rawPlan;
-
-        List<RowRecord> rowsFromExportedPlan = rowManager
-                .resultRows(rawPlanToExecute)
-                .stream().collect(Collectors.toList());
-        assertEquals("The row count from the exported list should match that of the rows from the original plan",
-                rowsFromPlan.size(), rowsFromExportedPlan.size());
-
-    }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/RowManagerFromParamWriteTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/RowManagerFromParamWriteTest.java
@@ -3,16 +3,13 @@ package com.marklogic.client.test;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marklogic.client.FailedRequestException;
 import com.marklogic.client.document.DocumentWriteSet;
-import com.marklogic.client.document.JSONDocumentManager;
 import com.marklogic.client.expression.PlanBuilder;
 import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.Format;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.row.RawPlanDefinition;
-import com.marklogic.client.row.RowManager;
 import com.marklogic.client.row.RowRecord;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.List;
@@ -20,15 +17,7 @@ import java.util.stream.Collectors;
 
 import static org.junit.Assert.*;
 
-public class RowManagerFromParamWriteTest {
-
-    @BeforeClass
-    public static void beforeClass() {
-        Common.connect();
-        Common.connectServerAdmin().newServerEval()
-                .xquery("cts:uri-match('/fromParam/*') ! xdmp:document-delete(.)")
-                .evalAs(String.class);
-    }
+public class RowManagerFromParamWriteTest extends AbstractRowManagerTest {
 
     @Test
     public void jsonDocumentWithAllMetadata() {
@@ -36,152 +25,144 @@ public class RowManagerFromParamWriteTest {
             return;
         }
 
-//         RowManager rowMgr = Common.client.newRowManager();
-//         PlanBuilder planBuilder = rowMgr.newPlanBuilder();
-//         PlanBuilder.Plan plan = planBuilder
-//                 .fromParam("myDocs", "", planBuilder.docColTypes())
-//                 .write();
+        PlanBuilder.Plan plan = op
+                .fromParam("myDocs", "", op.docColTypes())
+                .write();
 
-//         DocumentMetadataHandle metadata = new DocumentMetadataHandle()
-//                 .withQuality(2)
-// //                // TODO Metadata and permissions not supported by server yet
-// //                .withMetadataValue("meta1", "value1")
-// //                .withMetadataValue("meta2", "value2")
-//                 .withPermission("rest-reader", DocumentMetadataHandle.Capability.READ, DocumentMetadataHandle.Capability.UPDATE)
-//                 .withCollections("common-coll", "other-coll-1");
+        DocumentMetadataHandle metadata = new DocumentMetadataHandle()
+                .withQuality(2)
+//                // TODO Metadata and permissions not supported by server yet
+//                .withMetadataValue("meta1", "value1")
+//                .withMetadataValue("meta2", "value2")
+                .withPermission("rest-reader", DocumentMetadataHandle.Capability.READ, DocumentMetadataHandle.Capability.UPDATE)
+                .withCollections("common-coll", "other-coll-1");
 
-//         DocumentWriteSet writeSet = Common.client.newDocumentManager().newWriteSet();
-//         writeSet.add("/fromParam/doc1.json", metadata,
-//                 new JacksonHandle(new ObjectMapper().createObjectNode().put("value", 1)));
-//         plan = plan.bindParam("myDocs", writeSet);
+        DocumentWriteSet writeSet = Common.client.newDocumentManager().newWriteSet();
+        writeSet.add("/fromParam/doc1.json", metadata,
+                new JacksonHandle(new ObjectMapper().createObjectNode().put("value", 1)));
+        plan = plan.bindParam("myDocs", writeSet);
 
-//         List<RowRecord> rows = rowMgr.resultRows(plan).stream().collect(Collectors.toList());
-//         // TODO Is this expected - that we don't get any rows back?
-//         assertEquals(0, rows.size());
+        List<RowRecord> rows = rowManager.resultRows(plan).stream().collect(Collectors.toList());
+        // TODO Is this expected - that we don't get any rows back?
+        // See - https://bugtrack.marklogic.com/57902
+        assertEquals(0, rows.size());
 
-//         JSONDocumentManager mgr = Common.client.newJSONDocumentManager();
-
-//         metadata = mgr.readMetadata("/fromParam/doc1.json", new DocumentMetadataHandle());
-//         assertEquals(2, metadata.getQuality());
-//         assertTrue(metadata.getCollections().contains("common-coll"));
-//         assertTrue(metadata.getCollections().contains("other-coll-1"));
+        verifyMetadata("/fromParam/doc1.json", docMetadata -> {
+            assertEquals(2, docMetadata.getQuality());
+            assertTrue(docMetadata.getCollections().contains("common-coll"));
+            assertTrue(docMetadata.getCollections().contains("other-coll-1"));
+        });
     }
 
-//     @Test
-//     public void xmlDocumentWriteSet() {
-//         if (!Common.markLogicIsVersion11OrHigher()) {
-//             return;
-//         }
+    @Test
+    public void xmlDocumentWriteSet() {
+        if (!Common.markLogicIsVersion11OrHigher()) {
+            return;
+        }
 
-//         RowManager rowMgr = Common.client.newRowManager();
-//         PlanBuilder planBuilder = rowMgr.newPlanBuilder();
-//         PlanBuilder.Plan plan = planBuilder.fromParam("myDocs", "", planBuilder.docColTypes()).write();
+        PlanBuilder.Plan plan = op.fromParam("myDocs", "", op.docColTypes()).write();
 
-//         DocumentMetadataHandle metadata = new DocumentMetadataHandle();
-//         DocumentWriteSet writeSet = Common.client.newDocumentManager().newWriteSet();
-//         writeSet.add("/fromParam/doc1.xml", metadata, new StringHandle("<doc>1</doc>").withFormat(Format.XML));
-//         writeSet.add("/fromParam/doc2.xml", metadata, new StringHandle("<doc>2</doc>").withFormat(Format.XML));
-//         plan = plan.bindParam("myDocs", writeSet);
+        DocumentMetadataHandle metadata = new DocumentMetadataHandle();
+        DocumentWriteSet writeSet = Common.client.newDocumentManager().newWriteSet();
+        writeSet.add("/fromParam/doc1.xml", metadata, new StringHandle("<doc>1</doc>").withFormat(Format.XML));
+        writeSet.add("/fromParam/doc2.xml", metadata, new StringHandle("<doc>2</doc>").withFormat(Format.XML));
+        plan = plan.bindParam("myDocs", writeSet);
 
-//         rowMgr.resultRows(plan);
+        rowManager.resultRows(plan);
 
-//         verifyXmlDoc("/fromParam/doc1.xml", "<doc>1</doc>");
-//         verifyXmlDoc("/fromParam/doc2.xml", "<doc>2</doc>");
-//     }
+        verifyXmlDoc("/fromParam/doc1.xml", "<doc>1</doc>");
+        verifyXmlDoc("/fromParam/doc2.xml", "<doc>2</doc>");
+    }
 
-//     /**
-//      * This test is used to document the fact that mixed content cannot be written yet.
-//      */
-//     @Test
-//     public void jsonAndXmlDocumentsInDocumentWriteSet() {
-//         if (!Common.markLogicIsVersion11OrHigher()) {
-//             return;
-//         }
+    /**
+     * This test is used to document the fact that mixed content cannot be written yet.
+     */
+    @Test
+    public void jsonAndXmlDocumentsInDocumentWriteSet() {
+        if (!Common.markLogicIsVersion11OrHigher()) {
+            return;
+        }
 
-//         RowManager rowMgr = Common.client.newRowManager();
-//         PlanBuilder planBuilder = rowMgr.newPlanBuilder();
-//         PlanBuilder.Plan plan = planBuilder.fromParam("myDocs", "", planBuilder.docColTypes()).write();
+        PlanBuilder.Plan plan = op.fromParam("myDocs", "", op.docColTypes()).write();
 
-//         DocumentMetadataHandle metadata = new DocumentMetadataHandle();
-//         DocumentWriteSet writeSet = Common.client.newDocumentManager().newWriteSet();
-//         writeSet.add("/fromParam/doc1.xml", metadata, new StringHandle("<doc>1</doc>"));
-//         writeSet.add("/fromParam/doc2.json", metadata, new StringHandle("{\"doc\":2}").withFormat(Format.JSON));
-//         PlanBuilder.Plan finalPlan = plan.bindParam("myDocs", writeSet);
+        DocumentMetadataHandle metadata = new DocumentMetadataHandle();
+        DocumentWriteSet writeSet = Common.client.newDocumentManager().newWriteSet();
+        writeSet.add("/fromParam/doc1.xml", metadata, new StringHandle("<doc>1</doc>"));
+        writeSet.add("/fromParam/doc2.json", metadata, new StringHandle("{\"doc\":2}").withFormat(Format.JSON));
+        PlanBuilder.Plan finalPlan = plan.bindParam("myDocs", writeSet);
 
-//         // Example of expected error message:
-//         // Local message: failed to apply resource at rows: Bad Request. Server Message: XDMP-ARGTYPE: xdmp.documentInsert("/fromParam/doc2.json",
-//         // Sequence(), {collections:Sequence(), permissions:[{roleId:"7089338530631756591", capability:"read"},
-//         // {roleId:"7089338530631756591", capability:"update"}], metadata:[], ...}) -- arg2 is not of type Node
-//         FailedRequestException ex = assertThrows(FailedRequestException.class, () -> rowMgr.resultRows(finalPlan));
-//         assertTrue("Unexpected error: " + ex.getMessage() + "; the write should have failed because JSON and XML " +
-//                         "documents can't yet be written together", ex.getMessage().contains("arg2 is not of type Node"));
-//     }
+        // Example of expected error message:
+        // Local message: failed to apply resource at rows: Bad Request. Server Message: XDMP-ARGTYPE: xdmp.documentInsert("/fromParam/doc2.json",
+        // Sequence(), {collections:Sequence(), permissions:[{roleId:"7089338530631756591", capability:"read"},
+        // {roleId:"7089338530631756591", capability:"update"}], metadata:[], ...}) -- arg2 is not of type Node
+        FailedRequestException ex = assertThrows(FailedRequestException.class, () -> rowManager.resultRows(finalPlan));
+        assertTrue("Unexpected error: " + ex.getMessage() + "; the write should have failed because JSON and XML " +
+                "documents can't yet be written together", ex.getMessage().contains("arg2 is not of type Node"));
+    }
 
-//     /**
-//      * Verifies that the path through RawPlanImpl supports binding content params.
-//      */
-//     @Test
-//     public void rawPlanAndDocumentWriteSet() {
-//         if (!Common.markLogicIsVersion11OrHigher()) {
-//             return;
-//         }
+    /**
+     * Verifies that the path through RawPlanImpl supports binding content params.
+     */
+    @Test
+    public void rawPlanAndDocumentWriteSet() {
+        if (!Common.markLogicIsVersion11OrHigher()) {
+            return;
+        }
 
-//         RowManager rowMgr = Common.client.newRowManager();
+        RawPlanDefinition rawPlan = rowManager.newRawPlanDefinition(new StringHandle("{\n" +
+                "    \"$optic\": {\n" +
+                "        \"ns\": \"op\",\n" +
+                "        \"fn\": \"operators\",\n" +
+                "        \"args\": [\n" +
+                "            {\n" +
+                "                \"ns\": \"op\",\n" +
+                "                \"fn\": \"from-param\",\n" +
+                "                \"args\": [\n" +
+                "                    {\n" +
+                "                        \"ns\": \"xs\",\n" +
+                "                        \"fn\": \"string\",\n" +
+                "                        \"args\": [\n" +
+                "                            \"myDocs\"\n" +
+                "                        ]\n" +
+                "                    },\n" +
+                "                    {\n" +
+                "                        \"ns\": \"xs\",\n" +
+                "                        \"fn\": \"string\",\n" +
+                "                        \"args\": [\n" +
+                "                            \"\"\n" +
+                "                        ]\n" +
+                "                    },\n" +
+                "                    {\n" +
+                "                        \"ns\": \"op\",\n" +
+                "                        \"fn\": \"doc-col-types\",\n" +
+                "                        \"args\": []\n" +
+                "                    }\n" +
+                "                ]\n" +
+                "            },\n" +
+                "            {\n" +
+                "                \"ns\": \"op\",\n" +
+                "                \"fn\": \"write\",\n" +
+                "                \"args\": []\n" +
+                "            }\n" +
+                "        ]\n" +
+                "    }\n" +
+                "}"));
 
-//         RawPlanDefinition rawPlan = rowMgr.newRawPlanDefinition(new StringHandle("{\n" +
-//                 "    \"$optic\": {\n" +
-//                 "        \"ns\": \"op\",\n" +
-//                 "        \"fn\": \"operators\",\n" +
-//                 "        \"args\": [\n" +
-//                 "            {\n" +
-//                 "                \"ns\": \"op\",\n" +
-//                 "                \"fn\": \"from-param\",\n" +
-//                 "                \"args\": [\n" +
-//                 "                    {\n" +
-//                 "                        \"ns\": \"xs\",\n" +
-//                 "                        \"fn\": \"string\",\n" +
-//                 "                        \"args\": [\n" +
-//                 "                            \"myDocs\"\n" +
-//                 "                        ]\n" +
-//                 "                    },\n" +
-//                 "                    {\n" +
-//                 "                        \"ns\": \"xs\",\n" +
-//                 "                        \"fn\": \"string\",\n" +
-//                 "                        \"args\": [\n" +
-//                 "                            \"\"\n" +
-//                 "                        ]\n" +
-//                 "                    },\n" +
-//                 "                    {\n" +
-//                 "                        \"ns\": \"op\",\n" +
-//                 "                        \"fn\": \"doc-col-types\",\n" +
-//                 "                        \"args\": []\n" +
-//                 "                    }\n" +
-//                 "                ]\n" +
-//                 "            },\n" +
-//                 "            {\n" +
-//                 "                \"ns\": \"op\",\n" +
-//                 "                \"fn\": \"write\",\n" +
-//                 "                \"args\": []\n" +
-//                 "            }\n" +
-//                 "        ]\n" +
-//                 "    }\n" +
-//                 "}"));
+        DocumentMetadataHandle metadata = new DocumentMetadataHandle();
+        DocumentWriteSet writeSet = Common.client.newDocumentManager().newWriteSet();
+        writeSet.add("/fromParam/doc1.xml", metadata, new StringHandle("<doc>1</doc>").withFormat(Format.XML));
+        writeSet.add("/fromParam/doc2.xml", metadata, new StringHandle("<doc>2</doc>").withFormat(Format.XML));
+        PlanBuilder.Plan plan = rawPlan.bindParam("myDocs", writeSet);
 
-//         DocumentMetadataHandle metadata = new DocumentMetadataHandle();
-//         DocumentWriteSet writeSet = Common.client.newDocumentManager().newWriteSet();
-//         writeSet.add("/fromParam/doc1.xml", metadata, new StringHandle("<doc>1</doc>").withFormat(Format.XML));
-//         writeSet.add("/fromParam/doc2.xml", metadata, new StringHandle("<doc>2</doc>").withFormat(Format.XML));
-//         PlanBuilder.Plan plan = rawPlan.bindParam("myDocs", writeSet);
+        rowManager.resultRows(plan);
 
-//         rowMgr.resultRows(plan);
+        verifyXmlDoc("/fromParam/doc1.xml", "<doc>1</doc>");
+        verifyXmlDoc("/fromParam/doc2.xml", "<doc>2</doc>");
+    }
 
-//         verifyXmlDoc("/fromParam/doc1.xml", "<doc>1</doc>");
-//         verifyXmlDoc("/fromParam/doc2.xml", "<doc>2</doc>");
-//     }
-
-//     private void verifyXmlDoc(String uri, String expectedContent) {
-//         StringHandle doc = Common.client.newXMLDocumentManager().read(uri, new StringHandle());
-//         assertEquals(Format.XML, doc.getFormat());
-//         assertTrue("Unexpected content: " + doc.get(), doc.get().contains(expectedContent));
-//     }
+    private void verifyXmlDoc(String uri, String expectedContent) {
+        StringHandle doc = Common.client.newXMLDocumentManager().read(uri, new StringHandle());
+        assertEquals(Format.XML, doc.getFormat());
+        assertTrue("Unexpected content: " + doc.get(), doc.get().contains(expectedContent));
+    }
 }


### PR DESCRIPTION
Cutting down on some duplication across the RowManager tests. Also re-enabled the FromParam tests, as I don't think those are an issue, it's just some export tests that cause FromParam tests to later fail. 