### PR TITLE
JAVA-265: Initial support for fromDocDescriptors

### DIFF
--- a/marklogic-client-api/src/main/java/com/marklogic/client/expression/PlanBuilderBase.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/expression/PlanBuilderBase.java
@@ -17,6 +17,7 @@ package com.marklogic.client.expression;
 
 import java.util.Map;
 
+import com.marklogic.client.document.DocumentWriteOperation;
 import com.marklogic.client.document.DocumentWriteSet;
 import com.marklogic.client.io.marker.AbstractWriteHandle;
 import com.marklogic.client.io.marker.JSONReadHandle;
@@ -407,6 +408,22 @@ public interface PlanBuilderBase {
      * @return a sequence of column identifiers
      */
     PlanRowColTypesSeq colTypes(PlanRowColTypes... colTypes);
+
+    /**
+     * Build a single doc descriptor that can be used with {@code fromDocDescriptors}.
+     *
+     * @param writeOp contains the inputs for the doc descriptor
+     * @return a doc descriptor
+     */
+    PlanDocDescriptor docDescriptor(DocumentWriteOperation writeOp);
+
+    /**
+     * Build a sequence of doc descriptors that can be used with {@code fromDocDescriptors}.
+     *
+     * @param writeSet each {@code DocumentWriteOperation} in this will be converted into a doc descriptor
+     * @return a sequence of doc descriptors
+     */
+    PlanDocDescriptorSeq docDescriptors(DocumentWriteSet writeSet);
 
     /**
      * Defines base methods for Plan. This interface is an implementation detail.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/ContentParam.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/ContentParam.java
@@ -1,14 +1,7 @@
 package com.marklogic.client.impl;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.client.document.DocumentWriteSet;
-import com.marklogic.client.io.BaseHandle;
-import com.marklogic.client.io.DocumentMetadataHandle;
-import com.marklogic.client.io.Format;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.marker.AbstractWriteHandle;
 
@@ -59,79 +52,11 @@ class ContentParam {
      * @return
      */
     public static ContentParam fromDocumentWriteSet(PlanBuilderBaseImpl.PlanParamBase param, DocumentWriteSet writeSet) {
-        ArrayNode contentRows = new ObjectMapper().createArrayNode();
         Map<String, AbstractWriteHandle> attachments = new HashMap<>();
-
-        writeSet.stream().forEach(writeOp -> {
-            String uri = writeOp.getUri();
-            AbstractWriteHandle content = writeOp.getContent();
-
-            ObjectNode row = contentRows.addObject();
-            row.put("uri", uri);
-
-            JsonNode jsonContent = getJsonNodeFromContent(content);
-            if (jsonContent != null) {
-                // JSON attachments aren't supported yet, so we need to inline it
-                row.set("doc", jsonContent);
-            } else {
-                // For every other content type, make an attachment
-                row.put("doc", "attachment-" + uri);
-                attachments.put("attachment-" + uri, content);
-            }
-
-            if (writeOp.getMetadata() instanceof DocumentMetadataHandle) {
-                DocumentMetadataHandle metadata = (DocumentMetadataHandle) writeOp.getMetadata();
-                row.put("quality", metadata.getQuality());
-
-                if (!metadata.getCollections().isEmpty()) {
-                    ArrayNode collections = row.putArray("collections");
-                    metadata.getCollections().forEach(c -> collections.add(c));
-                }
-
-//          if (!metadata.getPermissions().isEmpty()) {
-//            ArrayNode permissions = row.putArray("permissions");
-//            for (String roleName : metadata.getPermissions().keySet()) {
-//              for (DocumentMetadataHandle.Capability c : metadata.getPermissions().get(roleName)) {
-//                permissions.addObject().put("roleId", "7089338530631756591").put("capability", c.toString().toLowerCase());
-//              }
-//            }
-//          }
-
-                // Hack until the REST endpoint supports a JSON serialization of permissions
-                ArrayNode permissions = row.putArray("permissions");
-                permissions.addObject().put("roleId", "7089338530631756591").put("capability", "read");
-                permissions.addObject().put("roleId", "7089338530631756591").put("capability", "update");
-
-                if (!metadata.getMetadataValues().isEmpty()) {
-                    ObjectNode values = row.putObject("metadata");
-                    for (String key : metadata.getMetadataValues().keySet()) {
-                        values.put(key, metadata.getMetadataValues().get(key));
-                    }
-                }
-            }
-        });
-
-        Map<String, Map<String, AbstractWriteHandle>> columnAttachments = attachments.isEmpty() ? null :
-                Collections.singletonMap("doc", attachments);
+        ArrayNode contentRows = DocDescriptorUtil.buildDocDescriptors(writeSet, attachments);
+        Map<String, Map<String, AbstractWriteHandle>> columnAttachments =
+                attachments.isEmpty() ? null : Collections.singletonMap("doc", attachments);
         JacksonHandle content = new JacksonHandle(contentRows);
         return new ContentParam(param, content, columnAttachments);
-    }
-
-    private static JsonNode getJsonNodeFromContent(AbstractWriteHandle content) {
-        if (content instanceof JacksonHandle) {
-            return ((JacksonHandle) content).get();
-        }
-        if (content instanceof BaseHandle) {
-            BaseHandle h = (BaseHandle) content;
-            if (Format.JSON.equals(h.getFormat())) {
-                String json = HandleAccessor.contentAsString(content);
-                try {
-                    return new ObjectMapper().readTree(json);
-                } catch (JsonProcessingException e) {
-                    throw new RuntimeException("Unable to read content as JSON; cause: " + e.getMessage(), e);
-                }
-            }
-        }
-        return null;
     }
 }

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/DocDescriptorUtil.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/DocDescriptorUtil.java
@@ -1,0 +1,123 @@
+package com.marklogic.client.impl;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.marklogic.client.document.DocumentWriteOperation;
+import com.marklogic.client.document.DocumentWriteSet;
+import com.marklogic.client.io.BaseHandle;
+import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.client.io.Format;
+import com.marklogic.client.io.JacksonHandle;
+import com.marklogic.client.io.marker.AbstractWriteHandle;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+/**
+ * Helper for constructing document descriptor rows, either when using {@code fromDocDescriptors} or when using
+ * {@code fromParam} and {@code bindParam} together.
+ */
+class DocDescriptorUtil {
+
+    public static ArrayNode buildDocDescriptors(DocumentWriteSet writeSet) {
+        return buildDocDescriptors(writeSet, null);
+    }
+
+    public static ArrayNode buildDocDescriptors(DocumentWriteSet writeSet,
+                                                Map<String, AbstractWriteHandle> attachments) {
+        ArrayNode docDescriptors = new ObjectMapper().createArrayNode();
+        writeSet.stream().forEach(writeOp -> populateDocDescriptor(writeOp, docDescriptors.addObject(), attachments));
+        return docDescriptors;
+    }
+
+    public static void populateDocDescriptor(DocumentWriteOperation writeOp, ObjectNode docDescriptor) {
+        populateDocDescriptor(writeOp, docDescriptor, null);
+    }
+
+    public static void populateDocDescriptor(DocumentWriteOperation writeOp,
+                                             ObjectNode docDescriptor,
+                                             Map<String, AbstractWriteHandle> attachments) {
+        String uri = writeOp.getUri();
+        docDescriptor.put("uri", uri);
+
+        if (StringUtils.isNotBlank(writeOp.getTemporalDocumentURI())) {
+            docDescriptor.put("temporalCollection", writeOp.getTemporalDocumentURI());
+        }
+
+        AbstractWriteHandle content = writeOp.getContent();
+        JsonNode jsonContent = getJsonNodeFromContent(content);
+        if (jsonContent != null) {
+            // JSON attachments aren't yet supported by the REST endpoint, so they are always inlined, regardless
+            // of whether client provided an attachments map or not
+            docDescriptor.set("doc", jsonContent);
+        } else if (attachments != null) {
+            docDescriptor.put("doc", "attachment-" + uri);
+            attachments.put("attachment-" + uri, content);
+        } else {
+            // As of the 5.6.0 release, an assumption is made here that if no attachments map is provided, then
+            // fromDocDescriptors is being used, which only supports JSON content
+            throw new IllegalArgumentException("Only JSON content can be used with fromDocDescriptors; " +
+                    "non-JSON content found for document with URI: " + uri);
+        }
+
+        if (writeOp.getMetadata() instanceof DocumentMetadataHandle) {
+            populateMetadata((DocumentMetadataHandle) writeOp.getMetadata(), docDescriptor);
+        } else if (writeOp.getMetadata() != null) {
+            LoggerFactory.getLogger(DocDescriptorUtil.class).warn("Can only add metadata to a doc descriptor when " +
+                    "the class is an instance of DocumentMetadataHandle; document URI: " + uri);
+        }
+    }
+
+    private static void populateMetadata(DocumentMetadataHandle metadata, ObjectNode docDescriptor) {
+        docDescriptor.put("quality", metadata.getQuality());
+
+        if (!metadata.getCollections().isEmpty()) {
+            ArrayNode collections = docDescriptor.putArray("collections");
+            metadata.getCollections().forEach(c -> collections.add(c));
+        }
+
+//          if (!metadata.getPermissions().isEmpty()) {
+//            ArrayNode permissions = row.putArray("permissions");
+//            for (String roleName : metadata.getPermissions().keySet()) {
+//              for (DocumentMetadataHandle.Capability c : metadata.getPermissions().get(roleName)) {
+//                permissions.addObject().put("roleId", "7089338530631756591").put("capability", c.toString().toLowerCase());
+//              }
+//            }
+//          }
+
+        // Hack until the REST endpoint supports a JSON serialization of permissions
+        ArrayNode permissions = docDescriptor.putArray("permissions");
+        permissions.addObject().put("roleId", "7089338530631756591").put("capability", "read");
+        permissions.addObject().put("roleId", "7089338530631756591").put("capability", "update");
+
+        if (!metadata.getMetadataValues().isEmpty()) {
+            ObjectNode values = docDescriptor.putObject("metadata");
+            for (String key : metadata.getMetadataValues().keySet()) {
+                values.put(key, metadata.getMetadataValues().get(key));
+            }
+        }
+    }
+
+    private static JsonNode getJsonNodeFromContent(AbstractWriteHandle content) {
+        if (content instanceof JacksonHandle) {
+            return ((JacksonHandle) content).get();
+        }
+        if (content instanceof BaseHandle) {
+            BaseHandle h = (BaseHandle) content;
+            if (Format.JSON.equals(h.getFormat())) {
+                String json = HandleAccessor.contentAsString(content);
+                try {
+                    return new ObjectMapper().readTree(json);
+                } catch (JsonProcessingException e) {
+                    throw new RuntimeException("Unable to read content as JSON; cause: " + e.getMessage(), e);
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/marklogic-client-api/src/test/java/com/marklogic/client/impl/PlanDocDescriptorImplTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/impl/PlanDocDescriptorImplTest.java
@@ -1,0 +1,74 @@
+package com.marklogic.client.impl;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.marklogic.client.document.DocumentWriteOperation;
+import com.marklogic.client.document.DocumentWriteOperation.OperationType;
+import com.marklogic.client.impl.PlanBuilderSubImpl.PlanDocDescriptorImpl;
+import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.client.io.DocumentMetadataHandle.Capability;
+import com.marklogic.client.io.Format;
+import com.marklogic.client.io.StringHandle;
+
+public class PlanDocDescriptorImplTest extends Assert {
+
+    @Test
+    public void minimalWriteOp() {
+        ObjectNode plan = export(new DocumentWriteOperationImpl(
+                "/test.json", new StringHandle("{\"hello\":1}").withFormat(Format.JSON)));
+        assertEquals("/test.json", plan.get("uri").asText());
+        assertEquals(1, plan.get("doc").get("hello").asInt());
+        assertEquals("Expecting only 'uri' and 'doc'", 2, plan.size());
+    }
+
+    @Test
+    public void completeWriteOp() {
+        DocumentMetadataHandle metadata = new DocumentMetadataHandle();
+        metadata.getCollections().addAll("c1", "c2");
+        metadata.setQuality(2);
+        metadata.getMetadataValues().add("key1", "value1");
+        metadata.getMetadataValues().add("key2", "value2");
+        metadata.getPermissions().add("rest-reader", Capability.READ, Capability.EXECUTE);
+        metadata.getPermissions().add("rest-writer", Capability.UPDATE);
+        metadata.getProperties().put("prop1", "value1");
+
+        ObjectNode plan = export(new DocumentWriteOperationImpl(OperationType.DOCUMENT_WRITE,
+                "/test2.json", metadata, new StringHandle("{}").withFormat(Format.JSON), "someTemporalCollection"));
+
+        assertEquals("/test2.json", plan.get("uri").asText());
+        assertEquals("someTemporalCollection", plan.get("temporalCollection").asText());
+        assertEquals(2, plan.get("quality").asInt());
+        assertEquals("c1", plan.get("collections").get(0).asText());
+        assertEquals("c2", plan.get("collections").get(1).asText());
+        // TODO Test permissions for real, not these hardcoded ones
+        // Should really be 3 permissions
+        assertEquals(2, plan.get("permissions").size());
+        assertEquals("value1", plan.get("metadata").get("key1").asText());
+        assertEquals("value2", plan.get("metadata").get("key2").asText());
+
+        assertEquals("Expecting uri, temporalCollection, doc, quality, collections, permissions, and metadata; "
+                + "document properties are not yet supported", 7, plan.size());
+    }
+
+    @Test
+    public void nonJsonContent() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> export(
+                new DocumentWriteOperationImpl("/test.xml", new StringHandle("<test/>").withFormat(Format.XML))));
+        assertEquals(
+                "Only JSON content can be used with fromDocDescriptors; non-JSON content found for document with URI: /test.xml",
+                ex.getMessage());
+    }
+
+    private ObjectNode export(DocumentWriteOperation writeOp) {
+        String template = new PlanDocDescriptorImpl(writeOp).exportAst(new StringBuilder()).toString();
+        try {
+            return (ObjectNode) new ObjectMapper().readTree(template);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/RowManagerFromDocDescriptorsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/RowManagerFromDocDescriptorsTest.java
@@ -1,0 +1,128 @@
+package com.marklogic.client.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.marklogic.client.document.DocumentWriteOperation;
+import com.marklogic.client.document.DocumentWriteSet;
+import com.marklogic.client.expression.PlanBuilder;
+import com.marklogic.client.impl.DocumentWriteOperationImpl;
+import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.client.io.Format;
+import com.marklogic.client.io.JacksonHandle;
+import com.marklogic.client.io.StringHandle;
+
+public class RowManagerFromDocDescriptorsTest extends AbstractRowManagerTest {
+
+    @Test
+    public void writeWithAllMetadata() {
+        DocumentMetadataHandle metadata = new DocumentMetadataHandle();
+        metadata.getCollections().addAll("docDescriptors1", "docDescriptors2");
+        metadata.setQuality(2);
+        // TODO Test permissions and metadata values once they're supported by the server
+
+        final String uri = "/fromParam/doc1.json";
+        DocumentWriteSet writeSet = Common.client.newDocumentManager().newWriteSet();
+        ObjectNode content = mapper.createObjectNode().put("hello", "world");
+        writeSet.add(uri, metadata, new JacksonHandle(content));
+
+        PlanBuilder.AccessPlan plan = op.fromDocDescriptors(op.docDescriptors(writeSet));
+        verifyExportedPlanReturnsSameRowCount(plan);
+
+        rowManager.resultRows(plan.write());
+
+        verifyJsonDoc(uri, doc -> assertEquals("world", doc.get("hello").asText()));
+        verifyMetadata(uri, docMetadata -> {
+            assertEquals(2, docMetadata.getQuality());
+            assertEquals(2, docMetadata.getCollections().size());
+            assertTrue(docMetadata.getCollections().contains("docDescriptors1"));
+            assertTrue(docMetadata.getCollections().contains("docDescriptors2"));
+        });
+    }
+
+    @Test
+    public void writeIndividualDocDescriptors() {
+        DocumentMetadataHandle metadata = new DocumentMetadataHandle();
+        ObjectNode doc1 = mapper.createObjectNode().put("hello", "doc1");
+        ObjectNode doc2 = mapper.createObjectNode().put("hello", "doc2");
+
+        PlanBuilder.AccessPlan plan = op.fromDocDescriptors(
+                op.docDescriptor(new DocumentWriteOperationImpl(DocumentWriteOperation.OperationType.DOCUMENT_WRITE,
+                        "/fromParam/doc1.json", metadata, new JacksonHandle(doc1))
+                ),
+                op.docDescriptor(new DocumentWriteOperationImpl(DocumentWriteOperation.OperationType.DOCUMENT_WRITE,
+                        "/fromParam/doc2.json", metadata, new JacksonHandle(doc2))
+                )
+        );
+        verifyExportedPlanReturnsSameRowCount(plan);
+
+        rowManager.resultRows(plan.write());
+
+        verifyJsonDoc("/fromParam/doc1.json", doc -> assertEquals("doc1", doc.get("hello").asText()));
+        verifyJsonDoc("/fromParam/doc2.json", doc -> assertEquals("doc2", doc.get("hello").asText()));
+    }
+
+    @Test
+    @Ignore("Known issue, erroneously does a temporal.documentInsert - see https://bugtrack.marklogic.com/57850")
+    public void documentWriteSetWithQualifier() {
+        final String uri = "/fromParam/doc1.json";
+        DocumentWriteSet writeSet = Common.client.newDocumentManager().newWriteSet();
+        ObjectNode content = mapper.createObjectNode().put("hello", "world");
+        writeSet.add(uri, new DocumentMetadataHandle(), new JacksonHandle(content));
+
+        final String qualifier = "myQualifier";
+        PlanBuilder.AccessPlan plan = op.fromDocDescriptors(op.docDescriptors(writeSet), qualifier);
+        verifyExportedPlanReturnsSameRowCount(plan);
+        rowManager.resultRows(plan.write(op.docCols(qualifier)));
+        verifyJsonDoc(uri, doc -> assertEquals("world", doc.get("hello").asText()));
+    }
+
+    @Test
+    public void writingNonJsonContentShouldFail() {
+        DocumentWriteSet writeSet = Common.client.newDocumentManager().newWriteSet();
+        writeSet.add("/fromParam/doc1.xml", new DocumentMetadataHandle(),
+                new StringHandle("<doc>1</doc>").withFormat(Format.XML));
+
+        IllegalArgumentException ex = assertThrows(
+                "Only JSON content is supported for the 5.6.0 release and 11.0 release of MarkLogic",
+                IllegalArgumentException.class,
+                () -> op.docDescriptors(writeSet)
+        );
+        assertEquals("Unexpected exception: " + ex.getMessage(),
+                "Only JSON content can be used with fromDocDescriptors; non-JSON content found for document with URI: /fromParam/doc1.xml",
+                ex.getMessage()
+        );
+    }
+
+    @Test
+    public void testExport() {
+        DocumentMetadataHandle metadata = new DocumentMetadataHandle();
+        DocumentWriteSet writeSet = Common.client.newDocumentManager().newWriteSet();
+        writeSet.add("/fromParam/doc1.json", metadata, new JacksonHandle(mapper.createObjectNode().put("hello", "doc1")));
+        writeSet.add("/fromParam/doc2.json", metadata, new JacksonHandle(mapper.createObjectNode().put("hello", "doc2")));
+
+        PlanBuilder.AccessPlan accessPlan = op.fromDocDescriptors(op.docDescriptors(writeSet));
+        ObjectNode plan = exportPlan(accessPlan);
+        JsonNode docDescriptorArgs = plan.get("$optic").get("args").get(0).get("args").get(0);
+        assertEquals("doc1", docDescriptorArgs.get(0).get("doc").get("hello").asText());
+        assertEquals("doc2", docDescriptorArgs.get(1).get("doc").get("hello").asText());
+
+        verifyExportedPlanReturnsSameRowCount(accessPlan);
+    }
+
+    private ObjectNode exportPlan(PlanBuilder.ExportablePlan plan) {
+        String json = plan.exportAs(JsonNode.class).toPrettyString();
+        try {
+            return (ObjectNode) mapper.readTree(json);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
Not all tests can pass yet as they're waiting in some server fixes. 

Main code change is I extracted all the logic for constructing a doc descriptor from a DocumentWriteOperation and tossed it into DocDescriptorUtil so that it can be easily reused by both `bindParam` and `fromDocDescriptors`. 