### PR TITLE
JAVA-235: Can now perform execute() on a plan

### DIFF
--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/OkHttpServices.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/OkHttpServices.java
@@ -3970,10 +3970,12 @@ public class OkHttpServices implements RESTServices {
       Request.Builder requestBldr = makePostWebResource(path, new RequestParameters());
 
       MultipartBody.Builder multiBuilder = new MultipartBody.Builder().setType(MediaType.parse("multipart/form-data"));
-      for ( String key : params.keySet() ) {
-          for ( String value : params.get(key) ) {
-              multiBuilder.addFormDataPart(key, value);
+      for (String key : params.keySet()) {
+        for (String value : params.get(key)) {
+          if (value != null) {
+            multiBuilder.addFormDataPart(key, value);
           }
+        }
       }
 
       contentParams.forEach(contentParam -> {

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/RowsParamsBuilder.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/RowsParamsBuilder.java
@@ -1,0 +1,80 @@
+package com.marklogic.client.impl;
+
+import java.util.Map;
+
+import com.marklogic.client.impl.PlanBuilderBaseImpl.RequestPlan;
+import com.marklogic.client.row.RowManager.RowSetPart;
+import com.marklogic.client.row.RowManager.RowStructure;
+import com.marklogic.client.util.RequestParameters;
+
+/**
+ * Helper for constructing request parameters for calls to /v1/rows.
+ */
+class RowsParamsBuilder {
+
+    private RequestParameters params = new RequestParameters();
+
+    public RowsParamsBuilder(RequestPlan requestPlan) {
+        Map<PlanBuilderBaseImpl.PlanParamBase, BaseTypeImpl.ParamBinder> planParams = requestPlan.getParams();
+        if (planParams != null) {
+            for (Map.Entry<PlanBuilderBaseImpl.PlanParamBase, BaseTypeImpl.ParamBinder> entry : planParams.entrySet()) {
+                BaseTypeImpl.ParamBinder binder = entry.getValue();
+                StringBuilder nameBuf = new StringBuilder("bind:");
+                nameBuf.append(entry.getKey().getName());
+                String paramQual = binder.getParamQualifier();
+                if (paramQual != null) {
+                    nameBuf.append(paramQual);
+                }
+                params.add(nameBuf.toString(), binder.getParamValue());
+            }
+        }
+    }
+
+    public RowsParamsBuilder withOutput(String output) {
+        if (output != null) {
+            params.add("output", output);
+        }
+        return this;
+    }
+
+    public RowsParamsBuilder withOutput(RowStructure rowStructure) {
+        if (rowStructure != null) {
+            switch (rowStructure) {
+                case ARRAY: return withOutput("array");
+                case OBJECT: return withOutput("object");
+            }
+        }
+        return this;
+    }
+    public RowsParamsBuilder withColumnTypes(RowSetPart columnTypes) {
+        if (columnTypes != null) {
+            switch (columnTypes) {
+                case HEADER:                
+                    params.add("column-types", "header");
+                    break;
+                case ROWS:
+                    params.add("column-types", "rows");
+                    break;
+            }
+        }
+        return this;
+    }
+
+    public RowsParamsBuilder withRowFormat(String rowFormat) {
+        if (rowFormat != null) {
+            params.add("row-format", rowFormat);
+        }
+        return this;
+    }
+
+    public RowsParamsBuilder withNodeColumns(String nodeColumns) {
+        if (nodeColumns != null) {
+            params.add("node-columns", nodeColumns);
+        }
+        return this;
+    }
+
+    public RequestParameters getRequestParameters() {
+        return this.params;
+    }
+}

--- a/marklogic-client-api/src/main/java/com/marklogic/client/row/RowManager.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/row/RowManager.java
@@ -106,6 +106,21 @@ public interface RowManager {
     RawSPARQLSelectPlan newRawSPARQLSelectPlan(TextWriteHandle handle);
 
     /**
+     * Execute the given plan without returning any result.
+     * 
+     * @param plan the definition of a plan
+     */
+    void execute(Plan plan);
+
+    /**
+     * Execute the given plan without returning any result.
+     * 
+     * @param plan the definition of a plan
+     * @param transaction a open transaction for the execute operation to run within
+     */
+    void execute(Plan plan, Transaction transaction);
+
+    /**
      * Constructs and retrieves a set of database rows based on a plan using
      * a map interface for the column values in each row.
      * @param plan	the definition of a plan for the database rows

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/RowManagerFromDocDescriptorsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/RowManagerFromDocDescriptorsTest.java
@@ -36,7 +36,7 @@ public class RowManagerFromDocDescriptorsTest extends AbstractRowManagerTest {
         PlanBuilder.AccessPlan plan = op.fromDocDescriptors(op.docDescriptors(writeSet));
         verifyExportedPlanReturnsSameRowCount(plan);
 
-        rowManager.resultRows(plan.write());
+        rowManager.execute(plan.write());
 
         verifyJsonDoc(uri, doc -> assertEquals("world", doc.get("hello").asText()));
         verifyMetadata(uri, docMetadata -> {
@@ -63,8 +63,7 @@ public class RowManagerFromDocDescriptorsTest extends AbstractRowManagerTest {
         );
         verifyExportedPlanReturnsSameRowCount(plan);
 
-        rowManager.resultRows(plan.write());
-
+        rowManager.execute(plan.write());
         verifyJsonDoc("/fromParam/doc1.json", doc -> assertEquals("doc1", doc.get("hello").asText()));
         verifyJsonDoc("/fromParam/doc2.json", doc -> assertEquals("doc2", doc.get("hello").asText()));
     }
@@ -80,8 +79,7 @@ public class RowManagerFromDocDescriptorsTest extends AbstractRowManagerTest {
         final String qualifier = "myQualifier";
         PlanBuilder.AccessPlan plan = op.fromDocDescriptors(op.docDescriptors(writeSet), qualifier);
         verifyExportedPlanReturnsSameRowCount(plan);
-        rowManager.resultRows(plan.write(op.docCols(qualifier)));
-        verifyJsonDoc(uri, doc -> assertEquals("world", doc.get("hello").asText()));
+        rowManager.execute(plan.write(op.docCols(qualifier))); verifyJsonDoc(uri, doc -> assertEquals("world", doc.get("hello").asText()));
     }
 
     @Test

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/RowManagerFromParamWriteTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/RowManagerFromParamWriteTest.java
@@ -68,7 +68,7 @@ public class RowManagerFromParamWriteTest extends AbstractRowManagerTest {
         writeSet.add("/fromParam/doc2.xml", metadata, new StringHandle("<doc>2</doc>").withFormat(Format.XML));
         plan = plan.bindParam("myDocs", writeSet);
 
-        rowManager.resultRows(plan);
+        rowManager.execute(plan);
 
         verifyXmlDoc("/fromParam/doc1.xml", "<doc>1</doc>");
         verifyXmlDoc("/fromParam/doc2.xml", "<doc>2</doc>");
@@ -95,7 +95,7 @@ public class RowManagerFromParamWriteTest extends AbstractRowManagerTest {
         // Local message: failed to apply resource at rows: Bad Request. Server Message: XDMP-ARGTYPE: xdmp.documentInsert("/fromParam/doc2.json",
         // Sequence(), {collections:Sequence(), permissions:[{roleId:"7089338530631756591", capability:"read"},
         // {roleId:"7089338530631756591", capability:"update"}], metadata:[], ...}) -- arg2 is not of type Node
-        FailedRequestException ex = assertThrows(FailedRequestException.class, () -> rowManager.resultRows(finalPlan));
+        FailedRequestException ex = assertThrows(FailedRequestException.class, () -> rowManager.execute(finalPlan));
         assertTrue("Unexpected error: " + ex.getMessage() + "; the write should have failed because JSON and XML " +
                 "documents can't yet be written together", ex.getMessage().contains("arg2 is not of type Node"));
     }
@@ -154,7 +154,7 @@ public class RowManagerFromParamWriteTest extends AbstractRowManagerTest {
         writeSet.add("/fromParam/doc2.xml", metadata, new StringHandle("<doc>2</doc>").withFormat(Format.XML));
         PlanBuilder.Plan plan = rawPlan.bindParam("myDocs", writeSet);
 
-        rowManager.resultRows(plan);
+        rowManager.execute(plan);
 
         verifyXmlDoc("/fromParam/doc1.xml", "<doc>1</doc>");
         verifyXmlDoc("/fromParam/doc2.xml", "<doc>2</doc>");


### PR DESCRIPTION
Refactored `RowManagerImpl` by extracting `RowsParamBuilder`, which is now used to construct a set of params for invoking the rows endpoint. That makes the code more readable and cuts down on the number of methods with several arguments. 

Renamed `makeRequest` to `submitPlan` for better readability too. 