### PR TITLE
Removing some obsolete TODO's

### DIFF
--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/DeleteListenerTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/DeleteListenerTest.java
@@ -476,7 +476,6 @@ public class DeleteListenerTest extends BasicJavaClientREST {
             try {
               Thread.currentThread().sleep(50L);
             } catch (InterruptedException e) {
-              // TODO Auto-generated catch block
               e.printStackTrace();
             }
 
@@ -497,7 +496,6 @@ public class DeleteListenerTest extends BasicJavaClientREST {
             try {
               Thread.currentThread().sleep(30L);
             } catch (InterruptedException e) {
-              // TODO Auto-generated catch block
               e.printStackTrace();
             }
 
@@ -575,7 +573,6 @@ public class DeleteListenerTest extends BasicJavaClientREST {
             try {
               Thread.currentThread().sleep(100L);
             } catch (InterruptedException e) {
-              // TODO Auto-generated catch block
               e.printStackTrace();
             }
 

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/QueryBatcherJobReportTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/QueryBatcherJobReportTest.java
@@ -321,7 +321,6 @@ public class QueryBatcherJobReportTest extends BasicJavaClientREST {
 			try {
 				Thread.currentThread().sleep(7000L);
 			} catch (Exception e) {
-				// TODO Auto-generated catch block
 				e.printStackTrace();
 			}
 			throwable.getBatcher().retry(throwable);
@@ -369,7 +368,6 @@ public class QueryBatcherJobReportTest extends BasicJavaClientREST {
 			try {
 				Thread.currentThread().sleep(5000L);
 			} catch (InterruptedException e) {
-				// TODO Auto-generated catch block
 				e.printStackTrace();
 			}
 
@@ -642,7 +640,6 @@ public class QueryBatcherJobReportTest extends BasicJavaClientREST {
 					try {
 						Thread.currentThread().sleep(15000L);
 					} catch (InterruptedException e) {
-						// TODO Auto-generated catch block
 						e.printStackTrace();
 					}
 					Set<Thread> threads = Thread.getAllStackTraces().keySet();
@@ -696,7 +693,6 @@ public class QueryBatcherJobReportTest extends BasicJavaClientREST {
 					try {
 						Thread.currentThread().sleep(3000);
 					} catch (InterruptedException e) {
-						// TODO Auto-generated catch block
 						e.printStackTrace();
 					}
 					dmManager.stopJob(qb);			

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/UrisToWriterListenerFuncTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/UrisToWriterListenerFuncTest.java
@@ -278,7 +278,6 @@ public class UrisToWriterListenerFuncTest extends BasicJavaClientREST {
         File file = new File(uriFile);
         file.deleteOnExit();
       } catch (Exception e) {
-        // TODO Auto-generated catch block
         e.printStackTrace();
       }
     }
@@ -411,7 +410,6 @@ public class UrisToWriterListenerFuncTest extends BasicJavaClientREST {
         File file = new File(uriFile);
         file.deleteOnExit();
       } catch (Exception e) {
-        // TODO Auto-generated catch block
         e.printStackTrace();
       }
     }
@@ -728,7 +726,6 @@ public class UrisToWriterListenerFuncTest extends BasicJavaClientREST {
         File file = new File(uriFile);
         file.deleteOnExit();
       } catch (Exception e) {
-        // TODO Auto-generated catch block
         e.printStackTrace();
       }
     }
@@ -889,7 +886,6 @@ public class UrisToWriterListenerFuncTest extends BasicJavaClientREST {
         File file = new File(uriFile);
         file.deleteOnExit();
       } catch (Exception e) {
-        // TODO Auto-generated catch block
         e.printStackTrace();
       }
     }
@@ -1007,7 +1003,6 @@ public class UrisToWriterListenerFuncTest extends BasicJavaClientREST {
         File file2 = new File(uriFile2);
         file2.deleteOnExit();
       } catch (Exception e) {
-        // TODO Auto-generated catch block
         e.printStackTrace();
       }
     }
@@ -1120,7 +1115,6 @@ public class UrisToWriterListenerFuncTest extends BasicJavaClientREST {
         File file = new File(uriFile);
         file.deleteOnExit();
       } catch (Exception e) {
-        // TODO Auto-generated catch block
         e.printStackTrace();
       }
     }
@@ -1202,7 +1196,6 @@ public class UrisToWriterListenerFuncTest extends BasicJavaClientREST {
                 try {
                   Thread.sleep(5000);
                 } catch (Exception e) {
-                  // TODO Auto-generated catch block
                   e.printStackTrace();
                 }
                 return "";

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/WriteBatcherJobReportTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/WriteBatcherJobReportTest.java
@@ -656,7 +656,6 @@ public class WriteBatcherJobReportTest extends BasicJavaClientREST {
 			try {
 				Thread.currentThread().sleep(20000L);
 			} catch (Exception e) {
-				// TODO Auto-generated catch block
 				e.printStackTrace();
 			}
 			ihbMT.retry(batch);

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/WriteHostBatcherTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/WriteHostBatcherTest.java
@@ -1439,7 +1439,6 @@ public class WriteHostBatcherTest extends BasicJavaClientREST {
 				try {
 					Thread.currentThread().sleep(15000L);
 				} catch (InterruptedException e) {
-					// TODO Auto-generated catch block
 					e.printStackTrace();
 				}
 				Set<Thread> threads = Thread.getAllStackTraces().keySet();
@@ -1524,7 +1523,6 @@ public class WriteHostBatcherTest extends BasicJavaClientREST {
 				try {
 					Thread.currentThread().sleep(15000L);
 				} catch (InterruptedException e) {
-					// TODO Auto-generated catch block
 					e.printStackTrace();
 				}
 				Set<Thread> threads = Thread.getAllStackTraces().keySet();
@@ -1616,7 +1614,6 @@ public class WriteHostBatcherTest extends BasicJavaClientREST {
 				try {
 					Thread.currentThread().sleep(15000L);
 				} catch (InterruptedException e) {
-					// TODO Auto-generated catch block
 					e.printStackTrace();
 				}
 				Set<Thread> threads = Thread.getAllStackTraces().keySet();
@@ -1748,7 +1745,6 @@ public class WriteHostBatcherTest extends BasicJavaClientREST {
 						// Sleep for 4 seconds so that the threads are spawned
 						Thread.currentThread().sleep(4000L);
 					} catch (InterruptedException e) {
-						// TODO Auto-generated catch block
 						e.printStackTrace();
 					}
 					Set<Thread> threads = Thread.getAllStackTraces().keySet();
@@ -2136,7 +2132,6 @@ public class WriteHostBatcherTest extends BasicJavaClientREST {
 			try {
 				Thread.currentThread().sleep(20000L);
 			} catch (Exception e) {
-				// TODO Auto-generated catch block
 				e.printStackTrace();
 			}
 			ihbMT.retry(batch);
@@ -2222,7 +2217,6 @@ public class WriteHostBatcherTest extends BasicJavaClientREST {
 			try {
 				Thread.currentThread().sleep(10000L);
 			} catch (InterruptedException e) {
-				// TODO Auto-generated catch block
 				e.printStackTrace();
 			}
 			properties.put("server-name", server);

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ConnectedRESTQA.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ConnectedRESTQA.java
@@ -2259,7 +2259,6 @@ public abstract class ConnectedRESTQA {
 		try {
 			Thread.sleep(2000);
 		} catch (InterruptedException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 
@@ -2372,13 +2371,10 @@ public abstract class ConnectedRESTQA {
 				client = DatabaseClientFactory.newClient(getRestServerHostName(), getRestServerPort(), user, password,
 						authType);
 		} catch (CertificateException certEx) {
-			// TODO Auto-generated catch block
 			certEx.printStackTrace();
 		} catch (KeyStoreException ksEx) {
-			// TODO Auto-generated catch block
 			ksEx.printStackTrace();
 		} catch (UnrecoverableKeyException unReovkeyEx) {
-			// TODO Auto-generated catch block
 			unReovkeyEx.printStackTrace();
 		}
 		return client;
@@ -2416,13 +2412,10 @@ public abstract class ConnectedRESTQA {
 				client = DatabaseClientFactory.newClient(hostName, port, databaseName, secContext, connType);
 			}
 		} catch (CertificateException certEx) {
-			// TODO Auto-generated catch block
 			certEx.printStackTrace();
 		} catch (KeyStoreException ksEx) {
-			// TODO Auto-generated catch block
 			ksEx.printStackTrace();
 		} catch (UnrecoverableKeyException unReovkeyEx) {
-			// TODO Auto-generated catch block
 			unReovkeyEx.printStackTrace();
 		}
 		return client;

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBulkReadSample1.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBulkReadSample1.java
@@ -128,7 +128,6 @@ public class TestBulkReadSample1 extends BasicJavaClientREST {
 		System.out.println("Document count test1ReadMultipleTextDoc " + count);
 		assertEquals("document count", 102, count);
 	} catch (Exception e) {
-		// TODO Auto-generated catch block
 		e.printStackTrace();
 	}
     finally {
@@ -181,7 +180,6 @@ public class TestBulkReadSample1 extends BasicJavaClientREST {
 		System.out.println("Document count test2ReadMultipleXMLDoc " + count);
 		assertEquals("document count", 102, count);
 	} catch (Exception e) {
-		// TODO Auto-generated catch block
 		e.printStackTrace();
 	}
     finally {
@@ -249,7 +247,6 @@ public class TestBulkReadSample1 extends BasicJavaClientREST {
 		System.out.println("Document count test3ReadMultipleBinaryDoc " + count);
 		assertEquals("document count", 1, count);
 	} catch (Exception e) {
-		// TODO Auto-generated catch block
 		e.printStackTrace();
 	}
     finally {
@@ -311,7 +308,6 @@ public class TestBulkReadSample1 extends BasicJavaClientREST {
 		System.out.println("Document count test4WriteMultipleJSONDocs " + count);
 		assertEquals("document count", 102, count);
 	} catch (Exception e) {
-		// TODO Auto-generated catch block
 		e.printStackTrace();
 	}
     finally {
@@ -410,7 +406,6 @@ public class TestBulkReadSample1 extends BasicJavaClientREST {
 		assertEquals("binary document count", isLBHost()?1:10, countJpg);
 		assertEquals("Json document count", 10, countJson);
 	} catch (Exception e) {
-		// TODO Auto-generated catch block
 		e.printStackTrace();
 	}
     finally {
@@ -467,7 +462,6 @@ public class TestBulkReadSample1 extends BasicJavaClientREST {
 		System.out.println("Document count test6CloseMethodforReadMultipleDoc " + count);
 		assertEquals("document count", 10, count);
 	} catch (Exception e) {
-		// TODO Auto-generated catch block
 		e.printStackTrace();
 	}
     finally {

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBulkWriteWithTransactions.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBulkWriteWithTransactions.java
@@ -215,7 +215,6 @@ public class TestBulkWriteWithTransactions extends BasicJavaClientREST {
 		  }
 		  assertEquals("document count", 102, count);
 	  } catch (Exception e) {
-		  // TODO Auto-generated catch block
 		  e.printStackTrace();
 	  }
 	  finally {
@@ -292,7 +291,6 @@ public class TestBulkWriteWithTransactions extends BasicJavaClientREST {
 			  }
 		  }
 	  } catch (Exception e) {
-		  // TODO Auto-generated catch block
 		  e.printStackTrace();
 	  }
 	  finally {
@@ -387,7 +385,6 @@ public class TestBulkWriteWithTransactions extends BasicJavaClientREST {
 			  }
 		  }
 	  } catch (Exception e) {
-		  // TODO Auto-generated catch block
 		  e.printStackTrace();
 	  }
 	  finally {

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientKerberosFromFile.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientKerberosFromFile.java
@@ -1066,7 +1066,6 @@ public class TestDatabaseClientKerberosFromFile extends BasicJavaClientREST {
 
       associateRESTServerWithKerberosExtSecurity(UberrestServerName, extSecurityName);
     } catch (Exception e) {
-      // TODO Auto-generated catch block
       e.printStackTrace();
     }
 
@@ -1095,7 +1094,6 @@ public class TestDatabaseClientKerberosFromFile extends BasicJavaClientREST {
       // Associate database to Documentst on App-Services.
       associateRESTServerWithDB(UberrestServerName, "Documents");
     } catch (Exception e) {
-      // TODO Auto-generated catch block
       e.printStackTrace();
     }
 

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientWithKerberos.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientWithKerberos.java
@@ -1010,7 +1010,6 @@ public class TestDatabaseClientWithKerberos extends BasicJavaClientREST {
 
       associateRESTServerWithKerberosExtSecurity(UberrestServerName, extSecurityName);
     } catch (Exception e) {
-      // TODO Auto-generated catch block
       e.printStackTrace();
     }
 
@@ -1039,7 +1038,6 @@ public class TestDatabaseClientWithKerberos extends BasicJavaClientREST {
       // Associate database to Documentst on App-Services.
       associateRESTServerWithDB(UberrestServerName, "Documents");
     } catch (Exception e) {
-      // TODO Auto-generated catch block
       e.printStackTrace();
     }
 

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestJacksonDateTimeFormat.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestJacksonDateTimeFormat.java
@@ -393,7 +393,6 @@ public class TestJacksonDateTimeFormat extends BasicJavaClientREST {
       artifact = pojoReposProducts.read(calTime);
       assertFalse("Test Expecting exception", true);
     } catch (ResourceNotFoundException e) {
-      // TODO Auto-generated catch block
       assertTrue("expected exception", true);
     } catch (Exception e) {
       assertFalse("Test got unexpected", true);

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestMetadata.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestMetadata.java
@@ -626,7 +626,6 @@ public class TestMetadata extends BasicJavaClientREST {
       try {
         Thread.sleep(5000);
       } catch (InterruptedException e) {
-        // TODO Auto-generated catch block
         e.printStackTrace();
       }
 
@@ -704,7 +703,6 @@ public class TestMetadata extends BasicJavaClientREST {
       try {
         Thread.sleep(5000);
       } catch (InterruptedException e) {
-        // TODO Auto-generated catch block
         e.printStackTrace();
       }
       // Validate the meta-data.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestOptimisticLocking.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestOptimisticLocking.java
@@ -722,7 +722,6 @@ public class TestOptimisticLocking extends BasicJavaClientREST {
 	  try {
 		  Thread.sleep(40000L);
 	  } catch (InterruptedException e) {
-		  // TODO Auto-generated catch block
 		  e.printStackTrace();
 	  }
 	  for (String filename : filenames2) {
@@ -732,7 +731,6 @@ public class TestOptimisticLocking extends BasicJavaClientREST {
 	  try {
 		  Thread.sleep(35000L);
 	  } catch (InterruptedException e) {
-		  // TODO Auto-generated catch block
 		  e.printStackTrace();
 	  }
 	  for (String filename : filenames3) {
@@ -741,7 +739,6 @@ public class TestOptimisticLocking extends BasicJavaClientREST {
 	  try {
 		  Thread.sleep(35000L);
 	  } catch (InterruptedException e) {
-		  // TODO Auto-generated catch block
 		  e.printStackTrace();
 	  }
 	  

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestSSLConnection.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestSSLConnection.java
@@ -225,19 +225,14 @@ public class TestSSLConnection extends BasicJavaClientREST {
 
 		@Override
 		public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {
-			// TODO Auto-generated method stub
-			
 		}
 
 		@Override
 		public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
-			// TODO Auto-generated method stub
-			
 		}
 
 		@Override
 		public X509Certificate[] getAcceptedIssuers() {
-			// TODO Auto-generated method stub
 			return null;
 		}}).withSSLHostnameVerifier(SSLHostnameVerifier.ANY);
     DatabaseClient client = DatabaseClientFactory.newClient(appServerHostname, 8033, secContext, getConnType());
@@ -294,19 +289,14 @@ public class TestSSLConnection extends BasicJavaClientREST {
 
 		@Override
 		public void checkClientTrusted(X509Certificate[] arg0, String arg1) throws CertificateException {
-			// TODO Auto-generated method stub
-			
 		}
 
 		@Override
 		public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
-			// TODO Auto-generated method stub
-			
 		}
 
 		@Override
 		public X509Certificate[] getAcceptedIssuers() {
-			// TODO Auto-generated method stub
 			return null;
 		}}).withSSLHostnameVerifier(SSLHostnameVerifier.ANY);
     DatabaseClient client = DatabaseClientFactory.newClient(appServerHostname, 8011, secContext, getConnType());
@@ -363,19 +353,14 @@ public class TestSSLConnection extends BasicJavaClientREST {
 
 		@Override
 		public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {
-			// TODO Auto-generated method stub
-			
 		}
 
 		@Override
 		public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
-			// TODO Auto-generated method stub
-			
 		}
 
 		@Override
 		public X509Certificate[] getAcceptedIssuers() {
-			// TODO Auto-generated method stub
 			return null;
 		}}).withSSLHostnameVerifier(SSLHostnameVerifier.ANY);
     DatabaseClient client = DatabaseClientFactory.newClient(appServerHostname, 8012, secContext, getConnType());
@@ -436,19 +421,14 @@ public class TestSSLConnection extends BasicJavaClientREST {
 
 		@Override
 		public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {
-			// TODO Auto-generated method stub
-			
 		}
 
 		@Override
 		public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
-			// TODO Auto-generated method stub
-			
 		}
 
 		@Override
 		public X509Certificate[] getAcceptedIssuers() {
-			// TODO Auto-generated method stub
 			return null;
 		}}).withSSLHostnameVerifier(SSLHostnameVerifier.ANY);
     DatabaseClient client = DatabaseClientFactory.newClient(appServerHostname, 8012, secContext, getConnType());

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestSemanticsGraphManager.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestSemanticsGraphManager.java
@@ -347,7 +347,6 @@ public class TestSemanticsGraphManager extends BasicJavaClientREST {
     assertTrue("Did not find expected content after inserting the triples:: Found: " + readContent,
         readContent.contains("/publications/journals/Journal1/1940"));
 	} catch (Exception e) {
-		// TODO Auto-generated catch block
 		e.printStackTrace();
 	}
 	finally {
@@ -1124,7 +1123,6 @@ public class TestSemanticsGraphManager extends BasicJavaClientREST {
 			while ((line = br.readLine()) != null)
 				readContentSB.append(line);
 		} catch (Exception e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		finally {

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestSparqlQueryManager.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestSparqlQueryManager.java
@@ -128,10 +128,8 @@ public class TestSparqlQueryManager extends BasicJavaClientREST {
         setbCompleted(true);
 
       } catch (ForbiddenUserException e) {
-        // TODO Auto-generated catch block
         e.printStackTrace();
       } catch (FailedRequestException e) {
-        // TODO Auto-generated catch block
         e.printStackTrace();
       } finally {
         if (t2 != null) {
@@ -184,10 +182,8 @@ public class TestSparqlQueryManager extends BasicJavaClientREST {
         setbCompleted(true);
 
       } catch (ForbiddenUserException e) {
-        // TODO Auto-generated catch block
         e.printStackTrace();
       } catch (FailedRequestException e) {
-        // TODO Auto-generated catch block
         e.printStackTrace();
       }
       if (t2 != null) {
@@ -2048,7 +2044,6 @@ public class TestSparqlQueryManager extends BasicJavaClientREST {
     try {
       Thread.sleep(3000);
     } catch (InterruptedException e) {
-      // TODO Auto-generated catch block
       e.printStackTrace();
     }
     qdef = null;

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ThreadClass.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ThreadClass.java
@@ -52,9 +52,7 @@ public class ThreadClass extends BasicJavaClientREST implements Runnable {
 
       // release client
       client.release();
-    } catch (KeyManagementException | NoSuchAlgorithmException
-        | IOException e) {
-      // TODO Auto-generated catch block
+    } catch (KeyManagementException | NoSuchAlgorithmException | IOException e) {
       e.printStackTrace();
     }
 

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ThreadSearch.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ThreadSearch.java
@@ -74,9 +74,7 @@ public class ThreadSearch extends BasicJavaClientREST implements Runnable {
 
       // release client
       client.release();
-    } catch (KeyManagementException | NoSuchAlgorithmException
-        | IOException e1) {
-      // TODO Auto-generated catch block
+    } catch (KeyManagementException | NoSuchAlgorithmException | IOException e1) {
       e1.printStackTrace();
     }
   }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ThreadWrite.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ThreadWrite.java
@@ -61,9 +61,7 @@ public class ThreadWrite extends BasicJavaClientREST implements Runnable {
 
       // release client
       client.release();
-    } catch (KeyManagementException | NoSuchAlgorithmException
-        | IOException e1) {
-      // TODO Auto-generated catch block
+    } catch (KeyManagementException | NoSuchAlgorithmException | IOException e1) {
       e1.printStackTrace();
     }
   }


### PR DESCRIPTION
The intent is to get the TODO's to both a manageable and meaningful list. These TODO's for auto-generated catch statements and overridden methods in our functional tests are neither. 