### PR TITLE
Moved RowManager tests into its own package

### DIFF
--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/AbstractRowManagerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/AbstractRowManagerTest.java
@@ -1,4 +1,4 @@
-package com.marklogic.client.test;
+package com.marklogic.client.test.rows;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -9,6 +9,8 @@ import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.row.RawPlanDefinition;
 import com.marklogic.client.row.RowManager;
 import com.marklogic.client.row.RowRecord;
+import com.marklogic.client.test.Common;
+
 import org.junit.Before;
 
 import java.util.List;

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerExportTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerExportTest.java
@@ -1,4 +1,4 @@
-package com.marklogic.client.test;
+package com.marklogic.client.test.rows;
 
 import com.marklogic.client.document.DocumentWriteSet;
 import com.marklogic.client.io.DocumentMetadataHandle;

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerFromDocDescriptorsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerFromDocDescriptorsTest.java
@@ -1,4 +1,4 @@
-package com.marklogic.client.test;
+package com.marklogic.client.test.rows;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
@@ -18,6 +18,7 @@ import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.Format;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.StringHandle;
+import com.marklogic.client.test.Common;
 
 public class RowManagerFromDocDescriptorsTest extends AbstractRowManagerTest {
 

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerFromParamTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerFromParamTest.java
@@ -1,4 +1,4 @@
-package com.marklogic.client.test;
+package com.marklogic.client.test.rows;
 
 import static org.junit.Assert.assertEquals;
 
@@ -21,6 +21,7 @@ import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.io.marker.AbstractWriteHandle;
 import com.marklogic.client.row.RawPlanDefinition;
 import com.marklogic.client.row.RowRecord;
+import com.marklogic.client.test.Common;
 import com.marklogic.client.type.PlanParamExpr;
 
 /**

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerFromParamWriteTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerFromParamWriteTest.java
@@ -1,4 +1,4 @@
-package com.marklogic.client.test;
+package com.marklogic.client.test.rows;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marklogic.client.FailedRequestException;
@@ -10,6 +10,8 @@ import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.row.RawPlanDefinition;
 import com.marklogic.client.row.RowRecord;
+import com.marklogic.client.test.Common;
+
 import org.junit.Test;
 
 import java.util.List;

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerJoinDocColsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerJoinDocColsTest.java
@@ -1,4 +1,4 @@
-package com.marklogic.client.test;
+package com.marklogic.client.test.rows;
 
 import static org.junit.Assert.assertEquals;
 

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerRemoveTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerRemoveTest.java
@@ -1,4 +1,4 @@
-package com.marklogic.client.test;
+package com.marklogic.client.test.rows;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -14,6 +14,7 @@ import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.Format;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.StringHandle;
+import com.marklogic.client.test.Common;
 
 public class RowManagerRemoveTest extends AbstractRowManagerTest {
 

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.marklogic.client.test;
+package com.marklogic.client.test.rows;
 
 import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
 import static org.junit.Assert.assertArrayEquals;
@@ -48,6 +48,7 @@ import com.marklogic.client.row.*;
 import com.marklogic.client.type.*;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -62,6 +63,7 @@ import com.marklogic.client.expression.PlanBuilder;
 import com.marklogic.client.row.RowManager.RowSetPart;
 import com.marklogic.client.row.RowManager.RowStructure;
 import com.marklogic.client.row.RowRecord.ColumnKind;
+import com.marklogic.client.test.Common;
 import com.marklogic.client.util.EditableNamespaceContext;
 
 public class RowManagerTest {
@@ -209,6 +211,8 @@ public class RowManagerTest {
   }
 
   @Test
+  @Ignore("Causing eventual segfaults, see https://bugtrack.marklogic.com/57916")
+
   public void testResultDoc() throws IOException, XPathExpressionException {
     RowManager rowMgr = Common.client.newRowManager();
 
@@ -330,6 +334,7 @@ public class RowManagerTest {
     }
   }
   @Test
+  @Ignore("Causing eventual segfaults, see https://bugtrack.marklogic.com/57916")
   public void testResultRows() throws IOException, XPathExpressionException {
     RowManager rowMgr = Common.client.newRowManager();
 
@@ -418,6 +423,7 @@ public class RowManagerTest {
     }
   }
   @Test
+  @Ignore("Causing eventual segfaults, see https://bugtrack.marklogic.com/57916")
   public void testResultRowDocs()
     throws IOException, XPathExpressionException, TransformerConfigurationException, TransformerException, TransformerFactoryConfigurationError, SAXException
   {

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowRecordTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowRecordTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.marklogic.client.test;
+package com.marklogic.client.test.rows;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -38,6 +38,7 @@ import com.marklogic.client.expression.PlanBuilder;
 import com.marklogic.client.row.RowManager;
 import com.marklogic.client.row.RowRecord;
 import com.marklogic.client.row.RowSet;
+import com.marklogic.client.test.Common;
 import com.marklogic.client.type.ItemVal;
 import com.marklogic.client.type.PlanExprCol;
 import com.marklogic.client.type.PlanPrefixer;


### PR DESCRIPTION
This makes it a lot easier to only run RowManager tests.

Also ignored 3 more tests that do an "export()" - those still cause a segfault on my Mac. Will un-ignore them once that segfault bug is fixed. 