### PR TITLE
JAVA-238: Added support for lockForUpdate()

### DIFF
--- a/marklogic-client-api/src/main/java/com/marklogic/client/expression/PlanBuilderBase.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/expression/PlanBuilderBase.java
@@ -168,6 +168,13 @@ public interface PlanBuilderBase {
      */
     PlanBuilder.AccessPlan fromDocUris(CtsQueryExpr querydef, String qualifierName);
     /**
+     * Convenience method for constructing an {@code AccessPlan} based on a given set of URIs.
+     * 
+     * @param uris one or more URIs to pass into a {@code cts.documentQuery}
+     * @return an AccessPlanObject
+     */
+    PlanBuilder.AccessPlan fromDocUris(String... uris);
+    /**
      * This function constructs a JSON object with the specified properties. The object can be used as the value of a column in a row or passed to a builtin function.
      * <p>
      * Provides a client interface to a server function. See <a href="http://docs.marklogic.com/op:json-object" target="mlserverdoc">op:json-object</a>
@@ -860,6 +867,17 @@ public interface PlanBuilderBase {
          * @return  a ModifyPlan object
          */
         PlanBuilder.ModifyPlan limit(PlanParamExpr length);
+        /**
+         * Acquires exclusive locks on the URI in the "uri" column of each row in the pipeline.
+         * @return a ModifyPlan object
+         */
+        PlanBuilder.ModifyPlan lockForUpdate();
+        /**
+         * Acquires exclusive locks on the URI in the given column of each row in the pipeline.
+         * @param uriColumn the column containing URIs to be locked
+         * @return a ModifyPlan object
+         */
+        PlanBuilder.ModifyPlan lockForUpdate(PlanColumn uriColumn);
         /**
          * This method returns a subset of the rows in the result set by skipping the number of rows specified by start and returning the remaining rows up to the number specified by the prototype.limit method.
          * @param start  The number of rows to skip. 

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/PlanBuilderSubImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/PlanBuilderSubImpl.java
@@ -204,6 +204,11 @@ public class PlanBuilderSubImpl extends PlanBuilderImpl {
   }
 
   @Override
+  public AccessPlan fromDocUris(String... uris) {
+    return fromDocUris(this.cts.documentQuery(xs.stringSeq(uris)));
+  }
+
+  @Override
   public AccessPlan fromDocUris(CtsQueryExpr querydef) {
     return fromDocUris(querydef, null);
   }
@@ -993,6 +998,16 @@ public class PlanBuilderSubImpl extends PlanBuilderImpl {
     @Override
     public ModifyPlan limit(PlanParamExpr length) {
       return new ModifyPlanSubImpl(this, "op", "limit", new Object[]{ length });
+    }
+    
+    @Override
+    public ModifyPlan lockForUpdate() {
+      return new ModifyPlanSubImpl(this, "op", "lockForUpdate", new Object[]{});
+    }
+
+    @Override
+    public ModifyPlan lockForUpdate(PlanColumn uriColumn) {
+      return new ModifyPlanSubImpl(this, "op", "lockForUpdate", new Object[]{uriColumn});
     }
 
     @Override

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/AbstractRowManagerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/AbstractRowManagerTest.java
@@ -3,6 +3,7 @@ package com.marklogic.client.test.rows;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.client.expression.PlanBuilder;
+import com.marklogic.client.expression.PlanBuilder.Plan;
 import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.StringHandle;
@@ -46,17 +47,13 @@ public abstract class AbstractRowManagerTest {
     protected final void verifyExportedPlanReturnsSameRowCount(PlanBuilder.ExportablePlan plan,
                                                                Function<PlanBuilder.Plan, PlanBuilder.Plan> bindingFunction) {
         PlanBuilder.Plan planToExecute = bindingFunction != null ? bindingFunction.apply(plan) : plan;
-        List<RowRecord> rowsFromPlan = rowManager
-                .resultRows(planToExecute)
-                .stream().collect(Collectors.toList());
+        List<RowRecord> rowsFromPlan = resultRows(planToExecute);
 
         String exportedPlan = plan.exportAs(String.class);
         RawPlanDefinition rawPlan = rowManager.newRawPlanDefinition(new StringHandle(exportedPlan));
         PlanBuilder.Plan rawPlanToExecute = bindingFunction != null ? bindingFunction.apply(rawPlan) : rawPlan;
 
-        List<RowRecord> rowsFromExportedPlan = rowManager
-                .resultRows(rawPlanToExecute)
-                .stream().collect(Collectors.toList());
+        List<RowRecord> rowsFromExportedPlan = resultRows(rawPlanToExecute);
         assertEquals("The row count from the exported list should match that of the rows from the original plan",
                 rowsFromPlan.size(), rowsFromExportedPlan.size());
     }
@@ -72,5 +69,15 @@ public abstract class AbstractRowManagerTest {
     protected final String getRowContentWithoutXmlDeclaration(RowRecord row, String columnName) {
         String content = row.getContentAs(columnName, String.class);
         return content.replace("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n", "");
+    }
+
+    /**
+     * Convenience method for executing a plan and getting the rows back as a list.
+     * 
+     * @param plan
+     * @return
+     */
+    protected final List<RowRecord> resultRows(Plan plan) {
+        return rowManager.resultRows(plan).stream().collect(Collectors.toList());
     }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerFromDocDescriptorsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerFromDocDescriptorsTest.java
@@ -24,6 +24,10 @@ public class RowManagerFromDocDescriptorsTest extends AbstractRowManagerTest {
 
     @Test
     public void writeWithAllMetadata() {
+        if (!Common.markLogicIsVersion11OrHigher()) {
+            return;
+        }
+
         DocumentMetadataHandle metadata = new DocumentMetadataHandle();
         metadata.getCollections().addAll("docDescriptors1", "docDescriptors2");
         metadata.setQuality(2);
@@ -50,6 +54,10 @@ public class RowManagerFromDocDescriptorsTest extends AbstractRowManagerTest {
 
     @Test
     public void writeIndividualDocDescriptors() {
+        if (!Common.markLogicIsVersion11OrHigher()) {
+            return;
+        }
+
         DocumentMetadataHandle metadata = new DocumentMetadataHandle();
         ObjectNode doc1 = mapper.createObjectNode().put("hello", "doc1");
         ObjectNode doc2 = mapper.createObjectNode().put("hello", "doc2");
@@ -72,6 +80,10 @@ public class RowManagerFromDocDescriptorsTest extends AbstractRowManagerTest {
     @Test
     @Ignore("Known issue, erroneously does a temporal.documentInsert - see https://bugtrack.marklogic.com/57850")
     public void documentWriteSetWithQualifier() {
+        if (!Common.markLogicIsVersion11OrHigher()) {
+            return;
+        }
+
         final String uri = "/fromParam/doc1.json";
         DocumentWriteSet writeSet = Common.client.newDocumentManager().newWriteSet();
         ObjectNode content = mapper.createObjectNode().put("hello", "world");
@@ -85,6 +97,10 @@ public class RowManagerFromDocDescriptorsTest extends AbstractRowManagerTest {
 
     @Test
     public void writingNonJsonContentShouldFail() {
+        if (!Common.markLogicIsVersion11OrHigher()) {
+            return;
+        }
+
         DocumentWriteSet writeSet = Common.client.newDocumentManager().newWriteSet();
         writeSet.add("/fromParam/doc1.xml", new DocumentMetadataHandle(),
                 new StringHandle("<doc>1</doc>").withFormat(Format.XML));
@@ -102,6 +118,10 @@ public class RowManagerFromDocDescriptorsTest extends AbstractRowManagerTest {
 
     @Test
     public void testExport() {
+        if (!Common.markLogicIsVersion11OrHigher()) {
+            return;
+        }
+        
         DocumentMetadataHandle metadata = new DocumentMetadataHandle();
         DocumentWriteSet writeSet = Common.client.newDocumentManager().newWriteSet();
         writeSet.add("/fromParam/doc1.json", metadata, new JacksonHandle(mapper.createObjectNode().put("hello", "doc1")));

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerFromParamTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerFromParamTest.java
@@ -48,7 +48,7 @@ public class RowManagerFromParamTest extends AbstractRowManagerTest {
         array.addObject().put("lastName", "Jones").put("firstName", "Jack");
         plan = plan.bindParam("myDocs", new JacksonHandle(array), null);
 
-        List<RowRecord> rows = rowManager.resultRows(plan).stream().collect(Collectors.toList());
+        List<RowRecord> rows = resultRows(plan);
         assertEquals(2, rows.size());
         assertEquals("Jane", rows.get(0).getString("firstName"));
         assertEquals("Smith", rows.get(0).getString("lastName"));
@@ -77,7 +77,7 @@ public class RowManagerFromParamTest extends AbstractRowManagerTest {
         attachments.put("doc2.xml", new StringHandle("<doc>2</doc>").withFormat(Format.XML));
         plan = plan.bindParam(param, new JacksonHandle(array), Collections.singletonMap("doc", attachments));
 
-        List<RowRecord> rows = rowManager.resultRows(plan).stream().collect(Collectors.toList());
+        List<RowRecord> rows = resultRows(plan);
         assertEquals(2, rows.size());
 
         RowRecord row = rows.get(0);
@@ -108,7 +108,7 @@ public class RowManagerFromParamTest extends AbstractRowManagerTest {
         attachments.put("doc2.bin", new BytesHandle("<doc>2</doc>".getBytes()).withFormat(Format.BINARY));
         plan = plan.bindParam("bindingParam", new JacksonHandle(array), Collections.singletonMap("doc", attachments));
 
-        List<RowRecord> rows = rowManager.resultRows(plan).stream().collect(Collectors.toList());
+        List<RowRecord> rows = resultRows(plan);
         assertEquals(2, rows.size());
 
         RowRecord row = rows.get(0);
@@ -139,7 +139,7 @@ public class RowManagerFromParamTest extends AbstractRowManagerTest {
         attachments.put("doc2.txt", new StringHandle("doc2-text").withFormat(Format.TEXT));
         plan = plan.bindParam("bindingParam", new JacksonHandle(array), Collections.singletonMap("doc", attachments));
 
-        List<RowRecord> rows = rowManager.resultRows(plan).stream().collect(Collectors.toList());
+        List<RowRecord> rows = resultRows(plan);
         assertEquals(2, rows.size());
 
         RowRecord row = rows.get(0);
@@ -214,7 +214,7 @@ public class RowManagerFromParamTest extends AbstractRowManagerTest {
         attachments.put("doc2.xml", new StringHandle("<doc>2</doc>").withFormat(Format.XML));
         PlanBuilder.Plan plan = rawPlan.bindParam(param, new JacksonHandle(array), Collections.singletonMap("doc", attachments));
 
-        List<RowRecord> rows = rowManager.resultRows(plan).stream().collect(Collectors.toList());
+        List<RowRecord> rows = resultRows(plan);
         assertEquals(2, rows.size());
 
         RowRecord row = rows.get(0);
@@ -257,7 +257,7 @@ public class RowManagerFromParamTest extends AbstractRowManagerTest {
         columnAttachments.put("otherDoc", attachments);
         plan = plan.bindParam(param, new JacksonHandle(array), columnAttachments);
 
-        List<RowRecord> rows = rowManager.resultRows(plan).stream().collect(Collectors.toList());
+        List<RowRecord> rows = resultRows(plan);
         assertEquals(2, rows.size());
 
         RowRecord row = rows.get(0);
@@ -284,7 +284,7 @@ public class RowManagerFromParamTest extends AbstractRowManagerTest {
         writeSet.add("/fromParam/doc1.xml", metadata, new StringHandle("<doc>1</doc>").withFormat(Format.XML));
         plan = plan.bindParam("myDocs", writeSet);
 
-        List<RowRecord> rows = rowManager.resultRows(plan).stream().collect(Collectors.toList());
+        List<RowRecord> rows = resultRows(plan);
         assertEquals(1, rows.size());
         RowRecord row = rows.get(0);
         assertEquals("/fromParam/doc1.xml", row.getString("uri"));

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerFromParamWriteTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerFromParamWriteTest.java
@@ -46,7 +46,7 @@ public class RowManagerFromParamWriteTest extends AbstractRowManagerTest {
                 new JacksonHandle(new ObjectMapper().createObjectNode().put("value", 1)));
         plan = plan.bindParam("myDocs", writeSet);
 
-        List<RowRecord> rows = rowManager.resultRows(plan).stream().collect(Collectors.toList());
+        List<RowRecord> rows = resultRows(plan);
         assertEquals(1, rows.size());
 
         verifyMetadata("/fromParam/doc1.json", docMetadata -> {
@@ -70,7 +70,7 @@ public class RowManagerFromParamWriteTest extends AbstractRowManagerTest {
         writeSet.add("/fromParam/doc2.xml", metadata, new StringHandle("<doc>2</doc>").withFormat(Format.XML));
         plan = plan.bindParam("myDocs", writeSet);
 
-        List<RowRecord> rows = rowManager.resultRows(plan).stream().collect(Collectors.toList());
+        List<RowRecord> rows = resultRows(plan);
         assertEquals(2, rows.size());
 
         verifyXmlDoc("/fromParam/doc1.xml", "<doc>1</doc>");

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerJoinDocColsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerJoinDocColsTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.client.expression.PlanBuilder;
 import com.marklogic.client.row.RowRecord;
+import com.marklogic.client.test.Common;
 
 public class RowManagerJoinDocColsTest extends AbstractRowManagerTest {
 
@@ -20,12 +21,16 @@ public class RowManagerJoinDocColsTest extends AbstractRowManagerTest {
 
     @Test
     public void defaultColumns() {
+        if (!Common.markLogicIsVersion11OrHigher()) {
+            return;
+        }
+
         PlanBuilder.Plan plan = op
                 .fromDocUris(op.cts.directoryQuery(MUSICIAN_DIRECTORY))
                 .joinDocCols(op.docCols(), op.col("uri"))
                 .orderBy(op.col("uri"));
 
-        List<RowRecord> rows = rowManager.resultRows(plan).stream().collect(Collectors.toList());
+        List<RowRecord> rows = resultRows(plan);
         assertEquals(4, rows.size());
 
         RowRecord firstRow = rows.get(0);
@@ -37,6 +42,10 @@ public class RowManagerJoinDocColsTest extends AbstractRowManagerTest {
 
     @Test
     public void customColumns() {
+        if (!Common.markLogicIsVersion11OrHigher()) {
+            return;
+        }
+        
         Map<String, String> columns = new HashMap<>();
         columns.put("doc", "doc2");
         columns.put("quality", "myQuality");
@@ -46,7 +55,7 @@ public class RowManagerJoinDocColsTest extends AbstractRowManagerTest {
                 .joinDocCols(op.docCols(columns), op.col("uri"))
                 .orderBy(op.col("uri"));
 
-        List<RowRecord> rows = rowManager.resultRows(plan).stream().collect(Collectors.toList());
+        List<RowRecord> rows = resultRows(plan);
         assertEquals(4, rows.size());
 
         RowRecord firstRow = rows.get(0);

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerLockForUpdateTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerLockForUpdateTest.java
@@ -1,0 +1,99 @@
+package com.marklogic.client.test.rows;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.marklogic.client.document.DocumentWriteOperation.OperationType;
+import com.marklogic.client.impl.DocumentWriteOperationImpl;
+import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.client.io.JacksonHandle;
+import com.marklogic.client.row.RowRecord;
+import com.marklogic.client.test.Common;
+
+public class RowManagerLockForUpdateTest extends AbstractRowManagerTest {
+
+    @Test
+    public void basicTest() {
+        if (!Common.markLogicIsVersion11OrHigher()) {
+            return;
+        }
+
+        final String uri = "/fromParam/doc1.json";
+        DocumentMetadataHandle metadata = new DocumentMetadataHandle();
+
+        // Write a document
+        rowManager.execute(op.fromDocDescriptors(
+                op.docDescriptor(new DocumentWriteOperationImpl(OperationType.DOCUMENT_WRITE, uri, metadata,
+                        new JacksonHandle(mapper.createObjectNode().put("hello", "world")))))
+                .write());
+        verifyJsonDoc(uri, doc -> assertEquals("world", doc.get("hello").asText()));
+
+        // Verify it can be locked; we don't have any effective way to verify that it
+        // was locked as we'd need to cause
+        // the plan invocation to "sleep" for awhile, and then use a second thread to
+        // inspect the status of the
+        // documents. So we assume that the return of a row for the URI is a measure of
+        // success.
+        List<RowRecord> rows = resultRows(op.fromDocUris(uri).lockForUpdate());
+        assertEquals(1, rows.size());
+
+        // Verify it can be updated - i.e. the lock was released in the previous call
+        rowManager.execute(op.fromDocDescriptors(
+                op.docDescriptor(new DocumentWriteOperationImpl(OperationType.DOCUMENT_WRITE, uri, metadata,
+                        new JacksonHandle(mapper.createObjectNode().put("hello", "modified")))))
+                .write());
+        verifyJsonDoc(uri, doc -> assertEquals("modified", doc.get("hello").asText()));
+    }
+
+    @Test
+    @Ignore("See https://bugtrack.marklogic.com/57963")
+    public void uriColumnSpecified() {
+        if (!Common.markLogicIsVersion11OrHigher()) {
+            return;
+        }
+
+        List<RowRecord> rows = resultRows(op
+                .fromDocUris("/optic/test/musician1.json")
+                .lockForUpdate(op.col("uri")));
+        assertEquals(1, rows.size());
+    }
+
+    @Test
+    @Ignore("See https://bugtrack.marklogic.com/57964")
+    public void fromParamWithCustomUriColumn() {
+        if (!Common.markLogicIsVersion11OrHigher()) {
+            return;
+        }
+
+        ArrayNode paramValue = mapper.createArrayNode();
+        paramValue.addObject().put("myUri", "/optic/test/musician1.json");
+
+        List<RowRecord> rows = resultRows(op
+                .fromParam("bindingParam", "", op.colTypes(op.colType("myUri", "string")))
+                .lockForUpdate(op.col("uri"))
+                .bindParam("bindParam", new JacksonHandle(paramValue), null));
+        assertEquals(1, rows.size());
+    }
+
+    @Test
+    @Ignore("See https://bugtrack.marklogic.com/57964")
+    public void fromParamWithQualifiedUriColumn() {
+        if (!Common.markLogicIsVersion11OrHigher()) {
+            return;
+        }
+
+        ArrayNode paramValue = mapper.createArrayNode();
+        paramValue.addObject().put("myUri", "/optic/test/musician1.json");
+
+        List<RowRecord> rows = resultRows(op
+                .fromParam("bindingParam", "myQualifier", op.colTypes(op.colType("myUri", "string")))
+                .lockForUpdate(op.viewCol("myQualifier", "uri"))
+                .bindParam("bindParam", new JacksonHandle(paramValue), null));
+        assertEquals(1, rows.size());
+    }
+}

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerRemoveTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerRemoveTest.java
@@ -26,14 +26,9 @@ public class RowManagerRemoveTest extends AbstractRowManagerTest {
 
         writeThreeXmlDocuments();
 
-        ModifyPlan plan = op
-                .fromDocUris(
-                        op.cts.orQuery(
-                                op.cts.documentQuery("/fromParam/doc1.xml"),
-                                op.cts.documentQuery("/fromParam/doc3.xml")))
-                .remove();
-
-        rowManager.execute(plan);
+        rowManager.execute(op
+                .fromDocUris("/fromParam/doc1.xml", "/fromParam/doc3.xml")
+                .remove());
         verifyDocsDeleted();
     }
 
@@ -46,14 +41,9 @@ public class RowManagerRemoveTest extends AbstractRowManagerTest {
 
         writeThreeXmlDocuments();
 
-        ModifyPlan plan = op
-                .fromDocUris(
-                        op.cts.orQuery(
-                                op.cts.documentQuery("/fromParam/doc1.xml"),
-                                op.cts.documentQuery("/fromParam/doc3.xml")))
-                .remove(op.col("uri"));
-
-        rowManager.execute(plan);
+        rowManager.execute(op
+                .fromDocUris("/fromParam/doc1.xml", "/fromParam/doc3.xml")
+                .remove(op.col("uri")));
         verifyDocsDeleted();
     }
 


### PR DESCRIPTION
Includes a few ignored tests that are waiting a server bugfix. 

Also added `op.fromDocUris(String... uris)` as syntactic sugar for what seems like a common use case. 

And some refactorings:

- Added the ML 11 check for several tests that didn't have it already
- Added `resultRows(plan)` to `AbstractRowManagerTest` to cut down on a bunch of duplication