### PR TITLE
JAVA-241: Can now use transformDoc()

### DIFF
--- a/marklogic-client-api/src/main/java/com/marklogic/client/expression/PlanBuilderBase.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/expression/PlanBuilderBase.java
@@ -446,6 +446,14 @@ public interface PlanBuilderBase {
     PlanDocDescriptorSeq docDescriptors(DocumentWriteSet writeSet);
 
     /**
+     * Build a transform definition for use with {@code transformDoc}.
+     * 
+     * @param path the path (URI) of either a *.mjs or *.xslt module in a modules database
+     * @return a new {@code TransformDefinition}
+     */
+    TransformDefinition transformDefinition(String path);
+
+    /**
      * Defines base methods for Plan. This interface is an implementation detail.
      * Use Plan as the type for instances of Plan.
      */
@@ -650,6 +658,17 @@ public interface PlanBuilderBase {
          * @return
          */
         PlanBuilder.Plan bindParam(PlanParamExpr param, DocumentWriteSet writeSet);
+        /**
+         * Specifies a content handle to replace a placeholder parameter during this
+         * execution of the plan in all expressions in which the parameter appears.
+         * <p>As when building a plan, binding a parameter constructs a new instance
+         * of the plan with the binding instead of mutating the existing instance
+         * of the plan.</p>
+         * @param param the name of a placeholder parameter
+         * @param content the content to replace the parameter
+         * @return a new instance of the Plan object with the parameter binding
+         */
+        PlanBuilder.Plan bindParam(String param, AbstractWriteHandle content);
         /**
          * Specifies a content handle to replace a placeholder parameter during this
          * execution of the plan in all expressions in which the parameter appears.
@@ -923,6 +942,15 @@ public interface PlanBuilderBase {
          * @return a ModifyPlan object
          */
         PlanBuilder.ModifyPlan remove(PlanColumn uriColumn);
+        /**
+         * Applies the given transformation to the content in the given column in each row. A {@code TransformDefinition}
+         * can be constructed via {@code PlanBuilder#transformDefinition(String)}.
+         * 
+         * @param docColumn the column containing content to be transformed
+         * @param transformDefinition
+         * @return a ModifyPlan object
+         */
+        PlanBuilder.ModifyPlan transformDoc(PlanColumn docColumn, TransformDefinition transformDefinition);
         /**
          * This method restricts the row set to rows matched by the boolean expression. Use boolean composers such as op.and and op.or to combine multiple expressions.
          * @param condition  The boolean expression on which to match. 

--- a/marklogic-client-api/src/main/java/com/marklogic/client/expression/TransformDefinition.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/expression/TransformDefinition.java
@@ -1,0 +1,36 @@
+package com.marklogic.client.expression;
+
+import java.util.Map;
+
+/**
+ * Defines a transform for using with the {@code transformDoc} operator; the
+ * assumption is that a factory method will be used to instantiate this which
+ * requires the path of the transform module.
+ */
+public interface TransformDefinition {
+    /**
+     * Define the kind of transform; either "mjs" (the default) or "xslt".
+     * 
+     * @param kind
+     * @return
+     */
+    TransformDefinition withKind(String kind);
+
+    /**
+     * Define a set of parameters to pass to the transform.
+     * 
+     * @param params
+     * @return
+     */
+    TransformDefinition withParams(Map<String, Object> params);
+
+    /**
+     * Convenience method for adding a single parameter to the transform definition. If a map of params has already been
+     * set via {@code withParams}, then this will add to that map.
+     * 
+     * @param name
+     * @param value
+     * @return
+     */
+    TransformDefinition withParam(String name, Object value);
+}

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/PlanBuilderSubImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/PlanBuilderSubImpl.java
@@ -24,6 +24,7 @@ import com.marklogic.client.document.DocumentWriteOperation;
 import com.marklogic.client.document.DocumentWriteSet;
 import com.marklogic.client.expression.PlanBuilder;
 import com.marklogic.client.expression.SemExpr;
+import com.marklogic.client.expression.TransformDefinition;
 import com.marklogic.client.io.marker.AbstractWriteHandle;
 import com.marklogic.client.io.marker.ContentHandle;
 import com.marklogic.client.io.marker.JSONReadHandle;
@@ -280,6 +281,12 @@ public class PlanBuilderSubImpl extends PlanBuilderImpl {
   @Override
   public PlanRowColTypes colType(String column, String type, Boolean nullable) {
     return new PlanRowColTypesImpl(column, type, nullable);
+  }
+
+  
+  @Override
+  public TransformDefinition transformDefinition(String path) {
+    return new TransformDefinitionImpl(path);
   }
 
   @Override
@@ -877,6 +884,11 @@ public class PlanBuilderSubImpl extends PlanBuilderImpl {
     }
 
     @Override
+    public Plan bindParam(String param, AbstractWriteHandle content) {
+      return bindParam(new PlanParamBase(param), content, null);
+    }
+
+    @Override
     public Plan bindParam(String param, AbstractWriteHandle content, Map<String, Map<String, AbstractWriteHandle>> columnAttachments) {
       return bindParam(new PlanParamBase(param), content, columnAttachments);
     }
@@ -1043,6 +1055,11 @@ public class PlanBuilderSubImpl extends PlanBuilderImpl {
     @Override
     public ModifyPlan remove(PlanColumn uriColumn) {
       return new ModifyPlanSubImpl(this, "op", "remove", new Object[]{uriColumn});
+    }
+
+    @Override
+    public ModifyPlan transformDoc(PlanColumn docColumn, TransformDefinition transformDefinition) {
+      return new ModifyPlanSubImpl(this, "op", "transformDoc", new Object[]{docColumn, transformDefinition});
     }
 
     @Override

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/RowManagerImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/RowManagerImpl.java
@@ -1698,6 +1698,11 @@ public class RowManagerImpl
     }
 
     @Override
+    public Plan bindParam(String param, AbstractWriteHandle content) {
+      return bindParam(new PlanBuilderBaseImpl.PlanParamBase(param), content, null);
+    }
+
+    @Override
     public Plan bindParam(String param, AbstractWriteHandle content, Map<String, Map<String, AbstractWriteHandle>> columnAttachments) {
       return bindParam(new PlanBuilderBaseImpl.PlanParamBase(param), content, columnAttachments);
     }

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/TransformDefinitionImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/TransformDefinitionImpl.java
@@ -1,0 +1,52 @@
+package com.marklogic.client.impl;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.marklogic.client.expression.TransformDefinition;
+import com.marklogic.client.impl.BaseTypeImpl.BaseArgImpl;
+
+public class TransformDefinitionImpl implements TransformDefinition, BaseArgImpl {
+
+    private String path;
+    private String kind = "mjs";
+    private Map<String, Object> params;
+
+    public TransformDefinitionImpl(String path) {
+        this.path = path;
+    }
+
+    @Override
+    public StringBuilder exportAst(StringBuilder strb) {
+        ObjectNode node = new ObjectMapper().createObjectNode();
+        node.put("path", path);
+        node.put("kind", kind);
+        if (params != null) {
+            node.putPOJO("params", params);
+        }
+        return strb.append(node.toString());
+    }
+
+    @Override
+    public TransformDefinition withKind(String kind) {
+        this.kind = kind;
+        return this;
+    }
+
+    @Override
+    public TransformDefinition withParams(Map<String, Object> params) {
+        this.params = params;
+        return this;
+    }
+
+    @Override
+    public TransformDefinition withParam(String name, Object value) {
+        if (this.params == null) {
+            this.params = new HashMap<>();
+        }
+        this.params.put(name, value);
+        return this;
+    }
+}

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerTransformDocTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerTransformDocTest.java
@@ -1,0 +1,185 @@
+package com.marklogic.client.test.rows;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.marklogic.client.FailedRequestException;
+import com.marklogic.client.expression.PlanBuilder.ModifyPlan;
+import com.marklogic.client.io.Format;
+import com.marklogic.client.io.JacksonHandle;
+import com.marklogic.client.io.StringHandle;
+import com.marklogic.client.io.marker.AbstractWriteHandle;
+import com.marklogic.client.row.RowRecord;
+import com.marklogic.client.test.Common;
+
+public class RowManagerTransformDocTest extends AbstractRowManagerTest {
+
+    @Test
+    public void mjsTransformWithParam() {
+        if (!Common.markLogicIsVersion11OrHigher()) {
+            return;
+        }
+
+        ArrayNode rows = mapper.createArrayNode();
+        rows.addObject().putObject("doc").put("some", "content");
+
+        ModifyPlan plan = op
+                .fromParam("myDocs", "", op.colTypes(op.colType("doc", "none")))
+                .transformDoc(op.col("doc"),
+                        op.transformDefinition("/etc/optic/test/transformDoc-test.mjs")
+                                .withParam("myParam", "my value"));
+
+        List<RowRecord> results = resultRows(plan.bindParam("myDocs", new JacksonHandle(rows)));
+        assertEquals(1, results.size());
+
+        ObjectNode transformedDoc = results.get(0).getContentAs("doc", ObjectNode.class);
+        assertEquals("world", transformedDoc.get("hello").asText());
+        assertEquals("my value", transformedDoc.get("yourParam").asText());
+        assertEquals(
+                "The transform is expected to receive the incoming doc via the 'doc' param and then toss it into the " +
+                        "response under the key 'thedoc'",
+                "content", transformedDoc.get("theDoc").get("some").asText());
+    }
+
+    @Test
+    @Ignore("See https://bugtrack.marklogic.com/57977")
+    public void mjsTransformWithoutParam() {
+        if (!Common.markLogicIsVersion11OrHigher()) {
+            return;
+        }
+
+        ArrayNode rows = mapper.createArrayNode();
+        rows.addObject().putObject("doc").put("some", "content");
+
+        ModifyPlan plan = op
+                .fromParam("myDocs", "", op.colTypes(op.colType("doc", "none")))
+                .transformDoc(op.col("doc"),
+                        op.transformDefinition("/etc/optic/test/transformDoc-test.mjs").withKind("mjs"));
+
+        List<RowRecord> results = resultRows(plan.bindParam("myDocs", new JacksonHandle(rows)));
+        assertEquals(1, results.size());
+
+        ObjectNode transformedDoc = results.get(0).getContentAs("doc", ObjectNode.class);
+        assertEquals("world", transformedDoc.get("hello").asText());
+        assertFalse("myParam was not specified, so yourParam should not exist", transformedDoc.has("yourParam"));
+        assertEquals("content", transformedDoc.get("theDoc").get("some").asText());
+    }
+
+    @Test
+    public void transformThrowsError() {
+        if (!Common.markLogicIsVersion11OrHigher()) {
+            return;
+        }
+
+        ModifyPlan plan = op
+                .fromDocUris("/optic/test/musician1.json")
+                .joinDoc(op.col("doc"), op.col("uri"))
+                .transformDoc(op.col("doc"), op.transformDefinition("/etc/optic/test/transformDoc-throwsError.mjs"));
+
+        FailedRequestException ex = assertThrows(FailedRequestException.class, () -> rowManager.execute(plan));
+        assertTrue("Unexpected message: " + ex.getMessage(), ex.getMessage().contains("throw Error(\"This is intentional\")"));
+    }
+
+    @Test
+    @Ignore("See https://bugtrack.marklogic.com/57987")
+    public void multipleJsonDocs() {
+        if (!Common.markLogicIsVersion11OrHigher()) {
+            return;
+        }
+
+        ModifyPlan plan = op
+                .fromDocUris("/optic/test/musician1.json", "/optic/test/musician2.json")
+                .joinDoc(op.col("doc"), op.col("uri"))
+                .transformDoc(op.col("doc"),
+                        op.transformDefinition("/etc/optic/test/transformDoc-test.mjs").withParam("myParam",
+                                "my value"));
+
+        List<RowRecord> results = resultRows(plan);
+        assertEquals(2, results.size());
+
+        ObjectNode transformedDoc = results.get(0).getContentAs("doc", ObjectNode.class);
+        assertEquals("world", transformedDoc.get("hello").asText());
+        assertEquals("my value", transformedDoc.get("yourParam").asText());
+        assertEquals("Armstrong", transformedDoc.get("theDoc").get("musician").get("lastName").asText());
+
+        transformedDoc = results.get(1).getContentAs("doc", ObjectNode.class);
+        assertEquals("world", transformedDoc.get("hello").asText());
+        assertEquals("my value", transformedDoc.get("yourParam").asText());
+        assertEquals("Byron", transformedDoc.get("theDoc").get("musician").get("lastName").asText());
+    }
+
+    @Test
+    @Ignore("See https://bugtrack.marklogic.com/57978#2; this works fine as a privileged user though")
+    public void xsltTransformWithParam() {
+        if (!Common.markLogicIsVersion11OrHigher()) {
+            return;
+        }
+
+        ArrayNode rows = mapper.createArrayNode();
+        rows.addObject().put("rowId", 1).put("doc", "doc1.xml");
+        Map<String, AbstractWriteHandle> attachments = new HashMap<>();
+        attachments.put("doc1.xml", new StringHandle("<doc>1</doc>").withFormat(Format.XML));
+
+        ModifyPlan plan = op
+                .fromParam("myDocs", "", op.colTypes(op.colType("rowId", "integer"), op.colType("doc", "none")))
+                .transformDoc(op.col("doc"),
+                        op.transformDefinition("/etc/optic/test/transformDoc-test.xslt")
+                                .withKind("xslt")
+                                .withParam("myParam", "my value"));
+
+        List<RowRecord> results = resultRows(
+                plan.bindParam("myDocs", new JacksonHandle(rows), Collections.singletonMap("doc", attachments)));
+        assertEquals(1, results.size());
+
+        String xml = getRowContentWithoutXmlDeclaration(results.get(0), "doc");
+        String message = "Unexpected XML doc: " + xml;
+        // marklogic-junit would make this much easier/nicer once we change this project
+        // to use JUnit 5
+        assertTrue(message, xml.startsWith("<result>"));
+        assertTrue(message, xml.contains("<doc>1</doc>"));
+        assertTrue(message, xml.contains("<hello>world</hello>"));
+        assertTrue(message, xml.contains("<yourParam>my value</yourParam"));
+        assertTrue(message, xml.endsWith("</result>"));
+    }
+
+    @Test
+    @Ignore("See https://bugtrack.marklogic.com/57978#2; this works fine as a privileged user though")
+    public void xsltTransformWithoutParam() {
+        if (!Common.markLogicIsVersion11OrHigher()) {
+            return;
+        }
+
+        ArrayNode rows = mapper.createArrayNode();
+        rows.addObject().put("doc", "doc1.xml");
+        Map<String, AbstractWriteHandle> attachments = new HashMap<>();
+        attachments.put("doc1.xml", new StringHandle("<doc>1</doc>").withFormat(Format.XML));
+
+        ModifyPlan plan = op
+                .fromParam("myDocs", "", op.colTypes(op.colType("doc", "none")))
+                .transformDoc(op.col("doc"),
+                        op.transformDefinition("/etc/optic/test/transformDoc-test.xslt").withKind("xslt"));
+
+        List<RowRecord> results = resultRows(
+                plan.bindParam("myDocs", new JacksonHandle(rows), Collections.singletonMap("doc", attachments)));
+        assertEquals(1, results.size());
+
+        String xml = getRowContentWithoutXmlDeclaration(results.get(0), "doc");
+        String message = "Unexpected XML doc: " + xml;
+        assertTrue(message, xml.startsWith("<result>"));
+        assertTrue(message, xml.contains("<hello>world</hello>"));
+        assertTrue(message, xml.contains("<yourParam/>"));
+        assertTrue(message, xml.endsWith("</result>"));
+    }
+}

--- a/marklogic-client-api/src/test/ml-modules/root/etc/optic/test/transformDoc-test.mjs
+++ b/marklogic-client-api/src/test/ml-modules/root/etc/optic/test/transformDoc-test.mjs
@@ -1,0 +1,7 @@
+'use strict';
+const result = {
+    "hello": "world",
+    "yourParam": external.params.myParam,
+    "theDoc": external.doc
+}
+result

--- a/marklogic-client-api/src/test/ml-modules/root/etc/optic/test/transformDoc-test.xslt
+++ b/marklogic-client-api/src/test/ml-modules/root/etc/optic/test/transformDoc-test.xslt
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+    <xsl:param name="myParam" />
+    <xsl:template match="/">
+        <result>
+            <xsl:copy-of select="/"/>
+            <hello>world</hello>
+            <yourParam><xsl:value-of select="$myParam"/></yourParam>
+        </result>
+    </xsl:template>
+</xsl:stylesheet>

--- a/marklogic-client-api/src/test/ml-modules/root/etc/optic/test/transformDoc-throwsError.mjs
+++ b/marklogic-client-api/src/test/ml-modules/root/etc/optic/test/transformDoc-throwsError.mjs
@@ -1,0 +1,2 @@
+'use strict';
+throw Error("This is intentional");


### PR DESCRIPTION
Test refers to multiple bugs though that need to be fixed; these are being tracked in JAVA-267. 

Also added a `bindParam(String, AbstractWriteHandle)` method for when the user does not need to include any attachments - I was finding it ugly to keep passing in `null` as the 3rd arg. 