### PR TITLE
JAVA-246: Added docCols(String[])

### DIFF
--- a/marklogic-client-api/src/main/java/com/marklogic/client/expression/PlanBuilderBase.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/expression/PlanBuilderBase.java
@@ -430,6 +430,17 @@ public interface PlanBuilderBase {
     PlanDocColsIdentifier docCols(Map<String, String> descriptorColumnMapping);
 
     /**
+     * Construct a {@code PlanDocColsIdentifier} that consists only of the given descriptor column names, each of which
+     * must be one of the following: uri, doc, collections, permissions, metadata, quality, and temporalCollection. Use
+     * this when constructing a plan for only writing certain parts of a document - e.g. when only updating the 
+     * collections on a set of URIs. 
+     * 
+     * @param descriptorColumnNames
+     * @return
+     */
+    PlanDocColsIdentifier docCols(String[] descriptorColumnNames);
+
+    /**
      * Build a single doc descriptor that can be used with {@code fromDocDescriptors}.
      *
      * @param writeOp contains the inputs for the doc descriptor

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/DocDescriptorUtil.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/DocDescriptorUtil.java
@@ -50,19 +50,22 @@ class DocDescriptorUtil {
         }
 
         AbstractWriteHandle content = writeOp.getContent();
-        JsonNode jsonContent = getJsonNodeFromContent(content);
-        if (jsonContent != null) {
-            // JSON attachments aren't yet supported by the REST endpoint, so they are always inlined, regardless
-            // of whether client provided an attachments map or not
-            docDescriptor.set("doc", jsonContent);
-        } else if (attachments != null) {
-            docDescriptor.put("doc", "attachment-" + uri);
-            attachments.put("attachment-" + uri, content);
-        } else {
-            // As of the 5.6.0 release, an assumption is made here that if no attachments map is provided, then
-            // fromDocDescriptors is being used, which only supports JSON content
-            throw new IllegalArgumentException("Only JSON content can be used with fromDocDescriptors; " +
-                    "non-JSON content found for document with URI: " + uri);
+        // content can be null for when user only wants to populate metadata
+        if (content != null) {
+            JsonNode jsonContent = getJsonNodeFromContent(content);
+            if (jsonContent != null) {
+                // JSON attachments aren't yet supported by the REST endpoint, so they are always inlined, regardless
+                // of whether client provided an attachments map or not
+                docDescriptor.set("doc", jsonContent);
+            } else if (attachments != null) {
+                docDescriptor.put("doc", "attachment-" + uri);
+                attachments.put("attachment-" + uri, content);
+            } else {
+                // As of the 5.6.0 release, an assumption is made here that if no attachments map is provided, then
+                // fromDocDescriptors is being used, which only supports JSON content
+                throw new IllegalArgumentException("Only JSON content can be used with fromDocDescriptors; " +
+                        "non-JSON content found for document with URI: " + uri);
+            }    
         }
 
         if (writeOp.getMetadata() instanceof DocumentMetadataHandle) {

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/DocumentWriteOperationImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/DocumentWriteOperationImpl.java
@@ -26,6 +26,18 @@ public class DocumentWriteOperationImpl implements DocumentWriteOperation {
   private DocumentMetadataWriteHandle metadata;
   private AbstractWriteHandle content;
 
+  /**
+   * Defaults the type of operation to {@code OperationType.DOCUMENT_WRITE}.
+   * 
+   * @param uri
+   * @param metadata
+   * @param content
+   */
+  public DocumentWriteOperationImpl(String uri, DocumentMetadataWriteHandle metadata, AbstractWriteHandle content)
+  {
+    this(OperationType.DOCUMENT_WRITE, uri, metadata, content, null);
+  }
+
   public DocumentWriteOperationImpl(OperationType type, String uri,
                                     DocumentMetadataWriteHandle metadata, AbstractWriteHandle content)
   {

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/PlanBuilderSubImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/PlanBuilderSubImpl.java
@@ -227,6 +227,11 @@ public class PlanBuilderSubImpl extends PlanBuilderImpl {
     return new PlanDocColsIdentifierImpl(descriptorColumnMapping);
   }
 
+  @Override
+  public PlanDocColsIdentifier docCols(String[] descriptorColumnNames) {
+    return new PlanDocColsIdentifierImpl(descriptorColumnNames);
+  }
+
   public static class PlanDocDescriptorImpl implements PlanDocDescriptor, BaseTypeImpl.BaseArgImpl {
     private String template;
     // Threadsafe, thus safe to reuse to avoid creating many instances

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/PlanDocColsIdentifierImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/PlanDocColsIdentifierImpl.java
@@ -19,6 +19,14 @@ public class PlanDocColsIdentifierImpl implements PlanDocColsIdentifier, BaseArg
         this.template = descriptor.toString();
     }
 
+    public PlanDocColsIdentifierImpl(String[] columnNames) {
+        ObjectNode descriptor = new ObjectMapper().createObjectNode();
+        for (String name : columnNames) {
+            descriptor.put(name, name);
+        }
+        this.template = descriptor.toString();
+    }
+
     @Override
     public StringBuilder exportAst(StringBuilder strb) {
         return strb.append(this.template);

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/AbstractRowManagerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/AbstractRowManagerTest.java
@@ -1,25 +1,29 @@
 package com.marklogic.client.test.rows;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.marklogic.client.expression.PlanBuilder;
-import com.marklogic.client.expression.PlanBuilder.Plan;
-import com.marklogic.client.io.DocumentMetadataHandle;
-import com.marklogic.client.io.JacksonHandle;
-import com.marklogic.client.io.StringHandle;
-import com.marklogic.client.row.RawPlanDefinition;
-import com.marklogic.client.row.RowManager;
-import com.marklogic.client.row.RowRecord;
-import com.marklogic.client.test.Common;
-
-import org.junit.Before;
+import static org.junit.Assert.assertEquals;
 
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Before;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.marklogic.client.document.DocumentWriteOperation;
+import com.marklogic.client.expression.PlanBuilder;
+import com.marklogic.client.expression.PlanBuilder.Plan;
+import com.marklogic.client.impl.DocumentWriteOperationImpl;
+import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.client.io.JacksonHandle;
+import com.marklogic.client.io.StringHandle;
+import com.marklogic.client.io.marker.AbstractWriteHandle;
+import com.marklogic.client.row.RawPlanDefinition;
+import com.marklogic.client.row.RowManager;
+import com.marklogic.client.row.RowRecord;
+import com.marklogic.client.test.Common;
 
 public abstract class AbstractRowManagerTest {
 
@@ -79,5 +83,13 @@ public abstract class AbstractRowManagerTest {
      */
     protected final List<RowRecord> resultRows(Plan plan) {
         return rowManager.resultRows(plan).stream().collect(Collectors.toList());
+    }
+
+    protected DocumentWriteOperation newWriteOp(String uri, JsonNode json) {
+        return newWriteOp(uri, new JacksonHandle(json));
+    }
+    
+    protected DocumentWriteOperation newWriteOp(String uri, AbstractWriteHandle content) {
+        return new DocumentWriteOperationImpl(uri, new DocumentMetadataHandle(), content);
     }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerLockForUpdateTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerLockForUpdateTest.java
@@ -23,12 +23,10 @@ public class RowManagerLockForUpdateTest extends AbstractRowManagerTest {
         }
 
         final String uri = "/fromParam/doc1.json";
-        DocumentMetadataHandle metadata = new DocumentMetadataHandle();
 
         // Write a document
         rowManager.execute(op.fromDocDescriptors(
-                op.docDescriptor(new DocumentWriteOperationImpl(OperationType.DOCUMENT_WRITE, uri, metadata,
-                        new JacksonHandle(mapper.createObjectNode().put("hello", "world")))))
+                op.docDescriptor(newWriteOp(uri, new JacksonHandle(mapper.createObjectNode().put("hello", "world")))))
                 .write());
         verifyJsonDoc(uri, doc -> assertEquals("world", doc.get("hello").asText()));
 
@@ -43,8 +41,7 @@ public class RowManagerLockForUpdateTest extends AbstractRowManagerTest {
 
         // Verify it can be updated - i.e. the lock was released in the previous call
         rowManager.execute(op.fromDocDescriptors(
-                op.docDescriptor(new DocumentWriteOperationImpl(OperationType.DOCUMENT_WRITE, uri, metadata,
-                        new JacksonHandle(mapper.createObjectNode().put("hello", "modified")))))
+                op.docDescriptor(newWriteOp(uri, new JacksonHandle(mapper.createObjectNode().put("hello", "modified")))))
                 .write());
         verifyJsonDoc(uri, doc -> assertEquals("modified", doc.get("hello").asText()));
     }


### PR DESCRIPTION
This is necessary for when the user only wants a subset of descriptor columns, but doesn't need to map them - having to specify a map just for this use case would be very annoying. 

Also added DocumentWriteOperationImpl(uri, metadata, content) and added newWriteOp to get rid of a lot of duplication in tests. 