### PR TITLE
Removed write privileges

### DIFF
--- a/marklogic-client-api/src/test/ml-config/security/roles/rest-delete-graph.json
+++ b/marklogic-client-api/src/test/ml-config/security/roles/rest-delete-graph.json
@@ -1,6 +1,6 @@
 {
   "role-name": "rest-delete-graph",
-  "description": "Addresses a bug found in ML 10.0-8.3 and ML 10.0-9.2 where term-query is needed to delete a graph; temporarily adding xdmp:invoke and any-uri until /v1/rows uses an amp to grant these for updates",
+  "description": "Addresses a bug found in ML 10.0-8.3 and ML 10.0-9.2 where term-query is needed to delete a graph; temporarily adding xdmp:invoke until /v1/rows uses an amp to grant these for transformDoc",
   "privilege": [
     {
       "privilege-name": "term-query",
@@ -10,16 +10,6 @@
     {
       "privilege-name": "xdmp:invoke",
       "action": "http://marklogic.com/xdmp/privileges/xdmp-invoke",
-      "kind": "execute"
-    },
-    {
-      "privilege-name": "any-uri",
-      "action": "http://marklogic.com/xdmp/privileges/any-uri",
-      "kind": "execute"
-    },
-    {
-      "privilege-name": "unprotected-collections",
-      "action": "http://marklogic.com/xdmp/privileges/unprotected-collections",
       "kind": "execute"
     }
   ]


### PR DESCRIPTION
These are no longer needed now that write() uses an amp