### PR TITLE
JAVA-246: Can now write and remove temporal documents

### DIFF
--- a/marklogic-client-api/src/main/java/com/marklogic/client/expression/PlanBuilderBase.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/expression/PlanBuilderBase.java
@@ -954,6 +954,15 @@ public interface PlanBuilderBase {
          */
         PlanBuilder.ModifyPlan remove(PlanColumn uriColumn);
         /**
+         * Removes (deletes) any temporal document with a URI matching the value of the given column in at least one 
+         * row in the pipeline. Results in each temporal document being marked as deleted. 
+         * 
+         * @param temporalCollection the name of the temporal collection containing URIs to remove
+         * @param uriColumn the column containing URIs to be removed
+         * @return a ModifyPlan object
+         */
+        PlanBuilder.ModifyPlan remove(String temporalCollection, PlanColumn uriColumn);
+        /**
          * Applies the given transformation to the content in the given column in each row. A {@code TransformDefinition}
          * can be constructed via {@code PlanBuilder#transformDefinition(String)}.
          * 

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/DocDescriptorUtil.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/DocDescriptorUtil.java
@@ -93,7 +93,7 @@ class DocDescriptorUtil {
 //            }
 //          }
 
-        // Hack until the REST endpoint supports a JSON serialization of permissions
+        // TODO Hack until the REST endpoint supports a JSON serialization of permissions
         ArrayNode permissions = docDescriptor.putArray("permissions");
         permissions.addObject().put("roleId", "7089338530631756591").put("capability", "read");
         permissions.addObject().put("roleId", "7089338530631756591").put("capability", "update");

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/PlanBuilderSubImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/PlanBuilderSubImpl.java
@@ -25,6 +25,7 @@ import com.marklogic.client.document.DocumentWriteSet;
 import com.marklogic.client.expression.PlanBuilder;
 import com.marklogic.client.expression.SemExpr;
 import com.marklogic.client.expression.TransformDefinition;
+import com.marklogic.client.impl.BaseTypeImpl.BaseArgImpl;
 import com.marklogic.client.io.marker.AbstractWriteHandle;
 import com.marklogic.client.io.marker.ContentHandle;
 import com.marklogic.client.io.marker.JSONReadHandle;
@@ -1060,6 +1061,25 @@ public class PlanBuilderSubImpl extends PlanBuilderImpl {
     @Override
     public ModifyPlan remove(PlanColumn uriColumn) {
       return new ModifyPlanSubImpl(this, "op", "remove", new Object[]{uriColumn});
+    }
+
+    static class TemporalRemoval implements BaseArgImpl {
+        private String template;
+
+        public TemporalRemoval(String temporalCollection, PlanColumn uriColumn) {
+            this.template = String.format("{\"temporalCollection\":\"%s\", \"uri\": %s}", temporalCollection,
+                    ((BaseArgImpl) uriColumn).exportAst(new StringBuilder()));
+        }
+
+        @Override
+        public StringBuilder exportAst(StringBuilder strb) {
+            return strb.append(template);
+        }
+    }
+
+    @Override
+    public ModifyPlan remove(String temporalCollection, PlanColumn uriColumn) {
+        return new ModifyPlanSubImpl(this, "op", "remove", new Object[]{new TemporalRemoval(temporalCollection, uriColumn)});
     }
 
     @Override

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/AbstractRowManagerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/AbstractRowManagerTest.java
@@ -17,6 +17,7 @@ import com.marklogic.client.expression.PlanBuilder;
 import com.marklogic.client.expression.PlanBuilder.Plan;
 import com.marklogic.client.impl.DocumentWriteOperationImpl;
 import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.client.io.Format;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.io.marker.AbstractWriteHandle;
@@ -26,6 +27,8 @@ import com.marklogic.client.row.RowRecord;
 import com.marklogic.client.test.Common;
 
 public abstract class AbstractRowManagerTest {
+
+    private final static String XML_PREAMBLE = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
 
     protected RowManager rowManager;
     protected PlanBuilder op;
@@ -66,13 +69,18 @@ public abstract class AbstractRowManagerTest {
         verifier.accept((ObjectNode) Common.client.newJSONDocumentManager().read(uri, new JacksonHandle()).get());
     }
 
+    protected final void verifyXmlDoc(String uri, Consumer<String> verifier) {
+        String content = Common.client.newXMLDocumentManager().read(uri, new StringHandle().withFormat(Format.XML)).get();
+        verifier.accept(content.replace(XML_PREAMBLE, ""));
+    }
+
     protected final void verifyMetadata(String uri, Consumer<DocumentMetadataHandle> verifier) {
         verifier.accept(Common.client.newJSONDocumentManager().readMetadata(uri, new DocumentMetadataHandle()));
     }
 
     protected final String getRowContentWithoutXmlDeclaration(RowRecord row, String columnName) {
         String content = row.getContentAs(columnName, String.class);
-        return content.replace("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n", "");
+        return content.replace(XML_PREAMBLE, "");
     }
 
     /**
@@ -91,5 +99,18 @@ public abstract class AbstractRowManagerTest {
     
     protected DocumentWriteOperation newWriteOp(String uri, AbstractWriteHandle content) {
         return new DocumentWriteOperationImpl(uri, new DocumentMetadataHandle(), content);
+    }
+
+    /**
+     * Defines the required fields for the temporal axes configured for the test project.
+     * 
+     * @return
+     */
+    protected final ObjectNode newTemporalContent() {
+        return mapper.createObjectNode()
+                .put("system-start", "")
+                .put("system-end", "")
+                .put("valid-start", "2015-01-01T00:00:00")
+                .put("valid-end", "2017-01-01T00:00:00");
     }
 }


### PR DESCRIPTION
The design may change here in case we require the temporal collection to be a column instead of a string. 