### PR TITLE
Renamed test URI prefix from /fromParam/ to /acme/

### DIFF
--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/AbstractRowManagerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/AbstractRowManagerTest.java
@@ -34,10 +34,11 @@ public abstract class AbstractRowManagerTest {
     @Before
     public void beforeClass() {
         Common.connect();
-        // Subclasses of this test are expected to only write URIs starting with /fromParam/, so delete all of them
-        // before running the test to ensure a document doesn't already exist.
+        // Subclasses of this test are expected to only write URIs starting with /acme/ (which is used so that test
+        // URIs show up near the top when exploring the database in qconsole), so delete all of them before running the
+        // test to ensure a document doesn't already exist.
         Common.connectServerAdmin().newServerEval()
-                .xquery("cts:uri-match('/fromParam/*') ! xdmp:document-delete(.)")
+                .xquery("cts:uri-match('/acme/*') ! xdmp:document-delete(.)")
                 .evalAs(String.class);
 
         rowManager = Common.client.newRowManager();
@@ -77,7 +78,7 @@ public abstract class AbstractRowManagerTest {
 
     /**
      * Convenience method for executing a plan and getting the rows back as a list.
-     * 
+     *
      * @param plan
      * @return
      */
@@ -88,7 +89,7 @@ public abstract class AbstractRowManagerTest {
     protected DocumentWriteOperation newWriteOp(String uri, JsonNode json) {
         return newWriteOp(uri, new JacksonHandle(json));
     }
-    
+
     protected DocumentWriteOperation newWriteOp(String uri, AbstractWriteHandle content) {
         return new DocumentWriteOperationImpl(uri, new DocumentMetadataHandle(), content);
     }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerExportTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerExportTest.java
@@ -51,8 +51,8 @@ public class RowManagerExportTest extends AbstractRowManagerTest {
 
         DocumentMetadataHandle metadata = new DocumentMetadataHandle();
         DocumentWriteSet writeSet = Common.client.newDocumentManager().newWriteSet();
-        writeSet.add("/fromParam/doc1.xml", metadata, new StringHandle("<doc>1</doc>").withFormat(Format.XML));
-        writeSet.add("/fromParam/doc2.xml", metadata, new StringHandle("<doc>2</doc>").withFormat(Format.XML));
+        writeSet.add("/acme/doc1.xml", metadata, new StringHandle("<doc>1</doc>").withFormat(Format.XML));
+        writeSet.add("/acme/doc2.xml", metadata, new StringHandle("<doc>2</doc>").withFormat(Format.XML));
 
         verifyExportedPlanReturnsSameRowCount(
                 op.fromParam("myDocs", "", op.docColTypes()),

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerFromDocDescriptorsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerFromDocDescriptorsTest.java
@@ -33,7 +33,7 @@ public class RowManagerFromDocDescriptorsTest extends AbstractRowManagerTest {
         metadata.setQuality(2);
         // TODO Test permissions and metadata values once they're supported by the server
 
-        final String uri = "/fromParam/doc1.json";
+        final String uri = "/acme/doc1.json";
         DocumentWriteSet writeSet = Common.client.newDocumentManager().newWriteSet();
         ObjectNode content = mapper.createObjectNode().put("hello", "world");
         writeSet.add(uri, metadata, new JacksonHandle(content));
@@ -80,14 +80,14 @@ public class RowManagerFromDocDescriptorsTest extends AbstractRowManagerTest {
 
         PlanBuilder.AccessPlan plan = op.fromDocDescriptors(
                 op.docDescriptor(
-                        new DocumentWriteOperationImpl("/fromParam/doc1.json", metadata, new JacksonHandle(doc1))),
+                        new DocumentWriteOperationImpl("/acme/doc1.json", metadata, new JacksonHandle(doc1))),
                 op.docDescriptor(
-                        new DocumentWriteOperationImpl("/fromParam/doc2.json", metadata, new JacksonHandle(doc2))));
+                        new DocumentWriteOperationImpl("/acme/doc2.json", metadata, new JacksonHandle(doc2))));
         verifyExportedPlanReturnsSameRowCount(plan);
 
         rowManager.execute(plan.write());
-        verifyJsonDoc("/fromParam/doc1.json", doc -> assertEquals("doc1", doc.get("hello").asText()));
-        verifyJsonDoc("/fromParam/doc2.json", doc -> assertEquals("doc2", doc.get("hello").asText()));
+        verifyJsonDoc("/acme/doc1.json", doc -> assertEquals("doc1", doc.get("hello").asText()));
+        verifyJsonDoc("/acme/doc2.json", doc -> assertEquals("doc2", doc.get("hello").asText()));
     }
 
     @Test
@@ -97,7 +97,7 @@ public class RowManagerFromDocDescriptorsTest extends AbstractRowManagerTest {
             return;
         }
 
-        final String uri = "/fromParam/doc1.json";
+        final String uri = "/acme/doc1.json";
         DocumentWriteSet writeSet = Common.client.newDocumentManager().newWriteSet();
         ObjectNode content = mapper.createObjectNode().put("hello", "world");
         writeSet.add(uri, new DocumentMetadataHandle(), new JacksonHandle(content));
@@ -116,7 +116,7 @@ public class RowManagerFromDocDescriptorsTest extends AbstractRowManagerTest {
         }
 
         DocumentWriteSet writeSet = Common.client.newDocumentManager().newWriteSet();
-        writeSet.add("/fromParam/doc1.xml", new DocumentMetadataHandle(),
+        writeSet.add("/acme/doc1.xml", new DocumentMetadataHandle(),
                 new StringHandle("<doc>1</doc>").withFormat(Format.XML));
 
         IllegalArgumentException ex = assertThrows(
@@ -124,7 +124,7 @@ public class RowManagerFromDocDescriptorsTest extends AbstractRowManagerTest {
                 IllegalArgumentException.class,
                 () -> op.docDescriptors(writeSet));
         assertEquals("Unexpected exception: " + ex.getMessage(),
-                "Only JSON content can be used with fromDocDescriptors; non-JSON content found for document with URI: /fromParam/doc1.xml",
+                "Only JSON content can be used with fromDocDescriptors; non-JSON content found for document with URI: /acme/doc1.xml",
                 ex.getMessage());
     }
 
@@ -135,8 +135,8 @@ public class RowManagerFromDocDescriptorsTest extends AbstractRowManagerTest {
         }
 
         DocumentWriteSet writeSet = Common.client.newDocumentManager().newWriteSet();
-        writeSet.add(newWriteOp("/fromParam/doc1.json", mapper.createObjectNode().put("hello", "doc1")));
-        writeSet.add(newWriteOp("/fromParam/doc2.json", mapper.createObjectNode().put("hello", "doc2")));
+        writeSet.add(newWriteOp("/acme/doc1.json", mapper.createObjectNode().put("hello", "doc1")));
+        writeSet.add(newWriteOp("/acme/doc2.json", mapper.createObjectNode().put("hello", "doc2")));
 
         PlanBuilder.AccessPlan accessPlan = op.fromDocDescriptors(op.docDescriptors(writeSet));
         ObjectNode plan = exportPlan(accessPlan);

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerFromParamTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerFromParamTest.java
@@ -281,13 +281,13 @@ public class RowManagerFromParamTest extends AbstractRowManagerTest {
 
         DocumentMetadataHandle metadata = new DocumentMetadataHandle();
         DocumentWriteSet writeSet = Common.client.newDocumentManager().newWriteSet();
-        writeSet.add("/fromParam/doc1.xml", metadata, new StringHandle("<doc>1</doc>").withFormat(Format.XML));
+        writeSet.add("/acme/doc1.xml", metadata, new StringHandle("<doc>1</doc>").withFormat(Format.XML));
         plan = plan.bindParam("myDocs", writeSet);
 
         List<RowRecord> rows = resultRows(plan);
         assertEquals(1, rows.size());
         RowRecord row = rows.get(0);
-        assertEquals("/fromParam/doc1.xml", row.getString("uri"));
+        assertEquals("/acme/doc1.xml", row.getString("uri"));
         assertEquals("<doc>1</doc>", getRowContentWithoutXmlDeclaration(row, "doc"));
     }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerFromParamWriteTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerFromParamWriteTest.java
@@ -41,14 +41,14 @@ public class RowManagerFromParamWriteTest extends AbstractRowManagerTest {
                 .withCollections("common-coll", "other-coll-1");
 
         DocumentWriteSet writeSet = Common.client.newDocumentManager().newWriteSet();
-        writeSet.add("/fromParam/doc1.json", metadata,
+        writeSet.add("/acme/doc1.json", metadata,
                 new JacksonHandle(new ObjectMapper().createObjectNode().put("value", 1)));
         plan = plan.bindParam("myDocs", writeSet);
 
         List<RowRecord> rows = resultRows(plan);
         assertEquals(1, rows.size());
 
-        verifyMetadata("/fromParam/doc1.json", docMetadata -> {
+        verifyMetadata("/acme/doc1.json", docMetadata -> {
             assertEquals(2, docMetadata.getQuality());
             assertTrue(docMetadata.getCollections().contains("common-coll"));
             assertTrue(docMetadata.getCollections().contains("other-coll-1"));
@@ -67,15 +67,15 @@ public class RowManagerFromParamWriteTest extends AbstractRowManagerTest {
 
         DocumentMetadataHandle metadata = new DocumentMetadataHandle();
         DocumentWriteSet writeSet = Common.client.newDocumentManager().newWriteSet();
-        writeSet.add("/fromParam/doc1.xml", metadata, new StringHandle("<doc>1</doc>").withFormat(Format.XML));
-        writeSet.add("/fromParam/doc2.xml", metadata, new StringHandle("<doc>2</doc>").withFormat(Format.XML));
+        writeSet.add("/acme/doc1.xml", metadata, new StringHandle("<doc>1</doc>").withFormat(Format.XML));
+        writeSet.add("/acme/doc2.xml", metadata, new StringHandle("<doc>2</doc>").withFormat(Format.XML));
         plan = plan.bindParam("myDocs", writeSet);
 
         List<RowRecord> rows = resultRows(plan);
         assertEquals(2, rows.size());
 
-        verifyXmlDoc("/fromParam/doc1.xml", "<doc>1</doc>");
-        verifyXmlDoc("/fromParam/doc2.xml", "<doc>2</doc>");
+        verifyXmlDoc("/acme/doc1.xml", "<doc>1</doc>");
+        verifyXmlDoc("/acme/doc2.xml", "<doc>2</doc>");
     }
 
     /**
@@ -91,12 +91,12 @@ public class RowManagerFromParamWriteTest extends AbstractRowManagerTest {
 
         DocumentMetadataHandle metadata = new DocumentMetadataHandle();
         DocumentWriteSet writeSet = Common.client.newDocumentManager().newWriteSet();
-        writeSet.add("/fromParam/doc1.xml", metadata, new StringHandle("<doc>1</doc>"));
-        writeSet.add("/fromParam/doc2.json", metadata, new StringHandle("{\"doc\":2}").withFormat(Format.JSON));
+        writeSet.add("/acme/doc1.xml", metadata, new StringHandle("<doc>1</doc>"));
+        writeSet.add("/acme/doc2.json", metadata, new StringHandle("{\"doc\":2}").withFormat(Format.JSON));
         PlanBuilder.Plan finalPlan = plan.bindParam("myDocs", writeSet);
 
         // Example of expected error message:
-        // Local message: failed to apply resource at rows: Bad Request. Server Message: XDMP-ARGTYPE: xdmp.documentInsert("/fromParam/doc2.json",
+        // Local message: failed to apply resource at rows: Bad Request. Server Message: XDMP-ARGTYPE: xdmp.documentInsert("/acme/doc2.json",
         // Sequence(), {collections:Sequence(), permissions:[{roleId:"7089338530631756591", capability:"read"},
         // {roleId:"7089338530631756591", capability:"update"}], metadata:[], ...}) -- arg2 is not of type Node
         FailedRequestException ex = assertThrows(FailedRequestException.class, () -> rowManager.execute(finalPlan));
@@ -154,14 +154,14 @@ public class RowManagerFromParamWriteTest extends AbstractRowManagerTest {
 
         DocumentMetadataHandle metadata = new DocumentMetadataHandle();
         DocumentWriteSet writeSet = Common.client.newDocumentManager().newWriteSet();
-        writeSet.add("/fromParam/doc1.xml", metadata, new StringHandle("<doc>1</doc>").withFormat(Format.XML));
-        writeSet.add("/fromParam/doc2.xml", metadata, new StringHandle("<doc>2</doc>").withFormat(Format.XML));
+        writeSet.add("/acme/doc1.xml", metadata, new StringHandle("<doc>1</doc>").withFormat(Format.XML));
+        writeSet.add("/acme/doc2.xml", metadata, new StringHandle("<doc>2</doc>").withFormat(Format.XML));
         PlanBuilder.Plan plan = rawPlan.bindParam("myDocs", writeSet);
 
         rowManager.execute(plan);
 
-        verifyXmlDoc("/fromParam/doc1.xml", "<doc>1</doc>");
-        verifyXmlDoc("/fromParam/doc2.xml", "<doc>2</doc>");
+        verifyXmlDoc("/acme/doc1.xml", "<doc>1</doc>");
+        verifyXmlDoc("/acme/doc2.xml", "<doc>2</doc>");
     }
 
     @Test
@@ -183,17 +183,17 @@ public class RowManagerFromParamWriteTest extends AbstractRowManagerTest {
         final String temporalCollection = "temporal-collection";
         DocumentMetadataHandle metadata = new DocumentMetadataHandle();
         DocumentWriteSet writeSet = Common.client.newDocumentManager().newWriteSet();
-        writeSet.add("/fromParam/doc1-temporal.xml", metadata, new StringHandle(contents).withFormat(Format.XML), temporalCollection);
-        writeSet.add("/fromParam/doc2-temporal.xml", metadata, new StringHandle(contents).withFormat(Format.XML), temporalCollection);
+        writeSet.add("/acme/doc1-temporal.xml", metadata, new StringHandle(contents).withFormat(Format.XML), temporalCollection);
+        writeSet.add("/acme/doc2-temporal.xml", metadata, new StringHandle(contents).withFormat(Format.XML), temporalCollection);
         plan = plan.bindParam("myDocs", writeSet);
 
         rowManager.resultRows(plan);
 
-        verifyXmlDoc("/fromParam/doc1-temporal.xml", contents);
-        verifyXmlDoc("/fromParam/doc2-temporal.xml", contents);
+        verifyXmlDoc("/acme/doc1-temporal.xml", contents);
+        verifyXmlDoc("/acme/doc2-temporal.xml", contents);
 
         XMLDocumentManager mgr = Common.client.newXMLDocumentManager();
-        metadata = mgr.readMetadata("/fromParam/doc1-temporal.xml", new DocumentMetadataHandle());
+        metadata = mgr.readMetadata("/acme/doc1-temporal.xml", new DocumentMetadataHandle());
         assertTrue("The document should be in the 'latest' collection if it was correctly inserted via " +
                 "temporal.documentInsert", metadata.getCollections().contains("latest"));
         assertTrue(metadata.getCollections().contains(temporalCollection));

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerLockForUpdateTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerLockForUpdateTest.java
@@ -22,7 +22,7 @@ public class RowManagerLockForUpdateTest extends AbstractRowManagerTest {
             return;
         }
 
-        final String uri = "/fromParam/doc1.json";
+        final String uri = "/acme/doc1.json";
 
         // Write a document
         rowManager.execute(op.fromDocDescriptors(

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerRemoveTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerRemoveTest.java
@@ -26,7 +26,7 @@ public class RowManagerRemoveTest extends AbstractRowManagerTest {
         writeThreeXmlDocuments();
 
         rowManager.execute(op
-                .fromDocUris("/fromParam/doc1.xml", "/fromParam/doc3.xml")
+                .fromDocUris("/acme/doc1.xml", "/acme/doc3.xml")
                 .remove());
         verifyDocsDeleted();
     }
@@ -40,7 +40,7 @@ public class RowManagerRemoveTest extends AbstractRowManagerTest {
         writeThreeXmlDocuments();
 
         rowManager.execute(op
-                .fromDocUris("/fromParam/doc1.xml", "/fromParam/doc3.xml")
+                .fromDocUris("/acme/doc1.xml", "/acme/doc3.xml")
                 .remove(op.col("uri")));
         verifyDocsDeleted();
     }
@@ -54,8 +54,8 @@ public class RowManagerRemoveTest extends AbstractRowManagerTest {
         writeThreeXmlDocuments();
 
         ArrayNode paramValue = mapper.createArrayNode();
-        paramValue.addObject().put("myUri", "/fromParam/doc1.xml");
-        paramValue.addObject().put("myUri", "/fromParam/doc3.xml");
+        paramValue.addObject().put("myUri", "/acme/doc1.xml");
+        paramValue.addObject().put("myUri", "/acme/doc3.xml");
 
         ModifyPlan plan = op
                 .fromParam("bindingParam", "", op.colTypes(op.colType("myUri", "string")))
@@ -74,8 +74,8 @@ public class RowManagerRemoveTest extends AbstractRowManagerTest {
         writeThreeXmlDocuments();
 
         ArrayNode paramValue = mapper.createArrayNode();
-        paramValue.addObject().put("uri", "/fromParam/doc1.xml");
-        paramValue.addObject().put("uri", "/fromParam/doc3.xml");
+        paramValue.addObject().put("uri", "/acme/doc1.xml");
+        paramValue.addObject().put("uri", "/acme/doc3.xml");
 
         ModifyPlan plan = op
                 .fromParam("bindingParam", "myQualifier", op.colTypes(op.colType("uri", "string")))
@@ -88,9 +88,9 @@ public class RowManagerRemoveTest extends AbstractRowManagerTest {
     private void writeThreeXmlDocuments() {
         DocumentMetadataHandle metadata = new DocumentMetadataHandle();
         DocumentWriteSet writeSet = Common.client.newDocumentManager().newWriteSet()
-                .add("/fromParam/doc1.xml", metadata, new StringHandle("<doc>1</doc>").withFormat(Format.XML))
-                .add("/fromParam/doc2.xml", metadata, new StringHandle("<doc>2</doc>").withFormat(Format.XML))
-                .add("/fromParam/doc3.xml", metadata, new StringHandle("<doc>3</doc>").withFormat(Format.XML));
+                .add("/acme/doc1.xml", metadata, new StringHandle("<doc>1</doc>").withFormat(Format.XML))
+                .add("/acme/doc2.xml", metadata, new StringHandle("<doc>2</doc>").withFormat(Format.XML))
+                .add("/acme/doc3.xml", metadata, new StringHandle("<doc>3</doc>").withFormat(Format.XML));
 
         rowManager.execute(op
                 .fromParam("myDocs", null, op.docColTypes())
@@ -101,8 +101,8 @@ public class RowManagerRemoveTest extends AbstractRowManagerTest {
     private void verifyDocsDeleted() {
         // Assumes that the test deleted doc1 and doc3
         GenericDocumentManager mgr = Common.client.newDocumentManager();
-        assertNull(mgr.exists("/fromParam/doc1.xml"));
-        assertNull(mgr.exists("/fromParam/doc3.xml"));
-        assertNotNull(mgr.exists("/fromParam/doc2.xml"));
+        assertNull(mgr.exists("/acme/doc1.xml"));
+        assertNull(mgr.exists("/acme/doc3.xml"));
+        assertNotNull(mgr.exists("/acme/doc2.xml"));
     }
 }


### PR DESCRIPTION
"fromParam" made sense for the first few tests that were specific to fromParam. Using "acme" as a generic prefix that conveniently shows up near the top of the results when exploring in qconsole. 

This includes a commit from the 246-temporal branch, so the PR for that branch should be merged in first. 