### PR TITLE
WriteBatcher does not write documents when total documents provided is less than 100 and without withBatchSize

### DIFF
--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/BatcherImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/BatcherImpl.java
@@ -24,7 +24,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public abstract class BatcherImpl implements Batcher {
   private String jobName = "unnamed";
   private String jobId = null;
-  private int batchSize = 100;
+  private int batchSize = 0;
   private int threadCount = 1;
   private ForestConfiguration forestConfig;
   private DataMovementManagerImpl moveMgr;

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/WriteBatcherTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/WriteBatcherTest.java
@@ -68,6 +68,7 @@ import com.marklogic.client.datamovement.WriteBatcher;
 
 import com.marklogic.client.test.Common;
 
+import static com.marklogic.client.io.Format.JSON;
 import static org.junit.Assert.*;
 
 public class WriteBatcherTest {
@@ -1186,5 +1187,24 @@ public class WriteBatcherTest {
 
     client.newDocumentManager().delete("/CXXXX_Ü_9999.json");
     client.newDocumentManager().delete("Ä_9999.json");
+  }
+
+  @Test
+  public void testWithDocumentsLessThanBatchSize(){
+    DataMovementManager moveMgr = client.newDataMovementManager();
+    WriteBatcher writeBatcher = moveMgr.newWriteBatcher();
+    DocumentMetadataHandle meta = new DocumentMetadataHandle().withCollections(whbTestCollection);
+    moveMgr.startJob(writeBatcher);
+    Set<String> set = new HashSet<>();
+    for(int i=0; i<99; i++){
+      writeBatcher.addAs("/testing/"+i,  meta, new StringHandle("{key:"+i+", value:\"value"+i+"\"}").withFormat(JSON));
+      set.add("/testing/"+i);
+    }
+    writeBatcher.awaitCompletion();
+    moveMgr.stopJob(writeBatcher);
+    DocumentManager docMgr = client.newDocumentManager();
+    for(String uri:set){
+      assertTrue(docMgr.exists(uri)!=null);
+    }
   }
 }


### PR DESCRIPTION

So we can incorporate your pull request, please share the following:
* What issue are you addressing with this pull request? https://github.com/marklogic/java-client-api/issues/1405
* Are you modifying the correct branch? (See CONTRIBUTING.md)
* Have you run unit tests? (See CONTRIBUTING.md)
* Version of MarkLogic Java Client API (see Readme.txt)
* Version of MarkLogic Server (see admin gui on port 8001)
* Java version (`java -version`)
* OS and version
* What Changed: What happened before this change? What happens without this change?
