### PR TITLE
More test fixes based on server updates

### DIFF
--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/DocDescriptorUtil.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/DocDescriptorUtil.java
@@ -12,7 +12,6 @@ import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.Format;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.marker.AbstractWriteHandle;
-
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.LoggerFactory;
 
@@ -65,7 +64,7 @@ class DocDescriptorUtil {
                 // fromDocDescriptors is being used, which only supports JSON content
                 throw new IllegalArgumentException("Only JSON content can be used with fromDocDescriptors; " +
                         "non-JSON content found for document with URI: " + uri);
-            }    
+            }
         }
 
         if (writeOp.getMetadata() instanceof DocumentMetadataHandle) {
@@ -84,19 +83,14 @@ class DocDescriptorUtil {
             metadata.getCollections().forEach(c -> collections.add(c));
         }
 
-//          if (!metadata.getPermissions().isEmpty()) {
-//            ArrayNode permissions = row.putArray("permissions");
-//            for (String roleName : metadata.getPermissions().keySet()) {
-//              for (DocumentMetadataHandle.Capability c : metadata.getPermissions().get(roleName)) {
-//                permissions.addObject().put("roleId", "7089338530631756591").put("capability", c.toString().toLowerCase());
-//              }
-//            }
-//          }
-
-        // Hack until the REST endpoint supports a JSON serialization of permissions
-        ArrayNode permissions = docDescriptor.putArray("permissions");
-        permissions.addObject().put("roleId", "7089338530631756591").put("capability", "read");
-        permissions.addObject().put("roleId", "7089338530631756591").put("capability", "update");
+        if (!metadata.getPermissions().isEmpty()) {
+            ArrayNode permissions = docDescriptor.putArray("permissions");
+            for (String roleName : metadata.getPermissions().keySet()) {
+                for (DocumentMetadataHandle.Capability c : metadata.getPermissions().get(roleName)) {
+                    permissions.addObject().put("roleName", roleName).put("capability", c.toString().toLowerCase());
+                }
+            }
+        }
 
         if (!metadata.getMetadataValues().isEmpty()) {
             ObjectNode values = docDescriptor.putObject("metadata");

--- a/marklogic-client-api/src/test/java/com/marklogic/client/impl/PlanDocDescriptorImplTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/impl/PlanDocDescriptorImplTest.java
@@ -44,9 +44,7 @@ public class PlanDocDescriptorImplTest extends Assert {
         assertEquals(2, plan.get("quality").asInt());
         assertEquals("c1", plan.get("collections").get(0).asText());
         assertEquals("c2", plan.get("collections").get(1).asText());
-        // TODO Test permissions for real, not these hardcoded ones
-        // Should really be 3 permissions
-        assertEquals(2, plan.get("permissions").size());
+        assertEquals(3, plan.get("permissions").size());
         assertEquals("value1", plan.get("metadata").get("key1").asText());
         assertEquals("value2", plan.get("metadata").get("key2").asText());
 

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/Common.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/Common.java
@@ -101,10 +101,13 @@ public class Common {
     return newClient(null);
   }
   public static DatabaseClient newClient(String databaseName) {
+    return newClientAsUser(Common.USER, databaseName);
+  }
+  public static DatabaseClient newClientAsUser(String username, String databaseName) {
     System.out.println("Connecting to: " + Common.HOST);
     return DatabaseClientFactory.newClient(Common.HOST, Common.PORT, databaseName,
-        new DatabaseClientFactory.DigestAuthContext(Common.USER, Common.PASS),
-          CONNECTION_TYPE);
+            new DatabaseClientFactory.DigestAuthContext(username, Common.PASS),
+            CONNECTION_TYPE);
   }
   public static DatabaseClient newAdminClient() {
     return newAdminClient(null);

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/ExportTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/ExportTest.java
@@ -20,7 +20,7 @@ import java.util.Map;
  * <p>
  * fromLiterals is not tested here because RowManagerTest already verifies export/import for it.
  */
-public class RowManagerExportTest extends AbstractRowManagerTest {
+public class ExportTest extends AbstractOpticUpdateTest {
 
     @Test
     public void fromDocUris() {

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/FromParamTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/FromParamTest.java
@@ -6,7 +6,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.junit.Test;
 
@@ -28,7 +27,7 @@ import com.marklogic.client.type.PlanParamExpr;
  * Tests various scenarios involving the {@code fromParam} accessor and the need to bind a content handle as a parameter
  * to the plan.
  */
-public class RowManagerFromParamTest extends AbstractRowManagerTest {
+public class FromParamTest extends AbstractOpticUpdateTest {
 
     @Test
     public void fromParamWithSimpleJsonArray() {

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/FromParamWriteTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/FromParamWriteTest.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 import static org.junit.Assert.*;
 
-public class RowManagerFromParamWriteTest extends AbstractRowManagerTest {
+public class FromParamWriteTest extends AbstractOpticUpdateTest {
 
     @Test
     public void jsonDocumentWithAllMetadata() {
@@ -32,12 +32,10 @@ public class RowManagerFromParamWriteTest extends AbstractRowManagerTest {
                 .fromParam("myDocs", "", op.docColTypes())
                 .write();
 
-        DocumentMetadataHandle metadata = new DocumentMetadataHandle()
+        DocumentMetadataHandle metadata = newDefaultMetadata()
                 .withQuality(2)
                 .withMetadataValue("meta1", "value1")
                 .withMetadataValue("meta2", "value2")
-                // Permissions not yet supported by server - see https://bugtrack.marklogic.com/57883
-                //.withPermission("rest-reader", DocumentMetadataHandle.Capability.READ, DocumentMetadataHandle.Capability.UPDATE)
                 .withCollections("common-coll", "other-coll-1");
 
         DocumentWriteSet writeSet = Common.client.newDocumentManager().newWriteSet();
@@ -50,6 +48,8 @@ public class RowManagerFromParamWriteTest extends AbstractRowManagerTest {
 
         verifyMetadata("/acme/doc1.json", docMetadata -> {
             assertEquals(2, docMetadata.getQuality());
+            assertEquals(DocumentMetadataHandle.Capability.READ, docMetadata.getPermissions().get("rest-reader").iterator().next());
+            assertEquals(DocumentMetadataHandle.Capability.UPDATE, docMetadata.getPermissions().get("test-rest-writer").iterator().next());
             assertTrue(docMetadata.getCollections().contains("common-coll"));
             assertTrue(docMetadata.getCollections().contains("other-coll-1"));
             assertEquals("value1", docMetadata.getMetadataValues().get("meta1"));
@@ -65,7 +65,7 @@ public class RowManagerFromParamWriteTest extends AbstractRowManagerTest {
 
         PlanBuilder.Plan plan = op.fromParam("myDocs", "", op.docColTypes()).write();
 
-        DocumentMetadataHandle metadata = new DocumentMetadataHandle();
+        DocumentMetadataHandle metadata = newDefaultMetadata();
         DocumentWriteSet writeSet = Common.client.newDocumentManager().newWriteSet();
         writeSet.add("/acme/doc1.xml", metadata, new StringHandle("<doc>1</doc>").withFormat(Format.XML));
         writeSet.add("/acme/doc2.xml", metadata, new StringHandle("<doc>2</doc>").withFormat(Format.XML));
@@ -152,7 +152,7 @@ public class RowManagerFromParamWriteTest extends AbstractRowManagerTest {
                 "    }\n" +
                 "}"));
 
-        DocumentMetadataHandle metadata = new DocumentMetadataHandle();
+        DocumentMetadataHandle metadata = newDefaultMetadata();
         DocumentWriteSet writeSet = Common.client.newDocumentManager().newWriteSet();
         writeSet.add("/acme/doc1.xml", metadata, new StringHandle("<doc>1</doc>").withFormat(Format.XML));
         writeSet.add("/acme/doc2.xml", metadata, new StringHandle("<doc>2</doc>").withFormat(Format.XML));

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/JoinDocColsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/JoinDocColsTest.java
@@ -1,26 +1,23 @@
 package com.marklogic.client.test.rows;
 
-import static org.junit.Assert.assertEquals;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.marklogic.client.expression.PlanBuilder;
+import com.marklogic.client.row.RowRecord;
+import com.marklogic.client.test.Common;
+import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.marklogic.client.expression.PlanBuilder;
-import com.marklogic.client.row.RowRecord;
-import com.marklogic.client.test.Common;
-
-public class RowManagerJoinDocColsTest extends AbstractRowManagerTest {
+public class JoinDocColsTest extends AbstractOpticUpdateTest {
 
     // 4 musician documents are expected to be in this directory via mlDeploy
     private final static String MUSICIAN_DIRECTORY = "/optic/test/";
 
     @Test
-    @Ignore("See https://bugtrack.marklogic.com/57988")
     public void defaultColumns() {
         if (!Common.markLogicIsVersion11OrHigher()) {
             return;
@@ -42,7 +39,6 @@ public class RowManagerJoinDocColsTest extends AbstractRowManagerTest {
     }
 
     @Test
-    @Ignore("See https://bugtrack.marklogic.com/57988")
     public void customColumns() {
         if (!Common.markLogicIsVersion11OrHigher()) {
             return;

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/LockForUpdateTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/LockForUpdateTest.java
@@ -7,14 +7,11 @@ import java.util.List;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.marklogic.client.document.DocumentWriteOperation.OperationType;
-import com.marklogic.client.impl.DocumentWriteOperationImpl;
-import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.row.RowRecord;
 import com.marklogic.client.test.Common;
 
-public class RowManagerLockForUpdateTest extends AbstractRowManagerTest {
+public class LockForUpdateTest extends AbstractOpticUpdateTest {
 
     @Test
     public void basicTest() {

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RemoveTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RemoveTest.java
@@ -15,7 +15,7 @@ import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.test.Common;
 
-public class RowManagerRemoveTest extends AbstractRowManagerTest {
+public class RemoveTest extends AbstractOpticUpdateTest {
 
     @Test
     public void removeTwoOfThreeDocs() {
@@ -86,7 +86,7 @@ public class RowManagerRemoveTest extends AbstractRowManagerTest {
     }
 
     private void writeThreeXmlDocuments() {
-        DocumentMetadataHandle metadata = new DocumentMetadataHandle();
+        DocumentMetadataHandle metadata = newDefaultMetadata();
         DocumentWriteSet writeSet = Common.client.newDocumentManager().newWriteSet()
                 .add("/acme/doc1.xml", metadata, new StringHandle("<doc>1</doc>").withFormat(Format.XML))
                 .add("/acme/doc2.xml", metadata, new StringHandle("<doc>2</doc>").withFormat(Format.XML))

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/TransformDocTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/TransformDocTest.java
@@ -24,7 +24,7 @@ import com.marklogic.client.io.marker.AbstractWriteHandle;
 import com.marklogic.client.row.RowRecord;
 import com.marklogic.client.test.Common;
 
-public class RowManagerTransformDocTest extends AbstractRowManagerTest {
+public class TransformDocTest extends AbstractOpticUpdateTest {
 
     @Test
     public void mjsTransformWithParam() {

--- a/marklogic-client-api/src/test/ml-config/security/roles/rest-delete-graph.json
+++ b/marklogic-client-api/src/test/ml-config/security/roles/rest-delete-graph.json
@@ -1,15 +1,10 @@
 {
   "role-name": "rest-delete-graph",
-  "description": "Addresses a bug found in ML 10.0-8.3 and ML 10.0-9.2 where term-query is needed to delete a graph; temporarily adding xdmp:invoke until /v1/rows uses an amp to grant these for transformDoc",
+  "description": "Addresses a bug found in ML 10.0-8.3 and ML 10.0-9.2 where term-query is needed to delete a graph",
   "privilege": [
     {
       "privilege-name": "term-query",
       "action": "http://marklogic.com/xdmp/privileges/term-query",
-      "kind": "execute"
-    },
-    {
-      "privilege-name": "xdmp:invoke",
-      "action": "http://marklogic.com/xdmp/privileges/xdmp-invoke",
       "kind": "execute"
     }
   ]

--- a/marklogic-client-api/src/test/ml-config/security/roles/test-rest-writer.json
+++ b/marklogic-client-api/src/test/ml-config/security/roles/test-rest-writer.json
@@ -1,0 +1,21 @@
+{
+  "role-name": "test-rest-writer",
+  "description": "Role for test users that can write documents; does not inherit the OOTB rest-writer role so as to avoid having default permissions; temporarily adding xdmp:invoke until /v1/rows uses an amp to grant these for transformDoc",
+  "privilege": [
+    {
+      "privilege-name": "rest-writer",
+      "action": "http://marklogic.com/xdmp/privileges/rest-writer",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "rest-reader",
+      "action": "http://marklogic.com/xdmp/privileges/rest-reader",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "xdmp:invoke",
+      "action": "http://marklogic.com/xdmp/privileges/xdmp-invoke",
+      "kind": "execute"
+    }
+  ]
+}

--- a/marklogic-client-api/src/test/ml-config/security/users/writer-no-default-permissions.json
+++ b/marklogic-client-api/src/test/ml-config/security/users/writer-no-default-permissions.json
@@ -1,0 +1,11 @@
+{
+  "user-name": "writer-no-default-permissions",
+  "description": "test user that does not have the rest-writer role so as to avoid having default permissions",
+  "role": [
+    "test-rest-writer",
+    "rest-delete-graph",
+    "rest-extension-user",
+    "rest-reader"
+  ],
+  "password": "x"
+}


### PR DESCRIPTION
Renamed a bunch of tests, dropping "RowManager" from them, and renamed the abstract base class to make it clear it's specific to Optic Update. 

Introduced a "writer-no-default-permissions" user so that by default, the user for Optic Update tests does not have any default permissions. 