### PR TITLE
Renamed TransformDefinition to TransformDef

### DIFF
--- a/marklogic-client-api/src/main/java/com/marklogic/client/expression/PlanBuilderBase.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/expression/PlanBuilderBase.java
@@ -460,9 +460,9 @@ public interface PlanBuilderBase {
      * Build a transform definition for use with {@code transformDoc}.
      * 
      * @param path the path (URI) of either a *.mjs or *.xslt module in a modules database
-     * @return a new {@code TransformDefinition}
+     * @return a new {@code TransformDef}
      */
-    TransformDefinition transformDefinition(String path);
+    TransformDef transformDef(String path);
 
     /**
      * Convenience method for constructing a permission that can then be used e.g. with {@code jsonArray} when binding
@@ -964,14 +964,14 @@ public interface PlanBuilderBase {
          */
         PlanBuilder.ModifyPlan remove(PlanColumn uriColumn);
         /**
-         * Applies the given transformation to the content in the given column in each row. A {@code TransformDefinition}
-         * can be constructed via {@code PlanBuilder#transformDefinition(String)}.
+         * Applies the given transformation to the content in the given column in each row. A {@code TransformDef}
+         * can be constructed via {@code PlanBuilder#transformDef(String)}.
          * 
          * @param docColumn the column containing content to be transformed
-         * @param transformDefinition
+         * @param transformDef
          * @return a ModifyPlan object
          */
-        PlanBuilder.ModifyPlan transformDoc(PlanColumn docColumn, TransformDefinition transformDefinition);
+        PlanBuilder.ModifyPlan transformDoc(PlanColumn docColumn, TransformDef transformDef);
         /**
          * This method restricts the row set to rows matched by the boolean expression. Use boolean composers such as op.and and op.or to combine multiple expressions.
          * @param condition  The boolean expression on which to match. 

--- a/marklogic-client-api/src/main/java/com/marklogic/client/expression/TransformDef.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/expression/TransformDef.java
@@ -7,14 +7,14 @@ import java.util.Map;
  * assumption is that a factory method will be used to instantiate this which
  * requires the path of the transform module.
  */
-public interface TransformDefinition {
+public interface TransformDef {
     /**
      * Define the kind of transform; either "mjs" (the default) or "xslt".
      * 
      * @param kind
      * @return
      */
-    TransformDefinition withKind(String kind);
+    TransformDef withKind(String kind);
 
     /**
      * Define a set of parameters to pass to the transform.
@@ -22,7 +22,7 @@ public interface TransformDefinition {
      * @param params
      * @return
      */
-    TransformDefinition withParams(Map<String, Object> params);
+    TransformDef withParams(Map<String, Object> params);
 
     /**
      * Convenience method for adding a single parameter to the transform definition. If a map of params has already been
@@ -32,5 +32,5 @@ public interface TransformDefinition {
      * @param value
      * @return
      */
-    TransformDefinition withParam(String name, Object value);
+    TransformDef withParam(String name, Object value);
 }

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/PlanBuilderSubImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/PlanBuilderSubImpl.java
@@ -24,7 +24,7 @@ import com.marklogic.client.document.DocumentWriteOperation;
 import com.marklogic.client.document.DocumentWriteSet;
 import com.marklogic.client.expression.PlanBuilder;
 import com.marklogic.client.expression.SemExpr;
-import com.marklogic.client.expression.TransformDefinition;
+import com.marklogic.client.expression.TransformDef;
 import com.marklogic.client.io.marker.AbstractWriteHandle;
 import com.marklogic.client.io.marker.ContentHandle;
 import com.marklogic.client.io.marker.JSONReadHandle;
@@ -290,8 +290,8 @@ public class PlanBuilderSubImpl extends PlanBuilderImpl {
 
   
   @Override
-  public TransformDefinition transformDefinition(String path) {
-    return new TransformDefinitionImpl(path);
+  public TransformDef transformDef(String path) {
+    return new TransformDefImpl(path);
   }
 
   @Override
@@ -1071,8 +1071,8 @@ public class PlanBuilderSubImpl extends PlanBuilderImpl {
     }
 
     @Override
-    public ModifyPlan transformDoc(PlanColumn docColumn, TransformDefinition transformDefinition) {
-      return new ModifyPlanSubImpl(this, "op", "transformDoc", new Object[]{docColumn, transformDefinition});
+    public ModifyPlan transformDoc(PlanColumn docColumn, TransformDef transformDef) {
+      return new ModifyPlanSubImpl(this, "op", "transformDoc", new Object[]{docColumn, transformDef});
     }
 
     @Override

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/TransformDefImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/TransformDefImpl.java
@@ -5,16 +5,16 @@ import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.marklogic.client.expression.TransformDefinition;
+import com.marklogic.client.expression.TransformDef;
 import com.marklogic.client.impl.BaseTypeImpl.BaseArgImpl;
 
-public class TransformDefinitionImpl implements TransformDefinition, BaseArgImpl {
+public class TransformDefImpl implements TransformDef, BaseArgImpl {
 
     private String path;
     private String kind = "mjs";
     private Map<String, Object> params;
 
-    public TransformDefinitionImpl(String path) {
+    public TransformDefImpl(String path) {
         this.path = path;
     }
 
@@ -26,23 +26,23 @@ public class TransformDefinitionImpl implements TransformDefinition, BaseArgImpl
         if (params != null) {
             node.putPOJO("params", params);
         }
-        return strb.append(node.toString());
+        return strb.append(node);
     }
 
     @Override
-    public TransformDefinition withKind(String kind) {
+    public TransformDef withKind(String kind) {
         this.kind = kind;
         return this;
     }
 
     @Override
-    public TransformDefinition withParams(Map<String, Object> params) {
+    public TransformDef withParams(Map<String, Object> params) {
         this.params = params;
         return this;
     }
 
     @Override
-    public TransformDefinition withParam(String name, Object value) {
+    public TransformDef withParam(String name, Object value) {
         if (this.params == null) {
             this.params = new HashMap<>();
         }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/TransformDocTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/TransformDocTest.java
@@ -34,7 +34,7 @@ public class TransformDocTest extends AbstractOpticUpdateTest {
         ModifyPlan plan = op
             .fromParam("myDocs", "", op.colTypes(op.colType("doc", "none")))
             .transformDoc(op.col("doc"),
-                op.transformDefinition("/etc/optic/test/transformDoc-test.mjs")
+                op.transformDef("/etc/optic/test/transformDoc-test.mjs")
                     .withParam("myParam", "my value"));
 
         List<RowRecord> results = resultRows(plan.bindParam("myDocs", new JacksonHandle(rows)));
@@ -61,7 +61,7 @@ public class TransformDocTest extends AbstractOpticUpdateTest {
         ModifyPlan plan = op
             .fromParam("myDocs", "", op.colTypes(op.colType("doc", "none")))
             .transformDoc(op.col("doc"),
-                op.transformDefinition("/etc/optic/test/transformDoc-test.mjs").withKind("mjs"));
+                op.transformDef("/etc/optic/test/transformDoc-test.mjs").withKind("mjs"));
 
         List<RowRecord> results = resultRows(plan.bindParam("myDocs", new JacksonHandle(rows)));
         assertEquals(1, results.size());
@@ -81,7 +81,7 @@ public class TransformDocTest extends AbstractOpticUpdateTest {
         ModifyPlan plan = op
             .fromDocUris("/optic/test/musician1.json")
             .joinDoc(op.col("doc"), op.col("uri"))
-            .transformDoc(op.col("doc"), op.transformDefinition("/etc/optic/test/transformDoc-throwsError.mjs"));
+            .transformDoc(op.col("doc"), op.transformDef("/etc/optic/test/transformDoc-throwsError.mjs"));
 
         FailedRequestException ex = assertThrows(FailedRequestException.class, () -> rowManager.execute(plan));
         assertTrue("Unexpected message: " + ex.getMessage(), ex.getMessage().contains("throw Error(\"This is intentional\")"));
@@ -98,7 +98,7 @@ public class TransformDocTest extends AbstractOpticUpdateTest {
             .fromDocUris("/optic/test/musician1.json", "/optic/test/musician2.json")
             .joinDoc(op.col("doc"), op.col("uri"))
             .transformDoc(op.col("doc"),
-                op.transformDefinition("/etc/optic/test/transformDoc-test.mjs").withParam("myParam",
+                op.transformDef("/etc/optic/test/transformDoc-test.mjs").withParam("myParam",
                     "my value"));
 
         List<RowRecord> results = resultRows(plan);
@@ -130,7 +130,7 @@ public class TransformDocTest extends AbstractOpticUpdateTest {
         ModifyPlan plan = op
             .fromParam("myDocs", "", op.colTypes(op.colType("rowId", "integer"), op.colType("doc", "none")))
             .transformDoc(op.col("doc"),
-                op.transformDefinition("/etc/optic/test/transformDoc-test.xslt")
+                op.transformDef("/etc/optic/test/transformDoc-test.xslt")
                     .withKind("xslt")
                     .withParam("myParam", "my value"));
 
@@ -164,7 +164,7 @@ public class TransformDocTest extends AbstractOpticUpdateTest {
         ModifyPlan plan = op
             .fromParam("myDocs", "", op.colTypes(op.colType("doc", "none")))
             .transformDoc(op.col("doc"),
-                op.transformDefinition("/etc/optic/test/transformDoc-test.xslt").withKind("xslt"));
+                op.transformDef("/etc/optic/test/transformDoc-test.xslt").withKind("xslt"));
 
         List<RowRecord> results = resultRows(
             plan.bindParam("myDocs", new JacksonHandle(rows), Collections.singletonMap("doc", attachments)));

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/UpdateUseCasesTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/UpdateUseCasesTest.java
@@ -2,10 +2,8 @@ package com.marklogic.client.test.rows;
 
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.NullNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.client.document.DocumentWriteOperation;
 import com.marklogic.client.document.DocumentWriteSet;
-import com.marklogic.client.expression.PlanBuilder;
 import com.marklogic.client.expression.PlanBuilder.ModifyPlan;
 import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.JacksonHandle;
@@ -206,7 +204,7 @@ public class UpdateUseCasesTest extends AbstractOpticUpdateTest {
             .lockForUpdate()
             .transformDoc(
                 op.col("doc"),
-                op.transformDefinition("/etc/optic/test/transformDoc-test.mjs")
+                op.transformDef("/etc/optic/test/transformDoc-test.mjs")
                     .withParam("myParam", "my value"))
             .write();
 


### PR DESCRIPTION
This is for consistency in the client.expression package, where `Expr` is used as an abbreviation, and thus we'll use `Def` as an abbreviation in this package as well. 