### PR TITLE
Adding several more joinDocCols tests

### DIFF
--- a/marklogic-client-api/src/main/java/com/marklogic/client/expression/PlanBuilderBase.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/expression/PlanBuilderBase.java
@@ -421,24 +421,14 @@ public interface PlanBuilderBase {
     PlanRowColTypesSeq colTypes(PlanRowColTypes... colTypes);
 
     /**
-     * Construct a mapping of document descriptor column names to names of columns in the plan. The available set of 
+     * Construct a mapping of document descriptor column names to columns in the plan. The available set of
      * document descriptor names are: uri, doc, collections, permissions, metadata, quality, and temporalCollection. 
-     * 
+     * Use this when mapping to non-standard column names.
+     *
      * @param descriptorColumnMapping
      * @return
      */
-    PlanDocColsIdentifier docCols(Map<String, String> descriptorColumnMapping);
-
-    /**
-     * Construct a {@code PlanDocColsIdentifier} that consists only of the given descriptor column names, each of which
-     * must be one of the following: uri, doc, collections, permissions, metadata, quality, and temporalCollection. Use
-     * this when constructing a plan for only writing certain parts of a document - e.g. when only updating the 
-     * collections on a set of URIs. 
-     * 
-     * @param descriptorColumnNames
-     * @return
-     */
-    PlanDocColsIdentifier docCols(String[] descriptorColumnNames);
+    PlanDocColsIdentifier docCols(Map<String, PlanColumn> descriptorColumnMapping);
 
     /**
      * Build a single doc descriptor that can be used with {@code fromDocDescriptors}.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/PlanBuilderSubImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/PlanBuilderSubImpl.java
@@ -221,13 +221,8 @@ public class PlanBuilderSubImpl extends PlanBuilderImpl {
   }
 
   @Override
-  public PlanDocColsIdentifier docCols(Map<String, String> descriptorColumnMapping) {
+  public PlanDocColsIdentifier docCols(Map<String, PlanColumn> descriptorColumnMapping) {
     return new PlanDocColsIdentifierImpl(descriptorColumnMapping);
-  }
-
-  @Override
-  public PlanDocColsIdentifier docCols(String[] descriptorColumnNames) {
-    return new PlanDocColsIdentifierImpl(descriptorColumnNames);
   }
 
   public static class PlanDocDescriptorImpl implements PlanDocDescriptor, BaseTypeImpl.BaseArgImpl {

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/PlanDocColsIdentifierImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/PlanDocColsIdentifierImpl.java
@@ -1,30 +1,29 @@
 package com.marklogic.client.impl;
 
-import java.util.Map;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.client.impl.BaseTypeImpl.BaseArgImpl;
+import com.marklogic.client.type.PlanColumn;
 import com.marklogic.client.type.PlanDocColsIdentifier;
+
+import java.util.Map;
 
 public class PlanDocColsIdentifierImpl implements PlanDocColsIdentifier, BaseArgImpl {
 
     private String template;
 
-    public PlanDocColsIdentifierImpl(Map<String, String> mapping) {
-        ObjectNode descriptor = new ObjectMapper().createObjectNode();
+    public PlanDocColsIdentifierImpl(Map<String, PlanColumn> mapping) {
+        StringBuilder sb = new StringBuilder("{");
         // Keys are not validated here as they will be caught by the server, and
         // restricting the set of keys could cause issues with future server releases
-        mapping.keySet().forEach(key -> descriptor.put(key, mapping.get(key)));
-        this.template = descriptor.toString();
-    }
-
-    public PlanDocColsIdentifierImpl(String[] columnNames) {
-        ObjectNode descriptor = new ObjectMapper().createObjectNode();
-        for (String name : columnNames) {
-            descriptor.put(name, name);
+        boolean firstOne = true;
+        for (String key : mapping.keySet()) {
+            if (!firstOne) {
+                sb.append(", ");
+            }
+            sb.append(String.format("\"%s\": ", key));
+            ((BaseArgImpl) mapping.get(key)).exportAst(sb);
+            firstOne = false;
         }
-        this.template = descriptor.toString();
+        this.template = sb.append("}").toString();
     }
 
     @Override

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/AbstractOpticUpdateTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/AbstractOpticUpdateTest.java
@@ -132,4 +132,8 @@ public abstract class AbstractOpticUpdateTest {
             .forEachRemaining(result -> uris.add(result.getString()));
         return uris;
     }
+
+    protected void printExport(PlanBuilder.ExportablePlan plan) {
+        System.out.println(plan.exportAs(ObjectNode.class).toPrettyString());
+    }
 }


### PR DESCRIPTION
Realized that `docCols(String[])` wasn't needed, now that xs.string works when using `docCols(null, xs.stringSeq)`. 

Reworked `docCols(Map<String, String>)` into `docCols(Map<String, PlanColumn>)` so that qualified columns can be referenced. 