### PR TITLE
Bumping jackson-databind to 2.13.4.2

### DIFF
--- a/marklogic-client-api-functionaltests/build.gradle
+++ b/marklogic-client-api-functionaltests/build.gradle
@@ -28,5 +28,5 @@ dependencies {
   implementation 'commons-io:commons-io:2.11.0'
   implementation group: 'com.squareup.okhttp3', name: 'okhttp', version:'4.10.0'
   implementation 'com.fasterxml.jackson.core:jackson-core:2.13.4'
-  implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
+  implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4.2'
 }

--- a/marklogic-client-api/build.gradle
+++ b/marklogic-client-api/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     implementation group: 'org.slf4j', name: 'slf4j-api', version:'1.7.36'
     implementation 'com.fasterxml.jackson.core:jackson-core:2.13.4'
     implementation 'com.fasterxml.jackson.core:jackson-annotations:2.13.4'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4.2'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.13.4'
     testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.13.4'
     testImplementation group: 'org.mockito', name: 'mockito-all', version:'1.10.19'


### PR DESCRIPTION
Addresses CVE https://avd.aquasec.com/nvd/2022/cve-2022-42003/