### PR TITLE
Un-ignoring xslt tests

### DIFF
--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/TransformDocTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/TransformDocTest.java
@@ -116,7 +116,6 @@ public class TransformDocTest extends AbstractOpticUpdateTest {
     }
 
     @Test
-    @Ignore("See https://bugtrack.marklogic.com/57978#2; this works fine as a privileged user though")
     public void xsltTransformWithParam() {
         if (!Common.markLogicIsVersion11OrHigher()) {
             return;
@@ -150,7 +149,6 @@ public class TransformDocTest extends AbstractOpticUpdateTest {
     }
 
     @Test
-    @Ignore("See https://bugtrack.marklogic.com/57978#2; this works fine as a privileged user though")
     public void xsltTransformWithoutParam() {
         if (!Common.markLogicIsVersion11OrHigher()) {
             return;

--- a/marklogic-client-api/src/test/ml-config/security/roles/test-rest-writer.json
+++ b/marklogic-client-api/src/test/ml-config/security/roles/test-rest-writer.json
@@ -1,6 +1,6 @@
 {
   "role-name": "test-rest-writer",
-  "description": "Role for test users that can write documents; does not inherit the OOTB rest-writer role so as to avoid having default permissions; temporarily adding xdmp:invoke until /v1/rows uses an amp to grant these for transformDoc",
+  "description": "Role for test users that can write documents; does not inherit the OOTB rest-writer role so as to avoid having default permissions",
   "privilege": [
     {
       "privilege-name": "rest-writer",
@@ -10,11 +10,6 @@
     {
       "privilege-name": "rest-reader",
       "action": "http://marklogic.com/xdmp/privileges/rest-reader",
-      "kind": "execute"
-    },
-    {
-      "privilege-name": "xdmp:invoke",
-      "action": "http://marklogic.com/xdmp/privileges/xdmp-invoke",
       "kind": "execute"
     }
   ]


### PR DESCRIPTION
And removing xdmp-invoke privilege from test-rest-writer . These fixes rely on the amp on "execute" in optic-amped.sjs being given the rest-reader-internal role.

Note that this will cause the transformDoc tests to fail for MJS transforms - https://bugtrack.marklogic.com/58123 will address that. 