### PR TITLE
Removed unused argument in Generator

### DIFF
--- a/ml-development-tools/src/main/kotlin/com/marklogic/client/tools/proxy/Generator.kt
+++ b/ml-development-tools/src/main/kotlin/com/marklogic/client/tools/proxy/Generator.kt
@@ -277,7 +277,7 @@ class Generator {
     val funcDecl    = mutableListOf<String>()
     val funcDepend  = mutableSetOf<String>()
     val funcSrc     = funcdefs.map{(root, funcdef) -> generateFuncSrc(
-      fieldDecl, fieldInit, funcDecl, funcDepend, className, servdef, moduleFiles[root]!!.name, funcdef
+      fieldDecl, fieldInit, funcDecl, funcDepend, servdef, moduleFiles[root]!!.name, funcdef
     )}.joinToString("\n")
     val fieldDecls   =
         if (fieldDecl.isEmpty()) ""
@@ -488,7 +488,7 @@ ${funcDecls}
   }
   fun generateFuncSrc(
       fieldDecl: MutableList<String>, fieldInit: MutableList<String>, funcDecl: MutableList<String>,
-      funcDepend: MutableSet<String>, className: String, servdef: ObjectNode, moduleFilename: String,
+      funcDepend: MutableSet<String>, servdef: ObjectNode, moduleFilename: String,
       funcdef: ObjectNode
   ): String {
     val funcName = funcdef.get("functionName")?.asText()


### PR DESCRIPTION
This was producing a warning during the build process, which makes the Jenkins logs a bit harder to debug. Trivial to remove. 