### PR TITLE
Fixing some Optic functional tests on ML 9/10

### DIFF
--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/MarkLogicVersion.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/MarkLogicVersion.java
@@ -1,0 +1,59 @@
+package com.marklogic.client;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Copy/paste from marklogic-client-api; TODO figure out how to share this class.
+ *
+ * Parses a MarkLogic version string - i.e. from xdmp.version() - into its major and minor versions. The minor version
+ * contains the patch number and starts with 100 representing minor version 1 with no patch number. This allows for
+ * any combination of minor and patch number to be compared easily.
+ */
+public class MarkLogicVersion {
+
+    private int major;
+    private Integer minor;
+    private boolean nightly;
+
+    private final static String VERSION_WITH_PATCH_PATTERN = "^.*-(.+)\\..*";
+
+    public static MarkLogicVersion getMarkLogicVersion(DatabaseClient adminClient) {
+        String version = adminClient.newServerEval().javascript("xdmp.version()").evalAs(String.class);
+        return new MarkLogicVersion(version);
+    }
+
+    public MarkLogicVersion(String version) {
+        int major = Integer.parseInt(version.replaceAll("([^.]+)\\..*", "$1"));
+        final String nightlyPattern = "[^-]+-(\\d{4})(\\d{2})(\\d{2})";
+        final String majorWithMinorPattern = "^.*-(.+)$";
+        if (version.matches(nightlyPattern)) {
+            this.nightly = true;
+        } else if (version.matches(majorWithMinorPattern)) {
+            this.minor = version.matches(VERSION_WITH_PATCH_PATTERN) ?
+                    parseMinorWithPatch(version) :
+                    Integer.parseInt(version.replaceAll(majorWithMinorPattern, "$1") + "00");
+        }
+        this.major = major;
+    }
+
+    private int parseMinorWithPatch(String version) {
+        final int minorNumber = Integer.parseInt(version.replaceAll(VERSION_WITH_PATCH_PATTERN, "$1"));
+        final int patch = Integer.parseInt(version.replaceAll("^.*-(.+)\\.(.*)", "$2"));
+        final String leftPaddedPatchNumber = patch < 10 ?
+                StringUtils.leftPad(String.valueOf(patch), 2, "0") :
+                String.valueOf(patch);
+        return Integer.parseInt(minorNumber + leftPaddedPatchNumber);
+    }
+
+    public int getMajor() {
+        return major;
+    }
+
+    public Integer getMinor() {
+        return minor;
+    }
+
+    public boolean isNightly() {
+        return nightly;
+    }
+}

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ConnectedRESTQA.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ConnectedRESTQA.java
@@ -44,7 +44,7 @@ import java.security.cert.X509Certificate;
 import java.util.*;
 
 public abstract class ConnectedRESTQA {
-	private String serverName = "";
+
 	private static String restServerName = null;
 	private static String restSslServerName = null;
 	private static String ssl_enabled = null;
@@ -66,7 +66,6 @@ public abstract class ConnectedRESTQA {
 	private static String mlRestReadPassword = null;
 	private static String ml_certificate_password = null;
 	private static String ml_certificate_file = null;
-	private static String ml_certificate_path = null;
 	private static String mlDataConfigDirPath = null;
 	private static Boolean isLBHost = false;
 	
@@ -78,8 +77,6 @@ public abstract class ConnectedRESTQA {
 	private static final int ML_RES_BADREQT = 400;
 	private static final int ML_RES_NOTFND = 404;
 	private static final String ML_MANAGE_DB = "App-Services";
-
-	SSLContext sslContext = null;
 
 	// Using MarkLogic client API's OKHttpClient Impl to connect to App-Services DB and use REST Manage API calls.
 	private static OkHttpClient createManageAdminClient(String username, String password) {
@@ -2492,7 +2489,6 @@ public abstract class ConnectedRESTQA {
 		ssl_enabled = property.getProperty("restSSLset");
 		ml_certificate_password = property.getProperty("ml_certificate_password");
 		ml_certificate_file = property.getProperty("ml_certificate_file");
-		ml_certificate_path = property.getProperty("ml_certificate_path");
 		mlDataConfigDirPath = property.getProperty("mlDataConfigDirPath");
 		isLBHost = Boolean.parseBoolean(property.getProperty("lbHost"));
 		PROPERTY_WAIT = Integer.parseInt(isLBHost ? "15000" : "0");		

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestOpticOnLexicons.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestOpticOnLexicons.java
@@ -28,6 +28,7 @@ import java.util.Map;
 
 import javax.xml.parsers.ParserConfigurationException;
 
+import com.marklogic.client.MarkLogicVersion;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -68,6 +69,7 @@ public class TestOpticOnLexicons extends BasicJavaClientREST {
  
   private static DatabaseClient client;
   private static String datasource = "src/test/java/com/marklogic/client/functionaltest/data/optics/";
+  private static boolean isML11OrHigher;
 
   @BeforeClass
   public static void setUp() throws Exception
@@ -140,7 +142,7 @@ public class TestOpticOnLexicons extends BasicJavaClientREST {
         schemaDBclient = DatabaseClientFactory.newClient(getRestServerHostName(), getRestServerPort(), schemadbName, new DigestAuthContext("opticUser", "0pt1c"));
         client = DatabaseClientFactory.newClient(getRestServerHostName(), getRestServerPort(), new DigestAuthContext("opticUser", "0pt1c"));
     }
-
+    isML11OrHigher = MarkLogicVersion.getMarkLogicVersion(client).getMajor() >= 11;
 
     // Install the TDE templates
     // loadFileToDB(client, filename, docURI, collection, document format)
@@ -244,8 +246,11 @@ public class TestOpticOnLexicons extends BasicJavaClientREST {
   }
 
   private String toWKT(String latLon) {
-    String[] parts = latLon.split(",");
-    return "POINT(" + parts[1] + " " + parts[0] + ")";
+    if (isML11OrHigher) {
+      String[] parts = latLon.split(",");
+      return "POINT(" + parts[1] + " " + parts[0] + ")";
+    }
+    return latLon;
   }
 
   /*


### PR DESCRIPTION
These started breaking after the tests were updated to run on ML 11, so they now check to see what version of ML is being used. 