### PR TITLE
Fixing functional tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,7 +64,7 @@ pipeline{
           export GRADLE_USER_HOME=$WORKSPACE/$GRADLE_DIR
           export PATH=$GRADLE_USER_HOME:$JAVA_HOME/bin:$PATH
           cd java-client-api
-          ./gradlew mlDeploy
+          ./gradlew -i mlDeploy -PmlForestDataDirectory=/space
         '''
         sh label:'marklogic client test', script: '''#!/bin/bash
           export JAVA_HOME=$JAVA_HOME_DIR
@@ -103,6 +103,7 @@ pipeline{
           export GRADLE_USER_HOME=$WORKSPACE/$GRADLE_DIR
           export PATH=$GRADLE_USER_HOME:$JAVA_HOME/bin:$PATH
           cd java-client-api
+          ./gradlew -i mlDeploy -PmlForestDataDirectory=/space
           ./gradlew marklogic-client-api-functionaltests:test  || true
         '''
         junit '**/build/**/TEST*.xml'

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/AbstractFunctionalTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/AbstractFunctionalTest.java
@@ -30,10 +30,15 @@ public abstract class AbstractFunctionalTest extends BasicJavaClientREST {
     protected static DatabaseClient client;
     protected static DatabaseClient schemasClient;
     protected static boolean isML11OrHigher;
+    private static String original_http_port;
 
     @BeforeClass
     public static void initializeClients() throws Exception {
         loadGradleProperties();
+        // Until all the tests can use the same ml-gradle-deployed app server, we need to have separate ports - one
+        // for "slow" tests that setup a new app server, and one for "fast" tests that use the deployed one
+        original_http_port = http_port;
+        http_port = fast_http_port;
         final String schemasDbName = "java-functest-schemas";
         if (IsSecurityEnabled()) {
             schemasClient = getDatabaseClientOnDatabase(getRestServerHostName(), getRestServerPort(), schemasDbName, OPTIC_USER, OPTIC_USER_PASSWORD, getConnType());
@@ -55,6 +60,7 @@ public abstract class AbstractFunctionalTest extends BasicJavaClientREST {
 
     @AfterClass
     public static void clearContentAndSchemaDatabases() {
+        http_port = original_http_port;
         client.release();
         schemasClient.release();
     }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ConnectedRESTQA.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ConnectedRESTQA.java
@@ -49,7 +49,8 @@ public abstract class ConnectedRESTQA {
 	private static String restSslServerName = null;
 	private static String ssl_enabled = null;
 	private static String https_port = null;
-	private static String http_port = null;
+	protected static String http_port = null;
+	protected static String fast_http_port = null;
 	private static String admin_port = null;
 	// This needs to be a FQDN when SSL is enabled. Else localhost. Set in
 	// test.properties
@@ -2466,6 +2467,7 @@ public abstract class ConnectedRESTQA {
 
 		https_port = property.getProperty("httpsPort");
 		http_port = property.getProperty("httpPort");
+		fast_http_port = property.getProperty("fastHttpPort");
 		admin_port = property.getProperty("adminPort");
 
 		// Machine names where ML Server runs

--- a/marklogic-client-api-functionaltests/src/test/resources/test.properties
+++ b/marklogic-client-api-functionaltests/src/test/resources/test.properties
@@ -12,7 +12,9 @@ mlRestReadUser=rest-reader
 mlRestReadPassword=x
 mlAppServerName=REST-Java-Client-API-Server
 mlAppServerSSLName=REST-Java-Client-API-SSL-Server
-httpPort=8014
+httpPort=8011
+# For fastfunctest tests
+fastHttpPort=8014
 httpsPort=8013
 adminPort=8002
 lbHost=false

--- a/marklogic-client-api/src/test/ml-schemas/tde/permissions.properties
+++ b/marklogic-client-api/src/test/ml-schemas/tde/permissions.properties
@@ -1,1 +1,1 @@
-*.tdex=rest-reader,read,rest-writer,update
+*=rest-reader,read,rest-writer,update


### PR DESCRIPTION
Had to add "fastHttpPort" so that the deployed app server isn't used by tests that aren't ready for it yet. 