### PR TITLE
Next batch of functional test fixes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 @Library('shared-libraries') _
 
 def runtests(String type, String version){
-            copyRPM 'Release','10.0-9.5'
+            copyRPM type, version
             setUpML '$WORKSPACE/xdmp/src/Mark*.rpm'
             copyConvertersRPM type,version
             setUpMLConverters '$WORKSPACE/xdmp/src/Mark*Converters*.rpm'
@@ -33,7 +33,7 @@ def runtests(String type, String version){
                 export GRADLE_USER_HOME=$WORKSPACE/$GRADLE_DIR
                 export PATH=$GRADLE_USER_HOME:$JAVA_HOME/bin:$PATH
                 cd java-client-api
-                ./gradlew marklogic-client-api-functionaltests:test  || true
+                ./gradlew marklogic-client-api-functionaltests:test --tests "com.marklogic.client.fastfunctest.*" || true
             '''
             sh label:'post-test-process', script: '''
                 cd $WORKSPACE/java-client-api/marklogic-client-api/build/test-results/test/
@@ -82,7 +82,6 @@ pipeline{
           cd java-client-api
           ./gradlew marklogic-client-api:test  || true
           ./gradlew marklogic-client-api-functionaltests:test --tests "com.marklogic.client.fastfunctest.*" || true
-          ./gradlew marklogic-client-api-functionaltests:test --tests "com.marklogic.client.converted.*" || true
         '''
         sh label:'ml development tool test', script: '''#!/bin/bash
           export JAVA_HOME=$JAVA_HOME_DIR
@@ -129,7 +128,7 @@ pipeline{
           export PATH=$GRADLE_USER_HOME:$JAVA_HOME/bin:$PATH
           cd java-client-api
           ./gradlew -i mlDeploy -PmlForestDataDirectory=/space
-          ./gradlew marklogic-client-api-functionaltests:test  || true
+          ./gradlew marklogic-client-api-functionaltests:test --tests "com.marklogic.client.fastfunctest.*" || true
         '''
         sh '''
             cd $WORKSPACE/java-client-api/marklogic-client-api-functionaltests/build/test-results/test/
@@ -157,23 +156,6 @@ pipeline{
         post{
             failure{
                 sendMail params.Email,'<h3>Some Tests Failed on Released 10.0-9.5 ML  Server Single Node </h3><h4><a href=${JENKINS_URL}/blue/organizations/jenkins/java-client-api-regression/detail/$JOB_BASE_NAME/$BUILD_ID/tests><font color=red>Check the Test Report</font></a></h4><h4><a href=${RUN_DISPLAY_URL}>Check the Pipeline View</a></h4><h4> <a href=${BUILD_URL}/console> Check Console Output Here</a></h4><h4>Please create bugs for the failed regressions and fix them</h4>',false,'${STAGE_NAME} on  develop against ML 10.0-9.5 Failed'
-            }
-        }
-    }
-    stage('regressions-9.0-13'){
-        when{
-            allOf{
-                branch 'develop'
-                expression {return params.regressions}
-            }
-        }
-        steps{
-            runtests('Release','9.0-13.8')
-            junit '**/build/**/TEST*.xml'
-        }
-        post{
-            failure{
-                sendMail params.Email,'<h3>Some Tests Failed on Released 9.0-13.8 ML  Server Single Node </h3><h4><a href=${JENKINS_URL}/blue/organizations/jenkins/java-client-api-regression/detail/$JOB_BASE_NAME/$BUILD_ID/tests><font color=red>Check the Test Report</font></a></h4><h4><a href=${RUN_DISPLAY_URL}>Check the Pipeline View</a></h4><h4> <a href=${BUILD_URL}/console> Check Console Output Here</a></h4><h4>Please create bugs for the failed regressions and fix them</h4>',false,'${STAGE_NAME} on  develop against ML 9.0-13.8 Failed'
             }
         }
     }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/MarkLogicVersion.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/MarkLogicVersion.java
@@ -14,6 +14,7 @@ public class MarkLogicVersion {
     private int major;
     private Integer minor;
     private boolean nightly;
+    private String versionString;
 
     private final static String VERSION_WITH_PATCH_PATTERN = "^.*-(.+)\\..*";
 
@@ -23,6 +24,7 @@ public class MarkLogicVersion {
     }
 
     public MarkLogicVersion(String version) {
+        this.versionString = version;
         int major = Integer.parseInt(version.replaceAll("([^.]+)\\..*", "$1"));
         final String nightlyPattern = "[^-]+-(\\d{4})(\\d{2})(\\d{2})";
         final String majorWithMinorPattern = "^.*-(.+)$";
@@ -55,5 +57,9 @@ public class MarkLogicVersion {
 
     public boolean isNightly() {
         return nightly;
+    }
+
+    public String getVersionString() {
+        return versionString;
     }
 }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/AbstractFunctionalTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/AbstractFunctionalTest.java
@@ -42,7 +42,9 @@ public abstract class AbstractFunctionalTest extends BasicJavaClientREST {
         // for "slow" tests that setup a new app server, and one for "fast" tests that use the deployed one
         original_http_port = http_port;
         http_port = fast_http_port;
-        isML11OrHigher = MarkLogicVersion.getMarkLogicVersion(connectAsAdmin()).getMajor() >= 11;
+        MarkLogicVersion version = MarkLogicVersion.getMarkLogicVersion(connectAsAdmin());
+        System.out.println("ML version: " + version.getVersionString());
+        isML11OrHigher = version.getMajor() >= 11;
         final String schemasDbName = "java-functest-schemas";
         final String modulesDbName = "java-unittest-modules";
         if (IsSecurityEnabled()) {

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnLiterals.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnLiterals.java
@@ -18,6 +18,7 @@ package com.marklogic.client.fastfunctest;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.client.expression.PlanBuilder;
 import com.marklogic.client.expression.PlanBuilder.ExportablePlan;
 import com.marklogic.client.expression.PlanBuilder.ModifyPlan;
@@ -1760,8 +1761,6 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
 
   @Test
   public void testLiteralsWithColumnInfo() {
-    System.out.println("In testLiteralsWithColumnInfo method");
-
     // Create a new Plan.
     RowManager rowMgr = client.newRowManager();
     PlanBuilder p = rowMgr.newPlanBuilder();
@@ -1769,14 +1768,21 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
     // plans from literals
     ModifyPlan plan1 = p.fromLiterals(literals1);
     ModifyPlan plan2 = p.fromLiterals(literals2);
-    ModifyPlan output = plan1.joinInner(plan2).orderBy(p.asc(p.col("rowId")));
+    ModifyPlan output = plan1.joinInner(plan2); //.orderBy(p.asc(p.col("rowId")));
 
     String colInfo = rowMgr.columnInfoAs(output, String.class);
-    System.out.println("COL: " + colInfo);
-    //System.out.println("In testLiteralsWithColumnInfo method" + colInfo);
-    assertTrue("Element 1 desc value incorrect: " + colInfo, colInfo.contains("{\"schema\":\"\", \"view\":\"\", \"column\":\"desc\", \"type\":\"string\", \"nullable\":false"));
-    assertTrue("Element 2 colorId value incorrect", colInfo.contains("{\"schema\":\"\", \"view\":\"\", \"column\":\"colorId\", \"type\":\"integer\", \"nullable\":false}"));
-    assertTrue("Element 3 rowId value incorrect", colInfo.contains("{\"schema\":\"\", \"view\":\"\", \"column\":\"rowId\", \"type\":\"integer\", \"nullable\":false}"));
-    assertTrue("Element 4 colorDesc value incorrect", colInfo.contains("{\"schema\":\"\", \"view\":\"\", \"column\":\"colorDesc\", \"type\":\"string\", \"nullable\":false}"));
+    System.out.println(colInfo);
+
+    String expectedType = isML11OrHigher ? "string": "unknown";
+    assertTrue("Element 1 desc value incorrect: " + colInfo,
+        colInfo.contains("{\"schema\":\"\", \"view\":\"\", \"column\":\"desc\", \"type\":\"" + expectedType + "\", \"nullable\":false"));
+    assertTrue("Element 4 colorDesc value incorrect: " + colInfo,
+        colInfo.contains("{\"schema\":\"\", \"view\":\"\", \"column\":\"colorDesc\", \"type\":\"" + expectedType + "\", \"nullable\":false}"));
+
+    expectedType = isML11OrHigher ? "integer": "unknown";
+    assertTrue("Element 2 colorId value incorrect: " + colInfo,
+        colInfo.contains("{\"schema\":\"\", \"view\":\"\", \"column\":\"colorId\", \"type\":\"" + expectedType + "\", \"nullable\":false}"));
+    assertTrue("Element 3 rowId value incorrect: " + colInfo,
+        colInfo.contains("{\"schema\":\"\", \"view\":\"\", \"column\":\"rowId\", \"type\":\"" + expectedType + "\", \"nullable\":false}"));
   }
 }

--- a/marklogic-client-api-functionaltests/src/test/resources/test.properties
+++ b/marklogic-client-api-functionaltests/src/test/resources/test.properties
@@ -1,6 +1,5 @@
 restSSLset=false
 restHost=localhost
-#restHost=54.226.115.206
 restSSLHost=localhost
 mlAdminUser=admin
 mlAdminPassword=admin

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/TraceLabelAndOptimizeTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/TraceLabelAndOptimizeTest.java
@@ -2,6 +2,7 @@ package com.marklogic.client.test.rows;
 
 import com.marklogic.client.FailedRequestException;
 import com.marklogic.client.row.RowRecord;
+import com.marklogic.client.test.Common;
 import org.junit.Test;
 
 import java.util.List;
@@ -17,6 +18,10 @@ public class TraceLabelAndOptimizeTest extends AbstractOpticUpdateTest {
 
     @Test
     public void validTraceLabelAndOptimize() {
+        if (!Common.markLogicIsVersion11OrHigher()) {
+            return;
+        }
+
         rowManager.setOptimize(1);
         rowManager.setTraceLabel("test");
 
@@ -27,6 +32,10 @@ public class TraceLabelAndOptimizeTest extends AbstractOpticUpdateTest {
 
     @Test
     public void optimizeLessThanZeroWithExecute() {
+        if (!Common.markLogicIsVersion11OrHigher()) {
+            return;
+        }
+
         rowManager.setOptimize(-1);
         FailedRequestException ex = assertThrows(
             FailedRequestException.class,
@@ -40,6 +49,10 @@ public class TraceLabelAndOptimizeTest extends AbstractOpticUpdateTest {
 
     @Test
     public void optimizeLessThanZeroWithResultRows() {
+        if (!Common.markLogicIsVersion11OrHigher()) {
+            return;
+        }
+
         rowManager.setOptimize(-1);
         FailedRequestException ex = assertThrows(
             FailedRequestException.class,


### PR DESCRIPTION
Summary:

- Added ML 11 check for TraceLabelAndOptimizeTest
- Adjusted testLiteralsWithColumnInfo based on different results from ML 10 and 11
- Removed ML 9 from regression suite; ML 9 users should be using Java Client 4.2.0
- Simplified plan in testRestrictedXPathPredicate, not sure why that's failing yet except that its failure is caused by a previous test :(