### PR TITLE
Fixing Optic from-triples tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,7 +81,8 @@ pipeline{
           export PATH=$GRADLE_USER_HOME:$JAVA_HOME/bin:$PATH
           cd java-client-api
           ./gradlew marklogic-client-api:test  || true
-          ./gradlew marklogic-client-api-functionaltests:test --tests "com.marklogic.client.converted2.*" || true
+          ./gradlew marklogic-client-api-functionaltests:test --tests "com.marklogic.client.fastfunctest.*" || true
+          ./gradlew marklogic-client-api-functionaltests:test --tests "com.marklogic.client.converted.*" || true
         '''
         sh label:'ml development tool test', script: '''#!/bin/bash
           export JAVA_HOME=$JAVA_HOME_DIR

--- a/marklogic-client-api-functionaltests/build.gradle
+++ b/marklogic-client-api-functionaltests/build.gradle
@@ -24,10 +24,12 @@ dependencies {
   implementation project (':marklogic-client-api')
   implementation group: 'org.skyscreamer', name: 'jsonassert', version: '1.5.0'
   implementation group: 'org.slf4j', name: 'slf4j-api', version:'1.7.36'
-  testImplementation group: 'ch.qos.logback', name: 'logback-classic', version:'1.2.11'
   implementation 'commons-io:commons-io:2.11.0'
   implementation group: 'com.squareup.okhttp3', name: 'okhttp', version:'4.10.0'
   implementation 'com.fasterxml.jackson.core:jackson-core:2.13.4'
   implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4.2'
   implementation "org.jdom:jdom2:2.0.6.1"
+  implementation "com.marklogic:ml-app-deployer:4.3.6"
+
+  testImplementation group: 'ch.qos.logback', name: 'logback-classic', version:'1.2.11'
 }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticEnhancements.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticEnhancements.java
@@ -23,6 +23,7 @@ import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.row.RowManager;
 import com.marklogic.client.type.PlanColumn;
 import com.marklogic.client.type.PlanPrefixer;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -42,6 +43,7 @@ public class TestOpticEnhancements extends AbstractFunctionalTest {
 
   @BeforeClass
   public static void setUp() throws Exception {
+    removeFieldIndices();
   // Install the TDE templates into schemadbName DB
   // loadFileToDB(client, filename, docURI, collection, document format)
   loadFileToDB(schemasClient, "masterDetail.tdex", "/optic/view/test/masterDetail.tdex", "XML", new String[]{"http://marklogic.com/xdmp/tde"});
@@ -191,6 +193,11 @@ public class TestOpticEnhancements extends AbstractFunctionalTest {
     row.put("sales", 750);
     row.put("storeName", "Boston");
     internetSales[3] = row;
+  }
+
+  @AfterClass
+  public static void teardown() {
+    restoreFieldIndices();
   }
 
   @Test

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnFromSparql.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnFromSparql.java
@@ -20,12 +20,12 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.expression.PlanBuilder;
 import com.marklogic.client.expression.PlanBuilder.ModifyPlan;
-import com.marklogic.client.fastfunctest.AbstractFunctionalTest;
 import com.marklogic.client.io.FileHandle;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.row.RowManager;
 import com.marklogic.client.semantics.GraphManager;
 import com.marklogic.client.semantics.RDFMimeTypes;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -47,14 +47,18 @@ public class TestOpticOnFromSparql extends AbstractFunctionalTest {
   private JsonNode jsonBindingsNodes;
   private JsonNode node;
 
-  
-@BeforeClass
-  public static void setUp() throws Exception
-  {
-    loadGraphToDB(client, "people.ttl", "/optic/sparql/test/people.ttl");
-    loadGraphToDB(client, "companies_100.ttl", "/optic/sparql/test/companies.ttl");
-  }
-  
+    @BeforeClass
+    public static void setUp() throws Exception {
+        removeFieldIndices();
+        loadGraphToDB(client, "people.ttl", "/optic/sparql/test/people.ttl");
+        loadGraphToDB(client, "companies_100.ttl", "/optic/sparql/test/companies.ttl");
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        restoreFieldIndices();
+    }
+
   @Before
   public void setUpBeforTest() {
 

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnTriples.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnTriples.java
@@ -66,6 +66,7 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
   @BeforeClass
   public static void setUp() throws Exception
   {
+    removeFieldIndices();
     // Install the TDE templates
     // loadFileToDB(client, filename, docURI, collection, document format)
     loadFileToDB(schemasClient, "masterDetail.tdex", "/optic/view/test/masterDetail.tdex", "XML", new String[] { "http://marklogic.com/xdmp/tde" });
@@ -93,6 +94,11 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
     loadFileToDB(client, "city3.json", "/optic/lexicon/test/city3.json", "JSON", new String[] { "/optic/lexicon/test" });
     loadFileToDB(client, "city4.json", "/optic/lexicon/test/city4.json", "JSON", new String[] { "/optic/lexicon/test" });
     loadFileToDB(client, "city5.json", "/optic/lexicon/test/city5.json", "JSON", new String[] { "/optic/lexicon/test" });
+  }
+
+  @AfterClass
+  public static void tearDown() {
+    restoreFieldIndices();
   }
 
   @Test


### PR DESCRIPTION
This is a temporary fix; something about the "field" config causes from-triples to go crazy. 

Brought in ml-app-deployer so it's easier/faster to make updates via the Manage API. Which will be swapping out a lot of the existing bespoke calls to the Manage API with ml-app-deployer over time. 