### PR TITLE
#1036: Deprecated unused mimetypes argument in ResourcesServices

### DIFF
--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestJSResourceExtensions.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestJSResourceExtensions.java
@@ -56,11 +56,8 @@ public class TestJSResourceExtensions extends AbstractFunctionalTest {
       params.add("arg1", docUri);
       params.add("arg2", "Earth");
 
-      // specify the mime type for each expected document returned
-      String[] mimetypes = new String[] { "text/plain" };
-
       // call the service
-      ServiceResultIterator resultItr = getServices().get(params, mimetypes);
+      ServiceResultIterator resultItr = getServices().get(params);
 
       // iterate over the results
       List<String> responses = new ArrayList<>();
@@ -81,12 +78,10 @@ public class TestJSResourceExtensions extends AbstractFunctionalTest {
     public String postJSON(String docUri) {
       RequestParameters params = new RequestParameters();
       params.add("uri", docUri);
-      // specify the mime type for each expected document returned
-      String[] mimetypes = new String[] { "text/plain" };
-      
+
       String input = "{\"array\" : [1,2,3]}";
       // call the service
-      ServiceResultIterator resultItr = getServices().post(params, new StringHandle(input).withFormat(Format.JSON), mimetypes);
+      ServiceResultIterator resultItr = getServices().post(params, new StringHandle(input).withFormat(Format.JSON));
       // iterate over the results
       List<String> responses = new ArrayList<>();
       StringHandle readHandle = new StringHandle();

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/JavascriptResourceExtension.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/JavascriptResourceExtension.java
@@ -92,11 +92,8 @@ public class JavascriptResourceExtension {
       params.add("service", "hello");
       params.add("planet", "Earth");
 
-      // specify the mime type for each expected document returned
-      String[] mimetypes = new String[] {"text/plain"};
-
       // call the service
-      ServiceResultIterator resultItr = getServices().get(params, mimetypes);
+      ServiceResultIterator resultItr = getServices().get(params);
 
       // iterate over the results
       List<String> responses = new ArrayList<>();

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/ResourceExtension.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/ResourceExtension.java
@@ -119,14 +119,8 @@ public class ResourceExtension {
       params.add("service", "check-dictionary");
       params.add("uris",    uris);
 
-      // specify the mime type for each expected document returned
-      String[] mimetypes = new String[uris.length];
-      for (int i=0; i < uris.length; i++) {
-        mimetypes[i] = "application/xml";
-      }
-
       // call the service
-      ServiceResultIterator resultItr = getServices().get(params, mimetypes);
+      ServiceResultIterator resultItr = getServices().get(params);
 
       // iterate over the results
       List<Document> documents = new ArrayList<>();

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/extension/BatchManager.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/extension/BatchManager.java
@@ -330,9 +330,6 @@ public class BatchManager extends ResourceManager {
     manifestBuilder.append("<?xml version='1.0' encoding='UTF-8'?>\n");
     manifestBuilder.append("<rapi:batch-requests xmlns:rapi='http://marklogic.com/rest-api'>\n");
 
-    List<String> readMimetypes = new ArrayList<>();
-    // read the response manifest first
-    readMimetypes.add("application/xml");
     for (Map.Entry<String,InputItem> entry: request.items.entrySet()) {
       String    uri  = entry.getKey();
       InputItem item = entry.getValue();
@@ -369,8 +366,6 @@ public class BatchManager extends ResourceManager {
         }
 
         if (ritem.mimetype != null) {
-          readMimetypes.add(ritem.mimetype);
-
           manifestBuilder.append("<rapi:content-mimetype>");
           manifestBuilder.append(ritem.mimetype);
           manifestBuilder.append("</rapi:content-mimetype>\n");
@@ -401,12 +396,9 @@ public class BatchManager extends ResourceManager {
     requestManifest.set(manifestBuilder.toString());
     requestManifest.setFormat(Format.XML);
 
-    String[] requestMimetypes = new String[readMimetypes.size()];
-
     ServiceResultIterator resultItr = getServices().post(
       new RequestParameters(),
-      requestHandles.toArray(new AbstractWriteHandle[requestHandles.size()]),
-      requestMimetypes
+      requestHandles.toArray(new AbstractWriteHandle[requestHandles.size()])
     );
 
     if (!resultItr.hasNext())

--- a/marklogic-client-api/src/main/java/com/marklogic/client/extensions/ResourceServices.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/extensions/ResourceServices.java
@@ -61,18 +61,18 @@ public interface ResourceServices {
   /**
    * Reads multiple resource content by calling a GET service.
    * @param params	the parameters for the call
-   * @param mimetypes	the mimetypes for the requested content
+   * @param mimetypes	the mimetypes for the requested content; deprecated since 6.0.0, has always been ignored by implementation
    * @return	an iterator over the requested content
    */
-  ServiceResultIterator get(RequestParameters params, String... mimetypes);
+  ServiceResultIterator get(RequestParameters params, @Deprecated String... mimetypes);
   /**
    * Reads multiple resource content by calling a GET service.
    * @param params	the parameters for the call
    * @param transaction	the transaction for reading content
-   * @param mimetypes	the mimetypes for the requested content
+   * @param mimetypes	the mimetypes for the requested content; deprecated since 6.0.0, has always been ignored by implementation
    * @return	an iterator over the requested content
    */
-  ServiceResultIterator get(RequestParameters params, Transaction transaction, String... mimetypes);
+  ServiceResultIterator get(RequestParameters params, Transaction transaction, @Deprecated String... mimetypes);
 
   /**
    * Writes content by calling a PUT service.
@@ -160,38 +160,38 @@ public interface ResourceServices {
    * Applies multiple content by calling a POST service.
    * @param params	the parameters for the call
    * @param input	the content passed with the call
-   * @param mimetypes	the mimetypes for the requested content
+   * @param mimetypes	the mimetypes for the requested content; deprecated since 6.0.0, has always been ignored by implementation
    * @return	an iterator over the requested content
    */
-  ServiceResultIterator post(RequestParameters params, AbstractWriteHandle input, String... mimetypes);
+  ServiceResultIterator post(RequestParameters params, AbstractWriteHandle input, @Deprecated String... mimetypes);
   /**
    * Applies multiple content by calling a POST service.
    * @param params	the parameters for the call
    * @param input	the content passed with the call
    * @param transaction	the transaction for applying content
-   * @param mimetypes	the mimetypes for the requested content
+   * @param mimetypes	the mimetypes for the requested content; deprecated since 6.0.0, has always been ignored by implementation
    * @return	an iterator over the requested content
    */
-  ServiceResultIterator post(RequestParameters params, AbstractWriteHandle input, Transaction transaction, String... mimetypes);
+  ServiceResultIterator post(RequestParameters params, AbstractWriteHandle input, Transaction transaction, @Deprecated String... mimetypes);
   /**
    * Applies multiple content by calling a POST service.
    * @param params	the parameters for the call
    * @param input	an array of content passed with the call
-   * @param mimetypes	the mimetypes for the requested content
+   * @param mimetypes	the mimetypes for the requested content; deprecated since 6.0.0, has always been ignored by implementation
    * @param <W> the type of AbstractWriteHandle's with content to send
    * @return	an iterator over the requested content
    */
-  <W extends AbstractWriteHandle> ServiceResultIterator post(RequestParameters params, W[] input, String... mimetypes);
+  <W extends AbstractWriteHandle> ServiceResultIterator post(RequestParameters params, W[] input, @Deprecated String... mimetypes);
   /**
    * Applies multiple content by calling a POST service.
    * @param params	the parameters for the call
    * @param input	an array of content passed with the call
    * @param transaction	the transaction for applying content
-   * @param mimetypes	the mimetypes for the requested content
+   * @param mimetypes	the mimetypes for the requested content; deprecated since 6.0.0, has always been ignored by implementation
    * @param <W> the type of AbstractWriteHandle's with content to send
    * @return	an iterator over the requested content
    */
-  <W extends AbstractWriteHandle> ServiceResultIterator post(RequestParameters params, W[] input, Transaction transaction, String... mimetypes);
+  <W extends AbstractWriteHandle> ServiceResultIterator post(RequestParameters params, W[] input, Transaction transaction, @Deprecated String... mimetypes);
 
   /**
    * Deletes content by calling a DELETE service.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/OkHttpServices.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/OkHttpServices.java
@@ -994,7 +994,7 @@ public class OkHttpServices implements RESTServices {
     }
 
     OkHttpResultIterator iterator = getIteratedResourceImpl(DefaultOkHttpResultIterator::new,
-      reqlog, path, transaction, params, MIMETYPE_MULTIPART_MIXED);
+      reqlog, path, transaction, params);
     if ( iterator != null ) {
       if ( iterator.getStart() == -1 ) iterator.setStart(1);
       if ( iterator.getSize() != -1 ) {
@@ -3222,14 +3222,14 @@ public class OkHttpServices implements RESTServices {
 
   @Override
   public RESTServiceResultIterator getIteratedResource(RequestLogger reqlog,
-                                                       String path, Transaction transaction, RequestParameters params, String... mimetypes)
+                                                       String path, Transaction transaction, RequestParameters params)
     throws ResourceNotFoundException, ForbiddenUserException, FailedRequestException
   {
-    return getIteratedResourceImpl(OkHttpServiceResultIterator::new, reqlog, path, transaction, params, mimetypes);
+    return getIteratedResourceImpl(OkHttpServiceResultIterator::new, reqlog, path, transaction, params);
   }
 
   private <U extends OkHttpResultIterator> U getIteratedResourceImpl(ResultIteratorConstructor<U> constructor,
-        RequestLogger reqlog, String path, Transaction transaction, RequestParameters params, String... mimetypes)
+        RequestLogger reqlog, String path, Transaction transaction, RequestParameters params)
     throws ResourceNotFoundException, ForbiddenUserException, FailedRequestException
   {
     if ( params == null ) params = new RequestParameters();
@@ -3950,12 +3950,11 @@ public class OkHttpServices implements RESTServices {
 
   @Override
   public RESTServiceResultIterator postIteratedResource(RequestLogger reqlog,
-                                                        String path, Transaction transaction, RequestParameters params, AbstractWriteHandle input,
-                                                        String... outputMimetypes)
+                                                        String path, Transaction transaction, RequestParameters params, AbstractWriteHandle input)
     throws ResourceNotFoundException, ResourceNotResendableException, ForbiddenUserException, FailedRequestException
   {
     return postIteratedResourceImpl(OkHttpServiceResultIterator::new,
-      reqlog, path, transaction, params, input, outputMimetypes);
+      reqlog, path, transaction, params, input);
   }
 
     public RESTServiceResultIterator postMultipartForm(
@@ -4040,7 +4039,7 @@ public class OkHttpServices implements RESTServices {
   private <U extends OkHttpResultIterator> U postIteratedResourceImpl(
     ResultIteratorConstructor<U> constructor, final RequestLogger reqlog,
     final String path, Transaction transaction, RequestParameters params,
-    AbstractWriteHandle input, String... outputMimetypes)
+    AbstractWriteHandle input)
     throws ResourceNotFoundException, ResourceNotResendableException, ForbiddenUserException, FailedRequestException
   {
     if ( params == null ) params = new RequestParameters();
@@ -4087,16 +4086,16 @@ public class OkHttpServices implements RESTServices {
   @Override
   public <W extends AbstractWriteHandle> RESTServiceResultIterator postIteratedResource(
     RequestLogger reqlog, String path, Transaction transaction, RequestParameters params,
-    W[] input, String... outputMimetypes)
+    W[] input)
     throws ResourceNotFoundException, ResourceNotResendableException, ForbiddenUserException, FailedRequestException
   {
     return postIteratedResourceImpl(OkHttpServiceResultIterator::new,
-      reqlog, path, transaction, params, input, outputMimetypes);
+      reqlog, path, transaction, params, input);
   }
 
   private <W extends AbstractWriteHandle, U extends OkHttpResultIterator> U postIteratedResourceImpl(
     ResultIteratorConstructor<U> constructor, RequestLogger reqlog, String path, Transaction transaction,
-    RequestParameters params, W[] input, String... outputMimetypes)
+    RequestParameters params, W[] input)
     throws ResourceNotFoundException, ResourceNotResendableException, ForbiddenUserException, FailedRequestException
   {
     if ( params == null ) params = new RequestParameters();

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/RESTServices.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/RESTServices.java
@@ -231,7 +231,7 @@ public interface RESTServices {
                                                         Transaction transaction, RequestParameters params, R output)
     throws ResourceNotFoundException, ForbiddenUserException, FailedRequestException;
   RESTServiceResultIterator getIteratedResource(
-    RequestLogger reqlog, String path, Transaction transaction, RequestParameters params, String... mimetypes)
+    RequestLogger reqlog, String path, Transaction transaction, RequestParameters params)
     throws ResourceNotFoundException, ForbiddenUserException, FailedRequestException;
 
   <R extends AbstractReadHandle> R putResource(
@@ -262,7 +262,7 @@ public interface RESTServices {
     ForbiddenUserException, FailedRequestException;
   RESTServiceResultIterator postIteratedResource(
     RequestLogger reqlog, String path, Transaction transaction, RequestParameters params,
-    AbstractWriteHandle input, String... outputMimetypes)
+    AbstractWriteHandle input)
     throws ResourceNotFoundException, ResourceNotResendableException, ForbiddenUserException,
     FailedRequestException;
   RESTServiceResultIterator postMultipartForm(
@@ -271,7 +271,7 @@ public interface RESTServices {
           FailedRequestException;
   <W extends AbstractWriteHandle> RESTServiceResultIterator postIteratedResource(
     RequestLogger reqlog, String path, Transaction transaction, RequestParameters params,
-    W[] input, String... outputMimetypes)
+    W[] input)
     throws ResourceNotFoundException, ResourceNotResendableException, ForbiddenUserException,
     FailedRequestException;
   EvalResultIterator postEvalInvoke(RequestLogger reqlog, String code, String modulePath,

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/ResourceServicesImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/ResourceServicesImpl.java
@@ -53,13 +53,12 @@ class ResourceServicesImpl
       transaction, prepareParams(params), output);
   }
   @Override
-  public ServiceResultIterator get(RequestParameters params, String... outputMimetypes) {
+  public ServiceResultIterator get(RequestParameters params, @Deprecated String... outputMimetypes) {
     return get(params, null, outputMimetypes);
   }
   @Override
-  public ServiceResultIterator get(RequestParameters params, Transaction transaction, String... outputMimetypes) {
-    return services.getIteratedResource(requestLogger, getResourcePath(),
-      transaction, prepareParams(params), outputMimetypes);
+  public ServiceResultIterator get(RequestParameters params, Transaction transaction, @Deprecated String... outputMimetypes) {
+    return services.getIteratedResource(requestLogger, getResourcePath(), transaction, prepareParams(params));
   }
 
   @Override
@@ -91,13 +90,13 @@ class ResourceServicesImpl
       requestLogger, getResourcePath(), transaction, prepareParams(params), input, output);
   }
   @Override
-  public ServiceResultIterator post(RequestParameters params, AbstractWriteHandle input, String... outputMimetypes) {
+  public ServiceResultIterator post(RequestParameters params, AbstractWriteHandle input, @Deprecated String... outputMimetypes) {
     return post(params, input, null, outputMimetypes);
   }
   @Override
-  public ServiceResultIterator post(RequestParameters params, AbstractWriteHandle input, Transaction transaction, String... outputMimetypes) {
+  public ServiceResultIterator post(RequestParameters params, AbstractWriteHandle input, Transaction transaction, @Deprecated String... outputMimetypes) {
     return services.postIteratedResource(
-      requestLogger, getResourcePath(), transaction, prepareParams(params), input, outputMimetypes);
+      requestLogger, getResourcePath(), transaction, prepareParams(params), input);
   }
   @Override
   public <R extends AbstractReadHandle, W extends AbstractWriteHandle> R post(RequestParameters params, W[] input, R output) {
@@ -109,13 +108,13 @@ class ResourceServicesImpl
       requestLogger, getResourcePath(), transaction, prepareParams(params), input, output);
   }
   @Override
-  public <W extends AbstractWriteHandle> ServiceResultIterator post(RequestParameters params, W[] input, String... outputMimetypes) {
+  public <W extends AbstractWriteHandle> ServiceResultIterator post(RequestParameters params, W[] input, @Deprecated String... outputMimetypes) {
     return post(params, input, null, outputMimetypes);
   }
   @Override
-  public <W extends AbstractWriteHandle> ServiceResultIterator post(RequestParameters params, W[] input, Transaction transaction, String... outputMimetypes) {
+  public <W extends AbstractWriteHandle> ServiceResultIterator post(RequestParameters params, W[] input, Transaction transaction, @Deprecated String... outputMimetypes) {
     return services.postIteratedResource(
-      requestLogger, getResourcePath(), transaction, prepareParams(params), input, outputMimetypes);
+      requestLogger, getResourcePath(), transaction, prepareParams(params), input);
   }
 
   @Override

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/ResourceServicesTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/ResourceServicesTest.java
@@ -73,9 +73,7 @@ public class ResourceServicesTest {
     assertNotNull("Failed to get resource service with single document", result);
     assertXpathEvaluatesTo("true", "/read-doc/param", result);
 
-    String[] mimetypes = {"application/xml", "application/xml"};
-
-    ServiceResultIterator resultItr = resourceMgr.getResourceServices().get(params, mimetypes);
+    ServiceResultIterator resultItr = resourceMgr.getResourceServices().get(params);
 
     List<Document> resultDocuments = new ArrayList<>();
     DOMHandle readHandle = new DOMHandle();
@@ -119,7 +117,7 @@ public class ResourceServicesTest {
     assertXpathEvaluatesTo("true", "/applied-doc/param", result);
     assertXpathEvaluatesTo("true", "/applied-doc/input-doc", result);
 
-    resultItr = resourceMgr.getResourceServices().post(params, writeHandles, mimetypes);
+    resultItr = resourceMgr.getResourceServices().post(params, writeHandles);
 
     resultDocuments = new ArrayList<>();
     readHandle = new DOMHandle();


### PR DESCRIPTION
Was able to remove this completely in OkHttpServices, as the argument wasn't used for anything. But can't remove it from ResourceServices since that's a public interface. So deprecating the argument in the 6 methods that have it. 

Adjusted each test and example not to pass in a mimetype argument anymore; those were misleading since it implied that the argument was having some impact. 