### PR TITLE
Prototype of Java 17 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,6 @@ build
 buildSrc/build
 
 .classpath
-.gitignore
-.classpath
 .project
 .settings/
 .idea

--- a/build.gradle
+++ b/build.gradle
@@ -21,8 +21,14 @@ subprojects {
  	tasks.withType(JavaCompile) {
     	options.encoding = 'UTF-8'
   	}
-    sourceCompatibility = "1.8"
-    targetCompatibility = "1.8"
+
+    // To ensure that the Java Client continues to support Java 8, both source and target compatibility are set to 1.8.
+    // May adjust this for src/test/java so that tests can take advantage of more expressive functions in Java 9+, such
+    // as Map.of().
+    java {
+        sourceCompatibility = 1.8
+        targetCompatibility = 1.8
+    }
 
     configurations {
         testImplementation.extendsFrom compileOnly
@@ -45,4 +51,11 @@ subprojects {
         systemProperty "javax.xml.stream.XMLOutputFactory", "com.sun.xml.internal.stream.XMLOutputFactoryImpl"
     }
 
+    // Until we do a cleanup of javadoc errors, the build (and specifically the javadoc task) fails on Java 11
+    // and higher. Preventing that until the cleanup can occur.
+    javadoc.failOnError = false
+
+    // Ignores warnings on param tags with no descriptions. Will remove this once javadoc errors are addressed.
+    // Until then, it's just a lot of noise.
+    javadoc.options.addStringOption('Xdoclint:none', '-quiet')
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/BasicJavaClientREST.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/BasicJavaClientREST.java
@@ -46,8 +46,8 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.BasicResponseHandler;
 import org.apache.http.impl.client.DefaultHttpClient;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/Product.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/Product.java
@@ -16,7 +16,7 @@
 
 package com.marklogic.client.functionaltest;
 
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement
 public class Product

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBiTempMetaValues.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBiTempMetaValues.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.Calendar;
 
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 import javax.xml.datatype.DatatypeFactory;
 
 import org.junit.After;

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBiTemporal.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBiTemporal.java
@@ -27,7 +27,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.TreeMap;
 
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 import javax.xml.parsers.DocumentBuilderFactory;
 
 import com.marklogic.client.expression.CtsQueryBuilder;

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientConnection.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientConnection.java
@@ -42,7 +42,6 @@ import java.util.TreeMap;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509TrustManager;
-import javax.xml.bind.JAXBException;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
 
@@ -57,8 +56,6 @@ import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.DatabaseClientFactory;
 import com.marklogic.client.DatabaseClientFactory.SSLHostnameVerifier;
 import com.marklogic.client.DatabaseClientFactory.SecurityContext;
-import com.marklogic.client.FailedRequestException;
-import com.marklogic.client.ForbiddenUserException;
 import com.marklogic.client.ResourceNotFoundException;
 import com.marklogic.client.Transaction;
 import com.marklogic.client.alerting.RuleDefinition;
@@ -72,7 +69,6 @@ import com.marklogic.client.document.DocumentWriteSet;
 import com.marklogic.client.document.TextDocumentManager;
 import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.InputStreamHandle;
-import com.marklogic.client.io.JAXBHandle;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.io.TuplesHandle;
 import com.marklogic.client.io.ValuesHandle;

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestSandBox.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestSandBox.java
@@ -30,7 +30,7 @@ import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;

--- a/marklogic-client-api/build.gradle
+++ b/marklogic-client-api/build.gradle
@@ -11,33 +11,51 @@ description = "The official MarkLogic Java client API."
 
 dependencies {
     if (JavaVersion.current().isJava9Compatible()) {
-        implementation group: 'javax.xml.bind', name: 'jaxb-api', version: '2.3.1'
-        implementation group: 'org.glassfish.jaxb', name: 'jaxb-runtime', version: '2.3.2'
-        implementation group: 'org.glassfish.jaxb', name: 'jaxb-core', version: '2.3.0.1'
+        println "\nJava version is 9 or higher, so using jakarta.xml.bind 4.0.0; Java version: " + JavaVersion.current()
+        implementation "jakarta.xml.bind:jakarta.xml.bind-api:4.0.0"
+        implementation "org.glassfish.jaxb:jaxb-runtime:4.0.1"
+        implementation "org.glassfish.jaxb:jaxb-core:4.0.1"
+    } else {
+        println "\nJava version is less than 9, so using jakarta.xml.bind 3.0.1; Java version: " + JavaVersion.current()
+        implementation "jakarta.xml.bind:jakarta.xml.bind-api:3.0.1"
+        implementation "org.glassfish.jaxb:jaxb-runtime:3.0.1"
+        implementation "org.glassfish.jaxb:jaxb-core:3.0.1"
     }
-    implementation group: 'com.squareup.okhttp3', name: 'okhttp', version:'4.10.0'
-    implementation group: 'com.squareup.okhttp3', name: 'logging-interceptor', version:'4.10.0'
-    implementation group: 'io.github.rburgst', name: 'okhttp-digest', version:'2.7'
-    implementation group: 'com.sun.mail', name: 'javax.mail', version:'1.6.2'
-    implementation group: 'javax.ws.rs', name: 'javax.ws.rs-api', version:'2.1.1'
-    implementation group: 'org.slf4j', name: 'slf4j-api', version:'1.7.36'
+
+    implementation "com.squareup.okhttp3:okhttp:4.10.0"
+    implementation "com.squareup.okhttp3:logging-interceptor:4.10.0"
+    implementation "io.github.rburgst:okhttp-digest:2.7"
+    implementation "com.sun.mail:javax.mail:1.6.2"
+    implementation "javax.ws.rs:javax.ws.rs-api:2.1.1"
+    implementation "org.slf4j:slf4j-api:1.7.36"
     implementation 'com.fasterxml.jackson.core:jackson-core:2.13.4'
     implementation 'com.fasterxml.jackson.core:jackson-annotations:2.13.4'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4.2'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.13.4'
+
     testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.13.4'
-    testImplementation group: 'org.mockito', name: 'mockito-all', version:'1.10.19'
-    testImplementation group: 'ch.qos.logback', name: 'logback-classic', version:'1.2.11'
-    testImplementation group: 'org.hsqldb', name: 'hsqldb', version:'2.5.1'
-// schema validation issue with testImplementation group: 'xerces', name: 'xercesImpl', version:'2.12.0'
-    testImplementation group: 'org.opengis.cite.xerces', name: 'xercesImpl-xsd11', version:'2.12-beta-r1667115'
-    compileOnly group: 'org.jdom', name: 'jdom2', version:'2.0.6'
-    compileOnly group: 'dom4j', name: 'dom4j', version:'1.6.1'
-    compileOnly group: 'com.google.code.gson', name: 'gson', version:'2.8.6'
-    compileOnly group: 'net.sourceforge.htmlcleaner', name: 'htmlcleaner', version:'2.24'
-    compileOnly group: 'com.opencsv', name: 'opencsv', version: '4.6'
-    compileOnly group: 'org.geonames', name: 'geonames', version:'1.0'
-    compileOnly 'org.springframework:spring-jdbc:5.3.23'
+    testImplementation "org.mockito:mockito-core:4.9.0"
+    testImplementation "org.mockito:mockito-inline:4.9.0"
+
+    // Cannot use >= 1.4 yet, requires Java 11
+    testImplementation "ch.qos.logback:logback-classic:1.3.4"
+
+    // Cannot use >= 2.6 yet, requires Java 11
+    testImplementation "org.hsqldb:hsqldb:2.5.2"
+
+    // Needed for tests that use SchemaFactory.newInstance
+    // xerces:xercesImpl does not work in StructuredQueryBuilderTest
+    testImplementation "org.opengis.cite.xerces:xercesImpl-xsd11:2.12-beta-r1667115"
+
+    // These only seem needed for the cookbook examples, which would ideally be in a separate subproject so that
+    // this project's Gradle file is simpler
+    compileOnly "org.jdom:jdom2:2.0.6.1"
+    compileOnly "dom4j:dom4j:1.6.1"
+    compileOnly "com.google.code.gson:gson:2.10"
+    compileOnly "net.sourceforge.htmlcleaner:htmlcleaner:2.26"
+    compileOnly "com.opencsv:opencsv:4.6"
+    compileOnly "org.geonames:geonames:1.0"
+    compileOnly "org.springframework:spring-jdbc:5.3.24"
 }
 
 // Ensure that mlHost and mlPassword can override the defaults of localhost/admin if they've been modified
@@ -72,9 +90,6 @@ javadoc {
     options.bottom = "Copyright &copy; 2022 MarkLogic Corporation"
     options.links = [ 'http://docs.oracle.com/javase/8/docs/api/' ]
     options.use = true
-    if (JavaVersion.current().isJava9Compatible()) {
-        options.addBooleanOption('html4', true)
-    }
     exclude([
             '**/impl/**', '**/jaxb/**', '**/test/**'
     ])
@@ -222,4 +237,12 @@ task generatePomForDependencyGraph(dependsOn: "generatePomFileForMainJavaPublica
 task testRows(type: Test) {
     description = "Run all 'rows' tests; i.e. those exercising Optic and Optic Update functionality"
     include "com/marklogic/client/test/rows/**"
+}
+
+task testXml(type: Test) {
+    description = "Run a bunch of XML-related tests for smoke-testing on a particular JVM"
+    include "com/marklogic/client/test/BufferableHandleTest.class"
+    include "com/marklogic/client/test/EvalTest.class"
+    include "com/marklogic/client/test/HandleAsTest.class"
+    include "com/marklogic/client/test/JAXBHandleTest.class"
 }

--- a/marklogic-client-api/src/main/java/com/marklogic/client/bitemporal/TemporalDescriptor.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/bitemporal/TemporalDescriptor.java
@@ -16,7 +16,7 @@
 package com.marklogic.client.bitemporal;
 
 import com.marklogic.client.document.DocumentDescriptor;
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 
 public interface TemporalDescriptor extends DocumentDescriptor {
   /**

--- a/marklogic-client-api/src/main/java/com/marklogic/client/bitemporal/TemporalDocumentManager.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/bitemporal/TemporalDocumentManager.java
@@ -18,11 +18,10 @@ package com.marklogic.client.bitemporal;
 
 import java.util.Calendar;
 
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 import javax.xml.datatype.Duration;
 
 import com.marklogic.client.*;
-import com.marklogic.client.bitemporal.TemporalDescriptor;
 import com.marklogic.client.document.DocumentDescriptor;
 import com.marklogic.client.document.DocumentManager;
 import com.marklogic.client.document.DocumentUriTemplate;

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/AllCookbookExamples.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/AllCookbookExamples.java
@@ -17,7 +17,7 @@ package com.marklogic.client.example.cookbook;
 
 import java.io.IOException;
 
-import javax.xml.bind.JAXBException;
+import jakarta.xml.bind.JAXBException;
 import javax.xml.xpath.XPathExpressionException;
 
 import com.marklogic.client.FailedRequestException;

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/JAXBDocument.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/JAXBDocument.java
@@ -17,9 +17,9 @@ package com.marklogic.client.example.cookbook;
 
 import java.io.IOException;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.DatabaseClientFactory;

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/datamovement/DatabaseClientSingleton.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/datamovement/DatabaseClientSingleton.java
@@ -19,7 +19,7 @@ import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.HashMap;
 
-import javax.xml.bind.JAXBException;
+import jakarta.xml.bind.JAXBException;
 
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.DatabaseClientFactory;

--- a/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/datamovement/WriteandReadPOJOs.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/example/cookbook/datamovement/WriteandReadPOJOs.java
@@ -15,8 +15,8 @@
  */
 package com.marklogic.client.example.cookbook.datamovement;
 
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/DocumentManagerImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/DocumentManagerImpl.java
@@ -18,7 +18,7 @@ package com.marklogic.client.impl;
 import java.nio.charset.CharsetEncoder;
 import java.util.*;
 
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 import javax.xml.datatype.Duration;
 
 import com.marklogic.client.query.SearchQueryDefinition;

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/DocumentMetadataPatchBuilderImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/DocumentMetadataPatchBuilderImpl.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import java.util.Set;
 
 import javax.xml.XMLConstants;
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/OkHttpServices.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/OkHttpServices.java
@@ -80,7 +80,7 @@ import javax.mail.internet.MimeMultipart;
 import javax.mail.util.ByteArrayDataSource;
 import javax.net.SocketFactory;
 import javax.net.ssl.*;
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 import java.io.ByteArrayInputStream;
 import java.io.Closeable;
 import java.io.File;

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/TuplesBuilder.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/TuplesBuilder.java
@@ -22,11 +22,11 @@ import com.marklogic.client.query.ValuesMetrics;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 /**
  * A TuplesBuilder parses a set of tuple results.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/ValueConverter.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/ValueConverter.java
@@ -25,7 +25,7 @@ import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 import javax.xml.datatype.Duration;
 
 /**

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/ValuesBuilder.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/ValuesBuilder.java
@@ -17,11 +17,11 @@ package com.marklogic.client.impl;
 
 import java.util.ArrayList;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 import com.marklogic.client.query.AggregateResult;
 import com.marklogic.client.query.CountedDistinctValue;

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/ValuesListBuilder.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/ValuesListBuilder.java
@@ -19,10 +19,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 /**
  * A ValuesListBuilder parses list of value results.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/ValuesMetricImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/ValuesMetricImpl.java
@@ -17,7 +17,7 @@ package com.marklogic.client.impl;
 
 import java.util.Calendar;
 
-import javax.xml.bind.annotation.XmlValue;
+import jakarta.xml.bind.annotation.XmlValue;
 import javax.xml.datatype.Duration;
 
 /**

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/ValuesMetricsImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/ValuesMetricsImpl.java
@@ -15,7 +15,7 @@
  */
 package com.marklogic.client.impl;
 
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElement;
 
 import com.marklogic.client.impl.ValuesBuilder.Values;
 import com.marklogic.client.query.ValuesMetrics;

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/XsValueImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/XsValueImpl.java
@@ -21,7 +21,7 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 import javax.xml.datatype.DatatypeConstants;
 import javax.xml.datatype.Duration;
 import javax.xml.datatype.XMLGregorianCalendar;

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/JAXBHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/JAXBHandle.java
@@ -26,10 +26,10 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.Unmarshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.Unmarshaller;
 
 import com.marklogic.client.io.marker.*;
 import org.slf4j.Logger;

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/QueryOptionsListHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/QueryOptionsListHandle.java
@@ -21,10 +21,10 @@ import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.Unmarshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.Unmarshaller;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/TuplesHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/TuplesHandle.java
@@ -22,9 +22,9 @@ import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/ValuesHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/ValuesHandle.java
@@ -22,9 +22,9 @@ import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/ValuesListHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/ValuesListHandle.java
@@ -20,9 +20,9 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/AggregateResult.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/AggregateResult.java
@@ -17,8 +17,8 @@ package com.marklogic.client.query;
 
 import com.marklogic.client.impl.ValueConverter;
 
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlValue;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlValue;
 
 /**
  * A CountedDistinctValue is a value that includes a frequency.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/CountedDistinctValue.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/CountedDistinctValue.java
@@ -17,8 +17,8 @@ package com.marklogic.client.query;
 
 import com.marklogic.client.impl.ValueConverter;
 
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlValue;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlValue;
 
 /**
  * A CountedDistinctValue is a value that includes a frequency.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/QueryOptionsListBuilder.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/QueryOptionsListBuilder.java
@@ -15,10 +15,10 @@
  */
 package com.marklogic.client.query;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/StructuredQueryBuilder.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/StructuredQueryBuilder.java
@@ -26,7 +26,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import javax.xml.XMLConstants;
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/Tuple.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/Tuple.java
@@ -17,8 +17,8 @@ package com.marklogic.client.query;
 
 import com.marklogic.client.impl.TuplesBuilder;
 
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/TypedDistinctValue.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/TypedDistinctValue.java
@@ -17,8 +17,8 @@ package com.marklogic.client.query;
 
 import com.marklogic.client.impl.ValueConverter;
 
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlValue;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlValue;
 
 /**
  * A TypedDistinctValue is a value that includes a type.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/BinaryDocumentTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/BinaryDocumentTest.java
@@ -22,7 +22,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Random;
 
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 
 import org.custommonkey.xmlunit.exceptions.XpathException;
 import org.junit.AfterClass;

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/BitemporalTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/BitemporalTest.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.fail;
 import java.util.Calendar;
 import java.util.Random;
 
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/BufferableHandleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/BufferableHandleTest.java
@@ -22,8 +22,8 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.util.HashMap;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/BulkReadWriteTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/BulkReadWriteTest.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
-import javax.xml.bind.JAXBException;
+import jakarta.xml.bind.JAXBException;
 import org.w3c.dom.Document;
 
 import static org.junit.Assert.assertEquals;

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/City.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/City.java
@@ -15,7 +15,7 @@
  */
 package com.marklogic.client.test;
 
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 import com.marklogic.client.pojo.annotation.Id;
 import com.marklogic.client.pojo.annotation.PathIndexProperty;

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/ClosingHandlesTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/ClosingHandlesTest.java
@@ -21,7 +21,7 @@ import java.io.ByteArrayInputStream;
 import java.io.Closeable;
 import java.io.IOException;
 
-import javax.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBContext;
 
 import org.junit.Test;
 

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/EvalTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/EvalTest.java
@@ -30,7 +30,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.TimeZone;
 
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.parsers.DocumentBuilderFactory;

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/HandleAsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/HandleAsTest.java
@@ -31,8 +31,8 @@ import java.io.StringReader;
 import java.util.HashSet;
 import java.util.Set;
 
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/JAXBHandleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/JAXBHandleTest.java
@@ -22,8 +22,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/QueryOptionsManagerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/QueryOptionsManagerTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.IOException;
 
-import javax.xml.bind.JAXBException;
+import jakarta.xml.bind.JAXBException;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/LegalHoldsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/LegalHoldsTest.java
@@ -55,7 +55,7 @@ import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 
 public class LegalHoldsTest {
   private Logger logger = LoggerFactory.getLogger(LegalHoldsTest.class);

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/JAXBDocumentTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/JAXBDocumentTest.java
@@ -19,7 +19,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 
-import javax.xml.bind.JAXBException;
+import jakarta.xml.bind.JAXBException;
 
 import org.junit.Test;
 

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/util/Refers.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/util/Refers.java
@@ -18,7 +18,7 @@ package com.marklogic.client.test.util;
 import java.util.List;
 import java.util.Map;
 
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement
 public class Refers {

--- a/ml-development-tools/.gitignore
+++ b/ml-development-tools/.gitignore
@@ -1,0 +1,2 @@
+src/test/java/com/marklogic/client/test/dbfunction/generated
+src/test/ml-modules/root/dbfunctiondef/generated

--- a/ml-development-tools/build.gradle
+++ b/ml-development-tools/build.gradle
@@ -17,6 +17,24 @@ dependencies {
 
     testCompileOnly gradleTestKit()
     testImplementation 'com.squareup.okhttp3:okhttp:4.10.0'
+
+    // The jakarta.xml.bind implementation dependencies don't appear to come over from the implementation dependency
+    // on the marklogic-client-api project, so they're declared here again.
+    if (JavaVersion.current().isJava9Compatible()) {
+        testImplementation "jakarta.xml.bind:jakarta.xml.bind-api:4.0.0"
+        testImplementation "org.glassfish.jaxb:jaxb-runtime:4.0.1"
+        testImplementation "org.glassfish.jaxb:jaxb-core:4.0.1"
+    } else {
+        testImplementation "jakarta.xml.bind:jakarta.xml.bind-api:3.0.1"
+        testImplementation "org.glassfish.jaxb:jaxb-runtime:3.0.1"
+        testImplementation "org.glassfish.jaxb:jaxb-core:3.0.1"
+    }
+}
+
+// Added to avoid problem where processResources fails because - somehow - the plugin properties file is getting
+// copied twice. This started occurring with the upgrade of Gradle from 6.x to 7.x.
+tasks.processResources {
+    duplicatesStrategy = "exclude"
 }
 
 task mlDevelopmentToolsJar(type: Jar, dependsOn: classes) {

--- a/ml-development-tools/src/test/java/com/marklogic/client/test/dbfunction/positive/AnyDocumentBundle.java
+++ b/ml-development-tools/src/test/java/com/marklogic/client/test/dbfunction/positive/AnyDocumentBundle.java
@@ -2,8 +2,8 @@ package com.marklogic.client.test.dbfunction.positive;
 
 // IMPORTANT: Do not edit. This file is generated.
 
-import java.util.stream.Stream;
 import com.marklogic.client.io.Format;
+import java.util.stream.Stream;
 
 
 import com.marklogic.client.DatabaseClient;
@@ -48,56 +48,26 @@ public interface AnyDocumentBundle {
             private DatabaseClient dbClient;
             private BaseProxy baseProxy;
 
-            private BaseProxy.DBFunctionRequest req_sendReceiveManyDocs;
-            private BaseProxy.DBFunctionRequest req_sendReceiveRequiredDoc;
             private BaseProxy.DBFunctionRequest req_sendReceiveOptionalDoc;
             private BaseProxy.DBFunctionRequest req_sendReceiveAnyDocs;
+            private BaseProxy.DBFunctionRequest req_sendReceiveRequiredDoc;
+            private BaseProxy.DBFunctionRequest req_sendReceiveManyDocs;
             private BaseProxy.DBFunctionRequest req_sendReceiveMappedDoc;
 
             private AnyDocumentBundleImpl(DatabaseClient dbClient, JSONWriteHandle servDecl) {
                 this.dbClient  = dbClient;
                 this.baseProxy = new BaseProxy("/dbf/test/anyDocument/", servDecl);
 
-                this.req_sendReceiveManyDocs = this.baseProxy.request(
-                    "sendReceiveManyDocs.sjs", BaseProxy.ParameterValuesKind.MULTIPLE_MIXED);
-                this.req_sendReceiveRequiredDoc = this.baseProxy.request(
-                    "sendReceiveRequiredDoc.sjs", BaseProxy.ParameterValuesKind.MULTIPLE_MIXED);
                 this.req_sendReceiveOptionalDoc = this.baseProxy.request(
                     "sendReceiveOptionalDoc.sjs", BaseProxy.ParameterValuesKind.MULTIPLE_MIXED);
                 this.req_sendReceiveAnyDocs = this.baseProxy.request(
                     "sendReceiveAnyDocs.sjs", BaseProxy.ParameterValuesKind.MULTIPLE_MIXED);
+                this.req_sendReceiveRequiredDoc = this.baseProxy.request(
+                    "sendReceiveRequiredDoc.sjs", BaseProxy.ParameterValuesKind.MULTIPLE_MIXED);
+                this.req_sendReceiveManyDocs = this.baseProxy.request(
+                    "sendReceiveManyDocs.sjs", BaseProxy.ParameterValuesKind.MULTIPLE_MIXED);
                 this.req_sendReceiveMappedDoc = this.baseProxy.request(
                     "sendReceiveMappedDoc.sjs", BaseProxy.ParameterValuesKind.MULTIPLE_MIXED);
-            }
-
-            @Override
-            public Stream<com.marklogic.client.io.InputStreamHandle> sendReceiveManyDocs(Stream<String> uris, Stream<com.marklogic.client.io.InputStreamHandle> docs) {
-                return sendReceiveManyDocs(
-                    this.req_sendReceiveManyDocs.on(this.dbClient), uris, docs
-                    );
-            }
-            private Stream<com.marklogic.client.io.InputStreamHandle> sendReceiveManyDocs(BaseProxy.DBFunctionRequest request, Stream<String> uris, Stream<com.marklogic.client.io.InputStreamHandle> docs) {
-              return request
-                      .withParams(
-                          BaseProxy.atomicParam("uris", false, BaseProxy.StringType.fromString(uris)),
-                          BaseProxy.documentParam("docs", false, docs)
-                          ).responseMultiple(false, Format.UNKNOWN)
-                      .asStreamOfHandles(null, new com.marklogic.client.io.InputStreamHandle());
-            }
-
-            @Override
-            public com.marklogic.client.io.InputStreamHandle sendReceiveRequiredDoc(String uri, com.marklogic.client.io.InputStreamHandle doc) {
-                return sendReceiveRequiredDoc(
-                    this.req_sendReceiveRequiredDoc.on(this.dbClient), uri, doc
-                    );
-            }
-            private com.marklogic.client.io.InputStreamHandle sendReceiveRequiredDoc(BaseProxy.DBFunctionRequest request, String uri, com.marklogic.client.io.InputStreamHandle doc) {
-              return request
-                      .withParams(
-                          BaseProxy.atomicParam("uri", false, BaseProxy.StringType.fromString(uri)),
-                          BaseProxy.documentParam("doc", false, doc)
-                          ).responseSingle(false, Format.UNKNOWN)
-                      .asHandle(new com.marklogic.client.io.InputStreamHandle());
             }
 
             @Override
@@ -131,6 +101,36 @@ public interface AnyDocumentBundle {
             }
 
             @Override
+            public com.marklogic.client.io.InputStreamHandle sendReceiveRequiredDoc(String uri, com.marklogic.client.io.InputStreamHandle doc) {
+                return sendReceiveRequiredDoc(
+                    this.req_sendReceiveRequiredDoc.on(this.dbClient), uri, doc
+                    );
+            }
+            private com.marklogic.client.io.InputStreamHandle sendReceiveRequiredDoc(BaseProxy.DBFunctionRequest request, String uri, com.marklogic.client.io.InputStreamHandle doc) {
+              return request
+                      .withParams(
+                          BaseProxy.atomicParam("uri", false, BaseProxy.StringType.fromString(uri)),
+                          BaseProxy.documentParam("doc", false, doc)
+                          ).responseSingle(false, Format.UNKNOWN)
+                      .asHandle(new com.marklogic.client.io.InputStreamHandle());
+            }
+
+            @Override
+            public Stream<com.marklogic.client.io.InputStreamHandle> sendReceiveManyDocs(Stream<String> uris, Stream<com.marklogic.client.io.InputStreamHandle> docs) {
+                return sendReceiveManyDocs(
+                    this.req_sendReceiveManyDocs.on(this.dbClient), uris, docs
+                    );
+            }
+            private Stream<com.marklogic.client.io.InputStreamHandle> sendReceiveManyDocs(BaseProxy.DBFunctionRequest request, Stream<String> uris, Stream<com.marklogic.client.io.InputStreamHandle> docs) {
+              return request
+                      .withParams(
+                          BaseProxy.atomicParam("uris", false, BaseProxy.StringType.fromString(uris)),
+                          BaseProxy.documentParam("docs", false, docs)
+                          ).responseMultiple(false, Format.UNKNOWN)
+                      .asStreamOfHandles(null, new com.marklogic.client.io.InputStreamHandle());
+            }
+
+            @Override
             public com.marklogic.client.io.StringHandle sendReceiveMappedDoc(String uri, com.marklogic.client.io.StringHandle doc) {
                 return sendReceiveMappedDoc(
                     this.req_sendReceiveMappedDoc.on(this.dbClient), uri, doc
@@ -150,24 +150,6 @@ public interface AnyDocumentBundle {
     }
 
   /**
-   * Invokes the sendReceiveManyDocs operation on the database server
-   *
-   * @param uris	provides input
-   * @param docs	provides input
-   * @return	as output
-   */
-    Stream<com.marklogic.client.io.InputStreamHandle> sendReceiveManyDocs(Stream<String> uris, Stream<com.marklogic.client.io.InputStreamHandle> docs);
-
-  /**
-   * Invokes the sendReceiveRequiredDoc operation on the database server
-   *
-   * @param uri	provides input
-   * @param doc	provides input
-   * @return	as output
-   */
-    com.marklogic.client.io.InputStreamHandle sendReceiveRequiredDoc(String uri, com.marklogic.client.io.InputStreamHandle doc);
-
-  /**
    * Invokes the sendReceiveOptionalDoc operation on the database server
    *
    * @param uri	provides input
@@ -184,6 +166,24 @@ public interface AnyDocumentBundle {
    * @return	as output
    */
     Stream<com.marklogic.client.io.InputStreamHandle> sendReceiveAnyDocs(Stream<String> uris, Stream<com.marklogic.client.io.InputStreamHandle> docs);
+
+  /**
+   * Invokes the sendReceiveRequiredDoc operation on the database server
+   *
+   * @param uri	provides input
+   * @param doc	provides input
+   * @return	as output
+   */
+    com.marklogic.client.io.InputStreamHandle sendReceiveRequiredDoc(String uri, com.marklogic.client.io.InputStreamHandle doc);
+
+  /**
+   * Invokes the sendReceiveManyDocs operation on the database server
+   *
+   * @param uris	provides input
+   * @param docs	provides input
+   * @return	as output
+   */
+    Stream<com.marklogic.client.io.InputStreamHandle> sendReceiveManyDocs(Stream<String> uris, Stream<com.marklogic.client.io.InputStreamHandle> docs);
 
   /**
    * Invokes the sendReceiveMappedDoc operation on the database server

--- a/ml-development-tools/src/test/java/com/marklogic/client/test/dbfunction/positive/DecoratorBaseBundle.java
+++ b/ml-development-tools/src/test/java/com/marklogic/client/test/dbfunction/positive/DecoratorBaseBundle.java
@@ -24,7 +24,7 @@ public interface DecoratorBaseBundle {
      * @return	an object for executing database operations
      */
     static DecoratorBaseBundle on(DatabaseClient db) {
-        return on(db, null);
+      return on(db, null);
     }
     /**
      * Creates a DecoratorBaseBundle object for executing operations on the database server.
@@ -54,21 +54,21 @@ public interface DecoratorBaseBundle {
                 this.baseProxy = new BaseProxy("/dbf/test/decoratorBase/", servDecl);
 
                 this.req_docify = this.baseProxy.request(
-                        "docify.sjs", BaseProxy.ParameterValuesKind.SINGLE_ATOMIC);
+                    "docify.sjs", BaseProxy.ParameterValuesKind.SINGLE_ATOMIC);
             }
 
             @Override
             public com.fasterxml.jackson.databind.JsonNode docify(String value) {
                 return docify(
-                        this.req_docify.on(this.dbClient), value
-                );
+                    this.req_docify.on(this.dbClient), value
+                    );
             }
             private com.fasterxml.jackson.databind.JsonNode docify(BaseProxy.DBFunctionRequest request, String value) {
-                return BaseProxy.JsonDocumentType.toJsonNode(
-                        request
-                                .withParams(
-                                        BaseProxy.atomicParam("value", true, BaseProxy.StringType.fromString(value))
-                                ).responseSingle(true, Format.JSON)
+              return BaseProxy.JsonDocumentType.toJsonNode(
+                request
+                      .withParams(
+                          BaseProxy.atomicParam("value", true, BaseProxy.StringType.fromString(value))
+                          ).responseSingle(true, Format.JSON)
                 );
             }
         }
@@ -76,12 +76,12 @@ public interface DecoratorBaseBundle {
         return new DecoratorBaseBundleImpl(db, serviceDeclaration);
     }
 
-    /**
-     * Invokes the docify operation on the database server
-     *
-     * @param value	provides input
-     * @return	as output
-     */
+  /**
+   * Invokes the docify operation on the database server
+   *
+   * @param value	provides input
+   * @return	as output
+   */
     com.fasterxml.jackson.databind.JsonNode docify(String value);
 
 }

--- a/ml-development-tools/src/test/java/com/marklogic/client/test/dbfunction/positive/SessionsBundle.java
+++ b/ml-development-tools/src/test/java/com/marklogic/client/test/dbfunction/positive/SessionsBundle.java
@@ -47,33 +47,33 @@ public interface SessionsBundle {
             private DatabaseClient dbClient;
             private BaseProxy baseProxy;
 
-            private BaseProxy.DBFunctionRequest req_beginTransactionNoSession;
-            private BaseProxy.DBFunctionRequest req_checkTransaction;
-            private BaseProxy.DBFunctionRequest req_sleepify;
-            private BaseProxy.DBFunctionRequest req_rollbackTransaction;
-            private BaseProxy.DBFunctionRequest req_setSessionField;
-            private BaseProxy.DBFunctionRequest req_getSessionField;
             private BaseProxy.DBFunctionRequest req_beginTransaction;
+            private BaseProxy.DBFunctionRequest req_getSessionField;
+            private BaseProxy.DBFunctionRequest req_checkTransaction;
+            private BaseProxy.DBFunctionRequest req_rollbackTransaction;
+            private BaseProxy.DBFunctionRequest req_sleepify;
+            private BaseProxy.DBFunctionRequest req_setSessionField;
+            private BaseProxy.DBFunctionRequest req_beginTransactionNoSession;
             private BaseProxy.DBFunctionRequest req_setSessionFieldNoSession;
 
             private SessionsBundleImpl(DatabaseClient dbClient, JSONWriteHandle servDecl) {
                 this.dbClient  = dbClient;
                 this.baseProxy = new BaseProxy("/dbf/test/sessions/", servDecl);
 
-                this.req_beginTransactionNoSession = this.baseProxy.request(
-                    "beginTransactionNoSession.sjs", BaseProxy.ParameterValuesKind.MULTIPLE_ATOMICS);
-                this.req_checkTransaction = this.baseProxy.request(
-                    "checkTransaction.sjs", BaseProxy.ParameterValuesKind.SINGLE_ATOMIC);
-                this.req_sleepify = this.baseProxy.request(
-                    "sleepify.sjs", BaseProxy.ParameterValuesKind.SINGLE_ATOMIC);
-                this.req_rollbackTransaction = this.baseProxy.request(
-                    "rollbackTransaction.sjs", BaseProxy.ParameterValuesKind.NONE);
-                this.req_setSessionField = this.baseProxy.request(
-                    "setSessionField.sjs", BaseProxy.ParameterValuesKind.SINGLE_ATOMIC);
-                this.req_getSessionField = this.baseProxy.request(
-                    "getSessionField.sjs", BaseProxy.ParameterValuesKind.MULTIPLE_ATOMICS);
                 this.req_beginTransaction = this.baseProxy.request(
                     "beginTransaction.sjs", BaseProxy.ParameterValuesKind.MULTIPLE_ATOMICS);
+                this.req_getSessionField = this.baseProxy.request(
+                    "getSessionField.sjs", BaseProxy.ParameterValuesKind.MULTIPLE_ATOMICS);
+                this.req_checkTransaction = this.baseProxy.request(
+                    "checkTransaction.sjs", BaseProxy.ParameterValuesKind.SINGLE_ATOMIC);
+                this.req_rollbackTransaction = this.baseProxy.request(
+                    "rollbackTransaction.sjs", BaseProxy.ParameterValuesKind.NONE);
+                this.req_sleepify = this.baseProxy.request(
+                    "sleepify.sjs", BaseProxy.ParameterValuesKind.SINGLE_ATOMIC);
+                this.req_setSessionField = this.baseProxy.request(
+                    "setSessionField.sjs", BaseProxy.ParameterValuesKind.SINGLE_ATOMIC);
+                this.req_beginTransactionNoSession = this.baseProxy.request(
+                    "beginTransactionNoSession.sjs", BaseProxy.ParameterValuesKind.MULTIPLE_ATOMICS);
                 this.req_setSessionFieldNoSession = this.baseProxy.request(
                     "setSessionFieldNoSession.sjs", BaseProxy.ParameterValuesKind.SINGLE_ATOMIC);
             }
@@ -83,76 +83,18 @@ public interface SessionsBundle {
             }
 
             @Override
-            public void beginTransactionNoSession(String uri, String text) {
-                beginTransactionNoSession(
-                    this.req_beginTransactionNoSession.on(this.dbClient), uri, text
+            public void beginTransaction(SessionState transaction, String uri, String text) {
+                beginTransaction(
+                    this.req_beginTransaction.on(this.dbClient), transaction, uri, text
                     );
             }
-            private void beginTransactionNoSession(BaseProxy.DBFunctionRequest request, String uri, String text) {
+            private void beginTransaction(BaseProxy.DBFunctionRequest request, SessionState transaction, String uri, String text) {
               request
+                      .withSession("transaction", transaction, false)
                       .withParams(
                           BaseProxy.atomicParam("uri", false, BaseProxy.StringType.fromString(uri)),
                           BaseProxy.atomicParam("text", false, BaseProxy.StringType.fromString(text))
                           ).responseNone();
-            }
-
-            @Override
-            public Boolean checkTransaction(SessionState transaction, String uri) {
-                return checkTransaction(
-                    this.req_checkTransaction.on(this.dbClient), transaction, uri
-                    );
-            }
-            private Boolean checkTransaction(BaseProxy.DBFunctionRequest request, SessionState transaction, String uri) {
-              return BaseProxy.BooleanType.toBoolean(
-                request
-                      .withSession("transaction", transaction, true)
-                      .withParams(
-                          BaseProxy.atomicParam("uri", false, BaseProxy.StringType.fromString(uri))
-                          ).responseSingle(false, null)
-                );
-            }
-
-            @Override
-            public Boolean sleepify(SessionState sleeper, Integer sleeptime) {
-                return sleepify(
-                    this.req_sleepify.on(this.dbClient), sleeper, sleeptime
-                    );
-            }
-            private Boolean sleepify(BaseProxy.DBFunctionRequest request, SessionState sleeper, Integer sleeptime) {
-              return BaseProxy.BooleanType.toBoolean(
-                request
-                      .withSession("sleeper", sleeper, false)
-                      .withParams(
-                          BaseProxy.atomicParam("sleeptime", false, BaseProxy.UnsignedIntegerType.fromInteger(sleeptime))
-                          ).responseSingle(false, null)
-                );
-            }
-
-            @Override
-            public void rollbackTransaction(SessionState transaction) {
-                rollbackTransaction(
-                    this.req_rollbackTransaction.on(this.dbClient), transaction
-                    );
-            }
-            private void rollbackTransaction(BaseProxy.DBFunctionRequest request, SessionState transaction) {
-              request
-                      .withSession("transaction", transaction, false).responseNone();
-            }
-
-            @Override
-            public Long setSessionField(SessionState timestamper, String fieldName) {
-                return setSessionField(
-                    this.req_setSessionField.on(this.dbClient), timestamper, fieldName
-                    );
-            }
-            private Long setSessionField(BaseProxy.DBFunctionRequest request, SessionState timestamper, String fieldName) {
-              return BaseProxy.UnsignedLongType.toLong(
-                request
-                      .withSession("timestamper", timestamper, false)
-                      .withParams(
-                          BaseProxy.atomicParam("fieldName", false, BaseProxy.StringType.fromString(fieldName))
-                          ).responseSingle(false, null)
-                );
             }
 
             @Override
@@ -173,14 +115,72 @@ public interface SessionsBundle {
             }
 
             @Override
-            public void beginTransaction(SessionState transaction, String uri, String text) {
-                beginTransaction(
-                    this.req_beginTransaction.on(this.dbClient), transaction, uri, text
+            public Boolean checkTransaction(SessionState transaction, String uri) {
+                return checkTransaction(
+                    this.req_checkTransaction.on(this.dbClient), transaction, uri
                     );
             }
-            private void beginTransaction(BaseProxy.DBFunctionRequest request, SessionState transaction, String uri, String text) {
+            private Boolean checkTransaction(BaseProxy.DBFunctionRequest request, SessionState transaction, String uri) {
+              return BaseProxy.BooleanType.toBoolean(
+                request
+                      .withSession("transaction", transaction, true)
+                      .withParams(
+                          BaseProxy.atomicParam("uri", false, BaseProxy.StringType.fromString(uri))
+                          ).responseSingle(false, null)
+                );
+            }
+
+            @Override
+            public void rollbackTransaction(SessionState transaction) {
+                rollbackTransaction(
+                    this.req_rollbackTransaction.on(this.dbClient), transaction
+                    );
+            }
+            private void rollbackTransaction(BaseProxy.DBFunctionRequest request, SessionState transaction) {
               request
-                      .withSession("transaction", transaction, false)
+                      .withSession("transaction", transaction, false).responseNone();
+            }
+
+            @Override
+            public Boolean sleepify(SessionState sleeper, Integer sleeptime) {
+                return sleepify(
+                    this.req_sleepify.on(this.dbClient), sleeper, sleeptime
+                    );
+            }
+            private Boolean sleepify(BaseProxy.DBFunctionRequest request, SessionState sleeper, Integer sleeptime) {
+              return BaseProxy.BooleanType.toBoolean(
+                request
+                      .withSession("sleeper", sleeper, false)
+                      .withParams(
+                          BaseProxy.atomicParam("sleeptime", false, BaseProxy.UnsignedIntegerType.fromInteger(sleeptime))
+                          ).responseSingle(false, null)
+                );
+            }
+
+            @Override
+            public Long setSessionField(SessionState timestamper, String fieldName) {
+                return setSessionField(
+                    this.req_setSessionField.on(this.dbClient), timestamper, fieldName
+                    );
+            }
+            private Long setSessionField(BaseProxy.DBFunctionRequest request, SessionState timestamper, String fieldName) {
+              return BaseProxy.UnsignedLongType.toLong(
+                request
+                      .withSession("timestamper", timestamper, false)
+                      .withParams(
+                          BaseProxy.atomicParam("fieldName", false, BaseProxy.StringType.fromString(fieldName))
+                          ).responseSingle(false, null)
+                );
+            }
+
+            @Override
+            public void beginTransactionNoSession(String uri, String text) {
+                beginTransactionNoSession(
+                    this.req_beginTransactionNoSession.on(this.dbClient), uri, text
+                    );
+            }
+            private void beginTransactionNoSession(BaseProxy.DBFunctionRequest request, String uri, String text) {
+              request
                       .withParams(
                           BaseProxy.atomicParam("uri", false, BaseProxy.StringType.fromString(uri)),
                           BaseProxy.atomicParam("text", false, BaseProxy.StringType.fromString(text))
@@ -212,48 +212,14 @@ public interface SessionsBundle {
     SessionState newSessionState();
 
   /**
-   * Invokes the beginTransactionNoSession operation on the database server
+   * Invokes the beginTransaction operation on the database server
    *
+   * @param transaction	provides input
    * @param uri	provides input
    * @param text	provides input
    * 
    */
-    void beginTransactionNoSession(String uri, String text);
-
-  /**
-   * Invokes the checkTransaction operation on the database server
-   *
-   * @param transaction	provides input
-   * @param uri	provides input
-   * @return	as output
-   */
-    Boolean checkTransaction(SessionState transaction, String uri);
-
-  /**
-   * Invokes the sleepify operation on the database server
-   *
-   * @param sleeper	provides input
-   * @param sleeptime	provides input
-   * @return	as output
-   */
-    Boolean sleepify(SessionState sleeper, Integer sleeptime);
-
-  /**
-   * Invokes the rollbackTransaction operation on the database server
-   *
-   * @param transaction	provides input
-   * 
-   */
-    void rollbackTransaction(SessionState transaction);
-
-  /**
-   * Invokes the setSessionField operation on the database server
-   *
-   * @param timestamper	provides input
-   * @param fieldName	provides input
-   * @return	as output
-   */
-    Long setSessionField(SessionState timestamper, String fieldName);
+    void beginTransaction(SessionState transaction, String uri, String text);
 
   /**
    * Invokes the getSessionField operation on the database server
@@ -266,14 +232,48 @@ public interface SessionsBundle {
     Boolean getSessionField(SessionState timestamper, String fieldName, Long fieldValue);
 
   /**
-   * Invokes the beginTransaction operation on the database server
+   * Invokes the checkTransaction operation on the database server
    *
    * @param transaction	provides input
+   * @param uri	provides input
+   * @return	as output
+   */
+    Boolean checkTransaction(SessionState transaction, String uri);
+
+  /**
+   * Invokes the rollbackTransaction operation on the database server
+   *
+   * @param transaction	provides input
+   * 
+   */
+    void rollbackTransaction(SessionState transaction);
+
+  /**
+   * Invokes the sleepify operation on the database server
+   *
+   * @param sleeper	provides input
+   * @param sleeptime	provides input
+   * @return	as output
+   */
+    Boolean sleepify(SessionState sleeper, Integer sleeptime);
+
+  /**
+   * Invokes the setSessionField operation on the database server
+   *
+   * @param timestamper	provides input
+   * @param fieldName	provides input
+   * @return	as output
+   */
+    Long setSessionField(SessionState timestamper, String fieldName);
+
+  /**
+   * Invokes the beginTransactionNoSession operation on the database server
+   *
    * @param uri	provides input
    * @param text	provides input
    * 
    */
-    void beginTransaction(SessionState transaction, String uri, String text);
+    void beginTransactionNoSession(String uri, String text);
 
   /**
    * Invokes the setSessionFieldNoSession operation on the database server

--- a/ml-development-tools/src/test/kotlin/com/marklogic/client/test/dbfunction/fntestgen.kt
+++ b/ml-development-tools/src/test/kotlin/com/marklogic/client/test/dbfunction/fntestgen.kt
@@ -46,7 +46,7 @@ enum class TestVariant {
 }
 fun getAtomicMappingImports(): String {
   return """
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 import javax.xml.datatype.DatatypeFactory;
 import java.time.format.DateTimeFormatter;
 import java.util.regex.Pattern;
@@ -1852,7 +1852,7 @@ import java.io.Reader;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.stream.Stream;
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 import java.lang.reflect.Array;
 
 $extraImports


### PR DESCRIPTION
Most of this is just replacing javax.xml with jakarta.xml. We do need to use a different version of jakarta.xml.bind though based on whether Java 8 or 11+ is used. 