### PR TITLE
Fixing stop-transform job tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,7 +40,11 @@ def runtests(String type, String version){
                 sed -i "s/classname=\\"/classname=\\"${STAGE_NAME}-/g" TEST*.xml
                 cd $WORKSPACE/java-client-api/ml-development-tools/build/test-results/test/
                 sed -i "s/classname=\\"/classname=\\"${STAGE_NAME}-/g" TEST*.xml
-                cd $WORKSPACE/java-client-api/marklogic-client-api-functionaltests/build/test-results/test/
+                cd $WORKSPACE/java-client-api/marklogic-client-api-functionaltests/build/test-results/runFragileTests/
+                sed -i "s/classname=\\"/classname=\\"${STAGE_NAME}-/g" TEST*.xml
+                cd $WORKSPACE/java-client-api/marklogic-client-api-functionaltests/build/test-results/runFastFunctionalTests/
+                sed -i "s/classname=\\"/classname=\\"${STAGE_NAME}-/g" TEST*.xml
+                cd $WORKSPACE/java-client-api/marklogic-client-api-functionaltests/build/test-results/runSlowFunctionalTests/
                 sed -i "s/classname=\\"/classname=\\"${STAGE_NAME}-/g" TEST*.xml
             '''
 }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/AbstractFunctionalTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/AbstractFunctionalTest.java
@@ -74,7 +74,7 @@ public abstract class AbstractFunctionalTest extends BasicJavaClientREST {
 
         // Clear the content and schemas databases so that the subclass can start with a "fresh" setup without any
         // data leftover from a previous test
-        Stream.of(client, schemasClient).forEach(c -> deleteDocuments(c));
+        Stream.of(connectAsAdmin(), schemasClient).forEach(c -> deleteDocuments(c));
     }
 
     protected static void deleteDocuments(DatabaseClient client) {


### PR DESCRIPTION
Root cause was that they were ignoring URIs that intermittently failed due to the InterruptedException. These URIs were being set to the failure handler, so they weren't being dropped. The tests just needed to account for them. 

Also made both of these extends AbstractFunctionalTest so that they run a lot faster now.

Fixed a typo in Jenkinsfile too.