### PR TITLE
Excluding tests from runSlowFunctionalTests

### DIFF
--- a/marklogic-client-api-functionaltests/build.gradle
+++ b/marklogic-client-api-functionaltests/build.gradle
@@ -59,6 +59,12 @@ task runSlowFunctionalTests(type: Test) {
   description = "Run slow functional tests; i.e. those that setup/teardown custom app servers / databases"
   include "com/marklogic/client/datamovement/functionaltests/**"
   include "com/marklogic/client/functionaltest/**"
+  exclude 'com/marklogic/client/functionaltest/TestSSLConnection.class'
+  exclude 'com/marklogic/client/functionaltest/TestBug18993.class'
+  exclude 'com/marklogic/client/functionaltest/TestDatabaseClientWithKerberos.class'
+  exclude 'com/marklogic/client/functionaltest/TestDatabaseClientKerberosFromFile.class'
+  exclude 'com/marklogic/client/functionaltest/TestDatabaseClientWithCertBasedAuth.class'
+  exclude 'com/marklogic/client/functionaltest/TestSandBox.class'
 }
 
 task runFunctionalTests {


### PR DESCRIPTION
Temporarily adding that to PR pipeline so I can immediately run those tests