### PR TITLE
Bumping to 6.0.0, couple minor tweaks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,11 @@ To build the client locally, complete the following steps:
 
 1. Clone this repository on your machine.
 2. Choose the appropriate branch (usually develop)
-3. Ensure you are using Java 8 or Java 11
+3. Ensure you are using Java 8 or Java 11 or Java 17 (the JVM version used to compile should not matter as compiler flags
+are set to ensure the compiled code will run on Java 8; Jenkins pipelines also exist to ensure that the tests pass on
+Java 8, 11, and 17, and thus they should for you locally as well; note that if you load the project into an IDE, you
+should use Java 8 in case your IDE does not process the build.gradle config that conditionally brings in JAXB dependencies
+required by Java 9+.)
 4. Verify that you can build the client by running `./gradlew build -x test`
 
 "Running the tests" in the context of developing and submitting a pull request refers to running the tests found

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.marklogic
-version=6.0-SNAPSHOT
+version=6.0.0
 describedName=MarkLogic Java Client API
 publishUrl=file:../marklogic-java/releases
 

--- a/marklogic-client-api/build.gradle
+++ b/marklogic-client-api/build.gradle
@@ -11,9 +11,9 @@ description = "The official MarkLogic Java client API."
 
 dependencies {
     if (JavaVersion.current().isJava9Compatible()) {
-        implementation group: 'javax.xml.bind', name: 'jaxb-api', version: '2.3.1'
-        implementation group: 'org.glassfish.jaxb', name: 'jaxb-runtime', version: '2.3.2'
-        implementation group: 'org.glassfish.jaxb', name: 'jaxb-core', version: '2.3.0.1'
+        implementation 'javax.xml.bind:jaxb-api:2.3.1'
+        implementation 'org.glassfish.jaxb:jaxb-runtime:2.3.2'
+        implementation 'org.glassfish.jaxb:jaxb-core:2.3.0.1'
     }
     implementation group: 'com.squareup.okhttp3', name: 'okhttp', version:'4.10.0'
     implementation group: 'com.squareup.okhttp3', name: 'logging-interceptor', version:'4.10.0'


### PR DESCRIPTION
Tweaks:

- Provided Java version guidance in CONTRIBUTING
- Modified how the JAXB dependencies are declared in build.gradle to match what's in the README (and the shorter syntax is easier to read/understand too)