### PR TITLE
Fixing tests failing on 11-nightly

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,6 +27,7 @@ def runtests(String type, String version){
                 export GRADLE_USER_HOME=$WORKSPACE/$GRADLE_DIR
                 export PATH=$GRADLE_USER_HOME:$JAVA_HOME/bin:$PATH
                 cd java-client-api
+                mkdir -p marklogic-client-api/build/test-results/test
                 ./gradlew marklogic-client-api:test  || true
             '''
             sh label:'run ml-development-tools tests', script: '''#!/bin/bash
@@ -34,6 +35,7 @@ def runtests(String type, String version){
                 export GRADLE_USER_HOME=$WORKSPACE/$GRADLE_DIR
                 export PATH=$GRADLE_USER_HOME:$JAVA_HOME/bin:$PATH
                 cd java-client-api
+                mkdir -p ml-development-tools/build/test-results/test
                 ./gradlew ml-development-tools:setupTestServer || true
                 ./gradlew ml-development-tools:generateTests || true
                 ./gradlew ml-development-tools:test || true
@@ -43,6 +45,9 @@ def runtests(String type, String version){
                 export GRADLE_USER_HOME=$WORKSPACE/$GRADLE_DIR
                 export PATH=$GRADLE_USER_HOME:$JAVA_HOME/bin:$PATH
                 cd java-client-api
+                mkdir -p marklogic-client-api-functionaltests/build/test-results/runFragileTests
+                mkdir -p marklogic-client-api-functionaltests/build/test-results/runFastFunctionalTests
+                mkdir -p marklogic-client-api-functionaltests/build/test-results/runSlowFunctionalTests
                 ./gradlew -i mlDeploy -PmlForestDataDirectory=/space
                 ./gradlew -i marklogic-client-api-functionaltests:runFunctionalTests || true
             '''

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/AbstractFunctionalTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/AbstractFunctionalTest.java
@@ -12,8 +12,6 @@ import com.marklogic.client.document.DocumentWriteSet;
 import com.marklogic.client.functionaltest.BasicJavaClientREST;
 import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.FileHandle;
-import com.marklogic.mgmt.ManageClient;
-import com.marklogic.mgmt.ManageConfig;
 import com.marklogic.mgmt.resource.databases.DatabaseManager;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -23,6 +21,8 @@ import javax.xml.parsers.ParserConfigurationException;
 import java.io.File;
 import java.io.IOException;
 import java.util.stream.Stream;
+
+import static org.junit.Assert.assertTrue;
 
 /**
  * Abstract class for functional tests that depend on the test app in ./marklogic-client-api/src/test, which is
@@ -256,5 +256,15 @@ public abstract class AbstractFunctionalTest extends BasicJavaClientREST {
         } catch (JsonProcessingException e) {
             throw new RuntimeException("Unable to restore field config", e);
         }
+    }
+
+    public static void assertColumnInfosExist(String actualColumnInfo, ColumnInfo... expectedColumnInfos) {
+        Stream
+            .of(expectedColumnInfos)
+            .map(columnInfo -> columnInfo.getExpectedJson())
+            .forEach(expectedJson -> assertTrue(
+                "Did not find expected JSON: " + expectedJson + "; colInfo: " + actualColumnInfo,
+                actualColumnInfo.contains(expectedJson))
+            );
     }
 }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/ColumnInfo.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/ColumnInfo.java
@@ -1,0 +1,42 @@
+package com.marklogic.client.fastfunctest;
+
+public class ColumnInfo {
+    private String schema = "";
+    private String view = "";
+    private String column;
+    private String type;
+    private boolean hidden;
+    private boolean nullable;
+
+    public ColumnInfo(String column, String type) {
+        this.column = column;
+        this.type = type;
+    }
+
+    public ColumnInfo(String schema, String view, String column, String type) {
+        this(column, type);
+        this.schema = schema;
+        this.view = view;
+    }
+
+    public ColumnInfo(String schema, String view, String column, String type, boolean hidden) {
+        this(schema, view, column, type);
+        this.hidden = hidden;
+    }
+
+    public ColumnInfo withNullable(boolean nullable) {
+        this.nullable = nullable;
+        return this;
+    }
+
+    public String getExpectedJson() {
+        String json = String.format("{\"schema\":\"%s\", \"view\":\"%s\", \"column\":\"%s\", \"type\":\"%s\", ",
+            this.schema, this.view, this.column, this.type);
+        if (AbstractFunctionalTest.isML11OrHigher) {
+            json += String.format("\"hidden\":%s, \"nullable\":%s}", this.hidden, this.nullable);
+        } else {
+            json += String.format("\"nullable\":%s}", this.nullable);
+        }
+        return json;
+    }
+}

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnCtsQuery.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnCtsQuery.java
@@ -311,8 +311,7 @@ public class TestOpticOnCtsQuery extends AbstractFunctionalTest {
     ModifyPlan plan2 = p.fromLexicons(index2, "myTeam", p.fragmentIdCol("fragId2"));
 
     ModifyPlan output = plan1.joinInner(plan2)
-        .where(p.eq(p.viewCol("myCity", "city"), p.col("cityName")))
-        .orderBy(p.asc(p.col("date")));
+        .where(p.eq(p.viewCol("myCity", "city"), p.col("cityName")));
 
     JacksonHandle jacksonHandle = new JacksonHandle();
     jacksonHandle.setMimetype("application/json");
@@ -321,7 +320,7 @@ public class TestOpticOnCtsQuery extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get();
 
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
-    assertTrue("Number of Elements after plan execution is incorrect. Should be 1", 1 == jsonBindingsNodes.size());
+    assertEquals("Unexpected result: " + jsonBindingsNodes.toPrettyString(), 1, jsonBindingsNodes.size());
     assertEquals("Row 1 myCity.city value incorrect", "london", jsonBindingsNodes.path(0).path("myCity.city").path("value").asText());
     assertEquals("Row 1 myCity.uri1 value incorrect", "/optic/lexicon/test/doc1.json", jsonBindingsNodes.path(0).path("myCity.uri1").path("value").asText());
     assertEquals("Row 1 myTeam.uri2 value incorrect", "/optic/lexicon/test/city1.json", jsonBindingsNodes.path(0).path("myTeam.uri2").path("value").asText());
@@ -331,7 +330,7 @@ public class TestOpticOnCtsQuery extends AbstractFunctionalTest {
    * Checks for cts queries with options on fromLexicons TEST 14
    */
   @Test
-  public void testCtsQueriesWithOptions() throws KeyManagementException, NoSuchAlgorithmException, IOException, SAXException, ParserConfigurationException
+  public void testCtsQueriesWithOptions()
   {
     System.out.println("In testCtsQueriesWithOptions method");
 
@@ -356,15 +355,9 @@ public class TestOpticOnCtsQuery extends AbstractFunctionalTest {
     // plan2 - fromLexicons
     ModifyPlan plan2 = p.fromLexicons(index2, "myTeam", p.fragmentIdCol("fragId2"));
 
-    XsStringSeqVal propertyName = p.xs.string("city");
-    XsStringSeqVal value = p.xs.string("*k");
-
-    XsStringSeqVal options = p.xs.stringSeq("wildcarded", "case-sensitive");
-
     ModifyPlan output = plan1.where(p.cts.jsonPropertyWordQuery("city", "*k", "wildcarded", "case-sensitive"))
         .joinInner(plan2)
-        .where(p.eq(p.viewCol("myCity", "city"), p.col("cityName")))
-        .orderBy(p.asc(p.col("date")));
+        .where(p.eq(p.viewCol("myCity", "city"), p.col("cityName")));
 
     JacksonHandle jacksonHandle = new JacksonHandle();
     jacksonHandle.setMimetype("application/json");
@@ -375,7 +368,7 @@ public class TestOpticOnCtsQuery extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
     System.out.println("Results are " + jsonBindingsNodes.toString());
 
-    assertTrue("Number of Elements after plan execution is incorrect. Should be 1", 1 == jsonBindingsNodes.size());
+    assertEquals("Number of Elements after plan execution is incorrect: " + jsonBindingsNodes.toPrettyString(), 1, jsonBindingsNodes.size());
     assertEquals("Row 1 myCity.city value incorrect", "new york", jsonBindingsNodes.path(0).path("myCity.city").path("value").asText());
   }
 

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnLexicons.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnLexicons.java
@@ -1252,8 +1252,7 @@ public class TestOpticOnLexicons extends AbstractFunctionalTest {
                 p.as(p.col("nodes"), p.xpath(p.col("doc"), p.xs.string("popularity[math:pow(., 2) eq 4]"))),
                 uriCol2, cityNameCol, cityTeamCol
             )
-            .where(p.isDefined(p.col("nodes")))
-            .orderBy(p.desc(p.col("distance")));
+            .where(p.isDefined(p.col("nodes")));
 
     JacksonHandle jacksonHandle = new JacksonHandle();
     jacksonHandle.setMimetype("application/json");
@@ -1261,8 +1260,7 @@ public class TestOpticOnLexicons extends AbstractFunctionalTest {
     rowMgr.resultDoc(UnnamedNodes, jacksonHandle);
     JsonNode jsonResults = jacksonHandle.get();
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
-    // Should have 1 node returned.
-    assertEquals("One node not returned from testJoinInnerKeymatchDateSort method ", 1, jsonBindingsNodes.size());
+    assertEquals("Expected 1 node: " + jsonBindingsNodes.toPrettyString(), 1, jsonBindingsNodes.size());
     JsonNode first = jsonBindingsNodes.path(0);
     assertEquals("Row 1 myCity.city value incorrect", "new jersey", first.path("myCity.city").path("value").asText());
   }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnLiterals.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnLiterals.java
@@ -559,7 +559,7 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
    * Test join inner doc on json and xml documents
    */
   @Test
-  public void testJoinInnerDocOnJson() throws KeyManagementException, NoSuchAlgorithmException, IOException, SAXException, ParserConfigurationException
+  public void testJoinInnerDocOnJson()
   {
     System.out.println("In testJoinInnerDocOnJson method");
 
@@ -627,15 +627,18 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
             p.col("val"),
             p.col("uri"),
             p.as("nodes", p.xpath("doc", "/doc/distance/@direction")))
-        .where(p.isDefined(p.col("nodes")))
-        .orderBy(p.asc("id"));
+        .where(p.isDefined(p.col("nodes")));
+
+    System.out.println(output17.exportAs(JsonNode.class).toPrettyString());
+
     JacksonHandle jacksonHandle17 = new JacksonHandle();
     jacksonHandle17.setMimetype("application/json");
     rowMgr.resultDoc(output17, jacksonHandle17);
     JsonNode jsonBindingsNodes17 = jacksonHandle17.get().path("rows");
 
-    // Should have 1 node returned.
-    assertEquals("One node not returned from testJoinInnerDocOnJson method", 1, jsonBindingsNodes17.size());
+    assertEquals("One node not returned from testJoinInnerDocOnJson method: " + jsonBindingsNodes17.toPrettyString(),
+        1, jsonBindingsNodes17.size());
+
     JsonNode node17 = jsonBindingsNodes17.path(0);
     assertEquals("Row 1 id value incorrect", "4", node17.path("id").path("value").asText());
     assertEquals("Row 1 val value incorrect", "8", node17.path("val").path("value").asText());
@@ -651,8 +654,8 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
             p.col("val"),
             p.col("uri"),
             p.as("nodes", p.xpath("doc", "/doc/location/latLonPair/(lat|long)/text()")))
-        .where(p.isDefined(p.col("nodes")))
-        .orderBy(p.asc("id"));
+        .where(p.isDefined(p.col("nodes")));
+
     JacksonHandle jacksonHandle18 = new JacksonHandle();
     jacksonHandle18.setMimetype("application/json");
     rowMgr.resultDoc(output18, jacksonHandle18);
@@ -710,8 +713,7 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
             p.col("val"),
             p.col("uri"),
             p.as("nodes", p.xpath("doc", "/doc/city")))
-        .where(p.isDefined(p.col("nodes")))
-        .orderBy(p.asc("id"));
+        .where(p.isDefined(p.col("nodes")));
     JacksonHandle jacksonHandle15 = new JacksonHandle();
     jacksonHandle15.setMimetype("application/json");
     rowMgr.resultDoc(output15, jacksonHandle15);
@@ -1772,15 +1774,14 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
     System.out.println(colInfo);
 
     String expectedType = isML11OrHigher ? "string": "unknown";
-    assertTrue("Element 1 desc value incorrect: " + colInfo,
-        colInfo.contains("{\"schema\":\"\", \"view\":\"\", \"column\":\"desc\", \"type\":\"" + expectedType + "\", \"nullable\":false"));
-    assertTrue("Element 4 colorDesc value incorrect: " + colInfo,
-        colInfo.contains("{\"schema\":\"\", \"view\":\"\", \"column\":\"colorDesc\", \"type\":\"" + expectedType + "\", \"nullable\":false}"));
+
+    assertColumnInfosExist(colInfo,
+        new ColumnInfo("desc", expectedType),
+        new ColumnInfo("colorDesc", expectedType));
 
     expectedType = isML11OrHigher ? "integer": "unknown";
-    assertTrue("Element 2 colorId value incorrect: " + colInfo,
-        colInfo.contains("{\"schema\":\"\", \"view\":\"\", \"column\":\"colorId\", \"type\":\"" + expectedType + "\", \"nullable\":false}"));
-    assertTrue("Element 3 rowId value incorrect: " + colInfo,
-        colInfo.contains("{\"schema\":\"\", \"view\":\"\", \"column\":\"rowId\", \"type\":\"" + expectedType + "\", \"nullable\":false}"));
+    assertColumnInfosExist(colInfo,
+        new ColumnInfo("colorId", expectedType),
+        new ColumnInfo("rowId", expectedType));
   }
 }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnTriples.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnTriples.java
@@ -453,16 +453,14 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
     ModifyPlan team_planSum = p.fromTriples(team_planSumSeq);
     
     ModifyPlan outputSum = player_planSum.joinInner(team_planSum)
-        .groupBy(null, p.sum(p.col("SumAll"), playerEffCol))
-        .orderBy(p.desc(p.col("SumAll")));
+        .groupBy(null, p.sum(p.col("SumAll"), playerEffCol));
     jacksonHandle = new JacksonHandle();
     jacksonHandle.setMimetype("application/json");
 
     rowMgr.resultDoc(outputSum, jacksonHandle);
     jsonResults = jacksonHandle.get();
     jsonBindingsNodes = jsonResults.path("rows");
-    // Should have 1 nodes returned.
-    assertEquals("Node not returned from testGroupByCountAndSum method - Sum", 1, jsonBindingsNodes.size());
+    assertEquals("Node not returned from testGroupByCountAndSum method: " + jsonBindingsNodes.toPrettyString(), 1, jsonBindingsNodes.size());
     third = jsonBindingsNodes.path(0);
     assertEquals("Row 1 Sum of All value incorrect", "843.75", third.path("SumAll").path("value").asText());
   }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnViews.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnViews.java
@@ -33,7 +33,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.w3c.dom.Document;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -2939,19 +2938,19 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
                     p.col("color")
             )
             .orderBy(p.desc(p.col("MasterName")));
-    String colInfo = rowMgr.columnInfoAs(plan3, String.class);
-    //System.out.println("In testColumnInfo method" + colInfo);
-    // Should have 5 nodes returned.
-    assertTrue("Element 1 MasterName value incorrect", colInfo.contains("{\"schema\":\"\", \"view\":\"\", \"column\":\"MasterName\", \"type\":\"string\", \"nullable\":true}"));
-    assertTrue("Element 2 master value incorrect", colInfo.contains("{\"schema\":\"opticFunctionalTest\", \"view\":\"master\", \"column\":\"date\", \"type\":\"date\", \"nullable\":true}"));
-    assertTrue("Element 3 DetailName value incorrect", colInfo.contains("{\"schema\":\"\", \"view\":\"\", \"column\":\"DetailName\", \"type\":\"string\", \"nullable\":true}"));
-    assertTrue("Element 4 amount value incorrect", colInfo.contains("{\"schema\":\"opticFunctionalTest\", \"view\":\"detail\", \"column\":\"amount\", \"type\":\"double\", \"nullable\":true}"));
-    assertTrue("Element 5 color value incorrect", colInfo.contains("{\"schema\":\"opticFunctionalTest\", \"view\":\"detail\", \"column\":\"color\", \"type\":\"string\", \"nullable\":true}"));
+
+    assertColumnInfosExist(rowMgr.columnInfoAs(plan3, String.class),
+        new ColumnInfo("MasterName", "string").withNullable(true),
+        new ColumnInfo("opticFunctionalTest", "master", "date", "date").withNullable(true),
+        new ColumnInfo("DetailName", "string").withNullable(true),
+        new ColumnInfo("opticFunctionalTest", "detail", "amount", "double").withNullable(true),
+        new ColumnInfo("opticFunctionalTest", "detail", "color", "string").withNullable(true)
+    );
   }
 
   // Test for fragment Id types. Similar to testExplainPlan
   @Test
-  public void testColInfoWithSysCols() throws IOException {
+  public void testColInfoWithSysCols() {
     System.out.println("In testColInfoWithSysCols method");
 
     // Create a new Plan.
@@ -2982,15 +2981,17 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
                     fIdCol2
             )
             .orderBy(p.desc(p.col("DetailName")));
-    String colInfo = rowMgr.columnInfoAs(output, String.class);
-    // Should have 7 nodes returned.
-    assertTrue("Element 1 MasterName value incorrect", colInfo.contains("{\"schema\":\"\", \"view\":\"\", \"column\":\"MasterName\", \"type\":\"string\", \"nullable\":false}"));
-    assertTrue("Element 2 master value incorrect", colInfo.contains("{\"schema\":\"opticFunctionalTest\", \"view\":\"master\", \"column\":\"date\", \"type\":\"date\", \"nullable\":false}"));
-    assertTrue("Element 3 DetailName value incorrect", colInfo.contains("{\"schema\":\"\", \"view\":\"\", \"column\":\"DetailName\", \"type\":\"string\", \"nullable\":false}"));
-    assertTrue("Element 4 detail-double value incorrect", colInfo.contains("{\"schema\":\"opticFunctionalTest\", \"view\":\"detail\", \"column\":\"amount\", \"type\":\"double\", \"nullable\":false}"));
-    assertTrue("Element 5 detail-string value incorrect", colInfo.contains("{\"schema\":\"opticFunctionalTest\", \"view\":\"detail\", \"column\":\"color\", \"type\":\"string\", \"nullable\":false}"));
-    final String expectedValue = isML11OrHigher ? "fragmentId": "fraghint";
-    assertTrue("Element 6 detail-unknown value incorrect", colInfo.contains("{\"schema\":\"opticFunctionalTest\", \"view\":\"detail\", \"column\":\"fragIdCol1\", \"type\":\"" + expectedValue + "\", \"nullable\":false}"));
-    assertTrue("Element 7 master-unknown value incorrect", colInfo.contains("{\"schema\":\"opticFunctionalTest\", \"view\":\"master\", \"column\":\"fragIdCol2\", \"type\":\"" + expectedValue + "\", \"nullable\":false}"));
+
+    final String expectedFragmentValue = isML11OrHigher ? "fragmentId": "fraghint";
+
+    assertColumnInfosExist(rowMgr.columnInfoAs(output, String.class),
+        new ColumnInfo("MasterName", "string"),
+        new ColumnInfo("opticFunctionalTest", "master", "date", "date"),
+        new ColumnInfo("DetailName", "string"),
+        new ColumnInfo("opticFunctionalTest", "detail", "amount", "double"),
+        new ColumnInfo("opticFunctionalTest", "detail", "color", "string"),
+        new ColumnInfo("opticFunctionalTest", "detail", "fragIdCol1", expectedFragmentValue, true),
+        new ColumnInfo("opticFunctionalTest", "master", "fragIdCol2", expectedFragmentValue, true)
+    );
   }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerTest.java
@@ -1281,34 +1281,36 @@ public class RowManagerTest {
       rowNum++;
     }
   }
+
   @Test
-  public void testColumnInfo() throws IOException {
-    String expected =
-            "{\"schema\":\"opticUnitTest\", \"view\":\"musician\", \"column\":\"lastName\", \"type\":\"string\", \"nullable\":false}\n" +
-            "{\"schema\":\"opticUnitTest\", \"view\":\"musician\", \"column\":\"firstName\", \"type\":\"string\", \"nullable\":false}\n" +
-            "{\"schema\":\"opticUnitTest\", \"view\":\"musician\", \"column\":\"dob\", \"type\":\"date\", \"nullable\":false}\n" +
-            "{\"schema\":\"opticUnitTest\", \"view\":\"musician\", \"column\":\"rowid\", \"type\":\"rowid\", \"nullable\":false}";
+  public void testColumnInfo() {
     RowManager rowMgr = Common.client.newRowManager();
-
     PlanBuilder p = rowMgr.newPlanBuilder();
-
     PlanBuilder.PreparePlan builtPlan =
-            p.fromView("opticUnitTest", "musician")
-                    .where(
-                            p.cts.andQuery(
-                                    p.cts.jsonPropertyWordQuery("instrument", "trumpet"),
-                                    p.cts.jsonPropertyWordQuery(p.xs.string("lastName"), p.xs.stringSeq("Armstrong", "Davis"))
-                            )
-                    )
-                    .orderBy(p.col("lastName"));
+        p.fromView("opticUnitTest", "musician")
+            .where(
+                p.cts.andQuery(
+                    p.cts.jsonPropertyWordQuery("instrument", "trumpet"),
+                    p.cts.jsonPropertyWordQuery(p.xs.string("lastName"), p.xs.stringSeq("Armstrong", "Davis"))
+                )
+            )
+            .orderBy(p.col("lastName"));
 
-    String result = rowMgr.columnInfo(builtPlan, new StringHandle()).get();
-    assertNotNull(result);
-    assertEquals(result, expected);
-    result = rowMgr.columnInfoAs(builtPlan, String.class);
-    assertNotNull(result);
-    assertEquals(result, expected);
+    String[] expectedColumnInfos = new String[]{
+        "{\"schema\":\"opticUnitTest\", \"view\":\"musician\", \"column\":\"lastName\", \"type\":\"string\"",
+        "{\"schema\":\"opticUnitTest\", \"view\":\"musician\", \"column\":\"firstName\", \"type\":\"string\"",
+        "{\"schema\":\"opticUnitTest\", \"view\":\"musician\", \"column\":\"dob\", \"type\":\"date\"",
+        "{\"schema\":\"opticUnitTest\", \"view\":\"musician\", \"column\":\"rowid\", \"type\":\"rowid\""
+    };
+
+    String stringHandleResult = rowMgr.columnInfo(builtPlan, new StringHandle()).get();
+    String stringResult = rowMgr.columnInfoAs(builtPlan, String.class);
+    for (String columnInfo : expectedColumnInfos) {
+      assertTrue("Did not find " + columnInfo + " in result: " + stringHandleResult, stringHandleResult.contains(columnInfo));
+      assertTrue("Did not find " + columnInfo + " in result: " + stringResult, stringResult.contains(columnInfo));
+    }
   }
+
   @Test
   public void testGenerateView() throws IOException {
     RowManager rowMgr = Common.client.newRowManager();


### PR DESCRIPTION
I opened BUG-60065 to capture the "null row" issue that may still cause the test to TestOpticOnLiterals to fail, as it relies on an orderBy for a few plans. 