### PR TITLE
DEVEXP-144: DatabaseClient now supports basePath

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -106,8 +106,8 @@ pipeline{
           export GRADLE_USER_HOME=$WORKSPACE/$GRADLE_DIR
           export PATH=$GRADLE_USER_HOME:$JAVA_HOME/bin:$PATH
           cd java-client-api
-          ./gradlew -i marklogic-client-api:test  || true
-          ./gradlew marklogic-client-api-functionaltests:runFastFunctionalTests || true
+          ./gradlew cleanTest marklogic-client-api:test
+          ./gradlew -i cleanTest -PtestUseReverseProxyServer=true test-app:runReverseProxyServer marklogic-client-api:test marklogic-client-api-functionaltests:runFastFunctionalTests || true
         '''
         junit '**/build/**/TEST*.xml'
       }

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,3 +7,6 @@ publishUrl=file:../marklogic-java/releases
 # project
 mlHost=localhost
 mlPassword=admin
+
+# Whether tests should run with the expectation that they'll use a basePath and talk to a reverse proxy server
+testUseReverseProxyServer=false

--- a/marklogic-client-api-functionaltests/build.gradle
+++ b/marklogic-client-api-functionaltests/build.gradle
@@ -7,6 +7,8 @@ test {
   /* For use in testing TestDatabaseClientKerberosFromFile */
   systemProperty "keytabFile", System.getProperty("keytabFile")
   systemProperty "principal", System.getProperty("principal")
+
+	systemProperty "TEST_USE_REVERSE_PROXY_SERVER", testUseReverseProxyServer
 }
 
 /* The minimal number of tests that run in a sandbox environment */

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/ClientApiFunctionalTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/ClientApiFunctionalTest.java
@@ -479,7 +479,11 @@ public class ClientApiFunctionalTest extends AbstractFunctionalTest {
 	}
 
 	private String buildUrl(String path) {
-		return "http://" + host + ":" + restTestport + path;
+		String url = "http://" + host + ":" + restTestport;
+		if (StringUtils.hasText(basePath)) {
+			url += "/" + basePath;
+		}
+		return url + path;
 	}
 
 	//Test Open API docs for Param In and Param Out

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientConnection.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientConnection.java
@@ -165,23 +165,23 @@ public class TestDatabaseClientConnection extends BasicJavaClientREST {
     // release client
     client.release();
   }
-  
+
   // To test getters of SecurityContext
   @Test
   public void testDatabaseClientGetters() throws KeyManagementException, NoSuchAlgorithmException, IOException
   {
     System.out.println("Running testDatabaseClientGetters");
-  
+
     DatabaseClient client = null;
 	SSLContext sslcontext = null;
 	SecurityContext secContext = newSecurityContext("rest-reader", "x");
-	
+
 		try {
 			sslcontext = getSslContext();
 		} catch (UnrecoverableKeyException | KeyStoreException | CertificateException e) {
 			e.printStackTrace();
 		}
-		
+
 		secContext.withSSLContext(sslcontext, new X509TrustManager() {
 			public void checkClientTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
 				// nothing to do
@@ -196,21 +196,21 @@ public class TestDatabaseClientConnection extends BasicJavaClientREST {
 			}
 		})
 		.withSSLHostnameVerifier(SSLHostnameVerifier.ANY);
-	
+
 		client = DatabaseClientFactory.newClient(getRestServerHostName(), getRestServerPort(),
 				secContext, getConnType());
 	SecurityContext readSecContext = client.getSecurityContext();
 	String verifier = readSecContext.getSSLHostnameVerifier().toString();
 	String protocol = readSecContext.getSSLContext().getProtocol();
-	boolean needClient = readSecContext.getSSLContext().getSupportedSSLParameters().getNeedClientAuth();    
-    
+	boolean needClient = readSecContext.getSSLContext().getSupportedSSLParameters().getNeedClientAuth();
+
     assertTrue("Verifier not Builtin", verifier.contains("Builtin"));
     assertTrue("Protocol incorrect", protocol.contains("TLSv1.2"));
     assertTrue("NeedClientAuth incorrect", needClient == false);
     // release client
     client.release();
   }
-  
+
 
   @Test
   public void testDatabaseClientConnectionInvalidPort() throws IOException
@@ -333,12 +333,12 @@ public class TestDatabaseClientConnection extends BasicJavaClientREST {
   /*
    * These tests are specifically to validate Git Issue 332.
    * https://github.com/marklogic/java-client-api/issues/332
-   * 
+   *
    * We need to test that REST calls can pass a database name and access that
    * database on the uber server port (8000). Create a database, forest and
    * associate the database to the uber server on port 8000, where App-Services
    * is running. We will be testing the following :
-   * 
+   *
    * QueryManager.suggest() QueryManager.tuples() QueryManager.values()
    * QueryManager.valuesList() Transaction.readStatus()
    * RuleManager.readRule(As)() RuleManager.match(As)() with
@@ -416,7 +416,7 @@ public class TestDatabaseClientConnection extends BasicJavaClientREST {
 
     String[] filenames = { "multibyte1.xml", "multibyte2.xml", "multibyte3.xml" };
     String queryOptionName = "suggestionOpt.xml";
-    
+
     SecurityContext secContext = newSecurityContext("eval-user", "x");
     DatabaseClient client = DatabaseClientFactory.newClient(appServerHostname, Uberport, UberdbName, secContext, getConnType());
     // write docs
@@ -849,7 +849,7 @@ public class TestDatabaseClientConnection extends BasicJavaClientREST {
     // release client
     client.release();
   }
-  
+
   @Test
   public void testDatabaseClientFactoryBean() throws IOException, ParserConfigurationException, SAXException, XpathException, KeyManagementException,
   NoSuchAlgorithmException
@@ -859,6 +859,7 @@ public class TestDatabaseClientConnection extends BasicJavaClientREST {
 		  DatabaseClientFactory.Bean clientFactoryBean = new DatabaseClientFactory.Bean();
 		  clientFactoryBean.setHost(getRestAppServerHostName());
 		  clientFactoryBean.setPort(getRestAppServerPort());
+		  clientFactoryBean.setBasePath(basePath);
 		  clientFactoryBean.setConnectionType(getConnType());
 		  SecurityContext secContext = newSecurityContext("rest-admin", "x");
 
@@ -886,7 +887,7 @@ public class TestDatabaseClientConnection extends BasicJavaClientREST {
 		  client.release();
 	  }
   }
-  
+
   // Verify that DatabaseClient from Bean handles transactions
   @Test
   public void testDBClientFactoryBeanTransaction() throws Exception {
@@ -896,12 +897,13 @@ public class TestDatabaseClientConnection extends BasicJavaClientREST {
 	  DatabaseClientFactory.Bean clientFactoryBean = new DatabaseClientFactory.Bean();
 	  clientFactoryBean.setHost(getRestAppServerHostName());
 	  clientFactoryBean.setPort(getRestAppServerPort());
+	  clientFactoryBean.setBasePath(basePath);
 	  clientFactoryBean.setConnectionType(getConnType());
 	  SecurityContext secContext = newSecurityContext("rest-writer", "x");
 
 	  clientFactoryBean.setSecurityContext(secContext);
 	  client = clientFactoryBean.newClient();
-	 
+
 	  DocumentMetadataHandle metadataHandle = new DocumentMetadataHandle();
 	  DocumentMetadataHandle readMetadataHandle = new DocumentMetadataHandle();
 	  DocumentMetadataValues metadatavalues = readMetadataHandle.getMetadataValues();

--- a/marklogic-client-api-functionaltests/src/test/resources/test.properties
+++ b/marklogic-client-api-functionaltests/src/test/resources/test.properties
@@ -17,6 +17,7 @@ httpPort=8011
 fastHttpPort=8014
 httpsPort=8013
 adminPort=8002
+basePath=
 lbHost=false
 ml_certificate_password=welcome
 ml_certificate_file=user.p12

--- a/marklogic-client-api/build.gradle
+++ b/marklogic-client-api/build.gradle
@@ -45,11 +45,12 @@ dependencies {
 
 // Ensure that mlHost and mlPassword can override the defaults of localhost/admin if they've been modified
 test {
-    systemProperty "TEST_HOST", mlHost
-    systemProperty "TEST_ADMIN_PASSWORD", mlPassword
-    // Needed by the tests for the example programs
-    systemProperty "EXAMPLE_HOST", mlHost
-    systemProperty "EXAMPLE_ADMIN_PASSWORD", mlPassword
+	systemProperty "TEST_HOST", mlHost
+	systemProperty "TEST_ADMIN_PASSWORD", mlPassword
+	// Needed by the tests for the example programs
+	systemProperty "EXAMPLE_HOST", mlHost
+	systemProperty "EXAMPLE_ADMIN_PASSWORD", mlPassword
+	systemProperty "TEST_USE_REVERSE_PROXY_SERVER", testUseReverseProxyServer
 }
 
 jar {

--- a/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClient.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClient.java
@@ -153,13 +153,13 @@ public interface DatabaseClient {
   SPARQLQueryManager newSPARQLQueryManager();
 
   /**
-   * Creates a PojoRepository specific to the specified class and its id type. 
+   * Creates a PojoRepository specific to the specified class and its id type.
    * The PojoRepository provides a facade for persisting, retrieving, and
    * querying data contained in Java objects.  Annotations are required to
    * identify the id field and any fields for which you wish to create indexes.
    *
    * @param clazz the class type for this PojoRepository to handle
-   * @param idClass the class type of the id field for this clazz, must obviously 
+   * @param idClass the class type of the id field for this clazz, must obviously
    *          be Serializable or we'll struggle to marshall it
    * @param <T> the pojo type this PojoRepository will manage
    * @param <ID> the scalar type of the id for pojos of type &lt;T&gt;
@@ -206,12 +206,12 @@ public interface DatabaseClient {
    *
    * You can call the getClass().getName() and getClass().getPackage().getName() to discover
    * the class of the current implementation object.
-   * @return	the object implementing communication with the server 
+   * @return	the object implementing communication with the server
    */
   Object getClientImplementation();
 
   /**
-   * Creates a ServerEvaluationCall for eval and invoke of server-side xquery or 
+   * Creates a ServerEvaluationCall for eval and invoke of server-side xquery or
    * javascript code.  Eval requires the xdbc:eval privilege and invoke requires the
    * xdbc:invoke privilege.  If this DatabaseClient is pointed at a database different
    * than the default for this REST server, you will need the xdbc:eval-in or xdbc:invoke-in
@@ -225,23 +225,30 @@ public interface DatabaseClient {
    * @return the connection type
    */
   ConnectionType getConnectionType();
-  
+
   /**
    * Checks if the connection is valid.
-   * @return {@link ConnectionResult} with a connected property of true or false. 
+   * @return {@link ConnectionResult} with a connected property of true or false.
    *  In the false case it contains the errorMessage property identifying the failure.
    */
   ConnectionResult checkConnection();
-  
+
   static public interface ConnectionResult {
 	  boolean isConnected();
 	  Integer getStatusCode();
-	  String getErrorMessage();  
+	  String getErrorMessage();
   }
 
   String getHost();
 
   int getPort();
+
+	/**
+	 *
+	 * @since 6.1.0
+	 * @return optional base path associated with this client instance
+	 */
+	String getBasePath();
 
   String getDatabase();
 

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/DatabaseClientImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/DatabaseClientImpl.java
@@ -54,19 +54,21 @@ public class DatabaseClientImpl implements DatabaseClient {
   private final RESTServices          services;
   private final String                host;
   private final int                   port;
+  private final String basePath;
   private final String                database;
   private final SecurityContext       securityContext;
   private final ConnectionType        connectionType;
 
   private HandleFactoryRegistry handleRegistry;
 
-  public DatabaseClientImpl(RESTServices services, String host, int port, String database,
+  public DatabaseClientImpl(RESTServices services, String host, int port, String basePath, String database,
                             SecurityContext securityContext, ConnectionType connectionType) {
     connectionType = (connectionType == null) ? DatabaseClient.ConnectionType.DIRECT : connectionType;
 
     this.services = services;
     this.host     = host;
     this.port     = port;
+	this.basePath = basePath;
     this.database = database;
     this.securityContext = securityContext;
     this.connectionType  = connectionType;
@@ -265,6 +267,11 @@ public class DatabaseClientImpl implements DatabaseClient {
   @Override
   public String getDatabase() {
     return database;
+  }
+
+  @Override
+  public String getBasePath() {
+	  return this.basePath;
   }
 
   @Override

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/RESTServices.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/RESTServices.java
@@ -114,7 +114,7 @@ public interface RESTServices {
   int getMaxDelay();
   void setMaxDelay(int maxDelay);
 
-  void connect(String host, int port, String database, SecurityContext securityContext);
+  void connect(String host, int port, String basePath, String database, SecurityContext securityContext);
   DatabaseClient getDatabaseClient();
   void setDatabaseClient(DatabaseClient client);
   void release();

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/HttpUrlBuilder.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/HttpUrlBuilder.java
@@ -1,0 +1,55 @@
+package com.marklogic.client.impl.okhttp;
+
+import okhttp3.HttpUrl;
+
+import javax.net.ssl.SSLContext;
+import java.util.List;
+
+/**
+ * Extracted from OkHttpServices so that it can be easily unit-tested.
+ */
+public class HttpUrlBuilder {
+
+	public static HttpUrl newBaseUrl(String host, int port, String basePath, SSLContext sslContext) {
+		HttpUrl.Builder builder = new HttpUrl.Builder()
+			.scheme(sslContext == null ? "http" : "https")
+			.host(host)
+			.port(port);
+
+		if (basePath != null && basePath.trim().length() > 0) {
+			if (basePath.startsWith("/")) {
+				basePath = basePath.substring(1);
+			}
+			builder.addPathSegments(basePath);
+		}
+		builder.addPathSegment("v1");
+		builder.addPathSegment("ping");
+		return builder.build();
+	}
+
+	/**
+	 * @param baseUrl expected to be produced via newBaseUrl, as Data Services uses the baseUrl in OkHttpServices to
+	 *                then assemble its own base URL for DS calls
+	 * @return
+	 */
+	public static HttpUrl newDataServicesBaseUri(HttpUrl baseUrl) {
+		HttpUrl.Builder builder = new HttpUrl.Builder()
+			.scheme(baseUrl.scheme())
+			.host(baseUrl.host())
+			.port(baseUrl.port());
+
+		List<String> segments = baseUrl.pathSegments();
+		int segmentCount = segments.size();
+
+		// Expected to default to /v1/ping if no basePath is set; otherwise, it's basePath + /v1/ping
+		if (segmentCount > 2) {
+			segments = segments.subList(0, segmentCount - 2);
+			for (String segment : segments) {
+				builder = builder.addPathSegment(segment);
+			}
+		}
+
+		builder = builder.addPathSegment("");
+		return builder.build();
+	}
+}

--- a/marklogic-client-api/src/test/java/com/marklogic/client/impl/okhttp/NewBaseUrlTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/impl/okhttp/NewBaseUrlTest.java
@@ -1,0 +1,54 @@
+package com.marklogic.client.impl.okhttp;
+
+import okhttp3.HttpUrl;
+import org.junit.Test;
+
+import javax.net.ssl.SSLContext;
+
+import static org.junit.Assert.assertEquals;
+
+public class NewBaseUrlTest {
+
+	@Test
+	public void nullBasePath() {
+		HttpUrl url = HttpUrlBuilder.newBaseUrl("anyhost", 8123, null, null);
+		assertEquals("OkHttpServices has always defaulted to including /v1/ping on the base URL; other " +
+				"parts of it expect that to be present, including the code for checkConnection",
+			"http://anyhost:8123/v1/ping", url.toString());
+		assertEquals("http://anyhost:8123/v1/documents", url.resolve("documents").toString());
+	}
+
+	@Test
+	public void nullBasePathWithSSL() throws Exception {
+		HttpUrl url = HttpUrlBuilder.newBaseUrl("anyhost", 8123, null, SSLContext.getDefault());
+		assertEquals("https://anyhost:8123/v1/ping", url.toString());
+		assertEquals("https://anyhost:8123/v1/documents", url.resolve("documents").toString());
+	}
+
+	@Test
+	public void emptyBasePath() {
+		HttpUrl url = HttpUrlBuilder.newBaseUrl("anyhost", 8123, "", null);
+		assertEquals("http://anyhost:8123/v1/ping", url.toString());
+	}
+
+	@Test
+	public void basePathNoSlashes() {
+		HttpUrl url = HttpUrlBuilder.newBaseUrl("localhost", 8123, "noSlashes", null);
+		assertEquals("http://localhost:8123/noSlashes/v1/ping", url.toString());
+		assertEquals("http://localhost:8123/noSlashes/v1/documents", url.resolve("documents").toString());
+	}
+
+	@Test
+	public void basePathWithForwardSlashes() {
+		HttpUrl url = HttpUrlBuilder.newBaseUrl("localhost", 8123, "has/forward/slashes", null);
+		assertEquals("http://localhost:8123/has/forward/slashes/v1/ping", url.toString());
+		assertEquals("http://localhost:8123/has/forward/slashes/v1/documents", url.resolve("documents").toString());
+	}
+
+	@Test
+	public void basePathStartsWithSlash() {
+		HttpUrl url = HttpUrlBuilder.newBaseUrl("localhost", 8123, "/starts/withSlash", null);
+		assertEquals("http://localhost:8123/starts/withSlash/v1/ping", url.toString());
+		assertEquals("http://localhost:8123/starts/withSlash/v1/documents", url.resolve("documents").toString());
+	}
+}

--- a/marklogic-client-api/src/test/java/com/marklogic/client/impl/okhttp/NewDataServicesBaseUrlTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/impl/okhttp/NewDataServicesBaseUrlTest.java
@@ -1,0 +1,50 @@
+package com.marklogic.client.impl.okhttp;
+
+import okhttp3.HttpUrl;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class NewDataServicesBaseUrlTest {
+
+	@Test
+	public void nullBasePath() {
+		HttpUrl url = HttpUrlBuilder.newDataServicesBaseUri(
+			HttpUrlBuilder.newBaseUrl("anyhost", 8000, null, null)
+		);
+		assertEquals("For DS, the expectation is that the v1 stuff doesn't exist, as endpoints are expected " +
+				"to be resolved from the root of the app server",
+			"http://anyhost:8000/", url.toString());
+		assertEquals("http://anyhost:8000/my/service/endpoint.sjs", url.resolve("my/service/endpoint.sjs").toString());
+	}
+
+	@Test
+	public void basePathWithNoSlashes() {
+		HttpUrl url = HttpUrlBuilder.newDataServicesBaseUri(
+			HttpUrlBuilder.newBaseUrl("anyhost", 8000, "noSlashes", null)
+		);
+		assertEquals("http://anyhost:8000/noSlashes/", url.toString());
+		assertEquals("http://anyhost:8000/noSlashes/my/service/endpoint.sjs",
+			url.resolve("my/service/endpoint.sjs").toString());
+	}
+
+	@Test
+	public void basePathWithSlashes() {
+		HttpUrl url = HttpUrlBuilder.newDataServicesBaseUri(
+			HttpUrlBuilder.newBaseUrl("anyhost", 8000, "my/base/path", null)
+		);
+		assertEquals("http://anyhost:8000/my/base/path/", url.toString());
+		assertEquals("http://anyhost:8000/my/base/path/my/service/endpoint.sjs",
+			url.resolve("my/service/endpoint.sjs").toString());
+	}
+
+	@Test
+	public void basePathStartsWithSlash() {
+		HttpUrl url = HttpUrlBuilder.newDataServicesBaseUri(
+			HttpUrlBuilder.newBaseUrl("anyhost", 8000, "/starts/withSlash", null)
+		);
+		assertEquals("http://anyhost:8000/starts/withSlash/", url.toString());
+		assertEquals("http://anyhost:8000/starts/withSlash/my/service/endpoint.sjs",
+			url.resolve("my/service/endpoint.sjs").toString());
+	}
+}

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/Common.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/Common.java
@@ -38,7 +38,6 @@ import org.xml.sax.SAXException;
 
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.DatabaseClientFactory;
-import com.marklogic.client.DatabaseClientFactory.DigestAuthContext;
 
 public class Common {
   final public static String USER= "rest-writer";
@@ -58,8 +57,10 @@ public class Common {
 
   final public static String  HOST          = System.getProperty("TEST_HOST", "localhost");
 
-  final public static int     PORT          = Integer.parseInt(System.getProperty("TEST_PORT", "8012"));
-  final public static String SECURITY_CONTEXT_TYPE = System.getProperty("TEST_SECURITY_CONTEXT_TYPE", "digest");
+  final public static boolean USE_REVERSE_PROXY_SERVER = Boolean.parseBoolean(System.getProperty("TEST_USE_REVERSE_PROXY_SERVER", "false"));
+  final public static int     PORT          = USE_REVERSE_PROXY_SERVER ? 8020 : Integer.parseInt(System.getProperty("TEST_PORT", "8012"));
+  final public static String SECURITY_CONTEXT_TYPE = USE_REVERSE_PROXY_SERVER ? "basic" : System.getProperty("TEST_SECURITY_CONTEXT_TYPE", "digest");
+  final public static String BASE_PATH = USE_REVERSE_PROXY_SERVER ? "test/marklogic/unit" : System.getProperty("TEST_BASE_PATH", null);
   final public static boolean WITH_WAIT     = Boolean.parseBoolean(System.getProperty("TEST_WAIT", "false"));
   final public static int     PROPERTY_WAIT = Integer.parseInt(System.getProperty("TEST_PROPERTY_WAIT", WITH_WAIT ? "8200" : "0"));
 
@@ -145,8 +146,8 @@ public class Common {
   public static DatabaseClient makeNewClient(String host, int port, String database,
                                              DatabaseClientFactory.SecurityContext securityContext,
                                              DatabaseClient.ConnectionType connectionType) {
-    System.out.println("Connecting to: " + Common.HOST + ":" + port);
-    return DatabaseClientFactory.newClient(host, port, database, securityContext, connectionType);
+    System.out.println("Connecting to: " + Common.HOST + ":" + port + "; basePath: " + BASE_PATH  + "; auth: " + securityContext.getClass().getSimpleName());
+    return DatabaseClientFactory.newClient(host, port, BASE_PATH, database, securityContext, connectionType);
   }
 
   public static DatabaseClient newAdminClient() {

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/HandleAsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/HandleAsTest.java
@@ -387,9 +387,8 @@ public class HandleAsTest {
     DatabaseClientFactory.Bean clientFactoryBean = new DatabaseClientFactory.Bean();
     clientFactoryBean.setHost(Common.HOST);
     clientFactoryBean.setPort(Common.PORT);
-    clientFactoryBean.setUser(Common.USER);
-    clientFactoryBean.setPassword(Common.PASS);
-    clientFactoryBean.setAuthentication(Authentication.DIGEST);
+	clientFactoryBean.setBasePath(Common.BASE_PATH);
+	clientFactoryBean.setSecurityContext(Common.newSecurityContext(Common.USER, Common.PASS));
     return clientFactoryBean;
   }
 
@@ -397,10 +396,11 @@ public class HandleAsTest {
     DatabaseClientFactory.Bean clientFactoryBean = new DatabaseClientFactory.Bean();
     clientFactoryBean.setHost(Common.HOST);
     clientFactoryBean.setPort(Common.PORT);
+    clientFactoryBean.setBasePath(Common.BASE_PATH);
     clientFactoryBean.setSecurityContext(Common.newSecurityContext(Common.USER, Common.PASS));
     return clientFactoryBean;
   }
-  
+
 
   static public class BufferHandle
     extends BaseHandle<String, String>

--- a/test-app/build.gradle
+++ b/test-app/build.gradle
@@ -1,3 +1,23 @@
 plugins {
-    id 'com.marklogic.ml-gradle' version '4.3.6'
+	id 'com.marklogic.ml-gradle' version '4.3.7'
+	id 'java'
+	id "com.github.psxpaul.execfork" version "0.2.2"
+}
+
+dependencies {
+	implementation "io.undertow:undertow-core:2.2.21.Final"
+	implementation "io.undertow:undertow-servlet:2.2.21.Final"
+}
+
+// See https://github.com/psxpaul/gradle-execfork-plugin for docs.
+// Note that the task will stop at the end of the build by default, which is typically the behavior we want when
+// running tests.
+task runReverseProxyServer(type: com.github.psxpaul.task.JavaExecFork, dependsOn: 'compileJava') {
+	description = "Run a reverse proxy so that the Java tests can be verified when talking to a reverse proxy instead of " +
+		"directly to MarkLogic"
+	classpath = sourceSets.main.runtimeClasspath
+	main = "com.marklogic.client.test.ReverseProxyServer"
+	workingDir = "$buildDir"
+	standardOutput = file("$buildDir/reverse-proxy.log")
+	errorOutput = file("$buildDir/reverse-proxy-error.log")
 }

--- a/test-app/src/main/java/com/marklogic/client/test/ReverseProxyServer.java
+++ b/test-app/src/main/java/com/marklogic/client/test/ReverseProxyServer.java
@@ -1,0 +1,145 @@
+package com.marklogic.client.test;
+
+import io.undertow.Undertow;
+import io.undertow.client.ClientCallback;
+import io.undertow.client.ClientConnection;
+import io.undertow.client.UndertowClient;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.server.ServerConnection;
+import io.undertow.server.handlers.proxy.ProxyCallback;
+import io.undertow.server.handlers.proxy.ProxyClient;
+import io.undertow.server.handlers.proxy.ProxyConnection;
+import io.undertow.server.handlers.proxy.ProxyHandler;
+import org.xnio.IoUtils;
+import org.xnio.OptionMap;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Credit to https://stackoverflow.com/a/39531382/3306099 for this, though it's been tweaked a bit.
+ * <p>
+ * Undertow has an example of a reverse proxy server as well -
+ * https://github.com/undertow-io/undertow/tree/master/examples/src/main/java/io/undertow/examples/reverseproxy
+ * <p>
+ * Note that this does not yet support digest authentication, which seems to be common with reverse proxy servers.
+ * That's fine for testing the Java Client, as verifying that the basePath works is not related to what kind of
+ * authentication is required by MarkLogic.
+ */
+public class ReverseProxyServer {
+
+	/**
+	 * Accepts up to 3 args: 1) the MarkLogic hostname to proxy to; 2) the hostname for this server;
+	 * 3) the port for this server. For current use cases though, including Jenkins, localhost should suffice for both
+	 * hostnames and 8020 should suffice as the port.
+	 *
+	 * @param args
+	 * @throws Exception
+	 */
+	public static void main(final String[] args) throws Exception {
+		String markLogicHost = "localhost";
+		String serverHost = "localhost";
+		int serverPort = 8020;
+
+		if (args.length > 0) {
+			markLogicHost = args[0];
+			if (args.length > 1) {
+				serverHost = args[1];
+				if (args.length > 2) {
+					serverPort = Integer.parseInt(args[2]);
+				}
+			}
+		}
+
+		// Set up the mapping of paths to MarkLogic ports. Paths with and without forward slashes are used to ensure
+		// both work properly.
+		Map<String, URI> mapping = new HashMap<>();
+		mapping.put("/test/marklogic/unit", new URI("http://" + markLogicHost + ":8012"));
+		// 8014 is for fast functional tests. Slow tests are not yet proxied, which currently will be difficult as they
+		// use a variety of ports. Best approach will be to convert them over to fast tests that all use 8014.
+		mapping.put("/testFunctional", new URI("http://" + markLogicHost + ":8014"));
+		System.out.println("Proxy mapping: " + mapping);
+
+		Undertow.builder()
+			.addHttpListener(serverPort, serverHost)
+			.setIoThreads(4)
+			.setHandler(ProxyHandler.builder()
+				.setProxyClient(new ReverseProxyClient(mapping))
+				.setMaxRequestTime(30000)
+				.build()
+			)
+			.build()
+			.start();
+	}
+
+	private static class ReverseProxyClient implements ProxyClient {
+		private static final ProxyTarget TARGET = new ProxyTarget() {
+		};
+
+		private final UndertowClient client;
+		private final Map<String, URI> mapping;
+
+		public ReverseProxyClient(Map<String, URI> mapping) {
+			this.client = UndertowClient.getInstance();
+			this.mapping = mapping;
+		}
+
+		@Override
+		public ProxyTarget findTarget(HttpServerExchange exchange) {
+			return TARGET;
+		}
+
+		@Override
+		public void getConnection(ProxyTarget target, HttpServerExchange exchange, ProxyCallback<ProxyConnection> callback, long timeout, TimeUnit timeUnit) {
+			final String requestURI = exchange.getRequestURI();
+			System.out.println("Received request: " + new Date() + "; " + requestURI);
+			URI targetUri = null;
+
+			for (String path : mapping.keySet()) {
+				if (requestURI.startsWith(path)) {
+					targetUri = mapping.get(path);
+					exchange.setRequestURI(requestURI.substring(path.length()));
+					break;
+				}
+			}
+
+			if (targetUri == null) {
+				throw new IllegalArgumentException("Unsupported request URI: " + exchange.getRequestURI());
+			}
+
+			System.out.println("Proxying to: " + targetUri + exchange.getRequestURI());
+			client.connect(
+				new ConnectNotifier(callback, exchange),
+				targetUri,
+				exchange.getIoThread(),
+				exchange.getConnection().getByteBufferPool(),
+				OptionMap.EMPTY);
+		}
+
+		private final class ConnectNotifier implements ClientCallback<ClientConnection> {
+			private final ProxyCallback<ProxyConnection> callback;
+			private final HttpServerExchange exchange;
+
+			private ConnectNotifier(ProxyCallback<ProxyConnection> callback, HttpServerExchange exchange) {
+				this.callback = callback;
+				this.exchange = exchange;
+			}
+
+			@Override
+			public void completed(final ClientConnection connection) {
+				final ServerConnection serverConnection = exchange.getConnection();
+				serverConnection.addCloseListener(serverConnection1 -> IoUtils.safeClose(connection));
+				callback.completed(exchange, new ProxyConnection(connection, "/"));
+			}
+
+			@Override
+			public void failed(IOException e) {
+				callback.failed(exchange);
+			}
+		}
+	}
+}

--- a/test-app/src/main/ml-config/servers/java-functest.json
+++ b/test-app/src/main/ml-config/servers/java-functest.json
@@ -1,12 +1,13 @@
 {
-  "server-name": "java-functest",
-  "port": 8014,
-  "server-type": "http",
-  "root": "/",
-  "content-database": "java-functest",
-  "modules-database": "%%MODULES_DATABASE%%",
-  "default-error-format": "json",
-  "error-handler": "/MarkLogic/rest-api/error-handler.xqy",
-  "url-rewriter": "/MarkLogic/rest-api/rewriter.xml",
-  "rewrite-resolves-globally": true
+	"server-name": "java-functest",
+	"port": 8014,
+	"server-type": "http",
+	"root": "/",
+	"content-database": "java-functest",
+	"modules-database": "%%MODULES_DATABASE%%",
+	"default-error-format": "json",
+	"error-handler": "/MarkLogic/rest-api/error-handler.xqy",
+	"url-rewriter": "/MarkLogic/rest-api/rewriter.xml",
+	"rewrite-resolves-globally": true,
+	"authentication": "digestbasic"
 }

--- a/test-app/src/main/ml-config/servers/java-unittest.json
+++ b/test-app/src/main/ml-config/servers/java-unittest.json
@@ -1,4 +1,5 @@
 {
-  "server-name": "java-unittest",
-  "distribute-timestamps": "cluster"
+	"server-name": "java-unittest",
+	"authentication": "digestbasic",
+	"distribute-timestamps": "cluster"
 }


### PR DESCRIPTION
The app changes were fairly simple here, with the most notable part being the addition of HttpUrlBuilder to encapsulate the logic for building a base URL, which has to account for basePath now. Added a bunch of unit tests for this too. 

Most of the rest of this PR is test stuff, specifically the new support for setting up a reverse proxy server and configuring the tests to use that server instead of talking to ML directly. 