### PR TITLE
Refactoring fast functional tests to create client via one method

### DIFF
--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/AbstractFunctionalTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/AbstractFunctionalTest.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.client.DatabaseClient;
-import com.marklogic.client.DatabaseClientFactory;
 import com.marklogic.client.MarkLogicVersion;
 import com.marklogic.client.document.DocumentManager;
 import com.marklogic.client.document.DocumentWriteSet;
@@ -60,11 +59,11 @@ public abstract class AbstractFunctionalTest extends BasicJavaClientREST {
             client = getDatabaseClient(OPTIC_USER, OPTIC_USER_PASSWORD, getConnType());
             adminModulesClient = getDatabaseClientOnDatabase(getRestServerHostName(), getRestServerPort(), modulesDbName, getAdminUser(), getAdminPassword(), getConnType());
         } else {
-            schemasClient = DatabaseClientFactory.newClient(getRestServerHostName(), getRestServerPort(), schemasDbName,
+            schemasClient = newClient(getRestServerHostName(), getRestServerPort(), schemasDbName,
                 newSecurityContext(OPTIC_USER, OPTIC_USER_PASSWORD));
-            client = DatabaseClientFactory.newClient(getRestServerHostName(), getRestServerPort(),
+            client = newClient(getRestServerHostName(), getRestServerPort(), null,
                 newSecurityContext(OPTIC_USER, OPTIC_USER_PASSWORD));
-            adminModulesClient = DatabaseClientFactory.newClient(getRestServerHostName(), getRestServerPort(), modulesDbName,
+            adminModulesClient = newClient(getRestServerHostName(), getRestServerPort(), modulesDbName,
                 newSecurityContext(getAdminUser(), getAdminPassword()));
         }
 
@@ -154,12 +153,12 @@ public abstract class AbstractFunctionalTest extends BasicJavaClientREST {
     }
 
     protected static DatabaseClient connectAsRestWriter() {
-        return DatabaseClientFactory.newClient(getRestServerHostName(), getRestServerPort(),
+        return newClient(getRestServerHostName(), getRestServerPort(),
             newSecurityContext("rest-writer", "x"), getConnType());
     }
 
     protected static DatabaseClient connectAsAdmin() {
-        return DatabaseClientFactory.newClient(getRestServerHostName(), getRestServerPort(),
+        return newClient(getRestServerHostName(), getRestServerPort(),
             newSecurityContext(getAdminUser(), getAdminPassword()), getConnType());
     }
 

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/ClientApiFunctionalTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/ClientApiFunctionalTest.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.marklogic.client.DatabaseClient;
-import com.marklogic.client.DatabaseClientFactory;
 import com.marklogic.client.DatabaseClientFactory.SecurityContext;
 import com.marklogic.client.FailedRequestException;
 import com.marklogic.client.SessionState;
@@ -284,7 +283,7 @@ public class ClientApiFunctionalTest extends AbstractFunctionalTest {
 		System.out.println("Running TestE2EUnAuthorizedUser");
 		associateRESTServerWithDefaultUser(serverName, "security", securityContextType);
 		SecurityContext secContext = newSecurityContext("ForbiddenUser", "ap1U53r");
-		DatabaseClient dbForbiddenclient = DatabaseClientFactory.newClient(host, port, secContext, getConnType());
+		DatabaseClient dbForbiddenclient = newClient(host, port, secContext, getConnType());
 		String msg;
 		try {
 			TestE2EIntegerParaReturnDouble.on(dbForbiddenclient).TestE2EItemPriceErrorCond(10, 50);
@@ -384,7 +383,7 @@ public class ClientApiFunctionalTest extends AbstractFunctionalTest {
 
 		System.out.println("Running TestE2EuserWithInvalidRole");
 		SecurityContext secContext = newSecurityContext("secondApiUser", "ap1U53r");
-		DatabaseClient dbSecondClient = DatabaseClientFactory.newClient(host, port, secContext, getConnType());
+		DatabaseClient dbSecondClient = newClient(host, port, secContext, getConnType());
 		String msg;
 		try {
 			TestE2EIntegerParaReturnDouble.on(dbSecondClient).TestE2EItemPriceErrorCond(10, 50);
@@ -450,7 +449,7 @@ public class ClientApiFunctionalTest extends AbstractFunctionalTest {
 			System.out.println("Exception - session2.json / session3.json - Client API call is " + ex);
 		}
 		SecurityContext secContext = newSecurityContext("apiUser", "ap1U53r");
-		DatabaseClient dbclientRest = DatabaseClientFactory.newClient(host, restTestport, secContext, getConnType());
+		DatabaseClient dbclientRest = newClient(host, restTestport, secContext, getConnType());
 		waitForPropertyPropagate();
 		JSONDocumentManager docMgr = dbclientRest.newJSONDocumentManager();
 		JacksonHandle jh = new JacksonHandle();

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkWriteWithTransformations.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkWriteWithTransformations.java
@@ -16,7 +16,6 @@
 
 package com.marklogic.client.fastfunctest;
 
-import com.marklogic.client.DatabaseClientFactory;
 import com.marklogic.client.DatabaseClientFactory.SecurityContext;
 import com.marklogic.client.Transaction;
 import com.marklogic.client.admin.ExtensionMetadata;
@@ -75,7 +74,7 @@ public class TestBulkWriteWithTransformations extends AbstractFunctionalTest {
     	client	= getDatabaseClient("eval-user", "x", getConnType());
     else {
     	SecurityContext secContext = newSecurityContext("eval-user", "x");
-    client = DatabaseClientFactory.newClient(appServerHostname, uberPort, "java-functest", secContext, getConnType());
+    client = newClient(appServerHostname, uberPort, "java-functest", secContext, getConnType());
     }
   }
 
@@ -113,7 +112,7 @@ public class TestBulkWriteWithTransformations extends AbstractFunctionalTest {
     }
     docMgr.write(writeset);
     FileHandle dh = new FileHandle();
-    
+
     try {
     docMgr.read(docId[0], dh);
     scanner = new Scanner(dh.get()).useDelimiter("\\Z");
@@ -209,7 +208,7 @@ public class TestBulkWriteWithTransformations extends AbstractFunctionalTest {
     transform.put("name", "Land");
     transform.put("value", "USA");
     int count = 1;
-    
+
     XMLDocumentManager docMgr = client.newXMLDocumentManager();
     docMgr.setWriteTransform(transform);
     Map<String, String> map = new HashMap<>();
@@ -232,7 +231,7 @@ public class TestBulkWriteWithTransformations extends AbstractFunctionalTest {
       uris[i] = DIRECTORY + "foo" + i + ".xml";
     }
     count = 0;
-    
+
     XMLDocumentManager docMgrRd = client.newXMLDocumentManager();
     DocumentPage page = docMgrRd.read(uris);
     DOMHandle dh = new DOMHandle();
@@ -335,13 +334,13 @@ public class TestBulkWriteWithTransformations extends AbstractFunctionalTest {
     String content = dhRdNull.toString();
 
     assertTrue("Attribute value incorrect :", content.contains("<foo>This is so foo Multiple</foo>"));
-    
-    // Git Issue 639 - Case 1: Test using documentManager.setReadTransform and passing in a SearchReadHandle 
+
+    // Git Issue 639 - Case 1: Test using documentManager.setReadTransform and passing in a SearchReadHandle
     // to verify it gets transformed .
-    
+
     DocumentWriteSet writesetSearch = docMgrRd.newWriteSet();
     writesetSearch.add(DIRECTORY + "MarkLogic9.0" + ".xml", new DOMHandle(getDocumentContent("This is the best NoSQL product")));
-    docMgrRd.write(writesetSearch);    
+    docMgrRd.write(writesetSearch);
 
     ServerTransform transformSrch = new ServerTransform("add-attr-xquery-transform");
     transformSrch.put("name", "Domicile");
@@ -355,9 +354,9 @@ public class TestBulkWriteWithTransformations extends AbstractFunctionalTest {
             "<cts:text>NoSQL</cts:text></cts:word-query>";
     StringHandle handle = new StringHandle().with(wordQuery);
     RawCtsQueryDefinition querydef = queryMgr.newRawCtsQueryDefinition(handle);
-    
+
     DocumentPage pageSrch = docMgrSrch.search(querydef, 1);
-    
+
     DOMHandle dhSrch = new DOMHandle();
     DocumentRecord recSrch = pageSrch.next();
     recSrch.getContent(dhSrch);
@@ -365,12 +364,12 @@ public class TestBulkWriteWithTransformations extends AbstractFunctionalTest {
 
     assertTrue("Transform value incorrect :", attribute.contains("Domicile=\"USA\""));
     assertTrue("URI value incorrect :", recSrch.getUri().trim().contains("/bulkTransform/MarkLogic9.0.xml"));
-    
+
     // Test search() with SearchReadHandle
     // create result handle
     DOMHandle resultsDOMHandle = new DOMHandle();
     DocumentPage pageSrch1 = docMgrSrch.search(querydef, 1, resultsDOMHandle);
-    
+
     //DOMHandle dhSrchHandle = new DOMHandle();
     DocumentRecord recSrchHandle = pageSrch1.next();
     recSrchHandle.getContent(resultsDOMHandle);
@@ -380,24 +379,24 @@ public class TestBulkWriteWithTransformations extends AbstractFunctionalTest {
     assertTrue("URI value incorrect :", recSrch.getUri().trim().contains("/bulkTransform/MarkLogic9.0.xml"));
 
     // Test with documentManager.setReadTransform and queryDefinition.setResponseTransform set to different transforms.
-    // Case 1 : Transform applies to same location 
+    // Case 1 : Transform applies to same location
     RawCtsQueryDefinition qdefWithTransform = queryMgr.newRawCtsQueryDefinition(handle);
     ServerTransform transformOnQdef = new ServerTransform("add-attr-xquery-transform");
     transformOnQdef.put("name", "Continent");
     transformOnQdef.put("value", "North America");
-    
+
     qdefWithTransform.setResponseTransform(transformOnQdef);
     DocumentPage pageSrch2 = docMgrSrch.search(qdefWithTransform, 1);
-    
+
     DOMHandle dhSrch2 = new DOMHandle();
     DocumentRecord recSrch2 = pageSrch2.next();
     recSrch2.getContent(dhSrch2);
     System.out.println("DOMHandle multiple Transforms " + dhSrch2.toString());
     attribute = dhSrch2.get().getDocumentElement().getAttributes().getNamedItem("Continent").toString();
-    
+
     assertTrue("Transform value incorrect :", attribute.contains("Continent=\"North America\""));
     assertTrue("URI value incorrect :", recSrch.getUri().trim().contains("/bulkTransform/MarkLogic9.0.xml"));
-    
+
     // Case 2 : Apply different transforms. QueryDef has add element transformation
     // throws java.lang.IllegalStateException
     String strExptdMsg = "QueryDefinition transform and DocumentManager transform have different names (add-element-xquery-transform, add-attr-xquery-transform)";
@@ -413,7 +412,7 @@ public class TestBulkWriteWithTransformations extends AbstractFunctionalTest {
         File transformFile2 = new File(
                 "src/test/java/com/marklogic/client/functionaltest/transforms/add-element-xquery-transform.xqy");
         FileHandle transformHandle2 = new FileHandle(transformFile2);
-        transMgr2.writeXQueryTransform("add-element-xquery-transform", transformHandle2, metadata2);        
+        transMgr2.writeXQueryTransform("add-element-xquery-transform", transformHandle2, metadata2);
         ServerTransform transform2 = new ServerTransform("add-element-xquery-transform");
         transform2.put("name", "Planet");
         transform2.put("value", "Earth");
@@ -437,7 +436,7 @@ public class TestBulkWriteWithTransformations extends AbstractFunctionalTest {
   /*
    * This test is similar to testBulkLoadWithXQueryTransform and is used to
    * validate Git Issue 396.
-   * 
+   *
    * Verify that a ServerTransform object is passed along when in transactions.
    */
 
@@ -522,9 +521,9 @@ public class TestBulkWriteWithTransformations extends AbstractFunctionalTest {
     }
     assertEquals("document count", 102, count);
   }
-  
+
 //Refer to BT 52461. Having bulk write with transform (no meta-data on the transform itself) used to throw
- // SVC-FILSTAT: cts:tokenize("attachment; filename=&quot;/bulkTransform/foo0.xml&quot;", "http://marklogic.com/collation/") 
+ // SVC-FILSTAT: cts:tokenize("attachment; filename=&quot;/bulkTransform/foo0.xml&quot;", "http://marklogic.com/collation/")
  // -- File status error: GetFileAttributes
  @Test
  public void testBulkWriteNoMetadataWithXQueryTransform() throws KeyManagementException, NoSuchAlgorithmException, Exception {

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestDatabaseAuthentication.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestDatabaseAuthentication.java
@@ -44,9 +44,8 @@ public class TestDatabaseAuthentication extends AbstractFunctionalTest {
     setDefaultUser("nobody", restServerName);
   }
 
-  // Should throw exceptions when none specified.
   @Test
-  public void testAuthenticationNone() throws IOException
+  public void testAuthenticationNone()
   {
     System.out.println("Running testAuthenticationNone");
     if (!IsSecurityEnabled()) {
@@ -55,7 +54,8 @@ public class TestDatabaseAuthentication extends AbstractFunctionalTest {
       // connect the client
       StringBuilder str = new StringBuilder();
       try {
-    	  DatabaseClient client = DatabaseClientFactory.newClient(getRestServerHostName(), getRestServerPort());
+		  // This does not need to specify basePath since it's expected to fail
+		  DatabaseClientFactory.newClient(getRestServerHostName(), getRestServerPort());
       } catch (Exception ex) {
         str.append(ex.getMessage());
       }
@@ -77,7 +77,7 @@ public class TestDatabaseAuthentication extends AbstractFunctionalTest {
 
       // connect the client
       SecurityContext secContext = new DatabaseClientFactory.BasicAuthContext("rest-writer", "x");
-      DatabaseClient client = DatabaseClientFactory.newClient(getRestServerHostName(), getRestServerPort(), secContext, getConnType());
+      DatabaseClient client = newClient(getRestServerHostName(), getRestServerPort(), secContext, getConnType());
 
       // write doc
       writeDocumentUsingStringHandle(client, filename, "/write-text-doc-basic/", "Text");

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestHandles.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestHandles.java
@@ -79,7 +79,7 @@ public class TestHandles extends AbstractFunctionalTest {
 
         // connect the client
         DatabaseClientFactory.SecurityContext secContext = newSecurityContext("eval-user", "x");
-        DatabaseClient client = DatabaseClientFactory.newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
+        DatabaseClient client = newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
 
         // write docs
         writeDocumentUsingBytesHandle(client, filename, uri, null, "XML");
@@ -141,7 +141,7 @@ public class TestHandles extends AbstractFunctionalTest {
 
         // connect the client
         DatabaseClientFactory.SecurityContext secContext = newSecurityContext("eval-user", "x");
-        DatabaseClient client = DatabaseClientFactory.newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
+        DatabaseClient client = newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
 
         // write docs
         writeDocumentUsingBytesHandle(client, filename, uri, "Text");
@@ -202,7 +202,7 @@ public class TestHandles extends AbstractFunctionalTest {
 
         // connect the client
         DatabaseClientFactory.SecurityContext secContext = newSecurityContext("eval-user", "x");
-        DatabaseClient client = DatabaseClientFactory.newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
+        DatabaseClient client = newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
 
         // write docs
         writeDocumentUsingBytesHandle(client, filename, uri, "JSON");
@@ -263,7 +263,7 @@ public class TestHandles extends AbstractFunctionalTest {
 
         // connect the client
         DatabaseClientFactory.SecurityContext secContext = newSecurityContext("eval-user", "x");
-        DatabaseClient client = DatabaseClientFactory.newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
+        DatabaseClient client = newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
 
         // write docs
         writeDocumentUsingBytesHandle(client, filename, uri, "Binary");

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPartialUpdate.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPartialUpdate.java
@@ -19,7 +19,6 @@ package com.marklogic.client.fastfunctest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.client.DatabaseClient;
-import com.marklogic.client.DatabaseClientFactory;
 import com.marklogic.client.DatabaseClientFactory.SecurityContext;
 import com.marklogic.client.FailedRequestException;
 import com.marklogic.client.Transaction;
@@ -67,7 +66,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
     String[] filenames = { "constraint1.xml", "constraint2.xml", "constraint3.xml", "constraint4.xml", "constraint5.xml" };
 
     SecurityContext secContext = newSecurityContext("eval-user", "x");
-    DatabaseClient client = DatabaseClientFactory.newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
+    DatabaseClient client = newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
 
     // write docs
     for (String filename : filenames) {
@@ -142,7 +141,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
     String[] filenames = { "json-original.json" };
 
     SecurityContext secContext = newSecurityContext("bad-eval-user", "x");
-    DatabaseClient client = DatabaseClientFactory.newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
+    DatabaseClient client = newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
 
     // write docs
     for (String filename : filenames) {
@@ -159,7 +158,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
     String[] filenames = { "json-original.json" };
 
     SecurityContext secContext = newSecurityContext("eval-user", "x");
-    DatabaseClient client = DatabaseClientFactory.newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
+    DatabaseClient client = newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
 
     // write docs
     for (String filename : filenames) {
@@ -233,7 +232,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
     String filename = "constraint1.xml";
 
     SecurityContext secContext = newSecurityContext("eval-user", "x");
-    DatabaseClient client = DatabaseClientFactory.newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
+    DatabaseClient client = newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
 
     // write docs
     writeDocumentUsingInputStreamHandle(client, filename, "/partial-update/", "XML");
@@ -327,7 +326,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
     System.out.println("Running testPartialUpdateDeletePath");
 
     SecurityContext secContext = newSecurityContext("eval-user", "x");
-    DatabaseClient client = DatabaseClientFactory.newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
+    DatabaseClient client = newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
 
     // write docs
     String filename = "constraint1.xml";
@@ -370,7 +369,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
   public void testPartialUpdateFragments() throws Exception {
     System.out.println("Running testPartialUpdateFragments");
     SecurityContext secContext = newSecurityContext("eval-user", "x");
-    DatabaseClient client = DatabaseClientFactory.newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
+    DatabaseClient client = newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
 
     // write docs
     String filename = "constraint1.xml";
@@ -408,7 +407,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
   public void testPartialUpdateInsertFragments() throws Exception {
     System.out.println("Running testPartialUpdateInsertFragments");
     SecurityContext secContext = newSecurityContext("eval-user", "x");
-    DatabaseClient client = DatabaseClientFactory.newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
+    DatabaseClient client = newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
 
     // write docs
     String filename = "constraint1.xml";
@@ -443,7 +442,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
   public void testPartialUpdateInsertExistingFragments() throws Exception {
     System.out.println("Running testPartialUpdateInsertExistingFragments");
     SecurityContext secContext = newSecurityContext("eval-user", "x");
-    DatabaseClient client = DatabaseClientFactory.newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
+    DatabaseClient client = newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
 
     // write docs
     String filename = "constraint1.xml";
@@ -478,7 +477,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
   public void testPartialUpdateReplaceApply() throws Exception {
     System.out.println("Running testPartialUpdateReplaceApply");
     SecurityContext secContext = newSecurityContext("rest-admin", "x");
-    DatabaseClient client = DatabaseClientFactory.newClient(appServerHostname, 8000, secContext, getConnType());
+    DatabaseClient client = newClient(appServerHostname, 8000, secContext, getConnType());
     ExtensionLibrariesManager libsMgr = client.newServerConfigManager().newExtensionLibrariesManager();
 
     libsMgr.write("/ext/patch/custom-lib.xqy", new FileHandle(new File("src/test/java/com/marklogic/client/functionaltest/data/custom-lib.xqy")).withFormat(Format.TEXT));
@@ -488,7 +487,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
     String filename2 = "constraint6.json";
     writeDocumentUsingInputStreamHandle(client, filename, "/partial-update/", "XML");
     writeDocumentUsingInputStreamHandle(client, filename2, "/partial-update/", "JSON");
-    
+
     String docId = "/partial-update/constraint6.xml";
 
     // Creating Manager
@@ -527,31 +526,31 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
     assertTrue("concatenateBetween Failed", content.contains("<concatenateBetween>ML Version 7</concatenateBetween>"));
     assertTrue("Ragex Failed", content.contains("<replaceRegex>C111nt</replaceRegex>"));
     assertTrue("Apply Library Fragments Failed ", content.contains("<applyLibrary>APIAPI</applyLibrary>"));
-    
+
     String docId2 = "/partial-update/constraint6.json";
-    
+
     JSONDocumentManager jdm = client.newJSONDocumentManager();
     DocumentPatchBuilder patchBldrSJS = jdm.newPatchBuilder();
     patchBldrSJS.pathLanguage(PathLanguage.JSONPATH);
-	
+
     patchBldrSJS.library("", "/ext/patch/qatests.sjs");
-    patchBldrSJS.replaceApply("root.divide", 
+    patchBldrSJS.replaceApply("root.divide",
     		patchBldrSJS.call().applyLibraryValues("Mymin", 18, 21));
     DocumentPatchHandle patchHandleSJS = patchBldrSJS.build();
     jdm.patch(docId2, patchHandleSJS);
     System.out.println(patchBldrSJS.build().toString());
-    
+
     waitForPropertyPropagate();
     String content1 = xmlDocMgr.read(docId2, new StringHandle()).get();
     System.out.println("After Update on divide with fn() values " + content1);
     assertTrue("Division Failed", content1.contains("\"divide\":18"));
-    
+
     // Work on the different element with different values and another patch update
     DocumentPatchBuilder patchBldrSJS1 = jdm.newPatchBuilder();
     patchBldrSJS1.pathLanguage(PathLanguage.JSONPATH);
-	
+
     patchBldrSJS1.library("", "/ext/patch/qatests.sjs");
-    patchBldrSJS1.replaceApply("root.add", 
+    patchBldrSJS1.replaceApply("root.add",
     		patchBldrSJS1.call().applyLibraryValues("Mymin", -12, 21));
     ObjectMapper mapper = new ObjectMapper();
     ObjectNode fragmentNode = mapper.createObjectNode();
@@ -559,23 +558,23 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
     fragmentNode.put("modulo", 2);
     String fragment = mapper.writeValueAsString(fragmentNode);
     patchBldrSJS1.insertFragment("root.divide", Position.AFTER, fragment);
-    
+
     DocumentPatchHandle patchHandleSJS1 = patchBldrSJS1.build();
     jdm.patch(docId2, patchHandleSJS1);
     System.out.println(patchBldrSJS1.build().toString());
-    
+
     waitForPropertyPropagate();
     String content2 = xmlDocMgr.read(docId2, new StringHandle()).get();
     System.out.println("After Update on add with fn() values " + content2);
     assertTrue("Add Failed", content2.contains("\"add\":-12"));
     assertTrue("Modulo Failed", content2.contains("\"modulo\":2"));
-    
+
     // Error condition checks
     DocumentPatchBuilder patchBldrSJSErr = jdm.newPatchBuilder();
     patchBldrSJSErr.pathLanguage(PathLanguage.JSONPATH);
-	
+
     patchBldrSJSErr.library("", "/ext/patch/qatests.sjs");
-    patchBldrSJSErr.replaceApply("root.add", 
+    patchBldrSJSErr.replaceApply("root.add",
     		patchBldrSJSErr.call().applyLibraryValues("Mymin", new String("A"),  new String("A")));
     StringBuilder strErr = new StringBuilder();
     try {
@@ -587,7 +586,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
     	strErr.append(ex.getMessage());
     }
     System.out.println(patchBldrSJSErr.build().toString());
-    
+
     waitForPropertyPropagate();
     String content3 = xmlDocMgr.read(docId2, new StringHandle()).get();
     System.out.println("After Update on divide with fn() values " + content3);
@@ -603,7 +602,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
   public void testPartialUpdateCombination() throws Exception {
     System.out.println("Running testPartialUpdateCombination");
     SecurityContext secContext = newSecurityContext("eval-user", "x");
-    DatabaseClient client = DatabaseClientFactory.newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
+    DatabaseClient client = newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
 
     // write docs
     String filename = "constraint1.xml";
@@ -635,7 +634,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
   public void testPartialUpdateCombinationTransc() throws Exception {
     System.out.println("Running testPartialUpdateCombination");
     SecurityContext secContext = newSecurityContext("eval-user", "x");
-    DatabaseClient client = DatabaseClientFactory.newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
+    DatabaseClient client = newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
     Transaction t = client.openTransaction("Transac");
     // write docs
     String filename = "constraint1.xml";
@@ -673,7 +672,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
   public void testPartialUpdateCombinationTranscRevert() throws Exception {
     System.out.println("Running testPartialUpdateCombinationTranscRevert");
     SecurityContext secContext = newSecurityContext("eval-user", "x");
-    DatabaseClient client = DatabaseClientFactory.newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
+    DatabaseClient client = newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
     // write docs
     String[] filenames = { "constraint1.xml", "constraint2.xml" };
     for (String filename : filenames) {
@@ -766,7 +765,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
   public void testPartialUpdateMetadata() throws Exception {
     System.out.println("Running testPartialUpdateMetadata");
     SecurityContext secContext = newSecurityContext("eval-user", "x");
-    DatabaseClient client = DatabaseClientFactory.newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
+    DatabaseClient client = newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
 
     // write docs
     String filename = "constraint1.xml";
@@ -791,7 +790,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
 
     // Check
     assertTrue("Collection not added", contentMetadata1.contains("<rapi:collection>/document/collection3</rapi:collection>"));
-    assertTrue("Permission not added", contentMetadata1.contains("<rapi:role-name>replaceRoleTest</rapi:role-name>"));    
+    assertTrue("Permission not added", contentMetadata1.contains("<rapi:role-name>replaceRoleTest</rapi:role-name>"));
     assertTrue("Property not added", contentMetadata1.contains("<Hello xsi:type=\"xs:string\">Hi</Hello>"));
 
     // //
@@ -841,7 +840,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
     String[] filenames = { "constraint1.xml", "constraint2.xml", "constraint3.xml", "constraint4.xml", "constraint5.xml" };
 
     SecurityContext secContext = newSecurityContext("eval-user", "x");
-    DatabaseClient client = DatabaseClientFactory.newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
+    DatabaseClient client = newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
 
     // write docs
     for (String filename : filenames) {
@@ -878,7 +877,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
     String[] filenames = { "json-original.json" };
 
     SecurityContext secContext = newSecurityContext("eval-user", "x");
-    DatabaseClient client = DatabaseClientFactory.newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
+    DatabaseClient client = newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
 
     // write docs
     for (String filename : filenames) {
@@ -923,7 +922,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
     String[] filenames = { "constraint1.xml", "constraint2.xml", "constraint3.xml", "constraint4.xml", "constraint5.xml" };
 
     SecurityContext secContext = newSecurityContext("eval-user", "x");
-    DatabaseClient client = DatabaseClientFactory.newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
+    DatabaseClient client = newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
 
     // write docs
     for (String filename : filenames) {
@@ -962,7 +961,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
     String[] filenames = { "json-original.json" };
 
     SecurityContext secContext = newSecurityContext("eval-user", "x");
-    DatabaseClient client = DatabaseClientFactory.newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
+    DatabaseClient client = newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
 
     // write docs
     for (String filename : filenames) {
@@ -1007,7 +1006,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
     String filename = "constraint1.xml";
 
     SecurityContext secContext = newSecurityContext("eval-user", "x");
-    DatabaseClient client = DatabaseClientFactory.newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
+    DatabaseClient client = newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
 
     // write docs
     writeDocumentUsingInputStreamHandle(client, filename, "/partial-update/", "XML");
@@ -1054,7 +1053,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
   /*
    * Purpose: This test is used to validate all of the patch builder functions
    * on a JSON document using JSONPath expressions.
-   * 
+   *
    * Function tested: replaceValue.
    */
   @Test
@@ -1065,7 +1064,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
     String[] filenames = { "json-original.json" };
 
     SecurityContext secContext = newSecurityContext("eval-user", "x");
-    DatabaseClient client = DatabaseClientFactory.newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
+    DatabaseClient client = newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
 
     // write docs
     for (String filename : filenames) {
@@ -1101,7 +1100,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
   /*
    * Purpose: This test is used to validate all of the patch builder functions
    * on a JSON document using JSONPath expressions.
-   * 
+   *
    * Functions tested : replaceFragment.
    */
   @Test
@@ -1112,7 +1111,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
     String[] filenames = { "json-original.json" };
 
     SecurityContext secContext = newSecurityContext("eval-user", "x");
-    DatabaseClient client = DatabaseClientFactory.newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
+    DatabaseClient client = newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
 
     // write docs
     for (String filename : filenames) {
@@ -1148,7 +1147,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
   /*
    * Purpose: This test is used to validate all of the patch builder functions
    * on a JSON document using JSONPath expressions.
-   * 
+   *
    * Functions tested : replaceInsertFragment. An new fragment is inserted when
    * unknown index is used.
    */
@@ -1160,7 +1159,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
     String[] filenames = { "json-original.json" };
 
     SecurityContext secContext = newSecurityContext("eval-user", "x");
-    DatabaseClient client = DatabaseClientFactory.newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
+    DatabaseClient client = newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
 
     // write docs
     for (String filename : filenames) {
@@ -1197,7 +1196,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
   /*
    * Purpose: This test is used to validate all of the patch builder functions
    * on a JSON document using JSONPath expressions.
-   * 
+   *
    * Functions tested : replaceInsertFragment. An existing fragment replaced
    * with another fragment.
    */
@@ -1209,7 +1208,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
     String[] filenames = { "json-original.json" };
 
     SecurityContext secContext = newSecurityContext("eval-user", "x");
-    DatabaseClient client = DatabaseClientFactory.newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
+    DatabaseClient client = newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
 
     // write docs
     for (String filename : filenames) {
@@ -1245,7 +1244,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
   /*
    * Purpose: This test is used to validate all of the patch builder functions
    * on a JSON document using JSONPath expressions.
-   * 
+   *
    * Function tested: delete.
    */
   @Test
@@ -1256,7 +1255,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
     String[] filenames = { "json-original.json" };
 
     SecurityContext secContext = newSecurityContext("eval-user", "x");
-    DatabaseClient client = DatabaseClientFactory.newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
+    DatabaseClient client = newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
 
     // write docs
     for (String filename : filenames) {
@@ -1288,8 +1287,8 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
     // release client
     client.release();
   }
-  
-  // Sanity test to make sure that restricted Xpath predicate functions can be used to patch documents. 
+
+  // Sanity test to make sure that restricted Xpath predicate functions can be used to patch documents.
   @Test
   public void testRestrictedXPath() throws IOException, JSONException {
       System.out.println("Running testRestrictedXPaths");
@@ -1308,7 +1307,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
       content1.append("]}}]}");
 
       SecurityContext secContext = newSecurityContext("eval-user", "x");
-      DatabaseClient client = DatabaseClientFactory.newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
+      DatabaseClient client = newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
       int count = 1;
       XMLDocumentManager docMgr = client.newXMLDocumentManager();
       // Write docs
@@ -1327,7 +1326,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
           docMgr.write(writeset1);
       }
       QueryManager queryMgr = client.newQueryManager();
-      
+
       String head = "<search:search xmlns:search=\"http://marklogic.com/appservices/search\">";
       String tail = "</search:search>";
       // object-node - Number Node
@@ -1359,7 +1358,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
       String docId = "/RXath/World-01-2.json";
       JSONDocumentManager JdocMgr = client.newJSONDocumentManager();
       DocumentPatchBuilder patchBldr = JdocMgr.newPatchBuilder();
-      
+
       // Replace 328 in the population to be 500.
       patchBldr.pathLanguage(PathLanguage.XPATH);
       patchBldr.replaceValue("/World//number-node()", 500);
@@ -1367,7 +1366,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
       DocumentPatchHandle patchHandle = patchBldr.build();
       docMgr.patch(docId, patchHandle);
       waitForPropertyPropagate();
-      
+
       // Verify the results again. Poppulation should be 500 for second document
       String content = docMgr.read(docId, new StringHandle()).get();
       System.out.println("Patched Number node element is " + content);
@@ -1378,7 +1377,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
    * Purpose: This test is used to validate Git issue 132. Apply a patch to
    * existing collections or permissions on a document using JSONPath
    * expressions.
-   * 
+   *
    * Functions tested : replaceInsertFragment. An new fragment is inserted when
    * unknown index is used.
    */
@@ -1390,7 +1389,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
     String[] filenames = { "json-original.json" };
 
     SecurityContext secContext = newSecurityContext("eval-user", "x");
-    DatabaseClient client = DatabaseClientFactory.newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
+    DatabaseClient client = newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
     DocumentMetadataHandle mhRead = new DocumentMetadataHandle();
 
     // write docs

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestRuntimeDBselection.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestRuntimeDBselection.java
@@ -51,7 +51,7 @@ public class TestRuntimeDBselection extends AbstractFunctionalTest {
         int restPort = getRestServerPort();
         SecurityContext secContext = new DatabaseClientFactory.BasicAuthContext("eval-user", "x");
 
-        client = DatabaseClientFactory.newClient(appServerHostname, restPort, "java-functest", secContext, getConnType());
+        client = newClient(appServerHostname, restPort, "java-functest", secContext, getConnType());
         String insertJSON = "xdmp:document-insert(\"test2.json\",object-node {\"test\":\"hello\"})";
         client.newServerEval().xquery(insertJSON).eval();
         String query1 = "fn:count(fn:doc())";


### PR DESCRIPTION
The intent is to make it simple to add a basePath in a follow up PR. No functionality change otherwise, just funneling every DatabaseClient construction via one method. 

"Slow" functional tests aren't impacted yet as it's not likely that we'll test those yet via the reverse proxy server. That's because they're hitting a variety of ports - which they don't need to do, but each needs to be refactored first. 