### PR TITLE
More test refactoring before basePath PR

### DIFF
--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/AbstractFunctionalTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/AbstractFunctionalTest.java
@@ -39,7 +39,8 @@ public abstract class AbstractFunctionalTest extends BasicJavaClientREST {
     protected static DatabaseClient adminModulesClient;
 
     protected static boolean isML11OrHigher;
-    private static String original_http_port;
+    private static String originalHttpPort;
+	private static String originalRestServerName;
 
     @BeforeClass
     public static void initializeClients() throws Exception {
@@ -47,8 +48,11 @@ public abstract class AbstractFunctionalTest extends BasicJavaClientREST {
 
         // Until all the tests can use the same ml-gradle-deployed app server, we need to have separate ports - one
         // for "slow" tests that setup a new app server, and one for "fast" tests that use the deployed one
-        original_http_port = http_port;
+        originalHttpPort = http_port;
         http_port = fast_http_port;
+		originalRestServerName = restServerName;
+		restServerName = "java-functest";
+
         MarkLogicVersion version = MarkLogicVersion.getMarkLogicVersion(connectAsAdmin());
         System.out.println("ML version: " + version.getVersionString());
         isML11OrHigher = version.getMajor() >= 11;
@@ -82,7 +86,8 @@ public abstract class AbstractFunctionalTest extends BasicJavaClientREST {
 
     @AfterClass
     public static void classTearDown() {
-        http_port = original_http_port;
+        http_port = originalHttpPort;
+		restServerName = originalRestServerName;
         client.release();
         schemasClient.release();
     }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkWriteWithTransformations.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkWriteWithTransformations.java
@@ -48,8 +48,6 @@ public class TestBulkWriteWithTransformations extends AbstractFunctionalTest {
   private static final int BATCH_SIZE = 100;
   private static final String DIRECTORY = "/bulkTransform/";
 
-  // Additional port to test for Uber port
-  private static int uberPort = 8000;
   private static String appServerHostname = null;
 
   @BeforeClass
@@ -74,7 +72,7 @@ public class TestBulkWriteWithTransformations extends AbstractFunctionalTest {
     	client	= getDatabaseClient("eval-user", "x", getConnType());
     else {
     	SecurityContext secContext = newSecurityContext("eval-user", "x");
-    client = newClient(appServerHostname, uberPort, "java-functest", secContext, getConnType());
+    client = newClient(appServerHostname, getRestServerPort(), getRestServerName(), secContext, getConnType());
     }
   }
 

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestDatabaseAuthentication.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestDatabaseAuthentication.java
@@ -16,11 +16,15 @@
 
 package com.marklogic.client.fastfunctest;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.DatabaseClientFactory;
 import com.marklogic.client.DatabaseClientFactory.SecurityContext;
 import com.marklogic.client.io.InputStreamHandle;
+import com.marklogic.mgmt.resource.appservers.ServerManager;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -37,10 +41,16 @@ import static org.junit.Assert.assertEquals;
 public class TestDatabaseAuthentication extends AbstractFunctionalTest {
 
   private static String restServerName = "java-functest";
+  private String originalServerAuthentication;
+
+  @Before
+  public void before() {
+	  originalServerAuthentication = getServerAuthentication(restServerName);
+  }
 
   @After
   public void teardown() throws Exception {
-    setAuthentication(securityContextType, restServerName);
+    setAuthentication(originalServerAuthentication, restServerName);
     setDefaultUser("nobody", restServerName);
   }
 

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestHandles.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestHandles.java
@@ -46,7 +46,6 @@ import static org.junit.Assert.assertTrue;
 public class TestHandles extends AbstractFunctionalTest {
 
     private static String dbName = "java-functest";
-    private static int uberPort = 8000;
     private static String appServerHostname = null;
 
     @BeforeClass
@@ -79,7 +78,7 @@ public class TestHandles extends AbstractFunctionalTest {
 
         // connect the client
         DatabaseClientFactory.SecurityContext secContext = newSecurityContext("eval-user", "x");
-        DatabaseClient client = newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
+        DatabaseClient client = newClient(appServerHostname, getRestServerPort(), dbName, secContext, getConnType());
 
         // write docs
         writeDocumentUsingBytesHandle(client, filename, uri, null, "XML");
@@ -141,7 +140,7 @@ public class TestHandles extends AbstractFunctionalTest {
 
         // connect the client
         DatabaseClientFactory.SecurityContext secContext = newSecurityContext("eval-user", "x");
-        DatabaseClient client = newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
+        DatabaseClient client = newClient(appServerHostname, getRestServerPort(), dbName, secContext, getConnType());
 
         // write docs
         writeDocumentUsingBytesHandle(client, filename, uri, "Text");
@@ -202,7 +201,7 @@ public class TestHandles extends AbstractFunctionalTest {
 
         // connect the client
         DatabaseClientFactory.SecurityContext secContext = newSecurityContext("eval-user", "x");
-        DatabaseClient client = newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
+        DatabaseClient client = newClient(appServerHostname, getRestServerPort(), dbName, secContext, getConnType());
 
         // write docs
         writeDocumentUsingBytesHandle(client, filename, uri, "JSON");
@@ -263,7 +262,7 @@ public class TestHandles extends AbstractFunctionalTest {
 
         // connect the client
         DatabaseClientFactory.SecurityContext secContext = newSecurityContext("eval-user", "x");
-        DatabaseClient client = newClient(appServerHostname, uberPort, dbName, secContext, getConnType());
+        DatabaseClient client = newClient(appServerHostname, getRestServerPort(), dbName, secContext, getConnType());
 
         // write docs
         writeDocumentUsingBytesHandle(client, filename, uri, "Binary");

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPartialUpdate.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPartialUpdate.java
@@ -46,13 +46,14 @@ import static org.junit.Assert.assertTrue;
 
 public class TestPartialUpdate extends AbstractFunctionalTest {
   private static String dbName = "java-functest";
-  // Additional port to test for Uber port
-  private static int uberPort = 8000;
+  private static int uberPort;
   private static String appServerHostname = null;
 
   @BeforeClass
   public static void setUp() throws Exception {
     System.out.println("In setup");
+	// Don't know why this was called "uberPort" or why it defaulted to 8000 before
+	uberPort = getRestServerPort();
     createUserRolesWithPrevilages("test-eval", "xdbc:eval", "xdbc:eval-in", "xdmp:eval-in", "any-uri", "xdbc:invoke");
     createUserRolesWithPrevilages("replaceRoleTest", "xdbc:eval", "xdbc:eval-in", "xdmp:eval-in", "any-uri", "xdbc:invoke");
     createRESTUser("eval-user", "x", "test-eval", "replaceRoleTest", "rest-admin", "rest-writer", "rest-reader");
@@ -477,7 +478,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
   public void testPartialUpdateReplaceApply() throws Exception {
     System.out.println("Running testPartialUpdateReplaceApply");
     SecurityContext secContext = newSecurityContext("rest-admin", "x");
-    DatabaseClient client = newClient(appServerHostname, 8000, secContext, getConnType());
+    DatabaseClient client = newClient(appServerHostname, uberPort, secContext, getConnType());
     ExtensionLibrariesManager libsMgr = client.newServerConfigManager().newExtensionLibrariesManager();
 
     libsMgr.write("/ext/patch/custom-lib.xqy", new FileHandle(new File("src/test/java/com/marklogic/client/functionaltest/data/custom-lib.xqy")).withFormat(Format.TEXT));

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestRuntimeDBselection.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestRuntimeDBselection.java
@@ -44,10 +44,11 @@ public class TestRuntimeDBselection extends AbstractFunctionalTest {
 
   // Issue 184 exists
   @Test
-  public void testRuntimeDBclientWithDifferentAuthType() throws Exception {
+  public void testRuntimeDBclientWithDifferentAuthType() {
     if (!IsSecurityEnabled()) {
+		String originalServerAuthentication = getServerAuthentication(getRestServerName());
       try {
-        associateRESTServerWithDefaultUser("java-functest", "nobody", "basic");
+		  setAuthentication("basic", getRestServerName());
         int restPort = getRestServerPort();
         SecurityContext secContext = new DatabaseClientFactory.BasicAuthContext("eval-user", "x");
 
@@ -63,7 +64,7 @@ public class TestRuntimeDBselection extends AbstractFunctionalTest {
         assertEquals("count of documents ", 0, response2);
         client.release();
       } finally {
-        associateRESTServerWithDefaultUser("java-functest", "nobody", securityContextType);
+		  setAuthentication(originalServerAuthentication, getRestServerName());
       }
     }
   }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/DatabaseClientTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/DatabaseClientTest.java
@@ -15,28 +15,20 @@
  */
 package com.marklogic.client.test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.DatabaseClient.ConnectionResult;
-import com.marklogic.client.DatabaseClientFactory;
 import com.marklogic.client.admin.QueryOptionsManager;
 import com.marklogic.client.alerting.RuleManager;
-import com.marklogic.client.document.BinaryDocumentManager;
-import com.marklogic.client.document.GenericDocumentManager;
-import com.marklogic.client.document.JSONDocumentManager;
-import com.marklogic.client.document.TextDocumentManager;
-import com.marklogic.client.document.XMLDocumentManager;
+import com.marklogic.client.document.*;
 import com.marklogic.client.eval.ServerEvaluationCall;
 import com.marklogic.client.pojo.PojoRepository;
 import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.util.RequestLogger;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 public class DatabaseClientTest {
   @BeforeClass
@@ -125,7 +117,7 @@ public class DatabaseClientTest {
   public void testCheckConnectionWithValidUser() {
 		
 	DatabaseClient marklogic = Common.makeNewClient(Common.HOST,
-		        8000, "unittest-nodeapi", Common.newSecurityContext(
+		        Common.PORT, Common.newSecurityContext(
 				        Common.SERVER_ADMIN_USER, Common.SERVER_ADMIN_PASS));
   
     ConnectionResult connResult = marklogic.checkConnection();
@@ -134,9 +126,8 @@ public class DatabaseClientTest {
   
   @Test
   public void testCheckConnectionWithInvalidUser() {
-		
 	DatabaseClient marklogic = Common.makeNewClient(Common.HOST,
-		        8000, "unittest-nodeapi", Common.newSecurityContext("invalid", "invalid"));
+		        Common.PORT, Common.newSecurityContext("invalid", "invalid"));
   
     ConnectionResult connResult = marklogic.checkConnection();
     assertFalse(connResult.isConnected());

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/FailedRequestTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/FailedRequestTest.java
@@ -116,25 +116,5 @@ public class FailedRequestTest {
     } catch (Exception e) {
       fail("Call failed with unexpected exception: "+e.getMessage());
     }
-
   }
-
-  @Test
-  public void testErrorOnNonREST() throws ForbiddenUserException {
-    DatabaseClient badClient = Common.makeNewClient(Common.HOST, 8001, Common.newSecurityContext(Common.USER, Common.PASS));
-    ServerConfigurationManager serverConfig = badClient
-      .newServerConfigManager();
-
-    try {
-      serverConfig.readConfiguration();
-    } catch (ForbiddenUserException e) {
-      assertEquals(
-        "Local message: User is not allowed to read config/properties. Server Message: SEC-NOADMIN: (err:FOER0000) User does not have admin-ui privilege.",
-        e.getMessage());
-      assertEquals(403, e.getServerStatusCode());
-      assertEquals("Forbidden", e.getServerStatus());
-    }
-
-  }
-
 }


### PR DESCRIPTION
These are all changes I've made on the basePath branch, but they are general test improvements that can be made before adding basePath, which will simplify that PR. 

Summary:

- Replaced usage of 8000 with standard functest port
- Made several improvements to ClientApiFunctionalTest, including adding a method for building a URL, which will be modified soon with basePath
- More cleanup in ConnectedRESTQA, including using ManageClient and did some renaming as well
- Removed pointless test from FailedRequestTest that was verifying that the REST API doesn't work on the Admin port; we can safely assume that any non-REST-API server will not work!