### PR TITLE
Migrating to JUnit 5

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -107,7 +107,7 @@ pipeline{
           export PATH=$GRADLE_USER_HOME:$JAVA_HOME/bin:$PATH
           cd java-client-api
           ./gradlew cleanTest marklogic-client-api:test
-          ./gradlew -i cleanTest -PtestUseReverseProxyServer=true test-app:runReverseProxyServer marklogic-client-api:test marklogic-client-api-functionaltests:runFastFunctionalTests || true
+          ./gradlew -PtestUseReverseProxyServer=true test-app:runReverseProxyServer marklogic-client-api-functionaltests:runFastFunctionalTests || true
         '''
         junit '**/build/**/TEST*.xml'
       }

--- a/build.gradle
+++ b/build.gradle
@@ -40,18 +40,16 @@ subprojects {
     }
 
     dependencies {
-        testImplementation group: 'junit', name: 'junit', version:'4.13'
-        testImplementation group: 'xmlunit', name: 'xmlunit', version:'1.6'
         compileOnly group: 'org.apache.commons', name: 'commons-lang3', version:'3.10'
         compileOnly group: 'org.apache.httpcomponents', name: 'httpclient', version:'4.5.12'
     }
 
-    test {
-    	systemProperty "file.encoding", "UTF-8"
-        systemProperty "javax.xml.stream.XMLOutputFactory", "com.sun.xml.internal.stream.XMLOutputFactoryImpl"
-    }
+	test {
+		systemProperty "file.encoding", "UTF-8"
+		systemProperty "javax.xml.stream.XMLOutputFactory", "com.sun.xml.internal.stream.XMLOutputFactoryImpl"
+	}
 
-    // Until we do a cleanup of javadoc errors, the build (and specifically the javadoc task) fails on Java 11
+	// Until we do a cleanup of javadoc errors, the build (and specifically the javadoc task) fails on Java 11
     // and higher. Preventing that until the cleanup can occur.
     javadoc.failOnError = false
 

--- a/marklogic-client-api-functionaltests/build.gradle
+++ b/marklogic-client-api-functionaltests/build.gradle
@@ -1,6 +1,7 @@
 // Copyright (c) 2022 MarkLogic Corporation
 
 test {
+	useJUnitPlatform()
   testLogging{
     events 'started','passed', 'skipped'
   }
@@ -29,9 +30,12 @@ dependencies {
   implementation "com.marklogic:ml-app-deployer:4.3.6"
 
   testImplementation group: 'ch.qos.logback', name: 'logback-classic', version:'1.2.11'
+	testImplementation 'org.junit.jupiter:junit-jupiter:5.9.1'
+	testImplementation 'org.xmlunit:xmlunit-legacy:2.9.0'
 }
 
 task runFragileTests(type: Test) {
+	useJUnitPlatform()
   description = "These are called 'fragile' because they'll pass when run by themselves, but when run as part of the " +
           "full suite, there seem to be one or more other fast functional tests that run before them and cause some of " +
           "their test methods to break. The Jenkinsfile thus calls these first before running the other functional " +
@@ -42,6 +46,7 @@ task runFragileTests(type: Test) {
 }
 
 task runFastFunctionalTests(type: Test) {
+	useJUnitPlatform()
   description = "Run all fast functional tests that don't setup/teardown custom app servers / databases"
   include "com/marklogic/client/fastfunctest/**"
   // Exclude the "fragile" ones
@@ -51,6 +56,7 @@ task runFastFunctionalTests(type: Test) {
 }
 
 task runSlowFunctionalTests(type: Test) {
+	useJUnitPlatform()
   description = "Run slow functional tests; i.e. those that setup/teardown custom app servers / databases"
   include "com/marklogic/client/datamovement/functionaltests/**"
   include "com/marklogic/client/functionaltest/**"

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/ExportListenerTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/ExportListenerTest.java
@@ -16,16 +16,15 @@
 
 package com.marklogic.client.datamovement.functionaltests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.*;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.*;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.marklogic.client.DatabaseClient;
@@ -54,12 +53,12 @@ public class ExportListenerTest extends BasicJavaClientREST {
   private static final String query1 = "fn:count(fn:doc())";
   private static String[] hostNames;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpBeforeClass() throws Exception {
     loadGradleProperties();
     server = getRestAppServerName();
     port = getRestAppServerPort();
-    
+
     hostNames = getHosts();
     createDB(dbName);
     Thread.currentThread().sleep(500L);
@@ -80,7 +79,7 @@ public class ExportListenerTest extends BasicJavaClientREST {
     dmManager = dbClient.newDataMovementManager();
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownAfterClass() throws Exception {
     associateRESTServerWithDB(server, "Documents");
     for (int i = 0; i < hostNames.length; i++) {
@@ -91,7 +90,7 @@ public class ExportListenerTest extends BasicJavaClientREST {
     deleteDB(dbName);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     String jsonDoc = "{" +
         "\"employees\": [" +
@@ -116,7 +115,7 @@ public class ExportListenerTest extends BasicJavaClientREST {
     wbatcher.flushAndWait();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     clearDB(port);
   }
@@ -204,8 +203,8 @@ public class ExportListenerTest extends BasicJavaClientREST {
     System.out.println("List size from second QueryBatcher is " + batcherList2.size());
     System.out.println("List size from Export Listener is " + docExporterList.size());
 
-    assertTrue("Docs deleted. Size incorrect", batcherList2.size() == 0);
-    assertTrue("Docs deleted. Size incorrect", docExporterList.size() == 100);
+    assertEquals(0, batcherList2.size());
+    assertEquals(100, docExporterList.size());
   }
 
   /*
@@ -252,7 +251,7 @@ public class ExportListenerTest extends BasicJavaClientREST {
               // Verifying getServerTimestamp with withConsistentSnapshot - Git
               // Issue 629.
               System.out.println("Server Time from Batch 1 in exportBatcher is " + batch.getServerTimestamp());
-              assertTrue("Server Timestamp incorrect", batch.getServerTimestamp() > 0);
+              assertTrue(batch.getServerTimestamp() > 0);
             }
             for (String u : batch.getItems()) {
               batchResults.append(u);
@@ -267,10 +266,10 @@ public class ExportListenerTest extends BasicJavaClientREST {
               docMgr.read("firstName11.json", jacksonhandle);
               JsonNode node = jacksonhandle.get();
               // 3 nodes available
-              assertTrue("URI attempted for delete", node.path("employees").size() == 3);
-              assertEquals("Doc content incorrect", "John", node.path("employees").get(0).path("firstName").asText());
-              assertEquals("Doc content incorrect", "Ann", node.path("employees").get(1).path("firstName").asText());
-              assertEquals("Doc content incorrect", "Bob", node.path("employees").get(2).path("firstName").asText());
+              assertEquals(3, node.path("employees").size());
+              assertEquals("John", node.path("employees").get(0).path("firstName").asText());
+              assertEquals("Ann", node.path("employees").get(1).path("firstName").asText());
+              assertEquals("Bob", node.path("employees").get(2).path("firstName").asText());
             }
             try {
               Thread.sleep(5000);
@@ -288,9 +287,9 @@ public class ExportListenerTest extends BasicJavaClientREST {
           .withConsistentSnapshot()
           .withBatchSize(100)
           .onUrisReady(batch -> {
-              if (batch.getJobBatchNumber() == 1) {               
+              if (batch.getJobBatchNumber() == 1) {
                 System.out.println("Server Time from Batch 1 in deleteBatcher is " + batch.getServerTimestamp());
-                assertTrue("Server Timestamp incorrect", batch.getServerTimestamp() > 0);
+                assertTrue(batch.getServerTimestamp() > 0);
               }
             }
           )
@@ -312,8 +311,8 @@ public class ExportListenerTest extends BasicJavaClientREST {
     System.out.println("List size from QueryBatcher is " + batcherList.size());
     System.out.println("List size from Export Listener is " + docExporterList.size());
 
-    assertTrue("Docs deleted. Size incorrect", batcherList.size() == 100);
-    assertTrue("Docs deleted. Size incorrect", docExporterList.size() == 100);
+    assertEquals(100, batcherList.size());
+    assertEquals(100, docExporterList.size());
 
     // Doc count should be zero after both batchers are done.
     assertEquals(0, dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue());
@@ -353,7 +352,7 @@ public class ExportListenerTest extends BasicJavaClientREST {
             System.out.println("Batch # is " + batch.getJobBatchNumber());
             System.out.println("Server Time from Batch is " + batch.getServerTimestamp());
             if (batch.getJobBatchNumber() == 1) {
-              assertTrue("Server Timestamp incorrect", batch.getServerTimestamp() < 0);
+              assertTrue(batch.getServerTimestamp() < 0);
             }
           })
           .onQueryFailure(exception -> {
@@ -419,10 +418,10 @@ public class ExportListenerTest extends BasicJavaClientREST {
               docMgr.read("firstName11.json", jacksonhandle);
               JsonNode node = jacksonhandle.get();
               // 3 nodes available
-              assertTrue("URI attempted for delete", node.path("employees").size() == 3);
-              assertEquals("Doc content incorrect", "John", node.path("employees").get(0).path("firstName").asText());
-              assertEquals("Doc content incorrect", "Ann", node.path("employees").get(1).path("firstName").asText());
-              assertEquals("Doc content incorrect", "Bob", node.path("employees").get(2).path("firstName").asText());
+              assertEquals(3, node.path("employees").size());
+              assertEquals("John", node.path("employees").get(0).path("firstName").asText());
+              assertEquals("Ann", node.path("employees").get(1).path("firstName").asText());
+              assertEquals("Bob", node.path("employees").get(2).path("firstName").asText());
             }
             try {
               Thread.sleep(1000);
@@ -457,8 +456,8 @@ public class ExportListenerTest extends BasicJavaClientREST {
     System.out.println("List size from QueryBatcher is " + batcherList.size());
     System.out.println("List size from Export Listener is " + docExporterList.size());
 
-    assertTrue("Docs deleted. Size incorrect", batcherList.size() == 100);
-    assertTrue("Docs deleted. Size incorrect", docExporterList.size() != 100);
+    assertTrue(batcherList.size() == 100);
+    assertTrue(docExporterList.size() != 100);
 
     // Doc count should be zero after both batchers are done.
     assertEquals(0, dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue());
@@ -538,8 +537,8 @@ public class ExportListenerTest extends BasicJavaClientREST {
     props.put("merge-timestamp", "0");
     changeProperty(props, "/manage/v2/databases/" + dbName + "/properties");
 
-    assertTrue("Docs deleted. Size incorrect", batcherList.size() != 100);
-    assertTrue("Docs deleted. Size incorrect", docExporterList.size() != 100);
+    assertTrue(batcherList.size() != 100);
+    assertTrue(docExporterList.size() != 100);
 
     // Doc count should be zero after both batchers are done.
     assertEquals(0, dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue());
@@ -619,6 +618,6 @@ public class ExportListenerTest extends BasicJavaClientREST {
     } finally {
     }
     System.out.println("On Batch Failure contents are " + onBatchFailureStr.toString());
-    assertTrue("On Batch Failure call has issues", onBatchFailureStr.toString().contains("From onBatchFailure QA Exception"));
+    assertTrue(onBatchFailureStr.toString().contains("From onBatchFailure QA Exception"));
   }
 }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/ExportToWriterListenerTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/ExportToWriterListenerTest.java
@@ -16,52 +16,34 @@
 
 package com.marklogic.client.datamovement.functionaltests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileReader;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.util.concurrent.TimeUnit;
-
-import javax.xml.parsers.ParserConfigurationException;
-
-import org.apache.commons.io.FileUtils;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.xml.sax.SAXException;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marklogic.client.DatabaseClient;
-import com.marklogic.client.datamovement.DataMovementManager;
-import com.marklogic.client.datamovement.DeleteListener;
-import com.marklogic.client.datamovement.ExportToWriterListener;
-import com.marklogic.client.datamovement.QueryBatcher;
-import com.marklogic.client.datamovement.WriteBatcher;
+import com.marklogic.client.datamovement.*;
 import com.marklogic.client.document.DocumentManager;
 import com.marklogic.client.functionaltest.Artifact;
 import com.marklogic.client.functionaltest.BasicJavaClientREST;
 import com.marklogic.client.functionaltest.Company;
-import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.client.io.*;
 import com.marklogic.client.io.DocumentMetadataHandle.DocumentMetadataValues;
-import com.marklogic.client.io.FileHandle;
-import com.marklogic.client.io.Format;
-import com.marklogic.client.io.InputStreamHandle;
-import com.marklogic.client.io.JacksonHandle;
-import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.pojo.PojoRepository;
 import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.query.StringQueryDefinition;
 import com.marklogic.client.query.StructuredQueryBuilder;
 import com.marklogic.client.query.StructuredQueryDefinition;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.*;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ExportToWriterListenerTest extends BasicJavaClientREST {
 
@@ -91,12 +73,12 @@ public class ExportToWriterListenerTest extends BasicJavaClientREST {
   private static String dataConfigDirPath = null;
   private static String outputFile = "/tmp/out.csv";
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpBeforeClass() throws Exception {
     loadGradleProperties();
     server = getRestAppServerName();
     port = getRestAppServerPort();
-    
+
     dataConfigDirPath = getDataConfigDirPath();
     hostNames = getHosts();
     createDB(dbName);
@@ -161,10 +143,10 @@ public class ExportToWriterListenerTest extends BasicJavaClientREST {
     }
 
     ihb2.flushAndWait();
-    Assert.assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 30);
+    assertEquals(30, dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue());
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownAfterClass() throws Exception {
     associateRESTServerWithDB(server, "Documents");
     for (int i = 0; i < hostNames.length; i++) {
@@ -177,14 +159,6 @@ public class ExportToWriterListenerTest extends BasicJavaClientREST {
     // Delete the output file
     File file = new File(outputFile);
     file.deleteOnExit();
-  }
-
-  @Before
-  public void setUp() throws Exception {
-  }
-
-  @After
-  public void tearDown() throws Exception {
   }
 
   @Test
@@ -228,7 +202,7 @@ public class ExportToWriterListenerTest extends BasicJavaClientREST {
       int lines = 0;
       while (reader.readLine() != null)
         lines++;
-      assertEquals("There should be 20 lines in the output file", 20, lines);
+      assertEquals(20, lines);
     }
   }
 
@@ -273,7 +247,7 @@ public class ExportToWriterListenerTest extends BasicJavaClientREST {
       int lines = 0;
       while (reader.readLine() != null)
         lines++;
-      assertEquals("There should be 20 lines in the output file", 20, lines);
+      assertEquals(20, lines);
     }
   }
 
@@ -321,7 +295,7 @@ public class ExportToWriterListenerTest extends BasicJavaClientREST {
         lines++;
         System.out.println("Line read from file with URIS is" + str);
       }
-      assertEquals("There should be 3 lines in the output file", 3, lines);
+      assertEquals(3, lines);
     }
   }
 
@@ -359,11 +333,11 @@ public class ExportToWriterListenerTest extends BasicJavaClientREST {
       while ((line = reader.readLine()) != null) {
         expLines++;
         System.out.println("Line read from file with URIS is" + line);
-        assertTrue("Export to Write - Incorrect contents", line.contains("{\"k1\":\"v1\"}") ? true :
+        assertTrue(line.contains("{\"k1\":\"v1\"}") ? true :
             line.contains("{\"a\":{\"b1\":{\"c\":\"jsonValue1\"}, \"b2\":[\"b2 val1\", \"b2 val2\"]}}") ? true : false);
-        assertTrue("Export to Write - Incorrect contents", !line.contains("/local/jsonA-1") || line.contains("/local/jsonB-1"));
+        assertTrue(!line.contains("/local/jsonA-1") || line.contains("/local/jsonB-1"));
       }
-      assertEquals("There should be 2 lines in the output file", 2, expLines);
+      assertEquals(2, expLines);
     }
   }
 
@@ -452,10 +426,10 @@ public class ExportToWriterListenerTest extends BasicJavaClientREST {
       while ((line = reader.readLine()) != null) {
         expLines++;
         System.out.println("Line read from file with URIS is " + line);
-        assertTrue("Export to Write - Incorrect collection contents", line.contains("QAKEYS") ? true : false);
-        assertTrue("Export to Write - Incorrect meta data values", line.contains("value1"));
+        assertTrue(line.contains("QAKEYS") ? true : false);
+        assertTrue(line.contains("value1"));
       }
-      assertEquals("There should be 2 lines in the output file", 2, expLines);
+      assertEquals(2, expLines);
     }
   }
 
@@ -513,13 +487,12 @@ public class ExportToWriterListenerTest extends BasicJavaClientREST {
           expLines++;
           System.out.println("Line read from file with URIS is" + line);
           // Verify that parts of the objects are avaialble in the file.
-          assertTrue("Export to Write - Incorrect contents", line.contains("\"name\":\"Cogs 1\"") ? true :
+          assertTrue(line.contains("\"name\":\"Cogs 1\"") ? true :
               line.contains("\"name\":\"Cogs 2\"") ? true : false);
-          assertTrue("Export to Write - Incorrect contents", line.contains("\"name\":\"Acme 2, Inc.\"") ? true :
+          assertTrue(line.contains("\"name\":\"Acme 2, Inc.\"") ? true :
               line.contains("\"name\":\"Widgets 1, Inc.\"") ? true : false);
         }
-        assertEquals("There should be 2 lines in the output file", 2, expLines);
-        fileReader.close();
+        assertEquals(2, expLines);
       }
     } catch (Exception ex) {
       System.out.println("Exception from method testPOJOExport " + ex.getMessage());
@@ -598,7 +571,7 @@ public class ExportToWriterListenerTest extends BasicJavaClientREST {
         throw new IllegalStateException("ERROR: Job did not finish within three minutes");
       }
     }
-    assertTrue("On Batch Failure call has issues", onBatchFailureStr.toString().contains("From onBatchFailure QA Exception"));
+    assertTrue(onBatchFailureStr.toString().contains("From onBatchFailure QA Exception"));
   }
 
   public Artifact getArtifact(int counter) {

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/QueryBatcherJobReportTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/QueryBatcherJobReportTest.java
@@ -31,10 +31,9 @@ import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.query.StringQueryDefinition;
 import com.marklogic.client.query.StructuredQueryBuilder;
 import org.apache.commons.io.FileUtils;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,8 +45,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class QueryBatcherJobReportTest extends AbstractFunctionalTest {
 
@@ -73,7 +71,7 @@ public class QueryBatcherJobReportTest extends AbstractFunctionalTest {
 	/**
 	 * @throws Exception
 	 */
-	@BeforeClass
+	@BeforeAll
 	public static void setUpBeforeClass() throws Exception {
 		dbClient = connectAsAdmin();
 		dmManager = dbClient.newDataMovementManager();
@@ -107,7 +105,7 @@ public class QueryBatcherJobReportTest extends AbstractFunctionalTest {
 		}
 
 		ihb2.flushAndWait();
-		Assert.assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 2000);
+		assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 2000);
 
 		for (int j = 0; j < 2000; j++) {
 			String uri = "/local/string-" + j;
@@ -115,7 +113,7 @@ public class QueryBatcherJobReportTest extends AbstractFunctionalTest {
 		}
 
 		ihb2.flushAndWait();
-		Assert.assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 4000);
+		assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 4000);
 
 		// Xquery transformation
 		TransformExtensionsManager transMgr = dbClient.newServerConfigManager().newTransformExtensionsManager();
@@ -151,13 +149,13 @@ public class QueryBatcherJobReportTest extends AbstractFunctionalTest {
 		});
 		batcher.onQueryFailure(throwable -> throwable.printStackTrace());
 		queryTicket = dmManager.startJob(batcher);
-		Assert.assertTrue("Job Id incorrect", jobId.equalsIgnoreCase(queryTicket.getJobId()));
-		Assert.assertTrue("Job Name incorrect", batcher.getJobName().trim().equalsIgnoreCase("XmlTransform"));
+		assertTrue(jobId.equalsIgnoreCase(queryTicket.getJobId()));
+		assertTrue(batcher.getJobName().trim().equalsIgnoreCase("XmlTransform"));
 		batcher.awaitCompletion(Long.MAX_VALUE, TimeUnit.DAYS);
 		dmManager.stopJob(queryTicket);
 		System.out.println("Number of success batches " + dmManager.getJobReport(queryTicket).getSuccessBatchesCount());
 		// Account for cluster env and number of forests; and/or single node env test runs.
-		Assert.assertTrue(dmManager.getJobReport(queryTicket).getSuccessBatchesCount() >= 4);
+		assertTrue(dmManager.getJobReport(queryTicket).getSuccessBatchesCount() >= 4);
 
 		batcher = dmManager.newQueryBatcher(new StructuredQueryBuilder().collection("XmlTransform"))
 				.withBatchSize(500)
@@ -169,7 +167,7 @@ public class QueryBatcherJobReportTest extends AbstractFunctionalTest {
 		queryTicket = dmManager.startJob(batcher);
 		batcher.awaitCompletion(Long.MAX_VALUE, TimeUnit.DAYS);
 		dmManager.stopJob(queryTicket);
-		Assert.assertEquals(dmManager.getJobReport(queryTicket).getSuccessEventsCount(), 2000);
+		assertEquals(dmManager.getJobReport(queryTicket).getSuccessEventsCount(), 2000);
 
 		batcher = dmManager.newQueryBatcher(new StructuredQueryBuilder().collection("XmlTransform"))
 				.withBatchSize(500)
@@ -187,8 +185,8 @@ public class QueryBatcherJobReportTest extends AbstractFunctionalTest {
 		batcher.awaitCompletion(Long.MAX_VALUE, TimeUnit.DAYS);
 		dmManager.stopJob(queryTicket);
 
-		Assert.assertEquals(0, dmManager.getJobReport(queryTicket).getFailureEventsCount());
-		Assert.assertEquals(dmManager.getJobReport(queryTicket).getSuccessBatchesCount(), count3.get());
+		assertEquals(0, dmManager.getJobReport(queryTicket).getFailureEventsCount());
+		assertEquals(dmManager.getJobReport(queryTicket).getSuccessBatchesCount(), count3.get());
 	}
 
 	@Test
@@ -200,16 +198,16 @@ public class QueryBatcherJobReportTest extends AbstractFunctionalTest {
 		WriteBatcher wbatcher = dmManager.newWriteBatcher().withBatchSize(32).withThreadCount(20);
 		try {
 			wbatcher.addAs("/nulldoc", node);
-			Assert.assertFalse("Exception was not thrown, when it should have been", 1 < 2);
+			fail("Exception was not thrown, when it should have been");
 		} catch (IllegalArgumentException e) {
-			Assert.assertTrue(e.getMessage().equals("content must not be null"));
+			assertTrue(e.getMessage().equals("content must not be null"));
 		}
 
 		try {
 			wbatcher.add("/nulldoc", jacksonHandle);
-			Assert.assertFalse("Exception was not thrown, when it should have been", 1 < 2);
+			fail("Exception was not thrown, when it should have been");
 		} catch (IllegalArgumentException e) {
-			Assert.assertTrue(e.getMessage().equals("contentHandle must not be null"));
+			assertTrue(e.getMessage().equals("contentHandle must not be null"));
 		}
 
 		QueryManager queryMgr = dbClient.newQueryManager();
@@ -219,14 +217,14 @@ public class QueryBatcherJobReportTest extends AbstractFunctionalTest {
 
 		try {
 			QueryBatcher batcher = dmManager.newQueryBatcher(querydef).withBatchSize(32).withThreadCount(20);
-			Assert.assertFalse("Exception was not thrown, when it should have been", 1 < 2);
+			fail("Exception was not thrown, when it should have been");
 		} catch (IllegalArgumentException e) {
-			Assert.assertTrue(e.getMessage().equals("query must not be null"));
+			assertTrue(e.getMessage().equals("query must not be null"));
 		}
 	}
 
 	@Test
-	@Ignore("Ignoring this test for now, as it's failing intermittently due to the bug captured at " +
+	@Disabled("Ignoring this test for now, as it's failing intermittently due to the bug captured at " +
 		"https://github.com/marklogic/java-client-api/issues/1327; did some cleanup on this before ignoring it, as " +
 		"when it passed, the onQueryFailure handler was never being invoked. So that stuff was removed. It appears " +
 		"that the intent of the test is to verify that the retry mechanism for QueryBatcher kicks in when a failure " +
@@ -267,8 +265,8 @@ public class QueryBatcherJobReportTest extends AbstractFunctionalTest {
 		batcher.awaitCompletion();
 
 		// Verify that the QueryBatcher was able to recover after the database was re-enabled
-		Assert.assertEquals(6000, dmManager.getJobReport(queryTicket).getSuccessEventsCount());
-		Assert.assertEquals(successfulBatchCount.intValue(), dmManager.getJobReport(queryTicket).getSuccessBatchesCount());
+		assertEquals(6000, dmManager.getJobReport(queryTicket).getSuccessEventsCount());
+		assertEquals(successfulBatchCount.intValue(), dmManager.getJobReport(queryTicket).getSuccessBatchesCount());
 	}
 
 	class DisabledDBRunnable implements Runnable {
@@ -325,9 +323,9 @@ public class QueryBatcherJobReportTest extends AbstractFunctionalTest {
 		System.out.println("Failure event: " + dmManager.getJobReport(queryTicket).getFailureEventsCount());
 		System.out.println("Failure batch: " + dmManager.getJobReport(queryTicket).getFailureBatchesCount());
 
-		Assert.assertTrue(dmManager.getJobReport(queryTicket).getSuccessEventsCount() > 40);
-		Assert.assertTrue(dmManager.getJobReport(queryTicket).getSuccessEventsCount() < 1000);
-		Assert.assertTrue(batchCount.get() == dmManager.getJobReport(queryTicket).getSuccessBatchesCount());
+		assertTrue(dmManager.getJobReport(queryTicket).getSuccessEventsCount() > 40);
+		assertTrue(dmManager.getJobReport(queryTicket).getSuccessEventsCount() < 1000);
+		assertTrue(batchCount.get() == dmManager.getJobReport(queryTicket).getSuccessBatchesCount());
 	}
 
 	// Making sure we can stop jobs based on the JobId.
@@ -365,9 +363,9 @@ public class QueryBatcherJobReportTest extends AbstractFunctionalTest {
 		System.out.println("Failure event: " + dmManager.getJobReport(queryTicket).getFailureEventsCount());
 		System.out.println("Failure batch: " + dmManager.getJobReport(queryTicket).getFailureBatchesCount());
 
-		Assert.assertTrue(dmManager.getJobReport(queryTicket).getSuccessEventsCount() > 40);
-		Assert.assertTrue(dmManager.getJobReport(queryTicket).getSuccessEventsCount() < 1000);
-		Assert.assertTrue(batchCount.get() == dmManager.getJobReport(queryTicket).getSuccessBatchesCount());
+		assertTrue(dmManager.getJobReport(queryTicket).getSuccessEventsCount() > 40);
+		assertTrue(dmManager.getJobReport(queryTicket).getSuccessEventsCount() < 1000);
+		assertTrue(batchCount.get() == dmManager.getJobReport(queryTicket).getSuccessBatchesCount());
 	}
 
 	@Test
@@ -397,10 +395,10 @@ public class QueryBatcherJobReportTest extends AbstractFunctionalTest {
 		queryTicket = dmManager.startJob(batcher);
 		batcher.awaitCompletion(Long.MAX_VALUE, TimeUnit.DAYS);
 		dmManager.stopJob(queryTicket);
-		Assert.assertTrue(success.get());
-		Assert.assertEquals(dmManager.getJobReport(queryTicket).getSuccessEventsCount(), 2000);
-		Assert.assertEquals(dmManager.getJobReport(queryTicket).getSuccessEventsCount(), successCount.get());
-		Assert.assertEquals(batchCount.get(), dmManager.getJobReport(queryTicket).getSuccessBatchesCount());
+		assertTrue(success.get());
+		assertEquals(dmManager.getJobReport(queryTicket).getSuccessEventsCount(), 2000);
+		assertEquals(dmManager.getJobReport(queryTicket).getSuccessEventsCount(), successCount.get());
+		assertEquals(batchCount.get(), dmManager.getJobReport(queryTicket).getSuccessBatchesCount());
 
 		AtomicInteger doccount = new AtomicInteger(0);
 		QueryBatcher resultBatcher = dmManager
@@ -415,12 +413,12 @@ public class QueryBatcherJobReportTest extends AbstractFunctionalTest {
 						if(dh.get().get("c").asText().equals("new Value"))
 							doccount.incrementAndGet();
 					}
-					
+
 				});
-		dmManager.startJob(resultBatcher);				
+		dmManager.startJob(resultBatcher);
 		resultBatcher.awaitCompletion();
 
-		assertEquals("document count", 2000, doccount.get());
+		assertEquals(2000, doccount.get());
 	}
 
 	@Test
@@ -461,7 +459,7 @@ public class QueryBatcherJobReportTest extends AbstractFunctionalTest {
 		// Wait an amount of time that should result in some docs being transformed but not all
 		Thread.currentThread().sleep(500L);
 		dmManager.stopJob(queryTicket);
-		
+
 		AtomicInteger transformedCount = new AtomicInteger(0);
 		QueryBatcher resultBatcher = dmManager
 				.newQueryBatcher(new StructuredQueryBuilder().collection("XmlTransform"))
@@ -482,43 +480,44 @@ public class QueryBatcherJobReportTest extends AbstractFunctionalTest {
 							skippedApplyTransCount.incrementAndGet();
 						}
 					}
-					
+
 				});
-		dmManager.startJob(resultBatcher);				
+		dmManager.startJob(resultBatcher);
 		resultBatcher.awaitCompletion();
 
 		System.out.println("stopTransformJobTest: Success: " + successUris.size());
 		System.out.println("stopTransformJobTest: Skipped Apply Transform count : " + skippedApplyTransCount.get());
 		System.out.println("stopTransformJobTest: Skipped: " + skippedUris.size());
 		System.out.println("stopTransformJobTest : Applied Trans count " + transformedCount.get());
-		
+
 		System.out.println("stopTransformJobTest : successCount.get() " + successCount.get());
 		// This fails intermittently when the successBatch size is one less than the appliedTranscount. Interestingly,
 		// a potentially similar off-by-one error occurs with the stopTransformJob test in ApplyTransformTest
-		assertTrue("Number of docs transformed must be <= number of docs selected; " +
-			"applied count: " + transformedCount.get() + "; success batch size: " + successUris.size() + "; failed count: " + failedUris.size(),
-			transformedCount.get() <= (successUris.size() + failedUris.size()));
+		assertTrue(
+			transformedCount.get() <= (successUris.size() + failedUris.size()),
+			"Number of docs transformed must be <= number of docs selected; " +
+				"applied count: " + transformedCount.get() + "; success batch size: " + successUris.size() + "; failed count: " + failedUris.size());
 	}
-	
+
 	/* Test 1 setMaxBatches(2035) - maximum specified in advance
 	 * Test 2 setMaxBatches() -- the uris collected thus far during a job
-	 * 
+	 *
 	 */
 	@Test
 	public void testStopBeforeListenerisComplete() throws Exception {
 		ArrayList<String> urisList = new ArrayList<String>();
 		final String qMaxBatches = "fn:count(cts:uri-match('/setMaxBatches*'))";
 		try {
-			
+
 			System.out.println("In testStopBeforeListenerisComplete method");
-		
+
 			final AtomicInteger count = new AtomicInteger(0);
 			final AtomicInteger failedBatch = new AtomicInteger(0);
 			final AtomicInteger successBatch = new AtomicInteger(0);
-			
+
 			final AtomicInteger failedBatch2 = new AtomicInteger(0);
 			final AtomicInteger successBatch2 = new AtomicInteger(0);
-			
+
 			String jsonDoc = "{" +
 				    "\"employees\": [" +
 				    "{ \"firstName\":\"John\" , \"lastName\":\"Doe\" }," +
@@ -586,25 +585,25 @@ public class QueryBatcherJobReportTest extends AbstractFunctionalTest {
 			countT.join();
 
 			t1.join();
-			
+
 			int docCnt = dbClient.newServerEval().xquery(qMaxBatches).eval().next().getNumber().intValue();
 			System.out.println("Doc count is " + docCnt);
-			Assert.assertTrue(docCnt == 50000);
+			assertTrue(docCnt == 50000);
 
 			Collection<String> batchResults = new LinkedHashSet<String>();
 			QueryBatcher qb = dmManager.newQueryBatcher(urisList.iterator())
 					.withBatchSize(12)
 					.withThreadCount(1)
-					.withJobId("ListenerCompletionTest")	            
+					.withJobId("ListenerCompletionTest")
 					.onUrisReady((QueryBatch batch) -> {
 
-						for (String str : batch.getItems()) {            		
-							batchResults.add(str);	                    
+						for (String str : batch.getItems()) {
+							batchResults.add(str);
 						}
 						successBatch.addAndGet(1);
 					})
 					.onQueryFailure(throwable-> {
-						failedBatch.addAndGet(1);                
+						failedBatch.addAndGet(1);
 					});
 			// Test 1 - Set max uris that can be collected in advance of the job.
 			qb.setMaxBatches(2035);
@@ -618,8 +617,8 @@ public class QueryBatcherJobReportTest extends AbstractFunctionalTest {
 					} catch (InterruptedException e) {
 						e.printStackTrace();
 					}
-					dmManager.stopJob(qb);			
-				}			
+					dmManager.stopJob(qb);
+				}
 			}
 
 			dmManager.startJob(qb);
@@ -632,9 +631,9 @@ public class QueryBatcherJobReportTest extends AbstractFunctionalTest {
 			// Validate Test 1 setMaxBatches(2035)
 			System.out.println("Max URIs size is : " + batchResults.size());
 			/* 12 times 2035 equals 24420 with one Thread on QueryBatcher.
-			 * With thread count > 1 on QueryBatcher, batchResults size is greater than 24420. 
+			 * With thread count > 1 on QueryBatcher, batchResults size is greater than 24420.
 			 */
-			assertTrue("Stop QueryBatcher with setMaxBatches set to 2035 is incorrect", batchResults.size() >= 24420);
+			assertTrue(batchResults.size() >= 24420);
 
 			/* Test 2 setMaxBatches()
 			 */
@@ -642,19 +641,19 @@ public class QueryBatcherJobReportTest extends AbstractFunctionalTest {
 			QueryBatcher qb2 = dmManager.newQueryBatcher(urisList.iterator())
 					.withBatchSize(12)
 					.withThreadCount(20)
-					.withJobId("ListenerCompletionTest2")	            
+					.withJobId("ListenerCompletionTest2")
 					.onUrisReady((QueryBatch batch) -> {
 
-						for (String str : batch.getItems()) {            		
-							batchResults2.add(str);	                    
+						for (String str : batch.getItems()) {
+							batchResults2.add(str);
 						}
 						successBatch2.addAndGet(1);
 					})
 					.onQueryFailure(throwable-> {
-						failedBatch2.addAndGet(1);                
+						failedBatch2.addAndGet(1);
 					});
 			qb2.setMaxBatches(203);
-			
+
 			class BatchesSoFarThread implements Runnable {
 
 				@Override
@@ -665,8 +664,8 @@ public class QueryBatcherJobReportTest extends AbstractFunctionalTest {
 					} catch (InterruptedException e) {
 						e.printStackTrace();
 					}
-					qb2.setMaxBatches();					
-				}			
+					qb2.setMaxBatches();
+				}
 			}
 
 			Thread tMBStop2 = new Thread(new BatchesSoFarThread());
@@ -677,18 +676,18 @@ public class QueryBatcherJobReportTest extends AbstractFunctionalTest {
 				e.printStackTrace();
 			}
 			dmManager.startJob(qb2);
-			
+
 			int initialUrisSize = batchResults2.size();
-			
+
 			tMBStop2.start();
 			qb2.awaitCompletion();
 			dmManager.stopJob(qb2);
-			
+
 			System.out.println("Doc count in initialUrisSize " + initialUrisSize);
 			System.out.println("Doc count after setMaxBatches() is called " +  batchResults2.size());
-			
-			assertTrue("Batches of URIs collected so far", batchResults2.size() > 0);
-			assertTrue("Number of Uris collected does not fall in the range", (batchResults2.size()>initialUrisSize && batchResults2.size()<= 2436));
+
+			assertTrue(batchResults2.size() > 0);
+			assertTrue((batchResults2.size()>initialUrisSize && batchResults2.size()<= 2436));
 		}
 		catch (Exception ex) {
 			ex.printStackTrace();
@@ -711,7 +710,7 @@ public class QueryBatcherJobReportTest extends AbstractFunctionalTest {
 			deleteBatcher.awaitCompletion(2, TimeUnit.MINUTES);
 			int docCnt = dbClient.newServerEval().xquery(qMaxBatches).eval().next().getNumber().intValue();
 			System.out.println("All setMaxBatches docs should have been deleted. Count after DeleteListener job is " + docCnt);
-			Assert.assertTrue(docCnt == 0);
+			assertTrue(docCnt == 0);
 		}
 	}
 }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/StringQueryHostBatcherTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/StringQueryHostBatcherTest.java
@@ -15,10 +15,10 @@
  */
 package com.marklogic.client.datamovement.functionaltests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -37,17 +37,13 @@ import com.marklogic.client.expression.CtsQueryBuilder;
 import com.marklogic.client.query.*;
 import com.marklogic.client.type.CtsQueryExpr;
 import com.marklogic.client.util.EditableNamespaceContext;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.marklogic.client.DatabaseClient;
-import com.marklogic.client.FailedRequestException;
-import com.marklogic.client.ForbiddenUserException;
-import com.marklogic.client.ResourceNotFoundException;
-import com.marklogic.client.ResourceNotResendableException;
 import com.marklogic.client.admin.ExtensionMetadata;
 import com.marklogic.client.admin.ServerConfigurationManager;
 import com.marklogic.client.admin.TransformExtensionsManager;
@@ -88,7 +84,7 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
   /**
    * @throws java.lang.Exception
    */
-  @BeforeClass
+  @BeforeAll
   public static void setUpBeforeClass() throws Exception {
     loadGradleProperties();
     restServerPort = getRestAppServerPort();
@@ -131,7 +127,7 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
   /**
    * @throws java.lang.Exception
    */
-  @AfterClass
+  @AfterAll
   public static void tearDownAfterClass() throws Exception {
     System.out.println("In tearDownAfterClass");
     // Release clients
@@ -145,7 +141,7 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
     deleteForest(fNames[0]);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception  {
     System.out.println("In setup");
     client = getDatabaseClient("eval-user", "x", getConnType());
@@ -155,7 +151,7 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
   /**
    * @throws java.lang.Exception
    */
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     System.out.println("In tearDown");
     client.release();
@@ -165,13 +161,13 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
   /*
    * To test String query with Document Manager (Java Client API write method)
    * and WriteBatcher.
-   * 
+   *
    * @throws IOException
-   * 
+   *
    * @throws ParserConfigurationException
-   * 
+   *
    * @throws SAXException
-   * 
+   *
    * @throws XpathException
    */
   @Test
@@ -204,8 +200,8 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
       assertEquals(1, searchResult.get("index").asInt());
       assertEquals("/abs-range-constraint/constraint4.xml", searchResult.get("uri").asText());
       String contents = searchResult.get("content").asText();
-      assertTrue("Expected String not available", contents.contains("Vannevar served"));
-      assertTrue("Expected amt not available", contents.contains("12.34"));
+      assertTrue( contents.contains("Vannevar served"));
+      assertTrue( contents.contains("12.34"));
 
       // Use WriteBatcher to write the same files.
       WriteBatcher batcher = dmManager.newWriteBatcher();
@@ -270,9 +266,9 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
         // Verify the batch results now.
         String[] res = batchResults.toString().split("\\|");
 
-        assertTrue("URI returned not correct", res[0].contains("/abs-range-constraint/batcher-contraints4.xml"));
+        assertTrue( res[0].contains("/abs-range-constraint/batcher-contraints4.xml"));
         // Verify Forest Name.
-        assertTrue("Forest name not correct", forestResults.toString().contains(fNames[0]));
+        assertTrue( forestResults.toString().contains(fNames[0]));
       }
       else {
     	  fail("testAndWordQuery test failed");
@@ -291,7 +287,7 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
       } catch (Exception ex) {
         batchIllegalState.append(ex.getMessage());
         System.out.println("Exceptions buffer from empty withCriteria : " + batchIllegalState.toString());
-        assertTrue("Exception message incorrect", batchIllegalState.toString().contains("Criteria cannot be an empty string"));
+        assertTrue( batchIllegalState.toString().contains("Criteria cannot be an empty string"));
       }
       } catch (Exception e) {
       System.out.print(e.getMessage());
@@ -299,13 +295,13 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
     	clearDB();
     }
   }
- 
+
   /*
    * To test that RawStructuredQueryDefinition can be used withQueryBatcher
    * Store options from a file to server. Read a query from a file into a handle
    * Create a RawCombinedQueryDefinition from handle and options, to be used in
    * QueryBatcher Job.
-   * 
+   *
    * @throws Exception
    */
   @Test
@@ -392,8 +388,8 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
 
         // Verify the batch results now.
         String[] res = batchResults.toString().split("\\|");
-        assertEquals("Number of reults returned is incorrect", 1, res.length);
-        assertTrue("URI returned not correct", res[0].contains(filenames[4]));
+        assertEquals(1, res.length);
+        assertTrue( res[0].contains(filenames[4]));
 
         // Read the document and assert on the value
         DOMHandle contentHandle = new DOMHandle();
@@ -401,9 +397,9 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
         Document readDoc = contentHandle.get();
         System.out.println(convertXMLDocumentToString(readDoc));
 
-        assertTrue("Document content returned not correct", readDoc.getElementsByTagName("id").item(0).getTextContent().contains("0026"));
-        assertTrue("Document content returned not correct", readDoc.getElementsByTagName("title").item(0).getTextContent().contains("The memex"));
-        assertTrue("Document content returned not correct", readDoc.getElementsByTagName("date").item(0).getTextContent().contains("2009-05-05"));
+        assertTrue( readDoc.getElementsByTagName("id").item(0).getTextContent().contains("0026"));
+        assertTrue( readDoc.getElementsByTagName("title").item(0).getTextContent().contains("The memex"));
+        assertTrue( readDoc.getElementsByTagName("date").item(0).getTextContent().contains("2009-05-05"));
       }
     } catch (Exception e) {
       System.out.println("Exceptions thrown from testRawCombinedQueryXMLWithWriteOptions");
@@ -419,7 +415,7 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
    * To test that RawStructuredQueryDefinition can be used withQueryBatcher -
    * JSON file Read a query from a combined file into a handle.
    * combinedQueryOptionJSON.json contains query, options in JSON format.
-   * 
+   *
    * @throws Exception
    */
   @Test
@@ -501,8 +497,8 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
 
         // Verify the batch results now.
         String[] res = batchResults.toString().split("\\|");
-        assertEquals("Number of reults returned is incorrect", 1, res.length);
-        assertTrue("URI returned not correct", res[0].contains(filenames[4]));
+        assertEquals(1, res.length);
+        assertTrue( res[0].contains(filenames[4]));
 
         // Read the document and assert on the value
         DOMHandle contentHandle = new DOMHandle();
@@ -510,9 +506,9 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
         Document readDoc = contentHandle.get();
         System.out.println(convertXMLDocumentToString(readDoc));
 
-        assertTrue("Document content returned not correct", readDoc.getElementsByTagName("id").item(0).getTextContent().contains("0026"));
-        assertTrue("Document content returned not correct", readDoc.getElementsByTagName("title").item(0).getTextContent().contains("The memex"));
-        assertTrue("Document content returned not correct", readDoc.getElementsByTagName("date").item(0).getTextContent().contains("2009-05-05"));
+        assertTrue( readDoc.getElementsByTagName("id").item(0).getTextContent().contains("0026"));
+        assertTrue( readDoc.getElementsByTagName("title").item(0).getTextContent().contains("The memex"));
+        assertTrue( readDoc.getElementsByTagName("date").item(0).getTextContent().contains("2009-05-05"));
       }
     } catch (Exception e) {
       System.out.println("Exceptions thrown from testRawCombinedQueryJSONWithWriteOptions");
@@ -528,7 +524,7 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
    * To test that RawStructuredQueryDefinition can be used withQueryBatcher -
    * Combined file Read a query from a combined file into a handle. Create a
    * RawCombinedQueryDefinition from handle, to be used in QueryBatcher Job.
-   * 
+   *
    * @throws Exception
    */
   @Test
@@ -562,7 +558,7 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
       wbatcher.add(filenames[0], contentHandle1);
       wbatcher.add(filenames[1], contentHandle2);
 
-      wbatcher.flushAndWait();     
+      wbatcher.flushAndWait();
       // get the combined query
       File file = new File(combQueryFileDir + combinedQueryFileName);
 
@@ -573,7 +569,7 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
       RawCombinedQueryDefinition querydef = queryMgr.newRawCombinedQueryDefinition(rawHandle);
 
       StringBuilder batchResults = new StringBuilder();
-      StringBuilder batchFailResults = new StringBuilder();   
+      StringBuilder batchFailResults = new StringBuilder();
 
       // Run a QueryBatcher on the new URIs.
       QueryBatcher queryBatcher1 = dmManagerTmp.newQueryBatcher(querydef);
@@ -605,9 +601,9 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
 
         // Verify the batch results now.
         String[] res = batchResults.toString().split("\\|");
-        assertEquals("Number of results returned is incorrect", 2, res.length);
-        assertTrue("URI returned not correct", res[0].contains("pathindex1.xml") ? true : (res[1].contains("pathindex1.xml") ? true : false));
-        assertTrue("URI returned not correct", res[0].contains("pathindex2.xml") ? true : (res[1].contains("pathindex2.xml") ? true : false));
+        assertEquals(2, res.length);
+        assertTrue( res[0].contains("pathindex1.xml") ? true : (res[1].contains("pathindex1.xml") ? true : false));
+        assertTrue( res[0].contains("pathindex2.xml") ? true : (res[1].contains("pathindex2.xml") ? true : false));
       }
     } catch (Exception e) {
       System.out.println("Exceptions thrown from testRawCombinedQueryPathIndex");
@@ -618,7 +614,7 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
       clearDB();
     }
   }
-  
+
   @Test
   public void testRawCtsQuery() throws IOException, InterruptedException {
     System.out.println("Running testRawCtsQuery");
@@ -686,7 +682,7 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
 
       System.out.println("Batch Results are : " + batchResults.toString());
       System.out.println("File name is : " + filenames[4]);
-      assertTrue("URI returned not correct", batchResults.toString().contains("cts-" + filenames[4]));
+      assertTrue( batchResults.toString().contains("cts-" + filenames[4]));
 
       // Read the document and assert on the value
       DOMHandle contentHandle = new DOMHandle();
@@ -698,10 +694,10 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
         e.printStackTrace();
       }
 
-      assertTrue("Document content returned not correct", readDoc.getElementsByTagName("id").item(0).getTextContent().contains("0026"));
-      assertTrue("Document content returned not correct", readDoc.getElementsByTagName("title").item(0).getTextContent().contains("The memex"));
+      assertTrue( readDoc.getElementsByTagName("id").item(0).getTextContent().contains("0026"));
+      assertTrue( readDoc.getElementsByTagName("title").item(0).getTextContent().contains("The memex"));
 
-      assertTrue("Document content returned not correct", readDoc.getElementsByTagName("date").item(0).getTextContent().contains("2009-05-05"));
+      assertTrue( readDoc.getElementsByTagName("date").item(0).getTextContent().contains("2009-05-05"));
 
       // Run a QueryBatcher with CtsQueryBuilder.
       CtsQueryBuilder ctsQueryBuilder = queryMgr.newCtsSearchBuilder();
@@ -734,7 +730,7 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
 
       System.out.println("Batch Results are : " + batchResults2.toString());
       System.out.println("File name is : " + filenames[4]);
-      assertTrue("URI returned not correct", batchResults2.toString().contains("cts-" + filenames[4]));
+      assertTrue( batchResults2.toString().contains("cts-" + filenames[4]));
 
       // Read the document and assert on the value
       Document readDoc2 = null;
@@ -747,10 +743,10 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
         e.printStackTrace();
       }
 
-      assertTrue("Document content returned not correct", readDoc2.getElementsByTagName("id").item(0).getTextContent().contains("0026"));
-      assertTrue("Document content returned not correct", readDoc2.getElementsByTagName("title").item(0).getTextContent().contains("The memex"));
+      assertTrue( readDoc2.getElementsByTagName("id").item(0).getTextContent().contains("0026"));
+      assertTrue( readDoc2.getElementsByTagName("title").item(0).getTextContent().contains("The memex"));
 
-      assertTrue("Document content returned not correct", readDoc2.getElementsByTagName("date").item(0).getTextContent().contains("2009-05-05"));
+      assertTrue( readDoc2.getElementsByTagName("date").item(0).getTextContent().contains("2009-05-05"));
     } catch (DOMException e) {
       e.printStackTrace();
       fail("testRawCtsQuery method failed");
@@ -763,17 +759,17 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
 		}
 	}
   }
-  
+
   /*
    * To test query by example with WriteBatcher and QueryBatcher with Query
    * Failure (incorrect query syntax).
-   * 
+   *
    * @throws IOException
-   * 
+   *
    * @throws InterruptedException
    */
   // EA 3 Modify the test for batch failure results. Remove the fail.
-  @Ignore
+  @Disabled
   public void testQueryBatcherQueryFailures() throws IOException, InterruptedException
   {
     System.out.println("Running testQueryBatcherQueryFailures");
@@ -884,9 +880,9 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
   /*
    * To test QueryBatcher's callback support by invoking the client object to do
    * a lookup Insert only one document to validate the functionality
-   * 
+   *
    * @throws IOException
-   * 
+   *
    * @throws InterruptedException
    */
   @Test
@@ -950,7 +946,7 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
 		  }
 		  System.out.println("Contents from the callback are : " + ccBuf.toString());
 		  // Verify the Callback contents.
-		  assertTrue("Lookup for a document from Callback using the client failed", ccBuf.toString().contains(expectedStr));
+		  assertTrue( ccBuf.toString().contains(expectedStr));
 		}
 		else {
 			fail("testQueryBatcherCallbackClient method failed");
@@ -966,7 +962,7 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
 			e.printStackTrace();
 		}
 	}
-    
+
   }
 
   /*
@@ -1006,7 +1002,7 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
 		boolean isstopped = queryBatcherNoResult.awaitCompletion(30, TimeUnit.SECONDS);
 
 		if (isstopped) {
-		  assertTrue("Query returned no results when there is no data", batchNoResults.toString().isEmpty());
+		  assertTrue( batchNoResults.toString().isEmpty());
 		}
 		else {
 			fail("testQueryBatcherWithNoData method failed");
@@ -1027,10 +1023,10 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
   /*
    * To test query with WriteBatcher and QueryBatcher 1) Verify batch
    * size on QueryBatcher.
-   * 
-   * 
+   *
+   *
    * @throws IOException
-   * 
+   *
    * @throws InterruptedException
    */
   @Test
@@ -1109,7 +1105,7 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
 		  System.out.println("Duration is ===== " + queryJobTimeoutValue);
 		  System.out.println(batchResults.toString());
 
-		  assertEquals("Number of batches should have been 50", batchResults.toString().split("\\|").length, 50);
+		  assertEquals(batchResults.toString().split("\\|").length, 50);
 		}
 		// Clear the contents for next query host batcher object results.
 		batchResults.delete(0, (batchResults.capacity() - 1));
@@ -1133,10 +1129,10 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
 		queryBatcherSmallTimeout.awaitCompletion(5, TimeUnit.MILLISECONDS);
 		if (queryBatcherSmallTimeout.isStopped()) {
 		  System.out.println(batchResults.toString());
-		  assertNotEquals("Number of batches should not have been 1", batchResults.toString().split("\\|").length, 5);
+		  assertNotEquals(batchResults.toString().split("\\|").length, 5);
 		}
 		if (batchFailResults != null && !batchFailResults.toString().isEmpty()) {
-		  assertTrue("Exceptions not found when query time out value reached", batchFailResults.toString().contains("Test has Exceptions"));
+		  assertTrue( batchFailResults.toString().contains("Test has Exceptions"));
 		}
 	} catch (Exception e) {
 		e.printStackTrace();
@@ -1154,10 +1150,10 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
   /*
    * To test query by example with WriteBatcher and QueryBatcher 1) Verify
    * awaitTermination method on QueryBatcher.
-   * 
-   * 
+   *
+   *
    * @throws IOException
-   * 
+   *
    * @throws InterruptedException
    */
   @Test
@@ -1236,7 +1232,7 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
 		if (queryBatcherAwait.isStopped()) {
 		  System.out.println("Duration is " + quertJobTimeoutValue);
 		  if (quertJobTimeoutValue >= 30 && quertJobTimeoutValue < 35) {
-		    assertTrue("Job termination with awaitTermination passed within specified time", quertJobTimeoutValue >= 30 && quertJobTimeoutValue < 35);
+		    assertTrue( quertJobTimeoutValue >= 30 && quertJobTimeoutValue < 35);
 		  } else if (quertJobTimeoutValue > 35) {
 		    fail("Job termination with awaitTermination failed");
 		  }
@@ -1335,15 +1331,15 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
         while (!queryBatcher1.isStopped()) {
         // Do nothing. Wait for batcher to complete.
         }
-		
+
 		if (queryBatcher1.isStopped()) {
 		  // Verify the batch results now.
 		  String[] res = batchResults.toString().split("\\|");
-		  assertEquals("Query results URI list length returned after transformation incorrect", res.length, 20);
+		  assertEquals(res.length, 20);
 
 		  // Get a random URI, since the URIs returned are not ordered. Get the 3rd
 		  // URI.
-		  assertTrue("URI returned not correct", res[2].contains("foo") || res[2].contains("bar"));
+		  assertTrue( res[2].contains("foo") || res[2].contains("bar"));
 
 		  // do a lookup with the first URI using the client to verify transforms
 		  // are done.
@@ -1354,8 +1350,8 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
 
 		  System.out.println("Contents are : " + contents);
 		  System.out.println("Contents are : " + attribute);
-		  assertTrue("Lookup for a document from Callback using the client failed", xmlStr1.contains(contents) || xmlStr2.contains(contents));
-		  assertTrue("Server transform failed", attribute.equalsIgnoreCase("English"));
+		  assertTrue( xmlStr1.contains(contents) || xmlStr2.contains(contents));
+		  assertTrue( attribute.equalsIgnoreCase("English"));
 		}
 		else {
 			fail("testServerXQueryTransform method failed");
@@ -1376,9 +1372,9 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
   /*
    * To test QueryBatcher functionality (errors if any) when a Forest is being
    * removed and added during a start job.
-   * 
+   *
    * @throws IOException
-   * 
+   *
    * @throws InterruptedException
    */
   @Test
@@ -1457,12 +1453,12 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
           System.out.print("Results from onUrisReady === ");
           System.out.print(batchResults.toString());
           // We should be having 10 batches numbered 1 to 10.
-          assertTrue("Batches not complete in results", batchResults.toString().contains("10"));
+          assertTrue( batchResults.toString().contains("10"));
         }
         if (batchFailResults != null && !batchFailResults.toString().isEmpty()) {
           System.out.print("Results from onQueryFailure === ");
           System.out.print(batchFailResults.toString());
-          assertTrue("Exceptions not found when forest added", batchFailResults.toString().contains("Test has Exceptions"));
+          assertTrue( batchFailResults.toString().contains("Test has Exceptions"));
         }
       }
 
@@ -1503,12 +1499,12 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
           // We should be having 10 batches numbered 1 to 10.
           // TODO Add rest of the validations when feature complete.
           System.out.print(batchResultsRem.toString());
-          assertTrue("Batches not complete in results when forest removed", batchResultsRem.toString().contains("10"));
+          assertTrue( batchResultsRem.toString().contains("10"));
         }
         if (batchFailResultsRem != null && !batchFailResultsRem.toString().isEmpty()) {
           System.out.print("Results from onQueryFailure === ");
           System.out.print(batchFailResultsRem.toString());
-          assertTrue("Exceptions not found when forest removed", batchFailResultsRem.toString().contains("Test has Exceptions"));
+          assertTrue( batchFailResultsRem.toString().contains("Test has Exceptions"));
         }
       }
     } catch (Exception e) {
@@ -1540,9 +1536,9 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
    * To test QueryBatcher's callback support with long lookup time for the client
    * object to do a lookup Insert documents to validate the functionality.
    * Induce a long pause which exceeds awaitTermination time.
-   * 
+   *
    * @throws IOException
-   * 
+   *
    * @throws InterruptedException
    */
   @Test
@@ -1634,10 +1630,10 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
         if (batchFailResults != null && !batchFailResults.toString().isEmpty()) {
           System.out.print("Results from onQueryFailure === ");
           System.out.print(batchFailResults.toString());
-          assertTrue("Exceptions not found when forest added", batchFailResults.toString().contains("Test has Exceptions"));
+          assertTrue( batchFailResults.toString().contains("Test has Exceptions"));
         }
       }
-      assertTrue("Batches are available in results when they should not be.", batchResults.toString().isEmpty());
+      assertTrue( batchResults.toString().isEmpty());
     } catch (Exception e) {
       System.out.print(e.getMessage());
       fail("testBatchClientLookupTimeout method failed");
@@ -1658,9 +1654,9 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
   /*
    * To test QueryBatcher when WriteBatcher writes same document. Simulate a
    * deadlock / resource contention.
-   * 
+   *
    * @throws IOException
-   * 
+   *
    * @throws InterruptedException
    */
 
@@ -1669,13 +1665,13 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
    * InterruptedException {
    * System.out.println("Running testSimultaneousBothBatcherAccess");
    * clearDB(restServerPort);
-   * 
+   *
    * String[] filenames = {"constraint1.json", "constraint2.json",
    * "constraint3.json", "constraint4.json", "constraint5.json"}; WriteBatcher
    * batcher = dmManager.newWriteBatcher();
-   * 
+   *
    * batcher.withBatchSize(2);
-   * 
+   *
    * InputStreamHandle contentHandle1 = new InputStreamHandle();
    * contentHandle1.set(new FileInputStream(dataFileDir + filenames[0]));
    * InputStreamHandle contentHandle2 = new InputStreamHandle();
@@ -1686,61 +1682,61 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
    * contentHandle4.set(new FileInputStream(dataFileDir + filenames[3]));
    * InputStreamHandle contentHandle5 = new InputStreamHandle();
    * contentHandle5.set(new FileInputStream(dataFileDir + filenames[4]));
-   * 
+   *
    * StringBuilder writebatchResults = new StringBuilder();
    * batcher.add("/batcher-contraints1.json", contentHandle1);
    * batcher.add("/batcher-contraints2.json", contentHandle2);
    * batcher.add("/batcher-contraints3.json", contentHandle3);
    * batcher.add("/batcher-contraints4.json", contentHandle4);
    * batcher.add("/batcher-contraints5.json", contentHandle5);
-   * 
+   *
    * // Flush batcher.flushAndWait();
-   * 
+   *
    * StringBuffer querybatchResults = new StringBuffer(); StringBuilder
    * querybatchFailResults = new StringBuilder();
-   * 
+   *
    * // get the query File file = new File(dataConfigDirPath + "qbe1.json");
    * FileHandle fileHandle = new FileHandle(file);
-   * 
+   *
    * QueryManager queryMgr = client.newQueryManager();
    * RawQueryByExampleDefinition qbyexDef =
    * queryMgr.newRawQueryByExampleDefinition
    * (fileHandle.withFormat(Format.JSON));
-   * 
+   *
    * // Run a QueryBatcher. QueryBatcher queryBatcher1 =
    * dmManager.newQueryBatcher(qbyexDef); queryBatcher1.onUrisReady(batch-> {
-   * 
+   *
    * for (String str : batch.getItems()) { querybatchResults.append(str)
    * .append('|'); }
-   * 
+   *
    * querybatchResults.append(batch.getForestResultsSoFar()) .append('|')
    * .append(batch.getForest().getForestName()) .append('|')
    * .append(batch.getJobBatchNumber()) .append('|');
-   * 
+   *
    * }); queryBatcher1.onQueryFailure(throwable-> {
    * System.out.println("Exceptions thrown from callback onQueryFailure");
    * throwable.printStackTrace();
    * querybatchFailResults.append("Test has Exceptions");
    * querybatchFailResults.append(throwable.getMessage()); } );
-   * 
+   *
    * // Trying to use a WriteBatcher on the same docId. WriteBatcher batcherTwo
    * = dmManager.newWriteBatcher(); String jsonDoc = "{" + "\"employees\": [" +
    * "{ \"firstName\":\"John\" , \"lastName\":\"Doe\" }," +
    * "{ \"firstName\":\"Ann\" , \"lastName\":\"Smith\" }," +
    * "{ \"firstName\":\"Bob\" , \"lastName\":\"Foo\" }]" + "}"; StringHandle
    * handle = new StringHandle(); handle.set(jsonDoc);
-   * 
+   *
    * // Update contents to same doc uri. batcherTwo.withBatchSize(1);
    * batcherTwo.add("/batcher-contraints11.json", handle);
    * batcherTwo.flushAndWait();
-   * 
+   *
    * JobTicket jobTicketWriteTwo = dmManager.startJob(batcherTwo);
-   * 
+   *
    * JobTicket jobTicket = dmManager.startJob(queryBatcher1);
    * queryBatcher1.awaitTermination(1, TimeUnit.MINUTES);
-   * 
+   *
    * if (queryBatcher1.isStopped()) {
-   * 
+   *
    * if( !querybatchFailResults.toString().isEmpty() &&
    * querybatchFailResults.toString().contains("Exceptions")) {
    * System.out.println("Query Batch Failed - Buffer Contents are:" +
@@ -1748,8 +1744,8 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
    * if( querybatchResults != null && !querybatchResults.toString().isEmpty()) {
    * // Verify the batch results now. String[] res =
    * querybatchResults.toString().split("\\|");
-   * 
-   * assertTrue("URI returned not correct",
+   *
+   * assertTrue(
    * res[0].contains("/batcher-contraints1.json"));
    * assertEquals("Bytes Moved","0", res[1]); assertEquals("Batch Number","0",
    * res[3]); } } }
@@ -1763,7 +1759,7 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
 
     try {
       System.out.println("Running testQueryBatcherJobDetails");
-      
+
       addRangeElementAttributeIndex(dbName, "decimal", "http://cloudbank.com", "price", "", "amt", "http://marklogic.com/collation/");
       Thread.sleep(10000);
 
@@ -1842,9 +1838,9 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
       JobTicket jobTicket = dmManagerTmp.startJob(queryBatcher1);
       String jobId = jobTicket.getJobId();
       String jobName = jobTicket.getJobType().name();
-      
-      assertTrue("Job Id is null or empty", !jobId.isEmpty());
-      assertTrue("Job Type name incorrect", jobName.equalsIgnoreCase("QUERY_BATCHER"));
+
+      assertTrue( !jobId.isEmpty());
+      assertTrue( jobName.equalsIgnoreCase("QUERY_BATCHER"));
 
       boolean bJobFinished = queryBatcher1.awaitCompletion(3, TimeUnit.MINUTES);
 
@@ -1855,21 +1851,21 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
 
         // Verify the batch results now.
         String[] res = batchResults.toString().split("\\|");
-        assertEquals("Number of reults returned is incorrect", 1, res.length);
-        assertTrue("URI returned not correct", res[0].contains("/abs-range-constraint/batcher-contraints2.xml"));
+        assertEquals(1, res.length);
+        assertTrue( res[0].contains("/abs-range-constraint/batcher-contraints2.xml"));
 
         // verify the Job and batch get method values.
         String[] batchDetailsArray = batchDetails.toString().split("\\|");
 
-        assertTrue("Job Batch Number not correct", Long.parseLong(batchDetailsArray[0]) > 0);
-        assertTrue("Job Results So Far Number not correct", Long.parseLong(batchDetailsArray[1]) > 0);
-        assertTrue("Forest Batch Number not correct", Long.parseLong(batchDetailsArray[2]) > 0);
+        assertTrue( Long.parseLong(batchDetailsArray[0]) > 0);
+        assertTrue( Long.parseLong(batchDetailsArray[1]) > 0);
+        assertTrue( Long.parseLong(batchDetailsArray[2]) > 0);
 
         // verify the forest get method values.
         String[] forestDetailsArray = forestDetails.toString().split("\\|");
-        assertTrue("Database name returned from batch is not correct", forestDetailsArray[0].equalsIgnoreCase(dbName));
-        assertTrue("Forest name returned from batch is not correct", forestDetailsArray[2].contains(dbName));
-  
+        assertTrue( forestDetailsArray[0].equalsIgnoreCase(dbName));
+        assertTrue( forestDetailsArray[2].contains(dbName));
+
       }
     } catch (Exception e) {
       System.out.println("Exceptions thrown from Test testAndWordQueryWithMultipleForests");
@@ -1955,7 +1951,7 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
       });
       dmManagerTmp.startJob(queryBatcher1);
       boolean bJobFinished = queryBatcher1.awaitCompletion(3, TimeUnit.MINUTES);
-     
+
       if (bJobFinished) {
 
         if (!batchWordFailResults.toString().isEmpty() && batchWordFailResults.toString().contains("Exceptions")) {
@@ -1964,8 +1960,8 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
 
         // Verify the batch results now.
         String[] res = batchWordResults.toString().split("\\|");
-        assertEquals("Number of reults returned is incorrect", 1, res.length);
-        assertTrue("URI returned not correct", res[0].contains("/abs-range-constraint/batcher-contraints5.xml"));
+        assertEquals(1, res.length);
+        assertTrue( res[0].contains("/abs-range-constraint/batcher-contraints5.xml"));
       }
 
       // Run a range query.
@@ -1994,11 +1990,11 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
         }
 
         // Verify the batch results now.
-        assertTrue("No of documents returned in range query not correct", batchRangeResults.size() == 4);
-        assertTrue("URI returned not correct", batchRangeResults.contains("/abs-range-constraint/batcher-contraints1.xml"));
-        assertTrue("URI returned not correct", batchRangeResults.contains("/abs-range-constraint/batcher-contraints2.xml"));
-        assertTrue("URI returned not correct", batchRangeResults.contains("/abs-range-constraint/batcher-contraints4.xml"));
-        assertTrue("URI returned not correct", batchRangeResults.contains("/abs-range-constraint/batcher-contraints5.xml"));
+        assertTrue( batchRangeResults.size() == 4);
+        assertTrue( batchRangeResults.contains("/abs-range-constraint/batcher-contraints1.xml"));
+        assertTrue( batchRangeResults.contains("/abs-range-constraint/batcher-contraints2.xml"));
+        assertTrue( batchRangeResults.contains("/abs-range-constraint/batcher-contraints4.xml"));
+        assertTrue( batchRangeResults.contains("/abs-range-constraint/batcher-contraints5.xml"));
       }
 
       // Run a ValueQueryOnAttribute query.
@@ -2020,15 +2016,15 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
       });
       dmManagerTmp.startJob(queryBatcher3);
       bJobFinished = queryBatcher3.awaitCompletion(3, TimeUnit.MINUTES);
-      
+
       if (bJobFinished) {
         if (!batchvalueFailResults.toString().isEmpty() && batchvalueFailResults.toString().contains("Exceptions")) {
           fail("Test failed due to exceptions in testDifferentQueryTypes - Word Query");
         }
 
         // Verify the batch results now.
-        assertTrue("No of documents returned in range query not correct", batchValueResults.size() == 1);
-        assertTrue("URI returned not correct", batchRangeResults.contains("/abs-range-constraint/batcher-contraints1.xml"));
+        assertTrue( batchValueResults.size() == 1);
+        assertTrue( batchRangeResults.contains("/abs-range-constraint/batcher-contraints1.xml"));
       }
     } catch (Exception e) {
       System.out.println("Exceptions thrown from Test testDifferentQueryTypes");
@@ -2039,7 +2035,7 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
       clearDB();
     }
   }
-  
+
   @Test
   public void testMinHostWithHostAvailabilityListener() throws Exception
   {
@@ -2083,12 +2079,12 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
 		  finally {
 			  client.release();
 			  System.out.println("Exception Message is " + batchFailResults.toString());
-			  assertTrue("Exception incorrect", batchFailResults.toString().contains("numHosts must be less than or equal to the number of hosts in the cluster"));
+			  assertTrue( batchFailResults.toString().contains("numHosts must be less than or equal to the number of hosts in the cluster"));
 			  clearDB();
 		  }
 	  }
   }
-  
+
   @Test
   public void testProgressListener() throws Exception {
 	  DatabaseClient clientTmp = null;
@@ -2141,7 +2137,7 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
 
 		  dmManager.startJob(batcher6000);
 		  batcher6000.awaitCompletion();
-          assertTrue("Progress Update incorrect", progressSet.toString().contains("Progress: 6000 results"));
+          assertTrue( progressSet.toString().contains("Progress: 6000 results"));
 
 		  // Read in smaller batches and monitor progress
           Set<String> progressSet60 = Collections.synchronizedSet(new HashSet<>());
@@ -2167,9 +2163,9 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
 		  batcher60.awaitCompletion();
 
 		  // Make sure all updates are available
-          assertTrue("Progress Update Batch 1 incorrect", progressSet60.toString().contains("Progress: 60 results"));
-		  assertTrue("Progress Update Batch 5940 incorrect", progressSet60.toString().contains("Progress: 5940 results"));
-		  assertTrue("Progress Update incorrect", progressSet60.toString().contains("Progress: 6000 results"));
+          assertTrue( progressSet60.toString().contains("Progress: 60 results"));
+		  assertTrue( progressSet60.toString().contains("Progress: 5940 results"));
+		  assertTrue( progressSet60.toString().contains("Progress: 6000 results"));
 		  // Batches read are uneven and with multiple threads
 
           Set<String> progressSet33 = Collections.synchronizedSet(new HashSet<>());
@@ -2193,12 +2189,12 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
 		  batcher33.awaitCompletion();
 
 		  // Make sure all updates are available
-		  assertTrue("Progress Update Batch 1 incorrect", progressSet33.toString().contains("Progress: 33 results"));
-		  assertTrue("Progress Update Batch 5973 incorrect", progressSet33.toString().contains("Progress: 5973 results"));
-		  assertTrue("Progress Update incorrect", progressSet33.toString().contains("Progress: 6000 results"));
+		  assertTrue( progressSet33.toString().contains("Progress: 33 results"));
+		  assertTrue( progressSet33.toString().contains("Progress: 5973 results"));
+		  assertTrue( progressSet33.toString().contains("Progress: 6000 results"));
 
 		  // Batches read errors
-		  StringBuilder strErr = new StringBuilder();	  
+		  StringBuilder strErr = new StringBuilder();
 		  StringQueryDefinition querydefErr = queryMgr.newStringDefinition();
 		  querydefErr.setCriteria("Jhn AND BAA");
 
@@ -2207,7 +2203,7 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
 				  new ProgressListener()
 				  .onProgressUpdate(progressUpdate -> {
 					  System.out.println("From ProgressListener (From Batch Err): " + progressUpdate.getProgressAsString());
-					  strErr.append(progressUpdate.getProgressAsString());	  
+					  strErr.append(progressUpdate.getProgressAsString());
 				  }))
 		  .onQueryFailure((throwable) -> {
 			  System.out.println("queryFailures Err: ");
@@ -2223,7 +2219,7 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
 
 		  System.out.println("From buffer Err: " + strErr.toString());
 		  // No updates are available
-		  assertTrue("Progress Update Batch 1 incorrect", strErr.toString().isEmpty());	  
+		  assertTrue( strErr.toString().isEmpty());
 	  }
 	  catch (Exception ex) {
 		  ex.printStackTrace();
@@ -2234,7 +2230,7 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
 		  clearDB();
 	  }
   }
-  
+
   @Test
   public void testQueryBatcherWithIterator() throws Exception {
 	  DatabaseClient clientTmp = null;
@@ -2258,7 +2254,7 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
 		  wbatcher.onBatchFailure((batch, throwable) -> throwable.printStackTrace());
 		  StringHandle handle = new StringHandle();
 		  handle.set(jsonDoc);
-		  
+
 		  // Insert 6 K documents
 		  for (int i = 0; i < 6000; i++) {
 			  uri = "/QBIteratorTest" + i + ".json";
@@ -2271,7 +2267,7 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
 
 		  wbatcher.flushAndWait();
 		  // Read all 6000 docs in a batch using an iterator.
-		  
+
 		  QueryBatcher queryBatcher = dmManager.newQueryBatcher(uris.iterator())
 				                               .withBatchSize(20)
 				                               .withThreadCount(1);
@@ -2292,12 +2288,12 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
 			  throwable.printStackTrace();
 
 		  });
-		  
+
 		  dmManager.startJob(queryBatcher);
 		  queryBatcher.awaitCompletion();
 		  System.out.println("First batch comprisions");
-		  
-		  assertTrue("Batch 1 incorrect", batchValueResults.equals(uris20));		    
+
+		  assertTrue( batchValueResults.equals(uris20));
 	  }
 	  catch (Exception ex) {
 	  ex.printStackTrace();
@@ -2390,8 +2386,8 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
 
             // Verify the batch results now.
             String[] res = batchResults.toString().split("\\|");
-            assertEquals("Number of reults returned is incorrect", 1, res.length);
-            assertTrue("URI returned not correct", res[0].trim().contains("/CXXXX_Ü_testqa.xml"));
+            assertEquals(1, res.length);
+            assertTrue( res[0].trim().contains("/CXXXX_Ü_testqa.xml"));
 
             // Read the document and assert on the value
             DOMHandle contentHandle = new DOMHandle();
@@ -2399,9 +2395,9 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
             Document readDoc = contentHandle.get();
             System.out.println(convertXMLDocumentToString(readDoc));
 
-            assertTrue("Document content returned not correct", readDoc.getElementsByTagName("id").item(0).getTextContent().contains("0026"));
-            assertTrue("Document content returned not correct", readDoc.getElementsByTagName("title").item(0).getTextContent().contains("The memex"));
-            assertTrue("Document content returned not correct", readDoc.getElementsByTagName("date").item(0).getTextContent().contains("2009-05-05"));
+            assertTrue( readDoc.getElementsByTagName("id").item(0).getTextContent().contains("0026"));
+            assertTrue( readDoc.getElementsByTagName("title").item(0).getTextContent().contains("The memex"));
+            assertTrue( readDoc.getElementsByTagName("date").item(0).getTextContent().contains("2009-05-05"));
           }
         } catch (Exception e) {
           System.out.println("Exceptions thrown from testUTF8InUri");
@@ -2535,11 +2531,11 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
         if (! failStr.toString().isEmpty()) {
           fail("QueryBatcher failed to query required docs.");
         }
-        assertEquals("Number of docs returned incorrect", 3, ndocs);
+        assertEquals(3, ndocs);
         String res = resultUris.toString();
-        assertTrue("Doc 1 returned incorrect", res.contains("/testdoc/doc3.xml"));
-        assertTrue("Doc 2 returned incorrect", res.contains("/testdoc/doc4.xml"));
-        assertTrue("Doc 3 returned incorrect", res.contains("/testdoc/doc5.xml"));
+        assertTrue( res.contains("/testdoc/doc3.xml"));
+        assertTrue( res.contains("/testdoc/doc4.xml"));
+        assertTrue( res.contains("/testdoc/doc5.xml"));
       }
 
     } catch (Exception e) {

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/UrisToWriterListenerFuncTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/UrisToWriterListenerFuncTest.java
@@ -16,52 +16,32 @@
 
 package com.marklogic.client.datamovement.functionaltests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileReader;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.util.TreeMap;
-
-import javax.xml.parsers.ParserConfigurationException;
-
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.xml.sax.SAXException;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.marklogic.client.DatabaseClient;
-import com.marklogic.client.datamovement.DataMovementManager;
-import com.marklogic.client.datamovement.JobTicket;
-import com.marklogic.client.datamovement.QueryBatcher;
-import com.marklogic.client.datamovement.UrisToWriterListener;
-import com.marklogic.client.datamovement.WriteBatcher;
-import com.marklogic.client.datamovement.WriteEvent;
+import com.marklogic.client.datamovement.*;
 import com.marklogic.client.document.JSONDocumentManager;
 import com.marklogic.client.functionaltest.Artifact;
 import com.marklogic.client.functionaltest.BasicJavaClientREST;
 import com.marklogic.client.functionaltest.Company;
 import com.marklogic.client.functionaltest.Product;
-import com.marklogic.client.io.DocumentMetadataHandle;
-import com.marklogic.client.io.Format;
-import com.marklogic.client.io.InputStreamHandle;
-import com.marklogic.client.io.JacksonDatabindHandle;
-import com.marklogic.client.io.JacksonHandle;
-import com.marklogic.client.io.StringHandle;
+import com.marklogic.client.io.*;
 import com.marklogic.client.io.marker.ContentHandleFactory;
 import com.marklogic.client.pojo.PojoRepository;
 import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.query.StringQueryDefinition;
 import com.marklogic.client.query.StructuredQueryBuilder;
 import com.marklogic.client.query.StructuredQueryDefinition;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.*;
+import java.util.TreeMap;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class UrisToWriterListenerFuncTest extends BasicJavaClientREST {
 
@@ -78,7 +58,7 @@ public class UrisToWriterListenerFuncTest extends BasicJavaClientREST {
   private static String uriFile2 = "testMultipleOutputListeners2.txt";
   private static FileWriter writer2 = null;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpBeforeClass() throws Exception {
     loadGradleProperties();
     restServerPort = getRestAppServerPort();
@@ -100,7 +80,7 @@ public class UrisToWriterListenerFuncTest extends BasicJavaClientREST {
     dmManagerTmp = clientQHBTmp.newDataMovementManager();
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownAfterClass() throws Exception {
     System.out.println("In tearDownAfterClass");
     // Release clients
@@ -114,12 +94,7 @@ public class UrisToWriterListenerFuncTest extends BasicJavaClientREST {
     deleteForest(fNames[0]);
   }
 
-  @Before
-  public void setUp() throws Exception {
-
-  }
-
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     System.out.println("In tearDown");
     clearDB(restServerPort);
@@ -128,13 +103,13 @@ public class UrisToWriterListenerFuncTest extends BasicJavaClientREST {
   /*
    * To test UriToWriterListener simple use case with multiple file types and
    * get URIs into an output file.
-   * 
+   *
    * @throws IOException
-   * 
+   *
    * @throws ParserConfigurationException
-   * 
+   *
    * @throws SAXException
-   * 
+   *
    * @throws XpathException
    */
   @Test
@@ -263,7 +238,7 @@ public class UrisToWriterListenerFuncTest extends BasicJavaClientREST {
         System.out.println("Line read from file with URIS is" + line);
         uriMap.put(line, "URI");
       }
-      assertTrue("URIs not read correctly from testMultipleFileTypes method ", expectedMap.equals(uriMap));
+      assertTrue(expectedMap.equals(uriMap));
     } catch (Exception ex) {
       System.out.println("Exceptions in testMultipleFileTypes method" + ex.getMessage());
     } finally {
@@ -286,13 +261,13 @@ public class UrisToWriterListenerFuncTest extends BasicJavaClientREST {
   /*
    * To test if URI from UriToWriterListener writer can be used to read
    * document.
-   * 
+   *
    * @throws IOException
-   * 
+   *
    * @throws ParserConfigurationException
-   * 
+   *
    * @throws SAXException
-   * 
+   *
    * @throws XpathException
    */
   @Test
@@ -384,7 +359,7 @@ public class UrisToWriterListenerFuncTest extends BasicJavaClientREST {
         System.out.println("Line read from file with URIS is" + line);
         docId = line.trim();
       }
-      assertTrue("Json URI not correct", docId.contains("product-microsoft.json"));
+      assertTrue(docId.contains("product-microsoft.json"));
       // Verify the URI from UrisToWriterListener writer by reading in the
       // document.
 
@@ -393,9 +368,9 @@ public class UrisToWriterListenerFuncTest extends BasicJavaClientREST {
       docMgr.read(docId, jacksonhandle);
       JsonNode resultNode = jacksonhandle.get();
 
-      assertEquals("Document content read back not correct in testReadbacks method ", "Windows 10", resultNode.path("name").asText());
-      assertEquals("Document content read back not correct in testReadbacks method ", "Software", resultNode.path("industry").asText());
-      assertEquals("Document content read back not correct in testReadbacks method ", "OS Server", resultNode.path("description").asText());
+      assertEquals("Windows 10", resultNode.path("name").asText());
+      assertEquals("Software", resultNode.path("industry").asText());
+      assertEquals("OS Server", resultNode.path("description").asText());
     } catch (Exception ex) {
       System.out.println("Exceptions thrown from testReadbacks method" + ex.getMessage());
     } finally {
@@ -531,7 +506,7 @@ public class UrisToWriterListenerFuncTest extends BasicJavaClientREST {
       while (reader1.readLine() != null) {
         lnCnt++;
       }
-      assertTrue("Number of URIs exported first time incorrect ", lnCnt == 4);
+      assertEquals(4, lnCnt);
       reader1.close();
       filereader1.close();
       // Use WriteBatcher2 to write files.
@@ -617,7 +592,7 @@ public class UrisToWriterListenerFuncTest extends BasicJavaClientREST {
         System.out.println("Line read from file with URIS is" + line);
         uriMap.put(line, "URI");
       }
-      assertTrue("URIs not read correctly from testWriteMultipleTimes method ", expectedMap.equals(uriMap));
+      assertTrue(expectedMap.equals(uriMap));
     } catch (Exception ex) {
       System.out.println("Exceptions thrown from testWriteMultipleTimes method " + ex.getMessage());
     } finally {
@@ -711,7 +686,7 @@ public class UrisToWriterListenerFuncTest extends BasicJavaClientREST {
         System.out.println("Line read from file with URIS is" + line);
         uriMap.put(line, "URI");
       }
-      assertTrue("URIs not read correctly from testPOJOUris method ", expectedMap.equals(uriMap));
+      assertTrue(expectedMap.equals(uriMap));
     } catch (Exception ex) {
       System.out.println("Exceptions from testPOJOUris method is" + ex.getMessage());
     } finally {
@@ -861,7 +836,7 @@ public class UrisToWriterListenerFuncTest extends BasicJavaClientREST {
         System.out.println("Line read from file with URIS is" + line);
         uriMap.put(line, "URI");
       }
-      assertTrue("URIs not read correctly from testPOJOUrisUsingDataBindHandle method ", expectedMap.equals(uriMap));
+      assertTrue(expectedMap.equals(uriMap));
       JSONDocumentManager docMgr = clientQHB.newJSONDocumentManager();
       // Read it back into JacksonDatabindHandle Product
       JacksonDatabindHandle<Product> jacksonDBReadHandle = new JacksonDatabindHandle<Product>(Product.class);
@@ -869,9 +844,9 @@ public class UrisToWriterListenerFuncTest extends BasicJavaClientREST {
       Product product2 = (Product) jacksonDBReadHandle.get();
 
       // Validate the first POJO
-      assertTrue("Did not return a iMac", product2.getName().equalsIgnoreCase("iMac"));
-      assertTrue("Did not return a Desktop", product2.getIndustry().equalsIgnoreCase("Desktop"));
-      assertTrue("Did not return a Air Book OS X", product2.getDescription().equalsIgnoreCase("Air Book OS X"));
+      assertTrue(product2.getName().equalsIgnoreCase("iMac"));
+      assertTrue(product2.getIndustry().equalsIgnoreCase("Desktop"));
+      assertTrue(product2.getDescription().equalsIgnoreCase("Air Book OS X"));
     } catch (Exception ex) {
       System.out.println("Exceptions from testPOJOUrisUsingDataBindHandle method is" + ex.getMessage());
     } finally {
@@ -971,7 +946,7 @@ public class UrisToWriterListenerFuncTest extends BasicJavaClientREST {
         System.out.println("Line read from file with URIS is " + line);
         uriMap1.put(line, "URI");
       }
-      assertTrue("URIs not read correctly from testMultipleOutputListeners method ", expectedMap1.equals(uriMap1));
+      assertTrue(expectedMap1.equals(uriMap1));
 
       // Verify the MyOutputListener (file) succeeded.
       freader2 = new FileReader(uriFile2);
@@ -980,7 +955,7 @@ public class UrisToWriterListenerFuncTest extends BasicJavaClientREST {
         System.out.println("Line read from file with MyOutputListener URIS is " + line);
         uriMap2.put(line, "URI");
       }
-      assertTrue("URIs not read correctly from testMultipleOutputListeners method ", expectedMap2.equals(uriMap2));
+      assertTrue(expectedMap2.equals(uriMap2));
     } catch (Exception ex) {
       System.out.println("Exceptions from testMultipleOutputListeners method is " + ex.getMessage());
     } finally {
@@ -1100,7 +1075,7 @@ public class UrisToWriterListenerFuncTest extends BasicJavaClientREST {
         System.out.println("Line read from file with URIS is" + line);
         docId = line.trim();
       }
-      assertTrue("Json URI not correct", docId.contains("ML9/product-microsoft.jsonGreat"));
+      assertTrue(docId.contains("ML9/product-microsoft.jsonGreat"));
     } catch (Exception ex) {
       System.out.println("Exceptions thrown from testPrefixAndSuffix method" + ex.getMessage());
     } finally {
@@ -1231,7 +1206,7 @@ public class UrisToWriterListenerFuncTest extends BasicJavaClientREST {
       }
     }
     System.out.println("Batch Failure contents are " + batchFailResults.toString());
-    assertTrue("Exception is not thrown", batchFailResults.toString().contains("QA OnBatchFailure Event"));
+    assertTrue(batchFailResults.toString().contains("QA OnBatchFailure Event"));
   }
 
   public Artifact getArtifact(int counter) {

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/WriteBatcherJobReportTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/WriteBatcherJobReportTest.java
@@ -15,52 +15,35 @@
  */
 package com.marklogic.client.datamovement.functionaltests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.io.File;
-import java.util.Calendar;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
-
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-
-import org.apache.commons.io.FileUtils;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.w3c.dom.Document;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.admin.ExtensionMetadata;
 import com.marklogic.client.admin.TransformExtensionsManager;
-import com.marklogic.client.datamovement.DataMovementManager;
-import com.marklogic.client.datamovement.DeleteListener;
-import com.marklogic.client.datamovement.JobReport;
-import com.marklogic.client.datamovement.JobTicket;
-import com.marklogic.client.datamovement.QueryBatcher;
-import com.marklogic.client.datamovement.WriteBatcher;
+import com.marklogic.client.datamovement.*;
 import com.marklogic.client.document.ServerTransform;
 import com.marklogic.client.functionaltest.BasicJavaClientREST;
-import com.marklogic.client.io.DOMHandle;
-import com.marklogic.client.io.DocumentMetadataHandle;
-import com.marklogic.client.io.FileHandle;
-import com.marklogic.client.io.Format;
-import com.marklogic.client.io.JacksonHandle;
-import com.marklogic.client.io.StringHandle;
+import com.marklogic.client.io.*;
 import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.query.StringQueryDefinition;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.File;
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class WriteBatcherJobReportTest extends BasicJavaClientREST {
 
@@ -93,12 +76,12 @@ public class WriteBatcherJobReportTest extends BasicJavaClientREST {
 
 	private static JobTicket writeTicket;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpBeforeClass() throws Exception {
 		loadGradleProperties();
 		server = getRestAppServerName();
 	    port = getRestAppServerPort();
-	    
+
 		host = getRestAppServerHostName();
 		hostNames = getHosts();
 		createDB(dbName);
@@ -153,7 +136,7 @@ public class WriteBatcherJobReportTest extends BasicJavaClientREST {
 		docMeta2.setFormat(Format.XML);
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void tearDownAfterClass() throws Exception {
 		associateRESTServerWithDB(server, "Documents");
 		for (int i = 0; i < hostNames.length; i++) {
@@ -165,12 +148,7 @@ public class WriteBatcherJobReportTest extends BasicJavaClientREST {
 		deleteDB(dbName);
 	}
 
-	@Before
-	public void setUp() throws Exception {
-
-	}
-
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 
 		Map<String, String> props = new HashMap<>();
@@ -196,7 +174,7 @@ public class WriteBatcherJobReportTest extends BasicJavaClientREST {
 	public void testJobReport() throws Exception {
 
 		final String query1 = "fn:count(fn:doc())";
-		Assert.assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 0);
+		assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 0);
 
 		WriteBatcher ihb1 = dmManager.newWriteBatcher();
 
@@ -246,7 +224,7 @@ public class WriteBatcherJobReportTest extends BasicJavaClientREST {
 
 		ihb1.flushAsync();
 		ihb1.awaitCompletion();
-		Assert.assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 0);
+		assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 0);
 
 		for (int i = 0; i < 10; i++) {
 			String uri = "/local/json-" + i;
@@ -256,9 +234,9 @@ public class WriteBatcherJobReportTest extends BasicJavaClientREST {
 		ihb1.flushAsync();
 		ihb1.awaitCompletion();
 
-		Assert.assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 10);
-		Assert.assertTrue(success.get());
-		Assert.assertTrue(failure.get());
+		assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 10);
+		assertTrue(success.get());
+		assertTrue(failure.get());
 
 		dmManager.stopJob(ihb1);
 		Thread.currentThread().sleep(2000L);
@@ -273,7 +251,7 @@ public class WriteBatcherJobReportTest extends BasicJavaClientREST {
 	public void testJobReportStopJob() throws Exception {
 
 		final String query1 = "fn:count(fn:doc())";
-		Assert.assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 0);
+		assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 0);
 
 		WriteBatcher ihb1 = dmManager.newWriteBatcher();
 
@@ -310,17 +288,17 @@ public class WriteBatcherJobReportTest extends BasicJavaClientREST {
 		ihb1.awaitCompletion();
 
 		System.out.println(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue());
-		Assert.assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == dmManager
+		assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == dmManager
 				.getJobReport(writeTicket).getSuccessEventsCount());
 
 		dmManager.stopJob(ihb1);
 	}
-	
+
 	@Test
 	public void testJobReportTimes() throws Exception {
 
 		final String query1 = "fn:count(fn:doc())";
-		Assert.assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 0);
+		assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 0);
 
 		WriteBatcher ihb1 = dmManager.newWriteBatcher();
 
@@ -443,15 +421,15 @@ public class WriteBatcherJobReportTest extends BasicJavaClientREST {
 		}
 		ihb2.flushAndWait();
 
-		Assert.assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 10);
-		Assert.assertTrue(succException.get());
-		Assert.assertTrue(failException.get());
+		assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 10);
+		assertTrue(succException.get());
+		assertTrue(failException.get());
 	}
 
 	@Test
 	public void testServerXQueryTransformSuccess() throws Exception {
 		final String query1 = "fn:count(fn:doc())";
-		Assert.assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 0);
+		assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 0);
 
 		TransformExtensionsManager transMgr = dbClient.newServerConfigManager().newTransformExtensionsManager();
 		ExtensionMetadata metadata = new ExtensionMetadata();
@@ -521,9 +499,9 @@ public class WriteBatcherJobReportTest extends BasicJavaClientREST {
 		}
 		// Flush
 		ihb1.flushAndWait();
-		Assert.assertTrue(success.get());
-		Assert.assertFalse(failure.get());
-		Assert.assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 8);
+		assertTrue(success.get());
+		assertFalse(failure.get());
+		assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 8);
 	}
 
 	// Multiple threads writing to same WHB object with unique uri's
@@ -572,10 +550,10 @@ public class WriteBatcherJobReportTest extends BasicJavaClientREST {
 		t2.join();
 		t3.join();
 
-		Assert.assertTrue(dmManager.getJobReport(writeTicket).getSuccessEventsCount() == 300);
-		Assert.assertTrue(dmManager.getJobReport(writeTicket).getFailureEventsCount() == 0);
-		Assert.assertTrue(dmManager.getJobReport(writeTicket).getFailureBatchesCount() == 0);
-		Assert.assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 300);
+		assertTrue(dmManager.getJobReport(writeTicket).getSuccessEventsCount() == 300);
+		assertTrue(dmManager.getJobReport(writeTicket).getFailureEventsCount() == 0);
+		assertTrue(dmManager.getJobReport(writeTicket).getFailureBatchesCount() == 0);
+		assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 300);
 	}
 
 	// ISSUE 48
@@ -627,14 +605,14 @@ public class WriteBatcherJobReportTest extends BasicJavaClientREST {
 		t3.join();
 		System.out.println(succEvent.intValue());
 		System.out.println(failEvent.intValue());
-		Assert.assertTrue(succEvent.intValue() + failEvent.intValue() == 300);
+		assertTrue(succEvent.intValue() + failEvent.intValue() == 300);
 	}
 
 	@Test
 	public void testRetry() throws Exception {
 
 		final String query1 = "fn:count(fn:doc())";
-		Assert.assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 0);
+		assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 0);
 		AtomicBoolean successCalled = new AtomicBoolean(false);
 		Map<String, String> properties = new HashMap<>();
 		AtomicInteger successEvents = new AtomicInteger(0);
@@ -676,10 +654,10 @@ public class WriteBatcherJobReportTest extends BasicJavaClientREST {
 		properties.put("enabled", "true");
 		changeProperty(properties, "/manage/v2/databases/" + dbName + "/properties");
 		ihbMT.awaitCompletion();
-		Assert.assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 200);
-		Assert.assertTrue(successEvents.get() == 200);
-		Assert.assertTrue(failureEvents.get() == 200);
-		Assert.assertTrue(successCalled.get());
+		assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 200);
+		assertTrue(successEvents.get() == 200);
+		assertTrue(failureEvents.get() == 200);
+		assertTrue(successCalled.get());
 	}
 
 	@Test
@@ -780,13 +758,13 @@ public class WriteBatcherJobReportTest extends BasicJavaClientREST {
 		}
 		// Flush
 		ihb1.flushAndWait();
-		Assert.assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 4);
+		assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 4);
 
 		// Account for a delta in the events
-		Assert.assertTrue(Math.abs(succEvents.intValue()-4) <= 2);
-		Assert.assertTrue(Math.abs(succBatches.intValue()-4) <= 2);
-		Assert.assertTrue(Math.abs(failEvents.intValue()-4) <= 2);
-		Assert.assertTrue(Math.abs(failBatches.intValue()-4) <= 2);
+		assertTrue(Math.abs(succEvents.intValue()-4) <= 2);
+		assertTrue(Math.abs(succBatches.intValue()-4) <= 2);
+		assertTrue(Math.abs(failEvents.intValue()-4) <= 2);
+		assertTrue(Math.abs(failBatches.intValue()-4) <= 2);
 
 	}
 
@@ -814,10 +792,10 @@ public class WriteBatcherJobReportTest extends BasicJavaClientREST {
 
 			ihb2.flushAndWait();
 
-			Assert.assertTrue(dmManager.getJobReport(writeTicket).getSuccessEventsCount() == 25000);
-			Assert.assertTrue(dmManager.getJobReport(writeTicket).getFailureBatchesCount() == 0);
-			Assert.assertTrue(dmManager.getJobReport(writeTicket).getFailureBatchesCount() == 0);
-			Assert.assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 25000);
+			assertTrue(dmManager.getJobReport(writeTicket).getSuccessEventsCount() == 25000);
+			assertTrue(dmManager.getJobReport(writeTicket).getFailureBatchesCount() == 0);
+			assertTrue(dmManager.getJobReport(writeTicket).getFailureBatchesCount() == 0);
+			assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 25000);
 
 		} catch (Exception e) {
 			e.printStackTrace();
@@ -828,7 +806,7 @@ public class WriteBatcherJobReportTest extends BasicJavaClientREST {
 	public void testAddMultiThreadedStopJob() throws Exception {
 
 		final String query1 = "fn:count(fn:doc())";
-		Assert.assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 0);
+		assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 0);
 
 		ihbMT = dmManager.newWriteBatcher();
 		ihbMT.withBatchSize(11).withThreadCount(5);
@@ -876,7 +854,7 @@ public class WriteBatcherJobReportTest extends BasicJavaClientREST {
 			fail("Exception should have been thrown");
 		} catch (IllegalStateException e) {
 			System.out.println(e.getMessage());
-			Assert.assertTrue(e.getMessage().contains("This instance has been stopped"));
+			assertTrue(e.getMessage().contains("This instance has been stopped"));
 
 		}
 		try {
@@ -884,7 +862,7 @@ public class WriteBatcherJobReportTest extends BasicJavaClientREST {
 			fail("Exception should have been thrown");
 		} catch (IllegalStateException e) {
 			System.out.println(e.getMessage());
-			Assert.assertTrue(e.getMessage().contains("This instance has been stopped"));
+			assertTrue(e.getMessage().contains("This instance has been stopped"));
 
 		}
 
@@ -892,7 +870,7 @@ public class WriteBatcherJobReportTest extends BasicJavaClientREST {
 
 		int count = dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue();
 		System.out.println(count);
-		Assert.assertTrue(count == dmManager.getJobReport(writeTicket).getSuccessEventsCount());
+		assertTrue(count == dmManager.getJobReport(writeTicket).getSuccessEventsCount());
 	}
 
 	public static Object[] getSummaryReport(JobTicket ticket) {

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/AbstractFunctionalTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/AbstractFunctionalTest.java
@@ -12,16 +12,15 @@ import com.marklogic.client.functionaltest.BasicJavaClientREST;
 import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.FileHandle;
 import com.marklogic.mgmt.resource.databases.DatabaseManager;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.xml.sax.SAXException;
 
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.File;
 import java.io.IOException;
 import java.util.stream.Stream;
-
-import static org.junit.Assert.assertTrue;
 
 /**
  * Abstract class for functional tests that depend on the test app in ./marklogic-client-api/src/test, which is
@@ -42,7 +41,7 @@ public abstract class AbstractFunctionalTest extends BasicJavaClientREST {
     private static String originalHttpPort;
 	private static String originalRestServerName;
 
-    @BeforeClass
+    @BeforeAll
     public static void initializeClients() throws Exception {
         loadGradleProperties();
 
@@ -84,7 +83,7 @@ public abstract class AbstractFunctionalTest extends BasicJavaClientREST {
         client.newServerEval().xquery("cts:uris((), (), cts:true-query()) ! xdmp:document-delete(.)").evalAs(String.class);
     }
 
-    @AfterClass
+    @AfterAll
     public static void classTearDown() {
         http_port = originalHttpPort;
 		restServerName = originalRestServerName;
@@ -266,9 +265,9 @@ public abstract class AbstractFunctionalTest extends BasicJavaClientREST {
         Stream
             .of(expectedColumnInfos)
             .map(columnInfo -> columnInfo.getExpectedJson())
-            .forEach(expectedJson -> assertTrue(
-                "Did not find expected JSON: " + expectedJson + "; colInfo: " + actualColumnInfo,
-                actualColumnInfo.contains(expectedJson))
-            );
+            .forEach(expectedJson -> Assertions.assertTrue(
+				actualColumnInfo.contains(expectedJson),
+				"Did not find expected JSON: " + expectedJson + "; colInfo: " + actualColumnInfo
+            ));
     }
 }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/ClientApiFunctionalTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/ClientApiFunctionalTest.java
@@ -21,17 +21,18 @@ import okhttp3.Credentials;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.springframework.util.StringUtils;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.stream.Stream;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ClientApiFunctionalTest extends AbstractFunctionalTest {
 
@@ -70,7 +71,7 @@ public class ClientApiFunctionalTest extends AbstractFunctionalTest {
 	- TestClientQAServer
 	- TestRESTServerOnAPI
 	 */
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() throws Exception {
 		createUserRolesWithPrevilages("apiRole", "xdbc:eval", "xdbc:eval-in", "xdmp:eval-in", "any-uri", "xdbc:invoke", "xdmp:eval", "xdmp:eval-in", "xdmp:invoke", "xdmp:invoke-in");
 		createRESTUser("apiUser", "ap1U53r", "apiRole", "rest-admin", "rest-writer", "rest-reader",
@@ -169,7 +170,7 @@ public class ClientApiFunctionalTest extends AbstractFunctionalTest {
 		docMgr.write(endPointURI_12+".api", metadataHandle, handle);
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void tearDownAfterClass() throws Exception {
 
 		System.out.println("In tear down");
@@ -211,12 +212,12 @@ public class ClientApiFunctionalTest extends AbstractFunctionalTest {
 		// Integer.MAX_VALUE
 		double responseBack6 = TestE2EIntegerParaReturnDouble.on(dbclient).TestE2EItemPrice(Integer.MAX_VALUE);
 		System.out.println("Expected Integer.MAX_VALUE.  Response from the Client API call is " + responseBack6);
-		assertTrue("Expected value not returned", String.valueOf(responseBack6).contains("2.147483648E9"));
+		assertTrue(String.valueOf(responseBack6).contains("2.147483648E9"));
 
 		// Integer.MIN_VALUE
 		double responseBack7 = TestE2EIntegerParaReturnDouble.on(dbclient).TestE2EItemPrice(Integer.MIN_VALUE);
 		System.out.println("Expected Integer.MIN_VALUE.  Response from the Client API call is " + responseBack7);
-		assertTrue("Expected value not returned", String.valueOf(responseBack7).contains("-2.147483647E9"));
+		assertTrue( String.valueOf(responseBack7).contains("-2.147483647E9"));
 
 		// Expecting incorrect data type from module
 		double responseBack8 = 0.0;
@@ -225,7 +226,7 @@ public class ClientApiFunctionalTest extends AbstractFunctionalTest {
 		} catch (Exception ex) {
 			System.out.println("Expecting 0. Response from the Client API call is " + responseBack8);
 			System.out.println("Exception response from the Client API call is " + ex);
-			assertTrue("Exception message incorrect", ex.toString().contains("java.lang.IllegalArgumentException: Could not convert to double: String10"));
+			assertTrue( ex.toString().contains("java.lang.IllegalArgumentException: Could not convert to double: String10"));
 			assertEquals(0.0, responseBack8, 0.00);
 		}
 
@@ -252,11 +253,11 @@ public class ClientApiFunctionalTest extends AbstractFunctionalTest {
 		// Invoke the function
 		String responseBack1 = TestE2EModuleXQY.on(dbclient).xqyfunction("MAGLITE");
 		System.out.println("Response from the Client API call is " + responseBack1);
-		assertTrue("Response when valid parameter passed incorrect", responseBack1.contains("QA Module Returns MAGLITE"));
+		assertTrue( responseBack1.contains("QA Module Returns MAGLITE"));
 		// Pass null for parameter
 		String responseBack2 = TestE2EModuleXQY.on(dbclient).xqyfunction(null);
 		System.out.println("Response from the Client API call is " + responseBack2);
-		assertTrue("Response when null parameter passed incorrect", responseBack2.contains("QA Module Returns Passed in null parameter."));
+		assertTrue( responseBack2.contains("QA Module Returns Passed in null parameter."));
 	}
 
 		// This test requires TestE2ERequiredParam.api Fn Decl file
@@ -271,8 +272,8 @@ public class ClientApiFunctionalTest extends AbstractFunctionalTest {
 		} catch (Exception ex) {
 			msg = ex.toString();
 			System.out.println("Exception response from the Client API call is " + ex);
-			assertTrue("Expected exception type not returned", msg.contains("RequiredParamException"));
-			assertTrue("Expected exception returned", msg.contains("null value for required parameter: items"));
+			assertTrue( msg.contains("RequiredParamException"));
+			assertTrue( msg.contains("null value for required parameter: items"));
 		}
 	}
 
@@ -285,7 +286,7 @@ public class ClientApiFunctionalTest extends AbstractFunctionalTest {
 			TestE2EIntegerParaReturnDouble.on(dbForbiddenclient).TestE2EItemPriceErrorCond(10, 50);
 		} catch (FailedRequestException ex) {
 			msg = ex.getMessage();
-			assertTrue("Unexpected exception: " + msg,
+			assertTrue(
 				msg.contains("failed to POST at") &&
 					msg.contains("/ext/TestE2EIntegerParamReturnDouble/TestE2EIntegerParamReturnDoubleErrorCond.sjs"));
 		}
@@ -301,9 +302,9 @@ public class ClientApiFunctionalTest extends AbstractFunctionalTest {
 		} catch (Exception ex) {
 			msg = ex.toString();
 			System.out.println("Exception response from the Client API call is " + ex);
-			assertTrue("Expected exception type not returned",
+			assertTrue(
 					msg.contains("com.marklogic.client.FailedRequestException"));
-			assertTrue("Unexpected message: " + msg,
+			assertTrue(
 				msg.contains("failed to POST at ") &&
 				msg.contains("/ext/TestE2EModuleNotFound/TestE2EModuleNotFound.sjs"));
 		}
@@ -356,7 +357,7 @@ public class ClientApiFunctionalTest extends AbstractFunctionalTest {
 		} finally {
 			modifyConcurrentUsersOnHttpServer(serverName, 0);
 			System.out.println("Exception from API responses of call are " + msgEx);
-			assertTrue("Unexpected error message: " + msgEx,
+			assertTrue(
 				msgEx.toString().contains("Local message: failed to POST at") &&
 				msgEx.toString().contains("/ext/TestE2EIntegerParamReturnDouble/TestE2EIntegerParamReturnDoubleErrorCond.sjs"));
 		}
@@ -375,7 +376,7 @@ public class ClientApiFunctionalTest extends AbstractFunctionalTest {
 			TestE2EIntegerParaReturnDouble.on(dbSecondClient).TestE2EItemPriceErrorCond(10, 50);
 		} catch (Exception ex) {
 			msg = ex.getMessage();
-			assertTrue("Unexpected exception: " + msg,
+			assertTrue(
 				msg.contains("failed to POST at") &&
 				msg.contains("ext/TestE2EIntegerParamReturnDouble/TestE2EIntegerParamReturnDoubleErrorCond.sjs"));
 		}
@@ -402,7 +403,7 @@ public class ClientApiFunctionalTest extends AbstractFunctionalTest {
 		try {
 			outputStrSeq = TestE2EMultipleStringsInMultipleStringsout.on(dbclient).stringsInAndStringOutAsArray(inputFiles, uris, searchItem);
 			System.out.println("outputStrSeq " + outputStrSeq.toString());
-			assertTrue("Correct URI not returned", outputStrSeq.get(0).asText().contains("constraint1.json"));
+			assertTrue( outputStrSeq.get(0).asText().contains("constraint1.json"));
 		} catch (Exception ex) {
 			System.out.println("Exception response from the Client API call is " + ex);
 		}
@@ -430,7 +431,7 @@ public class ClientApiFunctionalTest extends AbstractFunctionalTest {
 		docMgr.read("/session1.json", jh);
 		String nodeStr = jh.get().get("value").asText();
 		System.out.println("JacksonHandle 1: " + jh);
-		assertTrue("Server module returned false. session1.json not inserted? See Logs", nodeStr.contains("Checking first sessions") );
+		assertTrue( nodeStr.contains("Checking first sessions") );
 
 		// Try multiple calls sequentially - same session
 		SessionState apiSession4 = TestE2ESession.on(dbclient).newSessionState();
@@ -444,7 +445,7 @@ public class ClientApiFunctionalTest extends AbstractFunctionalTest {
 		docMgr.read("/session5.json", jh);
 		nodeStr = jh.get().get("value").asText();
 		System.out.println("JacksonHandle 5 " + jh);
-		assertTrue("Server module returned false. session5.json not inserted? See Logs",
+		assertTrue(
 				nodeStr.contains("Checking sessions 5"));
 
 		// Use null session
@@ -455,8 +456,8 @@ public class ClientApiFunctionalTest extends AbstractFunctionalTest {
 		} catch (Exception ex) {
 			String msg = ex.toString();
 			System.out.println("Exception - session6.json - Client API call is " + msg);
-			assertTrue("Exception incorrect - when sessions is null",msg.contains("RequiredParamException"));
-			assertTrue("Exception incorrect - when sessions is null",msg.contains("null value for required session parameter: api_session"));
+			assertTrue(msg.contains("RequiredParamException"));
+			assertTrue(msg.contains("null value for required session parameter: api_session"));
 		}
 
 		// Use session with cleared cookies
@@ -474,7 +475,7 @@ public class ClientApiFunctionalTest extends AbstractFunctionalTest {
 		docMgr.read("/session7.json", jh);
 		nodeStr = jh.get().get("value").asText();
 		System.out.println("JacksonHandle 7 " + jh);
-		assertTrue("Server module returned false. session7.json not inserted? See Logs",
+		assertTrue(
 				nodeStr.contains("Checking sessions 7"));
 	}
 
@@ -510,8 +511,8 @@ public class ClientApiFunctionalTest extends AbstractFunctionalTest {
 		JsonNode jsNode = mapper.readTree(respStr);
 		System.out.println(respStr);
 
-		assertTrue("OpenAPI response in TestOpenApiParamInParamOut incorrect", jsNode.path("openapi").asText().contains("3.0.0"));
-		assertTrue("OpenAPI response in TestOpenApiParamInParamOut incorrect", jsNode.path("info").path("title").asText().contains("TestE2EIntegerParamReturnDouble.sjs services"));
+		assertTrue( jsNode.path("openapi").asText().contains("3.0.0"));
+		assertTrue( jsNode.path("info").path("title").asText().contains("TestE2EIntegerParamReturnDouble.sjs services"));
 	}
 
 	private String makeCall(OkHttpClient client, Request request) throws IOException {
@@ -546,8 +547,8 @@ public class ClientApiFunctionalTest extends AbstractFunctionalTest {
 		JsonNode jsNode = mapper.readTree(respStr);
 		System.out.println(respStr);
 
-		assertTrue("OpenAPI response in TestOpenApiParamInDocOut incorrect", jsNode.path("openapi").asText().contains("3.0.0"));
-		assertTrue("OpenAPI response in TestOpenApiParamInDocOut incorrect", jsNode.path("info").path("title").asText().contains("TestOpenApiParamsInDocOut.sjs services"));
+		assertTrue( jsNode.path("openapi").asText().contains("3.0.0"));
+		assertTrue( jsNode.path("info").path("title").asText().contains("TestOpenApiParamsInDocOut.sjs services"));
 	}
 
 	//Test Open API docs for Param In and returns none from module function
@@ -574,8 +575,8 @@ public class ClientApiFunctionalTest extends AbstractFunctionalTest {
 		JsonNode jsNode = mapper.readTree(respStr);
 		System.out.println(respStr);
 
-		assertTrue("OpenAPI response in TestOpenApiParamInReturnsNone incorrect", jsNode.path("openapi").asText().contains("3.0.0"));
-		assertTrue("OpenAPI response in TestOpenApiParamInReturnsNone incorrect", jsNode.path("info").path("title").asText().contains("TestOpenApiParamInReturnsNone.sjs services"));
+		assertTrue( jsNode.path("openapi").asText().contains("3.0.0"));
+		assertTrue( jsNode.path("info").path("title").asText().contains("TestOpenApiParamInReturnsNone.sjs services"));
 	}
 
 	//Test Open API docs for Param In and returns "$javaClass" from module function
@@ -602,8 +603,8 @@ public class ClientApiFunctionalTest extends AbstractFunctionalTest {
 		JsonNode jsNode = mapper.readTree(respStr);
 		System.out.println(respStr);
 
-		assertTrue("OpenAPI response in TestOpenApiParamInReturnsJavaClass incorrect", jsNode.path("openapi").asText().contains("3.0.0"));
-		assertTrue("OpenAPI response in TestOpenApiParamInReturnsJavaClass incorrect", jsNode.path("info").path("title").asText().contains("TestE2EJsonStringsInStringsOut.sjs services"));
+		assertTrue( jsNode.path("openapi").asText().contains("3.0.0"));
+		assertTrue( jsNode.path("info").path("title").asText().contains("TestE2EJsonStringsInStringsOut.sjs services"));
 	}
 
 	//Test Open API docs for directory
@@ -630,8 +631,8 @@ public class ClientApiFunctionalTest extends AbstractFunctionalTest {
 		JsonNode jsNode = mapper.readTree(respStr);
 		System.out.println(respStr);
 
-		assertTrue("OpenAPI response in TestOpenApiDirectory incorrect", jsNode.path("openapi").asText().contains("3.0.0"));
-		assertTrue("OpenAPI response in TestOpenApiDirectory incorrect", jsNode.path("info").path("title").asText().contains("/ext/TestOpenApi services"));
+		assertTrue( jsNode.path("openapi").asText().contains("3.0.0"));
+		assertTrue( jsNode.path("info").path("title").asText().contains("/ext/TestOpenApi services"));
 	}
 
 	public static void modifyConcurrentUsersOnHttpServer(String restServerName, int numberOfUsers) {

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/RowBatcherFuncTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/RowBatcherFuncTest.java
@@ -7,20 +7,18 @@ import com.marklogic.client.expression.PlanBuilder;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.row.RowManager;
 import com.marklogic.client.type.CtsReferenceExpr;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.*;
 import java.util.stream.Stream;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class RowBatcherFuncTest extends AbstractFunctionalTest {
 
     private static DataMovementManager dmManager = null;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUpBeforeClass() throws Exception {
         // Install the TDE templates into schemadbName DB
         // loadFileToDB(client, filename, docURI, collection, document format)
@@ -252,7 +250,7 @@ public class RowBatcherFuncTest extends AbstractFunctionalTest {
         rowsBatcherOfJsonObj.awaitCompletion();
 
         Stream.of("new jersey", "cape town", "beijing", "new york", "london").forEach(city -> {
-            assertTrue("Did not find " + city + " in " + citiesFound, citiesFound.contains(city));
+            assertTrue(citiesFound.contains(city), "Did not find " + city + " in " + citiesFound);
         });
         assertEquals(5, citiesFound.size());
     }
@@ -363,7 +361,7 @@ public class RowBatcherFuncTest extends AbstractFunctionalTest {
             exBuf = ex.getMessage();
         }
         finally {
-            assertTrue("Exception message incorrect", exBuf.contains("First operation in Optic plan must be fromView()"));
+            assertTrue(exBuf.contains("First operation in Optic plan must be fromView()"));
         }
     }
 

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestAggregates.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestAggregates.java
@@ -25,8 +25,9 @@ import com.marklogic.client.query.AggregateResult;
 import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.query.ValuesDefinition;
 import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 import org.xml.sax.SAXException;
 
 import javax.xml.parsers.ParserConfigurationException;
@@ -36,11 +37,9 @@ import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.text.DecimalFormat;
 
-import static org.junit.Assert.assertEquals;
-
 public class TestAggregates extends AbstractFunctionalTest {
 
-  @After
+  @AfterEach
   public void tearDown() {
     deleteDocuments(client);
   }
@@ -76,27 +75,27 @@ public class TestAggregates extends AbstractFunctionalTest {
 
     AggregateResult[] agg = valuesHandle.getAggregates();
     System.out.println(agg.length);
-    assertEquals("Invalid length", 4, agg.length);
+    assertEquals( 4, agg.length);
     int sum = agg[0].get("xs:int", Integer.class);
     double avg = agg[1].get("xs:double", Double.class);
     int max = agg[2].get("xs:int", Integer.class);
     int min = agg[3].get("xs:int", Integer.class);
     System.out.println(sum);
-    assertEquals("Invalid sum", 22, sum);
+    assertEquals( 22, sum);
     System.out.println(avg);
-    assertEquals("Invalid avg", 4.4, avg, 0);
+    assertEquals( 4.4, avg, 0);
     System.out.println(max);
-    assertEquals("Invalid max", 5, max);
+    assertEquals( 5, max);
     System.out.println(min);
-    assertEquals("Invalid min", 3, min);
+    assertEquals( 3, min);
     System.out.println(agg[0].getValue());
-    assertEquals("Invalid sum", "22", agg[0].getValue());
+    assertEquals( "22", agg[0].getValue());
     System.out.println(agg[1].getValue());
-    assertEquals("Invalid avg", "4.4", agg[1].getValue());
+    assertEquals( "4.4", agg[1].getValue());
     System.out.println(agg[2].getValue());
-    assertEquals("Invalid max", "5", agg[2].getValue());
+    assertEquals( "5", agg[2].getValue());
     System.out.println(agg[3].getValue());
-    assertEquals("Invalid min", "3", agg[3].getValue());
+    assertEquals( "3", agg[3].getValue());
 
     QueryManager queryMgr1 = client.newQueryManager();
     // create query def
@@ -153,7 +152,7 @@ public class TestAggregates extends AbstractFunctionalTest {
 
     AggregateResult[] agg = valuesHandle.getAggregates();
     System.out.println(agg.length);
-    assertEquals("Invalid length", 4, agg.length);
+    assertEquals( 4, agg.length);
     double sum = agg[0].get("xs:double", Double.class);
     double avg = agg[1].get("xs:double", Double.class);
     double max = agg[2].get("xs:double", Double.class);
@@ -164,21 +163,21 @@ public class TestAggregates extends AbstractFunctionalTest {
     String roundedAvg = df.format(avg);
 
     System.out.println("roundedSum :" + roundedSum);
-    assertEquals("Invalid sum", "272.73", roundedSum);
+    assertEquals( "272.73", roundedSum);
     System.out.println("roundedAvg :" + roundedAvg);
-    assertEquals("Invalid avg", "54.55", roundedAvg);
+    assertEquals( "54.55", roundedAvg);
     System.out.println("Max :" + max);
-    assertEquals("Invalid max", 92.45, max, 0);
+    assertEquals( 92.45, max, 0);
     System.out.println("Min :" + min);
-    assertEquals("Invalid min", 12.34, min, 0);
+    assertEquals( 12.34, min, 0);
     System.out.println("agg[0] :" + agg[0].getValue() + " After Formatting :" + df.format(agg[0].get("xs:double", Double.class)));
-    assertEquals("Invalid sum", "272.73", df.format(agg[0].get("xs:double", Double.class)));
+    assertEquals( "272.73", df.format(agg[0].get("xs:double", Double.class)));
     System.out.println("agg[1] :" + agg[1].getValue() + " After Formatting :" + df.format(agg[1].get("xs:double", Double.class)));
-    assertEquals("Invalid avg", "54.55", df.format(agg[1].get("xs:double", Double.class)));
+    assertEquals( "54.55", df.format(agg[1].get("xs:double", Double.class)));
     System.out.println("agg[2] :" + agg[2].getValue());
-    assertEquals("Invalid max", "92.45", df.format(agg[2].get("xs:double", Double.class)));
+    assertEquals( "92.45", df.format(agg[2].get("xs:double", Double.class)));
     System.out.println("agg[3] :" + agg[3].getValue());
-    assertEquals("Invalid min", "12.34", df.format(agg[3].get("xs:double", Double.class)));
+    assertEquals( "12.34", df.format(agg[3].get("xs:double", Double.class)));
 
     // release client
     client.release();
@@ -216,7 +215,7 @@ public class TestAggregates extends AbstractFunctionalTest {
 
     AggregateResult[] agg = tuplesHandle.getAggregates();
     System.out.println(agg.length);
-    assertEquals("Invalid length", 2, agg.length);
+    assertEquals( 2, agg.length);
     double correlation = agg[0].get("xs:double", Double.class);
     double covariance = agg[1].get("xs:double", Double.class);
 
@@ -227,8 +226,8 @@ public class TestAggregates extends AbstractFunctionalTest {
     System.out.println(roundedCorrelation);
     System.out.println(roundedCovariance);
 
-    assertEquals("Invalid correlation", "0.26", roundedCorrelation);
-    assertEquals("Invalid covariance", "0.35", roundedCovariance);
+    assertEquals( "0.26", roundedCorrelation);
+    assertEquals( "0.35", roundedCovariance);
 
     // release client
     client.release();
@@ -304,7 +303,7 @@ public class TestAggregates extends AbstractFunctionalTest {
     queryMgr.values(queryDef, valuesHandle);
 
     AggregateResult[] agg = valuesHandle.getAggregates();
-    assertEquals("Wrong counting", "4", agg[0].getValue());
+    assertEquals( "4", agg[0].getValue());
 
     ValuesDefinition queryDef1 = queryMgr.newValuesDefinition("popularity", "aggregatesOpt3Occ.xml");
     queryDef1.setAggregate("correlation", "covariance");
@@ -316,7 +315,7 @@ public class TestAggregates extends AbstractFunctionalTest {
 
     AggregateResult[] aggn = tuplesHandle.getAggregates();
     System.out.println(aggn.length);
-    assertEquals("Invalid length", 2, aggn.length);
+    assertEquals( 2, aggn.length);
     double correlation = aggn[0].get("xs:double", Double.class);
     double covariance = aggn[1].get("xs:double", Double.class);
 
@@ -326,8 +325,8 @@ public class TestAggregates extends AbstractFunctionalTest {
 
     System.out.println(roundedCorrelation);
     System.out.println(roundedCovariance);
-    assertEquals("Invalid correlation", "0.43", roundedCorrelation);
-    assertEquals("Invalid covariance", "0.67", roundedCovariance);
+    assertEquals( "0.43", roundedCorrelation);
+    assertEquals( "0.67", roundedCovariance);
     // release client
     client.release();
   }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestAppServerConstraints.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestAppServerConstraints.java
@@ -27,9 +27,10 @@ import com.marklogic.client.query.StringQueryDefinition;
 import com.marklogic.client.query.StructuredQueryBuilder;
 import com.marklogic.client.query.StructuredQueryDefinition;
 import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.junit.After;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
@@ -41,18 +42,18 @@ import java.security.NoSuchAlgorithmException;
 
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathNotExists;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+
+
 
 public class TestAppServerConstraints extends AbstractFunctionalTest {
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() throws Exception {
         System.out.println("In setup");
         client = getDatabaseClient("rest-admin", "x", getConnType());
     }
 
-    @After
+    @AfterEach
     public void testCleanUp() throws Exception {
         deleteDocuments(connectAsAdmin());
     }
@@ -456,7 +457,7 @@ public class TestAppServerConstraints extends AbstractFunctionalTest {
             e.toString();
         }
 
-        assertTrue("Expected Warning message is not thrown",
+        assertTrue(
                 result.contains("<search:warning id=\"SEARCH-IGNOREDQTEXT\">[Invalid text, cannot parse geospatial point from '12,A'.]</search:warning>"));
     }
 
@@ -645,7 +646,7 @@ public class TestAppServerConstraints extends AbstractFunctionalTest {
             e.toString();
         }
 
-        assertTrue("Expected Warning message is not thrown",
+        assertTrue(
                 result.contains("<search:warning id=\"SEARCH-IGNOREDQTEXT\">[Invalid text, cannot parse geospatial point from '12,A'.]</search:warning>"));
     }
 
@@ -843,7 +844,7 @@ public class TestAppServerConstraints extends AbstractFunctionalTest {
             e.toString();
         }
 
-        assertTrue("Expected Warning message is not thrown",
+        assertTrue(
                 result.contains("<search:warning id=\"SEARCH-IGNOREDQTEXT\">[Invalid text, cannot parse geospatial point from '12,A'.]</search:warning>"));
     }
 
@@ -1039,7 +1040,7 @@ public class TestAppServerConstraints extends AbstractFunctionalTest {
             e.toString();
         }
 
-        assertTrue("Expected Warning message is not thrown",
+        assertTrue(
                 result.contains("<search:warning id=\"SEARCH-IGNOREDQTEXT\">[Invalid text, cannot parse geospatial point from '-12,A'.]</search:warning>"));
     }
 
@@ -1213,9 +1214,9 @@ public class TestAppServerConstraints extends AbstractFunctionalTest {
      * "com.marklogic.client.FailedRequestException: Local message: search failed: Internal Server ErrorServer Message: XDMP-ELEMRIDXNOTFOUND"
      * ;
      *
-     * //assertEquals("Wrong exception", expectedException, exception); boolean
+     * //assertEquals( expectedException, exception); boolean
      * exceptionIsThrown = exception.contains(expectedException);
-     * assertTrue("Exception is not thrown", exceptionIsThrown);
+     * assertTrue( exceptionIsThrown);
      *
      * // release client
      * //client.release(); }
@@ -1256,9 +1257,9 @@ public class TestAppServerConstraints extends AbstractFunctionalTest {
 
         String expectedException = "com.marklogic.client.FailedRequestException: Local message: search failed: Bad Request. Server Message: XDMP-ELEMRIDXNOTFOUND";
 
-        // assertEquals("Wrong exception", expectedException, exception);
+        // assertEquals( expectedException, exception);
         boolean exceptionIsThrown = exception.contains(expectedException);
-        assertTrue("Exception is not thrown", exceptionIsThrown);
+        assertTrue( exceptionIsThrown);
     }
     // End of TestAppServicesRangeConstraint
 
@@ -1734,7 +1735,7 @@ public class TestAppServerConstraints extends AbstractFunctionalTest {
         String expectedSearchResult = "|Matched 1 locations in /range-constraint/bbq4.xml|Matched 1 locations in /range-constraint/bbq3.xml";
         System.out.println(searchResult);
 
-        assertEquals("Search result difference", expectedSearchResult, searchResult);
+        assertEquals( expectedSearchResult, searchResult);
     }
     // End of TestRangeConstraint
 
@@ -1761,7 +1762,7 @@ public class TestAppServerConstraints extends AbstractFunctionalTest {
         // search result
         String result = "Matched " + resultsHandle.getTotalResults();
         String expectedResult = "Matched 5";
-        assertEquals("Document match difference", expectedResult, result);
+        assertEquals( expectedResult, result);
     }
     // End of TestRangeConstraintRelativeBucket
 
@@ -1788,7 +1789,7 @@ public class TestAppServerConstraints extends AbstractFunctionalTest {
         String searchResult = returnSearchResult(resultsHandle);
 
         String expectedSearchResult = "|Matched 1 locations in /range-constraint-abs-bucket/bbq1.xml|Matched 1 locations in /range-constraint-abs-bucket/bbq3.xml|Matched 1 locations in /range-constraint-abs-bucket/bbq5.xml";
-        assertEquals("Search result difference", expectedSearchResult, searchResult);
+        assertEquals( expectedSearchResult, searchResult);
     }
     // End of TestRangeConstraintAbsoluteBucket
 

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBug18026.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBug18026.java
@@ -30,7 +30,8 @@ import org.custommonkey.xmlunit.SimpleNamespaceContext;
 import org.custommonkey.xmlunit.XMLUnit;
 import org.custommonkey.xmlunit.XpathEngine;
 import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
@@ -44,7 +45,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
-import static org.junit.Assert.assertTrue;
 
 public class TestBug18026 extends AbstractFunctionalTest {
 
@@ -168,12 +168,12 @@ public class TestBug18026 extends AbstractFunctionalTest {
 
     JsonNode contentAfter = mapper.readValue(strAfter, JsonNode.class);
 
-    assertTrue("Buffered JSON document difference", contentBefore.equals(contentAfter));
+    assertTrue( contentBefore.equals(contentAfter));
 
     // release client
     client.release();
   }
-  
+
   @Test
   public void testBug19016() throws KeyManagementException, NoSuchAlgorithmException, IOException, ParserConfigurationException, SAXException, XpathException
   {
@@ -198,7 +198,7 @@ public class TestBug18026 extends AbstractFunctionalTest {
 
     System.out.println(result);
 
-    assertTrue("qtext is not correct", result.contains("<search:qtext>this\"is\"an%33odd string</search:qtext>"));
+    assertTrue( result.contains("<search:qtext>this\"is\"an%33odd string</search:qtext>"));
 
     // release client
     client.release();

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBug18920.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBug18920.java
@@ -22,19 +22,20 @@ import com.marklogic.client.admin.ServerConfigurationManager.UpdatePolicy;
 import com.marklogic.client.document.DocumentDescriptor;
 import com.marklogic.client.document.XMLDocumentManager;
 import com.marklogic.client.io.FileHandle;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestBug18920 extends AbstractFunctionalTest {
 
   private static ServerConfigurationManager configMgr;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception
   {
     System.out.println("In setup");
@@ -94,12 +95,12 @@ public class TestBug18920 extends AbstractFunctionalTest {
     }
     System.out.println("Exception is " + exception);
     System.out.println("Status message --- codenumber are " + statusCode + " --- " + expCode);
-    assertTrue("Status code message is incorrect", statusCode.contains("RESTAPI-CONTENTNOVERSION"));
-    assertTrue("Status code is not 428", expCode == 428);
-    assertTrue("Exception is not thrown", exception.contains(expectedException));
+    assertTrue( statusCode.contains("RESTAPI-CONTENTNOVERSION"));
+    assertTrue( expCode == 428);
+    assertTrue( exception.contains(expectedException));
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() throws Exception {
     System.out.println("In tear down");
 

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBug26248.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBug26248.java
@@ -20,7 +20,8 @@ import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.document.TextDocumentManager;
 import com.marklogic.client.io.InputStreamHandle;
 import com.marklogic.client.io.StringHandle;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkReadSample1.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkReadSample1.java
@@ -21,10 +21,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.document.*;
 import com.marklogic.client.io.*;
-import org.junit.BeforeClass;
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import java.io.File;
 import java.security.KeyManagementException;
@@ -32,11 +32,11 @@ import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /*
  * This test is designed to to test simple bulk reads with different types of Managers and different content type like JSON,text,binary,XMl by passing set of uris
- * 
+ *
  *  TextDocumentManager
  *  XMLDocumentManager
  *  BinaryDocumentManager
@@ -44,7 +44,7 @@ import static org.junit.Assert.*;
  *  GenericDocumentManager
  */
 
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@TestMethodOrder(MethodOrderer.MethodName.class)
 public class TestBulkReadSample1 extends AbstractFunctionalTest {
 
   private static final int BATCH_SIZE = 100;
@@ -53,19 +53,19 @@ public class TestBulkReadSample1 extends AbstractFunctionalTest {
 
   private static DatabaseClient client;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception
   {
 	  if (isLBHost()) {
 		  ndocCount = 5;
 	  }
 	  else {
-		  ndocCount = 10; 
+		  ndocCount = 10;
 	  }
   }
 
   /*
-   * 
+   *
    * Use StringHandle to load 102 text documents using bulk write set. Test Bulk
    * Read to see you can read all the documents?
    */
@@ -76,7 +76,7 @@ public class TestBulkReadSample1 extends AbstractFunctionalTest {
     try {
 		int count = 1;
 		client = getDatabaseClient("rest-admin", "x", getConnType());
-		
+
 		TextDocumentManager docMgr = client.newTextDocumentManager();
 		DocumentWriteSet writeset = docMgr.newWriteSet();
 
@@ -104,7 +104,7 @@ public class TestBulkReadSample1 extends AbstractFunctionalTest {
 		  count++;
 		}
 		System.out.println("Document count test1ReadMultipleTextDoc " + count);
-		assertEquals("document count", 102, count);
+		assertEquals(102, count);
 	} catch (Exception e) {
 		e.printStackTrace();
 	}
@@ -152,11 +152,11 @@ public class TestBulkReadSample1 extends AbstractFunctionalTest {
 		  DocumentRecord rec = page.next();
 		  validateRecord(rec, Format.XML);
 		  rec.getContent(dh);
-		  assertEquals("Comparing the content :", map.get(rec.getUri()), convertXMLDocumentToString(dh.get()));
+		  assertEquals( map.get(rec.getUri()), convertXMLDocumentToString(dh.get()));
 		  count++;
 		}
 		System.out.println("Document count test2ReadMultipleXMLDoc " + count);
-		assertEquals("document count", 102, count);
+		assertEquals( 102, count);
 	} catch (Exception e) {
 		e.printStackTrace();
 	}
@@ -173,7 +173,7 @@ public class TestBulkReadSample1 extends AbstractFunctionalTest {
   public void test3ReadMultipleBinaryDoc() throws KeyManagementException, NoSuchAlgorithmException, Exception
   {
 	  System.out.println("Inside test3ReadMultipleBinaryDoc");
-	  
+
     try {
 		String docId[] = { "Sega-4MB.jpg" };
 		int count = 1;
@@ -194,7 +194,7 @@ public class TestBulkReadSample1 extends AbstractFunctionalTest {
 		/*if (count % BATCH_SIZE > 0) {
 		  docMgr.write(writeset);
 		}*/
-		
+
 		String uris[] = new String[ndocCount];
 		for (int i = 0; i < ndocCount; i++) {
 		  uris[i] = DIRECTORY + "binary" + i + ".jpg";
@@ -206,12 +206,12 @@ public class TestBulkReadSample1 extends AbstractFunctionalTest {
 		  DocumentRecord rec = page.next();
 		  validateRecord(rec, Format.BINARY);
 		  rec.getContent(rh);
-		  assertEquals("Content length :", file1.length(), rh.get().length());
+		  assertEquals(file1.length(), rh.get().length());
 		  count++;
 		}
-		assertEquals("document count", ndocCount, count);
+		assertEquals( ndocCount, count);
 		// Testing the multiple same uris will not read multiple records
-		
+
 		for (int i = 0; i < ndocCount; i++) {
 		  uris[i] = DIRECTORY + "binary" + 1 + ".jpg";
 		}
@@ -223,7 +223,7 @@ public class TestBulkReadSample1 extends AbstractFunctionalTest {
 		  count++;
 		}
 		System.out.println("Document count test3ReadMultipleBinaryDoc " + count);
-		assertEquals("document count", 1, count);
+		assertEquals( 1, count);
 	} catch (Exception e) {
 		e.printStackTrace();
 	}
@@ -266,7 +266,7 @@ public class TestBulkReadSample1 extends AbstractFunctionalTest {
 		  docMgr.write(writeset);
 		}
 		waitForPropertyPropagate();
-		
+
 		String uris[] = new String[103];
 		for (int i = 0; i < 102; i++) {
 		  uris[i] = DIRECTORY + "dog" + i + ".json";
@@ -280,11 +280,11 @@ public class TestBulkReadSample1 extends AbstractFunctionalTest {
 		  rec = page.next();
 		  validateRecord(rec, Format.JSON);
 		  rec.getContent(jh);
-		  assertEquals("Comparing the content :", map.get(rec.getUri()), jh.get().toString());
+		  assertEquals( map.get(rec.getUri()), jh.get().toString());
 		  count++;
 		}
 		System.out.println("Document count test4WriteMultipleJSONDocs " + count);
-		assertEquals("document count", 102, count);
+		assertEquals( 102, count);
 	} catch (Exception e) {
 		e.printStackTrace();
 	}
@@ -313,7 +313,7 @@ public class TestBulkReadSample1 extends AbstractFunctionalTest {
 		for (int i = 0; i < 10; i++) {
 		writesetXML.add(DIRECTORY + "foo" + i + ".xml", new DOMHandle(getDocumentContent("This is so foo" + i)));
 		uris[count++] =  DIRECTORY + "foo" + i + ".xml";
-		} 
+		}
 		xmldocMgr.write(writesetXML);
 
 		TextDocumentManager txtdocMgr = client.newTextDocumentManager();
@@ -321,7 +321,7 @@ public class TestBulkReadSample1 extends AbstractFunctionalTest {
 
 		for (int i = 0; i < 10; i++) {
 		writesetTXT.add(DIRECTORY + "foo" + i + ".txt", new StringHandle().with("This is so foo" + i));
-		uris[count++] =  DIRECTORY + "foo" + i + ".txt";    
+		uris[count++] =  DIRECTORY + "foo" + i + ".txt";
 		}
 		txtdocMgr.write(writesetTXT);
 
@@ -333,8 +333,8 @@ public class TestBulkReadSample1 extends AbstractFunctionalTest {
 				file1 = new File("src/test/java/com/marklogic/client/functionaltest/data/" + docId[0]);
 		FileHandle h1 = new FileHandle(file1);
 		for (int i = 0; i < 10; i++) {
-		writesetBIN.add(DIRECTORY + "binary" + i + ".jpg", h1); 
-		uris[count++] = DIRECTORY + "binary" + i + ".jpg";   
+		writesetBIN.add(DIRECTORY + "binary" + i + ".jpg", h1);
+		uris[count++] = DIRECTORY + "binary" + i + ".jpg";
 		}
 		bindocMgr.write(writesetBIN);
 
@@ -349,7 +349,7 @@ public class TestBulkReadSample1 extends AbstractFunctionalTest {
 		uris[count++] = DIRECTORY + "dog" + i + ".json";
 		}
 		jsondocMgr.write(writesetJSON);
-		
+
 		// for(String uri:uris){System.out.println(uri);}
 		DocumentPage page = docMgr.read(uris);
 
@@ -379,10 +379,10 @@ public class TestBulkReadSample1 extends AbstractFunctionalTest {
 		System.out.println("Document countTEXT test5WriteGenericDocMgr " + countTEXT);
 		System.out.println("Document countJpg test5WriteGenericDocMgr " + countJpg);
 		System.out.println("Document countJson test5WriteGenericDocMgr " + countJson);
-		assertEquals("xml document count", 10, countXML);
-		assertEquals("text document count", 10, countTEXT);
-		assertEquals("binary document count", isLBHost()?1:10, countJpg);
-		assertEquals("Json document count", 10, countJson);
+		assertEquals( 10, countXML);
+		assertEquals( 10, countTEXT);
+		assertEquals( isLBHost()?1:10, countJpg);
+		assertEquals( 10, countJson);
 	} catch (Exception e) {
 		e.printStackTrace();
 	}
@@ -431,14 +431,14 @@ public class TestBulkReadSample1 extends AbstractFunctionalTest {
 		    rec = page.next();
 		    validateRecord(rec, Format.JSON);
 		    rec.getContent(jh);
-		    assertEquals("Comparing the content :", map.get(rec.getUri()), jh.get().toString());
+		    assertEquals( map.get(rec.getUri()), jh.get().toString());
 		    count++;
 		  }
-		  page.close();		  
+		  page.close();
 		}
 		// validateRecord(rec,Format.JSON);
 		System.out.println("Document count test6CloseMethodforReadMultipleDoc " + count);
-		assertEquals("document count", 10, count);
+		assertEquals( 10, count);
 	} catch (Exception e) {
 		e.printStackTrace();
 	}
@@ -448,9 +448,9 @@ public class TestBulkReadSample1 extends AbstractFunctionalTest {
   }
 
   public void validateRecord(DocumentRecord record, Format type) {
-    assertNotNull("DocumentRecord should never be null", record);
-    assertNotNull("Document uri should never be null", record.getUri());
-    assertTrue("Document uri should start with " + DIRECTORY, record.getUri().startsWith(DIRECTORY));
-    assertEquals("All records are expected to be in same format", type, record.getFormat());
+    assertNotNull( record);
+    assertNotNull( record.getUri());
+    assertTrue(record.getUri().startsWith(DIRECTORY));
+    assertEquals( type, record.getFormat());
   }
 }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkReadWriteMetaDataChange.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkReadWriteMetaDataChange.java
@@ -31,30 +31,32 @@ import com.marklogic.client.io.DocumentMetadataHandle.DocumentPermissions;
 import com.marklogic.client.io.DocumentMetadataHandle.DocumentProperties;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.StringHandle;
-import org.junit.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.*;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Calendar;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+
+
 
 /**
- * 
+ *
  * This test is designed to update meta-data bulk writes and reads with one type
  * of Manager and one content type text.
- * 
+ *
  * TextDocumentManager
- * 
+ *
  */
 public class TestBulkReadWriteMetaDataChange extends AbstractFunctionalTest {
 
   /**
    * @throws java.lang.Exception
    */
-  @BeforeClass
+  @BeforeAll
   public static void setUpBeforeClass() throws Exception {
     createRESTUser("app-user", "password", "rest-writer", "rest-reader");
   }
@@ -62,7 +64,7 @@ public class TestBulkReadWriteMetaDataChange extends AbstractFunctionalTest {
   /**
    * @throws java.lang.Exception
    */
-  @AfterClass
+  @AfterAll
   public static void tearDownAfterClass() throws Exception {
     deleteRESTUser("app-user");
   }
@@ -70,7 +72,7 @@ public class TestBulkReadWriteMetaDataChange extends AbstractFunctionalTest {
   /**
    * @throws java.lang.Exception
    */
-  @Before
+  @BeforeEach
   public void setUp() throws KeyManagementException, NoSuchAlgorithmException, Exception {
     // create new connection for each test below
     client = getDatabaseClient("app-user", "password", getConnType());
@@ -79,7 +81,7 @@ public class TestBulkReadWriteMetaDataChange extends AbstractFunctionalTest {
   /**
    * @throws java.lang.Exception
    */
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     System.out.println("Running clear script");
     // release client
@@ -138,32 +140,32 @@ public class TestBulkReadWriteMetaDataChange extends AbstractFunctionalTest {
     System.out.println("Returned properties: " + actualProperties);
     StringBuffer calProperty = new StringBuffer("myCalendar:").append(Calendar.getInstance().get(Calendar.YEAR));
 
-    assertTrue("Document properties difference in size value", actualProperties.contains("size:5"));
-    assertTrue("Document property reviewed not found or not correct", actualProperties.contains("reviewed:true"));
-    assertTrue("Document property myInteger not found or not correct", actualProperties.contains("myInteger:10"));
-    assertTrue("Document property myDecimal not found or not correct", actualProperties.contains("myDecimal:34.56678"));
-    assertTrue("Document property myCalendar not found or not correct", actualProperties.contains(calProperty.toString()));
-    assertTrue("Document property myString not found or not correct", actualProperties.contains("myString:foo"));
+    assertTrue( actualProperties.contains("size:5"));
+    assertTrue( actualProperties.contains("reviewed:true"));
+    assertTrue( actualProperties.contains("myInteger:10"));
+    assertTrue( actualProperties.contains("myDecimal:34.56678"));
+    assertTrue( actualProperties.contains(calProperty.toString()));
+    assertTrue( actualProperties.contains("myString:foo"));
 
     // Permissions
     String actualPermissions = getDocumentPermissionsString(permissions);
     System.out.println("Returned permissions: " + actualPermissions);
 
-    assertTrue("Document permissions difference in size value", actualPermissions.contains("size:5"));
-    assertTrue("Document permissions difference in rest-reader permission", actualPermissions.contains("rest-reader:[READ]"));
-    assertTrue("Document permissions difference in rest-writer permission", actualPermissions.contains("rest-writer:[UPDATE]"));
-    assertTrue("Document permissions difference in app-user permissions",
+    assertTrue( actualPermissions.contains("size:5"));
+    assertTrue( actualPermissions.contains("rest-reader:[READ]"));
+    assertTrue( actualPermissions.contains("rest-writer:[UPDATE]"));
+    assertTrue(
         (actualPermissions.contains("app-user:[UPDATE, READ]") || actualPermissions.contains("app-user:[READ, UPDATE]")));
-    assertTrue("Document permissions difference in harmonized-updater permission", actualPermissions.contains("harmonized-updater:[UPDATE]"));
-    assertTrue("Document permissions difference in harmonized-reader permission", actualPermissions.contains("harmonized-reader:[READ]"));
+    assertTrue( actualPermissions.contains("harmonized-updater:[UPDATE]"));
+    assertTrue( actualPermissions.contains("harmonized-reader:[READ]"));
 
     // Collections
     String actualCollections = getDocumentCollectionsString(collections);
     System.out.println("Returned collections: " + actualCollections);
 
-    assertTrue("Document collections difference in size value", actualCollections.contains("size:2"));
-    assertTrue("my-collection1 not found", actualCollections.contains("my-collection1"));
-    assertTrue("my-collection2 not found", actualCollections.contains("my-collection2"));
+    assertTrue( actualCollections.contains("size:2"));
+    assertTrue( actualCollections.contains("my-collection1"));
+    assertTrue( actualCollections.contains("my-collection2"));
   }
 
   public void validateUpdatedMetadataProperties(DocumentMetadataHandle mh) {
@@ -177,32 +179,32 @@ public class TestBulkReadWriteMetaDataChange extends AbstractFunctionalTest {
     System.out.println("Returned properties after Meta-data only update: " + actualProperties);
     StringBuffer calProperty = new StringBuffer("myCalendar:").append(Calendar.getInstance().get(Calendar.YEAR));
 
-    assertTrue("Document properties difference in size value", actualProperties.contains("size:5"));
-    assertTrue("Document property reviewed not found or not correct", actualProperties.contains("reviewed:true"));
-    assertTrue("Document property myInteger not found or not correct", actualProperties.contains("myInteger:10"));
-    assertTrue("Document property myDecimal not found or not correct", actualProperties.contains("myDecimal:34.56678"));
-    assertTrue("Document property myCalendar not found or not correct", actualProperties.contains(calProperty.toString()));
-    assertTrue("Document property myString not found or not correct", actualProperties.contains("myString:foo"));
+    assertTrue( actualProperties.contains("size:5"));
+    assertTrue( actualProperties.contains("reviewed:true"));
+    assertTrue( actualProperties.contains("myInteger:10"));
+    assertTrue( actualProperties.contains("myDecimal:34.56678"));
+    assertTrue( actualProperties.contains(calProperty.toString()));
+    assertTrue( actualProperties.contains("myString:foo"));
 
     // Permissions
     String actualPermissions = getDocumentPermissionsString(permissions);
     System.out.println("Returned permissions: " + actualPermissions);
 
-    assertTrue("Document permissions difference in size value", actualPermissions.contains("size:5"));
-    assertTrue("Document permissions difference in rest-reader permission", actualPermissions.contains("rest-reader:[READ]"));
-    assertTrue("Document permissions difference in rest-writer permission", actualPermissions.contains("rest-writer:[UPDATE]"));
-    assertTrue("Document permissions difference in app-user permissions",
+    assertTrue( actualPermissions.contains("size:5"));
+    assertTrue( actualPermissions.contains("rest-reader:[READ]"));
+    assertTrue( actualPermissions.contains("rest-writer:[UPDATE]"));
+    assertTrue(
         (actualPermissions.contains("app-user:[UPDATE, READ]") || actualPermissions.contains("app-user:[READ, UPDATE]")));
-    assertTrue("Document permissions difference in harmonized-updater permission", actualPermissions.contains("harmonized-updater:[UPDATE]"));
-    assertTrue("Document permissions difference in harmonized-reader permission", actualPermissions.contains("harmonized-reader:[READ]"));
+    assertTrue( actualPermissions.contains("harmonized-updater:[UPDATE]"));
+    assertTrue( actualPermissions.contains("harmonized-reader:[READ]"));
 
     // Collections
     String actualCollections = getDocumentCollectionsString(collections);
     System.out.println("Returned collections: " + actualCollections);
 
-    assertTrue("Document collections difference in size value", actualCollections.contains("size:2"));
-    assertTrue("my-collection1 not found", actualCollections.contains("my-collection1"));
-    assertTrue("my-collection2 not found", actualCollections.contains("my-collection2"));
+    assertTrue( actualCollections.contains("size:2"));
+    assertTrue( actualCollections.contains("my-collection1"));
+    assertTrue( actualCollections.contains("my-collection2"));
   }
 
   public void validateUpdatedMetadataCollections(DocumentMetadataHandle mh) {
@@ -216,32 +218,32 @@ public class TestBulkReadWriteMetaDataChange extends AbstractFunctionalTest {
     System.out.println("Returned properties: " + actualProperties);
     StringBuffer calProperty = new StringBuffer("myCalendar:").append(Calendar.getInstance().get(Calendar.YEAR));
 
-    assertTrue("Document properties difference in size value", actualProperties.contains("size:5"));
-    assertTrue("Document property reviewed not found or not correct", actualProperties.contains("reviewed:true"));
-    assertTrue("Document property myInteger not found or not correct", actualProperties.contains("myInteger:10"));
-    assertTrue("Document property myDecimal not found or not correct", actualProperties.contains("myDecimal:34.56678"));
-    assertTrue("Document property myCalendar not found or not correct", actualProperties.contains(calProperty.toString()));
-    assertTrue("Document property myString not found or not correct", actualProperties.contains("myString:foo"));
+    assertTrue( actualProperties.contains("size:5"));
+    assertTrue( actualProperties.contains("reviewed:true"));
+    assertTrue( actualProperties.contains("myInteger:10"));
+    assertTrue( actualProperties.contains("myDecimal:34.56678"));
+    assertTrue( actualProperties.contains(calProperty.toString()));
+    assertTrue( actualProperties.contains("myString:foo"));
 
     // Permissions
     String actualPermissions = getDocumentPermissionsString(permissions);
     System.out.println("Returned permissions: " + actualPermissions);
 
-    assertTrue("Document permissions difference in size value", actualPermissions.contains("size:5"));
-    assertTrue("Document permissions difference in rest-reader permission", actualPermissions.contains("rest-reader:[READ]"));
-    assertTrue("Document permissions difference in rest-writer permission", actualPermissions.contains("rest-writer:[UPDATE]"));
-    assertTrue("Document permissions difference in app-user permissions",
+    assertTrue( actualPermissions.contains("size:5"));
+    assertTrue( actualPermissions.contains("rest-reader:[READ]"));
+    assertTrue( actualPermissions.contains("rest-writer:[UPDATE]"));
+    assertTrue(
         (actualPermissions.contains("app-user:[UPDATE, READ]") || actualPermissions.contains("app-user:[READ, UPDATE]")));
-    assertTrue("Document permissions difference in harmonized-updater permission", actualPermissions.contains("harmonized-updater:[UPDATE]"));
-    assertTrue("Document permissions difference in harmonized-reader permission", actualPermissions.contains("harmonized-reader:[READ]"));
+    assertTrue( actualPermissions.contains("harmonized-updater:[UPDATE]"));
+    assertTrue( actualPermissions.contains("harmonized-reader:[READ]"));
 
     // Collections
     String actualCollections = getDocumentCollectionsString(collections);
     System.out.println("Returned collections: " + actualCollections);
 
-    assertTrue("Document collections difference in size value", actualCollections.contains("size:2"));
-    assertTrue("my-collection1 not found", actualCollections.contains("my-collection3"));
-    assertTrue("my-collection2 not found", actualCollections.contains("my-collection4"));
+    assertTrue( actualCollections.contains("size:2"));
+    assertTrue( actualCollections.contains("my-collection3"));
+    assertTrue( actualCollections.contains("my-collection4"));
   }
 
   /*
@@ -270,7 +272,7 @@ public class TestBulkReadWriteMetaDataChange extends AbstractFunctionalTest {
     System.out.println(sh.get());
     DocumentPage page = docMgr.read(docId);
     // Issue #294 DocumentPage.size() should return correct size
-    assertTrue("DocumentPage Size did not return expected value:: returned==  " + page.size(), page.size() == 3);
+    assertTrue(page.size() == 3);
 
     while (page.hasNext()) {
       DocumentRecord rec = page.next();
@@ -380,7 +382,7 @@ public class TestBulkReadWriteMetaDataChange extends AbstractFunctionalTest {
 
       DocumentPage page = docMgr.read(transaction, docId[0], docId[1], docId[2]);
       // Issue #294 DocumentPage.size() should return correct size
-      assertTrue("DocumentPage Size did not return expected value:: returned==  " + page.size(), page.size() == 3);
+      assertTrue(page.size() == 3);
 
       while (page.hasNext()) {
         DocumentRecord rec = page.next();
@@ -467,7 +469,7 @@ public class TestBulkReadWriteMetaDataChange extends AbstractFunctionalTest {
 
     DocumentPage page = docMgr.readMetadata(docId[0], docId[1], docId[2]);
     // Issue #294 DocumentPage.size() should return correct size
-    assertTrue("DocumentPage Size did not return expected value:: returned==  " + page.size(), page.size() == 3);
+    assertTrue(page.size() == 3);
 
     while (page.hasNext()) {
       DocumentRecord rec = page.next();
@@ -506,7 +508,7 @@ public class TestBulkReadWriteMetaDataChange extends AbstractFunctionalTest {
 
     DocumentPage page = docMgr.read(docId);
     // Issue #294 DocumentPage.size() should return correct size
-    assertTrue("DocumentPage Size did not return expected value:: returned==  " + page.size(), page.size() == 3);
+    assertTrue(page.size() == 3);
 
     DocumentMetadataHandle metadataHandleRead = new DocumentMetadataHandle();
 
@@ -543,7 +545,7 @@ public class TestBulkReadWriteMetaDataChange extends AbstractFunctionalTest {
       docMgr.write(writeset);
 
       StringHandle sh = docMgr.read(docId[0], new StringHandle());
-      assertEquals("Doc content incorrect", "This is so foo1", sh.get());
+      assertEquals( "This is so foo1", sh.get());
       docMgr.readMetadata(docId[0], mhRead);
 
       DocumentCollections collections = mhRead.getCollections();
@@ -551,7 +553,7 @@ public class TestBulkReadWriteMetaDataChange extends AbstractFunctionalTest {
       System.out.println(actualCollections);
 
       String expectedCollections1 = "size:1|specificDocCollection|";
-      assertEquals("Document collections difference", expectedCollections1, actualCollections);
+      assertEquals( expectedCollections1, actualCollections);
 
       // Verify that docId[1] does not have specificDoccollection
       mhRead = new DocumentMetadataHandle();
@@ -561,7 +563,7 @@ public class TestBulkReadWriteMetaDataChange extends AbstractFunctionalTest {
       System.out.println(actualCollections);
 
       String expectedCollections2 = "size:1|groupCollections|";
-      assertEquals("Document collections difference", expectedCollections2, actualCollections);
+      assertEquals( expectedCollections2, actualCollections);
       // Reset metadata
       docMgr.writeDefaultMetadata(docId);
       Thread.sleep(5000);
@@ -572,7 +574,7 @@ public class TestBulkReadWriteMetaDataChange extends AbstractFunctionalTest {
       actualCollections = getDocumentCollectionsString(collections);
       System.out.println(actualCollections);
       String expectedCollections3 = "size:0|";
-      assertEquals("Document collections difference", expectedCollections3, actualCollections);
+      assertEquals( expectedCollections3, actualCollections);
 
       // Call in a writeDefaultMetadata transaction
       String docIdTx[] = {"/foo/test/myFoo4.txt", "/foo/test/myFoo5.txt"};
@@ -591,7 +593,7 @@ public class TestBulkReadWriteMetaDataChange extends AbstractFunctionalTest {
       t1 = null;
 
       sh = docMgrTx.read(docIdTx[0], new StringHandle());
-      assertEquals("Doc content incorrect", "This is so foo4", sh.get());
+      assertEquals( "This is so foo4", sh.get());
       docMgrTx.readMetadata(docIdTx[0], mhRead);
 
       collections = mhRead.getCollections();
@@ -599,7 +601,7 @@ public class TestBulkReadWriteMetaDataChange extends AbstractFunctionalTest {
       System.out.println(actualCollections);
 
       String expectedCollections4 = "size:1|TransSpecificDocCollection|";
-      assertEquals("Document collections difference", expectedCollections4, actualCollections);
+      assertEquals( expectedCollections4, actualCollections);
 
       tReset = client.openTransaction();
       docMgrTx.writeDefaultMetadata(tReset, docIdTx);
@@ -612,7 +614,7 @@ public class TestBulkReadWriteMetaDataChange extends AbstractFunctionalTest {
       System.out.println(actualCollections);
 
       expectedCollections4 = "size:1|TransSpecificDocCollection|";
-      assertEquals("Document collections difference", expectedCollections4, actualCollections);
+      assertEquals( expectedCollections4, actualCollections);
 
       // Now commit transaction and verify if collections reset.
       tReset.commit();
@@ -626,7 +628,7 @@ public class TestBulkReadWriteMetaDataChange extends AbstractFunctionalTest {
       actualCollections = getDocumentCollectionsString(collections);
       System.out.println(actualCollections);
       String expectedCollections5 = "size:0|";
-      assertEquals("Document collections difference", expectedCollections5, actualCollections);
+      assertEquals( expectedCollections5, actualCollections);
 
       // Negative case - Call with empty args
       StringBuilder negStr = new StringBuilder();
@@ -638,12 +640,12 @@ public class TestBulkReadWriteMetaDataChange extends AbstractFunctionalTest {
         negStr.append(e.getMessage());
       }
       finally {
-        assertTrue("Negative case failure", negStr.toString().contains("Resetting document metadata with empty identifier list"));
+        assertTrue( negStr.toString().contains("Resetting document metadata with empty identifier list"));
       }
     }
     catch (Exception ex) {
       System.out.println("Exceptions thrown" + ex.getStackTrace());
-      Assert.fail("Test failed due to exceptions");
+      fail("Test failed due to exceptions");
     }
     finally {
         if (t1 != null) {

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkReadWriteWithJacksonDataBind.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkReadWriteWithJacksonDataBind.java
@@ -31,9 +31,10 @@ import com.marklogic.client.io.Format;
 import com.marklogic.client.io.JacksonDatabindHandle;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.marker.ContentHandleFactory;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
@@ -41,7 +42,7 @@ import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+
 
 /*
  * This test is designed to to test all of bulk reads and write of JSON  with JacksonDataBindHandle Manager by passing set of uris
@@ -51,13 +52,13 @@ import static org.junit.Assert.*;
 public class TestBulkReadWriteWithJacksonDataBind extends AbstractFunctionalTest {
   private static final String DIRECTORY = "/";
 
-  @Before
+  @BeforeEach
   public void testSetup() throws KeyManagementException, NoSuchAlgorithmException, Exception {
     // create new connection for each test below
     client = getDatabaseClient("rest-admin", "x", getConnType());
   }
 
-  @After
+  @AfterEach
   public void testCleanUp() throws Exception {
     System.out.println("Running CleanUp script");
     // release client
@@ -92,37 +93,36 @@ public class TestBulkReadWriteWithJacksonDataBind extends AbstractFunctionalTest
     // "size:5|reviewed:true|myInteger:10|myDecimal:34.56678|myCalendar:2014|myString:foo|";
     String actualProperties = getDocumentPropertiesString(properties);
     boolean result = actualProperties.contains("size:5|");
-    assertTrue("Document properties count", result);
+    assertTrue( result);
 
     // Permissions
     String actualPermissions = getDocumentPermissionsString(permissions);
     System.out.println(actualPermissions);
 
-    assertTrue("Document permissions difference in size value",
+    assertTrue(
         actualPermissions.contains("size:6"));
     // assertTrue(
     // "Document permissions difference in flexrep-eval permission",
     // actualPermissions.contains("flexrep-eval:[READ]"));
-    assertTrue("Document permissions difference in rest-reader permission",
+    assertTrue(
         actualPermissions.contains("rest-reader:[READ]"));
-    assertTrue("Document permissions difference in rest-writer permission",
+    assertTrue(
         actualPermissions.contains("rest-writer:[UPDATE]"));
     assertTrue(
-        "Document permissions difference in app-user permissions",
         (actualPermissions.contains("app-user:[UPDATE, READ]") || actualPermissions
             .contains("app-user:[READ, UPDATE]")));
-    assertTrue("Document permissions difference in harmonized-updater permission", actualPermissions.contains("harmonized-updater:[UPDATE]"));
-    assertTrue("Document permissions difference in harmonized-reader permission", actualPermissions.contains("harmonized-reader:[READ]"));
+    assertTrue( actualPermissions.contains("harmonized-updater:[UPDATE]"));
+    assertTrue( actualPermissions.contains("harmonized-reader:[READ]"));
 
     // Collections
     String actualCollections = getDocumentCollectionsString(collections);
     System.out.println(collections);
 
-    assertTrue("Document collections difference in size value",
+    assertTrue(
         actualCollections.contains("size:2"));
-    assertTrue("my-collection1 not found",
+    assertTrue(
         actualCollections.contains("my-collection1"));
-    assertTrue("my-collection2 not found",
+    assertTrue(
         actualCollections.contains("my-collection2"));
   }
 
@@ -136,22 +136,22 @@ public class TestBulkReadWriteWithJacksonDataBind extends AbstractFunctionalTest
     String actualProperties = getDocumentPropertiesString(properties);
     boolean result = actualProperties.contains("size:0|");
     System.out.println(actualProperties + result);
-    assertTrue("Document default last modified properties count1?", result);
+    assertTrue( result);
 
     // Permissions
     String actualPermissions = getDocumentPermissionsString(permissions);
 
-    assertTrue("Document permissions difference in size value", actualPermissions.contains("size:2"));
-    // assertTrue("Document permissions difference in flexrep-eval permission",
+    assertTrue( actualPermissions.contains("size:2"));
+    // assertTrue(
     // actualPermissions.contains("flexrep-eval:[READ]"));
-    assertTrue("Document permissions difference in rest-reader permission", actualPermissions.contains("rest-reader:[READ]"));
-    assertTrue("Document permissions difference in rest-writer permission", actualPermissions.contains("rest-writer:[UPDATE]"));
+    assertTrue( actualPermissions.contains("rest-reader:[READ]"));
+    assertTrue( actualPermissions.contains("rest-writer:[UPDATE]"));
 
     // Collections
     String expectedCollections = "size:0|";
     String actualCollections = getDocumentCollectionsString(collections);
 
-    assertEquals("Document collections difference", expectedCollections, actualCollections);
+    assertEquals( expectedCollections, actualCollections);
   }
 
   /*
@@ -192,17 +192,17 @@ public class TestBulkReadWriteWithJacksonDataBind extends AbstractFunctionalTest
     docMgr.read(docId + jsonFilename3, handleRead);
     Product product3 = (Product) handleRead.get();
 
-    assertTrue("Did not return a iPhone 6", product1.getName().equalsIgnoreCase("iPhone 6"));
-    assertTrue("Did not return a Mobile Phone", product1.getIndustry().equalsIgnoreCase("Mobile Hardware"));
-    assertTrue("Did not return a Mobile Phone", product1.getDescription().equalsIgnoreCase("Bending Iphone"));
+    assertTrue( product1.getName().equalsIgnoreCase("iPhone 6"));
+    assertTrue( product1.getIndustry().equalsIgnoreCase("Mobile Hardware"));
+    assertTrue( product1.getDescription().equalsIgnoreCase("Bending Iphone"));
 
-    assertTrue("Did not return a iPhone 6", product2.getName().equalsIgnoreCase("Windows 10"));
-    assertTrue("Did not return a Mobile Phone", product2.getIndustry().equalsIgnoreCase("Software"));
-    assertTrue("Did not return a Mobile Phone", product2.getDescription().equalsIgnoreCase("OS Server"));
+    assertTrue( product2.getName().equalsIgnoreCase("Windows 10"));
+    assertTrue( product2.getIndustry().equalsIgnoreCase("Software"));
+    assertTrue( product2.getDescription().equalsIgnoreCase("OS Server"));
 
-    assertTrue("Did not return a iPhone 6", product3.getName().equalsIgnoreCase("Elite Book"));
-    assertTrue("Did not return a Mobile Phone", product3.getIndustry().equalsIgnoreCase("PC Hardware"));
-    assertTrue("Did not return a Mobile Phone", product3.getDescription().equalsIgnoreCase("Very cool laptop"));
+    assertTrue( product3.getName().equalsIgnoreCase("Elite Book"));
+    assertTrue( product3.getIndustry().equalsIgnoreCase("PC Hardware"));
+    assertTrue( product3.getDescription().equalsIgnoreCase("Very cool laptop"));
   }
 
   @Test
@@ -241,27 +241,27 @@ public class TestBulkReadWriteWithJacksonDataBind extends AbstractFunctionalTest
     docMgr.read(docId[0], jacksonDBReadHandle);
     Product product1 = (Product) jacksonDBReadHandle.get();
 
-    assertTrue("Did not return a iPhone 6", product1.getName().equalsIgnoreCase("iPhone 6"));
-    assertTrue("Did not return a Mobile Phone", product1.getIndustry().equalsIgnoreCase("Mobile Phone"));
-    assertTrue("Did not return a Mobile Phone", product1.getDescription().equalsIgnoreCase("New iPhone 6"));
+    assertTrue( product1.getName().equalsIgnoreCase("iPhone 6"));
+    assertTrue( product1.getIndustry().equalsIgnoreCase("Mobile Phone"));
+    assertTrue( product1.getDescription().equalsIgnoreCase("New iPhone 6"));
 
     docMgr.readMetadata(docId[0], mhRead);
     validateMetadata(mhRead);
 
     docMgr.read(docId[1], jacksonDBReadHandle);
     Product product2 = (Product) jacksonDBReadHandle.get();
-    assertTrue("Did not return a iMac", product2.getName().equalsIgnoreCase("iMac"));
-    assertTrue("Did not return a Desktop", product2.getIndustry().equalsIgnoreCase("Desktop"));
-    assertTrue("Did not return a Air Book OS X", product2.getDescription().equalsIgnoreCase("Air Book OS X"));
+    assertTrue( product2.getName().equalsIgnoreCase("iMac"));
+    assertTrue( product2.getIndustry().equalsIgnoreCase("Desktop"));
+    assertTrue( product2.getDescription().equalsIgnoreCase("Air Book OS X"));
 
     docMgr.readMetadata(docId[1], mhRead);
     validateMetadata(mhRead);
 
     docMgr.read(docId[2], jacksonDBReadHandle);
     Product product3 = (Product) jacksonDBReadHandle.get();
-    assertTrue("Did not return a iPad", product3.getName().equalsIgnoreCase("iPad"));
-    assertTrue("Did not return a Tablet", product3.getIndustry().equalsIgnoreCase("Tablet"));
-    assertTrue("Did not return a iPad Mini", product3.getDescription().equalsIgnoreCase("iPad Mini"));
+    assertTrue( product3.getName().equalsIgnoreCase("iPad"));
+    assertTrue( product3.getIndustry().equalsIgnoreCase("Tablet"));
+    assertTrue( product3.getDescription().equalsIgnoreCase("iPad Mini"));
 
     docMgr.readMetadata(docId[2], mhRead);
     validateMetadata(mhRead);
@@ -332,27 +332,27 @@ public class TestBulkReadWriteWithJacksonDataBind extends AbstractFunctionalTest
     docMgr.read(docId[0], jacksonDBReadHandle);
     Product product1 = (Product) jacksonDBReadHandle.get();
 
-    assertTrue("Did not return a iPhone 6", product1.getName().equalsIgnoreCase("iPhone 6"));
-    assertTrue("Did not return a Mobile Phone", product1.getIndustry().equalsIgnoreCase("Mobile Phone"));
-    assertTrue("Did not return a Mobile Phone", product1.getDescription().equalsIgnoreCase("New iPhone 6"));
+    assertTrue( product1.getName().equalsIgnoreCase("iPhone 6"));
+    assertTrue( product1.getIndustry().equalsIgnoreCase("Mobile Phone"));
+    assertTrue( product1.getDescription().equalsIgnoreCase("New iPhone 6"));
 
     docMgr.readMetadata(docId[0], mhRead);
     validateMetadata(mhRead);
 
     docMgr.read(docId[1], jacksonDBReadHandle);
     Product product2 = (Product) jacksonDBReadHandle.get();
-    assertTrue("Did not return a iMac", product2.getName().equalsIgnoreCase("iMac"));
-    assertTrue("Did not return a Desktop", product2.getIndustry().equalsIgnoreCase("Desktop"));
-    assertTrue("Did not return a Air Book OS X", product2.getDescription().equalsIgnoreCase("Air Book OS X"));
+    assertTrue( product2.getName().equalsIgnoreCase("iMac"));
+    assertTrue( product2.getIndustry().equalsIgnoreCase("Desktop"));
+    assertTrue( product2.getDescription().equalsIgnoreCase("Air Book OS X"));
 
     docMgr.readMetadata(docId[1], mhRead);
     validateMetadata(mhRead);
 
     docMgr.read(docId[2], jacksonDBReadHandle);
     Product product3 = (Product) jacksonDBReadHandle.get();
-    assertTrue("Did not return a iPad", product3.getName().equalsIgnoreCase("iPad"));
-    assertTrue("Did not return a Tablet", product3.getIndustry().equalsIgnoreCase("Tablet"));
-    assertTrue("Did not return a iPad Mini", product3.getDescription().equalsIgnoreCase("iPad Mini"));
+    assertTrue( product3.getName().equalsIgnoreCase("iPad"));
+    assertTrue( product3.getIndustry().equalsIgnoreCase("Tablet"));
+    assertTrue( product3.getDescription().equalsIgnoreCase("iPad Mini"));
 
     docMgr.readMetadata(docId[2], mhRead);
     validateMetadata(mhRead);
@@ -361,7 +361,7 @@ public class TestBulkReadWriteWithJacksonDataBind extends AbstractFunctionalTest
   /*
    * Purpose: To test Git Issue # 89. Issue Description: If you read more than
    * 100 JSON objects, the Client API stops reading them.
-   * 
+   *
    * Use one Jackson Handles instance.
    */
   @Test
@@ -413,25 +413,25 @@ public class TestBulkReadWriteWithJacksonDataBind extends AbstractFunctionalTest
     while (page.hasNext()) {
       rec = page.next();
 
-      assertNotNull("DocumentRecord should never be null", rec);
-      assertNotNull("Document uri should never be null", rec.getUri());
-      assertTrue("Document uri should start with " + DIRECTORY, rec.getUri().startsWith(DIRECTORY));
+      assertNotNull( rec);
+      assertNotNull( rec.getUri());
+      assertTrue(rec.getUri().startsWith(DIRECTORY));
 
       rec.getContent(jh);
       // Verify the contents: comparing Map with JacksonHandle's.
-      assertEquals("Comparing the content :", jsonMap.get(rec.getUri()), jh.get().toString());
+      assertEquals( jsonMap.get(rec.getUri()), jh.get().toString());
       count++;
     }
-    assertEquals("document count", 102, count);
+    assertEquals( 102, count);
     // Issue #294 DocumentPage.size() should return correct size
-    assertTrue("DocumentPage Size did not return expected value:: returned==  " + page.size(), page.size() == 102);
+    assertTrue(page.size() == 102);
 
   }
 
   /*
    * Purpose: To test Git Issue # 89. Issue Description: If you read more than
    * 100 JSON objects, the Client API stops reading them.
-   * 
+   *
    * Use multiple Jackson Handle instances.
    */
   @Test
@@ -483,16 +483,16 @@ public class TestBulkReadWriteWithJacksonDataBind extends AbstractFunctionalTest
     while (page.hasNext()) {
       rec = page.next();
 
-      assertNotNull("DocumentRecord should never be null", rec);
-      assertNotNull("Document uri should never be null", rec.getUri());
-      assertTrue("Document uri should start with " + DIRECTORY, rec.getUri().startsWith(DIRECTORY));
+      assertNotNull( rec);
+      assertNotNull( rec.getUri());
+      assertTrue(rec.getUri().startsWith(DIRECTORY));
 
       rec.getContent(jh);
       // Verify the contents: comparing Map with JacksonHandle's.
-      assertEquals("Comparing the content :", jsonMap.get(rec.getUri()), jh.get().toString());
+      assertEquals( jsonMap.get(rec.getUri()), jh.get().toString());
       count++;
     }
-    assertEquals("document count", 102, count);
+    assertEquals( 102, count);
 
   }
 }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkReadWriteWithJacksonHandle.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkReadWriteWithJacksonHandle.java
@@ -30,18 +30,15 @@ import com.marklogic.client.io.DocumentMetadataHandle.DocumentPermissions;
 import com.marklogic.client.io.DocumentMetadataHandle.DocumentProperties;
 import com.marklogic.client.io.Format;
 import com.marklogic.client.io.JacksonHandle;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.io.File;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Calendar;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 /*
  * This test is designed to to test all of bulk reads and write of JSON  with JacksonHandle Manager by passing set of uris
@@ -52,14 +49,14 @@ public class TestBulkReadWriteWithJacksonHandle extends AbstractFunctionalTest {
 
   private static final String DIRECTORY = "/bulkread/";
 
-  @Before
+  @BeforeEach
   public void testSetup() throws Exception
   {
     // create new connection for each test below
     client = getDatabaseClient("rest-admin", "x", getConnType());
   }
 
-  @After
+  @AfterEach
   public void testCleanUp() throws Exception
   {
     System.out.println("Running CleanUp script");
@@ -92,29 +89,29 @@ public class TestBulkReadWriteWithJacksonHandle extends AbstractFunctionalTest {
     // "size:5|reviewed:true|myInteger:10|myDecimal:34.56678|myCalendar:2014|myString:foo|";
     String actualProperties = getDocumentPropertiesString(properties);
     boolean result = actualProperties.contains("size:5|");
-    assertTrue("Document properties count", result);
+    assertTrue( result);
 
     // Permissions
     String actualPermissions = getDocumentPermissionsString(permissions);
     System.out.println(actualPermissions);
 
-    assertTrue("Document permissions difference in size value", actualPermissions.contains("size:6"));
-    // assertTrue("Document permissions difference in flexrep-eval permission",
+    assertTrue( actualPermissions.contains("size:6"));
+    // assertTrue(
     // actualPermissions.contains("flexrep-eval:[READ]"));
-    assertTrue("Document permissions difference in rest-reader permission", actualPermissions.contains("rest-reader:[READ]"));
-    assertTrue("Document permissions difference in rest-writer permission", actualPermissions.contains("rest-writer:[UPDATE]"));
-    assertTrue("Document permissions difference in app-user permissions",
+    assertTrue( actualPermissions.contains("rest-reader:[READ]"));
+    assertTrue( actualPermissions.contains("rest-writer:[UPDATE]"));
+    assertTrue(
         (actualPermissions.contains("app-user:[UPDATE, READ]") || actualPermissions.contains("app-user:[READ, UPDATE]")));
-    assertTrue("Document permissions difference in harmonized-updater permission", actualPermissions.contains("harmonized-updater:[UPDATE]"));
-    assertTrue("Document permissions difference in harmonized-reader permission", actualPermissions.contains("harmonized-reader:[READ]"));
+    assertTrue( actualPermissions.contains("harmonized-updater:[UPDATE]"));
+    assertTrue( actualPermissions.contains("harmonized-reader:[READ]"));
 
     // Collections
     String actualCollections = getDocumentCollectionsString(collections);
     System.out.println(collections);
 
-    assertTrue("Document collections difference in size value", actualCollections.contains("size:2"));
-    assertTrue("my-collection1 not found", actualCollections.contains("my-collection1"));
-    assertTrue("my-collection2 not found", actualCollections.contains("my-collection2"));
+    assertTrue( actualCollections.contains("size:2"));
+    assertTrue( actualCollections.contains("my-collection1"));
+    assertTrue( actualCollections.contains("my-collection2"));
   }
 
   public void validateDefaultMetadata(DocumentMetadataHandle mh) {
@@ -127,24 +124,24 @@ public class TestBulkReadWriteWithJacksonHandle extends AbstractFunctionalTest {
     String actualProperties = getDocumentPropertiesString(properties);
     boolean result = actualProperties.contains("size:0|");
     System.out.println(actualProperties + result);
-    assertTrue("Document default last modified properties count1?", result);
+    assertTrue(result);
 
     // Permissions
     String actualPermissions = getDocumentPermissionsString(permissions);
 
-    assertTrue("Document permissions difference in size value", actualPermissions.contains("size:5"));
-    // assertTrue("Document permissions difference in flexrep-eval permission",
+    assertTrue( actualPermissions.contains("size:5"));
+    // assertTrue(
     // actualPermissions.contains("flexrep-eval:[READ]"));
-    assertTrue("Document permissions difference in rest-reader permission", actualPermissions.contains("rest-reader:[READ]"));
-    assertTrue("Document permissions difference in rest-writer permission", actualPermissions.contains("rest-writer:[UPDATE]"));
-    assertTrue("Document permissions difference in harmonized-updater permission", actualPermissions.contains("harmonized-updater:[UPDATE]"));
-    assertTrue("Document permissions difference in harmonized-reader permission", actualPermissions.contains("harmonized-reader:[READ]"));
+    assertTrue( actualPermissions.contains("rest-reader:[READ]"));
+    assertTrue( actualPermissions.contains("rest-writer:[UPDATE]"));
+    assertTrue( actualPermissions.contains("harmonized-updater:[UPDATE]"));
+    assertTrue( actualPermissions.contains("harmonized-reader:[READ]"));
 
     // Collections
     String expectedCollections = "size:0|";
     String actualCollections = getDocumentCollectionsString(collections);
 
-    assertEquals("Document collections difference", expectedCollections, actualCollections);
+    assertEquals( expectedCollections, actualCollections);
   }
 
   @Test
@@ -195,7 +192,7 @@ public class TestBulkReadWriteWithJacksonHandle extends AbstractFunctionalTest {
   }
 
   /*
-   * 
+   *
    * Use JacksonHandle to load JSON strings using bulk write set. Test Bulk Read
    * to see you can read the document specific meta-data.
    */
@@ -241,7 +238,7 @@ public class TestBulkReadWriteWithJacksonHandle extends AbstractFunctionalTest {
 
     DocumentPage page = docMgr.read(docId);
     // Issue #294 DocumentPage.size() should return correct size
-    assertTrue("DocumentPage Size did not return expected value:: returned==  " + page.size(), page.size() == 3);
+    assertEquals(3, page.size());
     while (page.hasNext()) {
       DocumentRecord rec = page.next();
       docMgr.readMetadata(rec.getUri(), mh);
@@ -252,7 +249,7 @@ public class TestBulkReadWriteWithJacksonHandle extends AbstractFunctionalTest {
   }
 
   /*
-   * 
+   *
    * Use JacksonHandle to load JSON strings using bulk write set. Test Bulk Read
    * to see you can read all the documents
    */
@@ -335,15 +332,15 @@ public class TestBulkReadWriteWithJacksonHandle extends AbstractFunctionalTest {
     rec = page.next();
     jdm.readMetadata(rec.getUri(), mh);
     validateDefaultMetadata(mh);
-    assertEquals("default quality", 0, mh.getQuality());
+    assertEquals( 0, mh.getQuality());
 
     // Doc2 should use the first batch default meta-data, with quality 1
     page = jdm.read("doc2.json");
     rec = page.next();
     jdm.readMetadata(rec.getUri(), mh);
     System.out.print(mh.getCollections().isEmpty());
-    assertEquals("default quality", 1, mh.getQuality());
-    assertTrue("default collections reset", mh.getCollections().isEmpty());
+    assertEquals( 1, mh.getQuality());
+    assertTrue( mh.getCollections().isEmpty());
 
     // Doc3 should have the system default document quality (0) because quality
     // was not included in the document-specific meta-data. It should be in the
@@ -352,8 +349,8 @@ public class TestBulkReadWriteWithJacksonHandle extends AbstractFunctionalTest {
     page = jdm.read("doc3.json");
     rec = page.next();
     jdm.readMetadata(rec.getUri(), mh);
-    assertEquals("default quality", 0, mh.getQuality());
-    assertEquals("default collection must change", "[mySpecificCollection]", mh.getCollections().toString());
+    assertEquals( 0, mh.getQuality());
+    assertEquals("[mySpecificCollection]", mh.getCollections().toString());
 
     DocumentMetadataHandle doc3Metadata =
         jdm.readMetadata("doc3.json", new DocumentMetadataHandle());
@@ -368,13 +365,13 @@ public class TestBulkReadWriteWithJacksonHandle extends AbstractFunctionalTest {
     page = jdm.read("doc4.json");
     rec = page.next();
     jdm.readMetadata(rec.getUri(), mh);
-    assertEquals("default quality", 1, mh.getQuality());
-    assertTrue("default collections reset", mh.getCollections().isEmpty());
+    assertEquals( 1, mh.getQuality());
+    assertTrue( mh.getCollections().isEmpty());
     // Doc5 should use the 2nd batch default meta-data, with quality 2
     page = jdm.read("doc5.json");
     rec = page.next();
     jdm.readMetadata(rec.getUri(), mh);
-    assertEquals("default quality", 2, mh.getQuality());
+    assertEquals( 2, mh.getQuality());
 
   }
 

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkReadWriteWithJacksonParserHandle.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkReadWriteWithJacksonParserHandle.java
@@ -29,9 +29,10 @@ import com.marklogic.client.io.marker.ContentHandleFactory;
 import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.query.QueryManager.QueryView;
 import com.marklogic.client.query.RawQueryByExampleDefinition;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.xml.sax.SAXException;
 
@@ -43,7 +44,7 @@ import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Calendar;
 
-import static org.junit.Assert.*;
+
 
 /*
  * This test is designed to to test all of bulk reads and write of JSON  with JacksonParserHandle Manager by passing set of uris
@@ -54,13 +55,13 @@ public class TestBulkReadWriteWithJacksonParserHandle extends AbstractFunctional
 
   private static final String DIRECTORY = "/";
 
-  @Before
+  @BeforeEach
   public void testSetup() throws Exception {
     // create new connection for each test below
     client = getDatabaseClient("rest-admin", "x", getConnType());
   }
 
-  @After
+  @AfterEach
   public void testCleanUp() throws Exception {
     System.out.println("Running CleanUp script");
     // release client
@@ -95,37 +96,36 @@ public class TestBulkReadWriteWithJacksonParserHandle extends AbstractFunctional
     // "size:5|reviewed:true|myInteger:10|myDecimal:34.56678|myCalendar:2014|myString:foo|";
     String actualProperties = getDocumentPropertiesString(properties);
     boolean result = actualProperties.contains("size:5|");
-    assertTrue("Document properties count", result);
+    assertTrue( result);
 
     // Permissions
     String actualPermissions = getDocumentPermissionsString(permissions);
     System.out.println(actualPermissions);
 
-    assertTrue("Document permissions difference in size value",
+    assertTrue(
         actualPermissions.contains("size:6"));
     // assertTrue(
     // "Document permissions difference in flexrep-eval permission",
     // actualPermissions.contains("flexrep-eval:[READ]"));
-    assertTrue("Document permissions difference in rest-reader permission",
+    assertTrue(
         actualPermissions.contains("rest-reader:[READ]"));
-    assertTrue("Document permissions difference in rest-writer permission",
+    assertTrue(
         actualPermissions.contains("rest-writer:[UPDATE]"));
     assertTrue(
-        "Document permissions difference in app-user permissions",
         (actualPermissions.contains("app-user:[UPDATE, READ]") || actualPermissions
             .contains("app-user:[READ, UPDATE]")));
-    assertTrue("Document permissions difference in harmonized-updater permission", actualPermissions.contains("harmonized-updater:[UPDATE]"));
-    assertTrue("Document permissions difference in harmonized-reader permission", actualPermissions.contains("harmonized-reader:[READ]"));
+    assertTrue( actualPermissions.contains("harmonized-updater:[UPDATE]"));
+    assertTrue( actualPermissions.contains("harmonized-reader:[READ]"));
 
     // Collections
     String actualCollections = getDocumentCollectionsString(collections);
     System.out.println(collections);
 
-    assertTrue("Document collections difference in size value",
+    assertTrue(
         actualCollections.contains("size:2"));
-    assertTrue("my-collection1 not found",
+    assertTrue(
         actualCollections.contains("my-collection1"));
-    assertTrue("my-collection2 not found",
+    assertTrue(
         actualCollections.contains("my-collection2"));
   }
 
@@ -139,24 +139,24 @@ public class TestBulkReadWriteWithJacksonParserHandle extends AbstractFunctional
     String actualProperties = getDocumentPropertiesString(properties);
     boolean result = actualProperties.contains("size:0|");
     System.out.println(actualProperties + result);
-    assertTrue("Document default last modified properties count1?", result);
+    assertTrue( result);
 
     // Permissions
     String actualPermissions = getDocumentPermissionsString(permissions);
 
-    assertTrue("Document permissions difference in size value", actualPermissions.contains("size:5"));
-    // assertTrue("Document permissions difference in flexrep-eval permission",
+    assertTrue( actualPermissions.contains("size:5"));
+    // assertTrue(
     // actualPermissions.contains("flexrep-eval:[READ]"));
-    assertTrue("Document permissions difference in rest-reader permission", actualPermissions.contains("rest-reader:[READ]"));
-    assertTrue("Document permissions difference in rest-writer permission", actualPermissions.contains("rest-writer:[UPDATE]"));
-    assertTrue("Document permissions difference in harmonized-updater permission", actualPermissions.contains("harmonized-updater:[UPDATE]"));
-    assertTrue("Document permissions difference in harmonized-reader permission", actualPermissions.contains("harmonized-reader:[READ]"));
+    assertTrue( actualPermissions.contains("rest-reader:[READ]"));
+    assertTrue( actualPermissions.contains("rest-writer:[UPDATE]"));
+    assertTrue( actualPermissions.contains("harmonized-updater:[UPDATE]"));
+    assertTrue( actualPermissions.contains("harmonized-reader:[READ]"));
 
     // Collections
     String expectedCollections = "size:0|";
     String actualCollections = getDocumentCollectionsString(collections);
 
-    assertEquals("Document collections difference", expectedCollections, actualCollections);
+    assertEquals( expectedCollections, actualCollections);
   }
 
   /*
@@ -261,7 +261,7 @@ public class TestBulkReadWriteWithJacksonParserHandle extends AbstractFunctional
   }
 
   /*
-   * 
+   *
    * Use JacksonParserHandle to load JSON strings using bulk write set. Test
    * Bulk Read to see you can read the document specific meta-data.
    */
@@ -314,7 +314,7 @@ public class TestBulkReadWriteWithJacksonParserHandle extends AbstractFunctional
   }
 
   /*
-   * 
+   *
    * Use JacksonParserHandle to load JSON strings using bulk write set. Test
    * Bulk Read to see you can read all the documents
    */
@@ -381,15 +381,15 @@ public class TestBulkReadWriteWithJacksonParserHandle extends AbstractFunctional
     rec = page.next();
     jdm.readMetadata(rec.getUri(), mh);
     validateDefaultMetadata(mh);
-    assertEquals("default quality", 0, mh.getQuality());
+    assertEquals( 0, mh.getQuality());
 
     // Doc2 should use the first batch default meta-data, with quality 1
     page = jdm.read("doc2.json");
     rec = page.next();
     jdm.readMetadata(rec.getUri(), mh);
     System.out.print(mh.getCollections().isEmpty());
-    assertEquals("default quality", 1, mh.getQuality());
-    assertTrue("default collections reset", mh.getCollections().isEmpty());
+    assertEquals( 1, mh.getQuality());
+    assertTrue( mh.getCollections().isEmpty());
 
     // Doc3 should have the system default document quality (0) because
     // quality
@@ -401,8 +401,8 @@ public class TestBulkReadWriteWithJacksonParserHandle extends AbstractFunctional
     page = jdm.read("doc3.json");
     rec = page.next();
     jdm.readMetadata(rec.getUri(), mh);
-    assertEquals("default quality", 0, mh.getQuality());
-    assertEquals("default collection must change",
+    assertEquals( 0, mh.getQuality());
+    assertEquals(
         "[mySpecificCollection]", mh.getCollections().toString());
 
     DocumentMetadataHandle doc3Metadata = jdm.readMetadata("doc3.json",
@@ -419,13 +419,13 @@ public class TestBulkReadWriteWithJacksonParserHandle extends AbstractFunctional
     page = jdm.read("doc4.json");
     rec = page.next();
     jdm.readMetadata(rec.getUri(), mh);
-    assertEquals("default quality", 1, mh.getQuality());
-    assertTrue("default collections reset", mh.getCollections().isEmpty());
+    assertEquals( 1, mh.getQuality());
+    assertTrue( mh.getCollections().isEmpty());
     // Doc5 should use the 2nd batch default meta-data, with quality 2
     page = jdm.read("doc5.json");
     rec = page.next();
     jdm.readMetadata(rec.getUri(), mh);
-    assertEquals("default quality", 2, mh.getQuality());
+    assertEquals( 2, mh.getQuality());
     // Close handles.
     jacksonParserHandle1.close();
     jacksonParserHandle2.close();
@@ -549,8 +549,8 @@ public class TestBulkReadWriteWithJacksonParserHandle extends AbstractFunctional
       count = 0;
       page = docMgr.search(qd, pageNo, sh);
       if (pageNo > 1) {
-        assertFalse("Is this first Page", page.isFirstPage());
-        assertTrue("Is page has previous page ?", page.hasPreviousPage());
+        assertFalse( page.isFirstPage());
+        assertTrue( page.hasPreviousPage());
       }
       while (page.hasNext()) {
         DocumentRecord rec = page.next();
@@ -563,17 +563,16 @@ public class TestBulkReadWriteWithJacksonParserHandle extends AbstractFunctional
       // Add additional asserts once JacksonParserHandle is ready to handle bulk
       // Search set.
 
-      // assertTrue("Page start in results and on page",sh.get().get("start").asLong()
+      // assertTrue(sh.get().get("start").asLong()
       // == page.getStart());
-      assertEquals("document count", page.size(), count);
-      // assertEquals("Page Number #",pageNo,page.getPageNumber());
+      assertEquals( page.size(), count);
       pageNo = pageNo + page.getPageSize();
     } while (!page.isLastPage() && page.hasContent());
 
-    assertEquals("page count is  ", 1, page.getTotalPages());
-    assertFalse("Page has previous page ?", page.hasPreviousPage());
-    assertEquals("page size", 25, page.getPageSize());
-    assertEquals("document count", 1, page.getTotalSize());
+    assertEquals( 1, page.getTotalPages());
+    assertFalse( page.hasPreviousPage());
+    assertEquals( 25, page.getPageSize());
+    assertEquals( 1, page.getTotalSize());
     // Close handles.
     jacksonParserHandle1.close();
     jacksonParserHandle2.close();
@@ -582,11 +581,10 @@ public class TestBulkReadWriteWithJacksonParserHandle extends AbstractFunctional
 
   public void validateRecord(DocumentRecord record, Format type) {
 
-    assertNotNull("DocumentRecord should never be null", record);
-    assertNotNull("Document uri should never be null", record.getUri());
-    assertTrue("Document uri should start with " + DIRECTORY, record
-        .getUri().startsWith(DIRECTORY));
-    assertEquals("All records are expected to be in same format", type,
+    assertNotNull( record);
+    assertNotNull( record.getUri());
+    assertTrue(record.getUri().startsWith(DIRECTORY));
+    assertEquals( type,
         record.getFormat());
 
   }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkSearchEWithQBE.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkSearchEWithQBE.java
@@ -28,7 +28,10 @@ import com.marklogic.client.query.QueryManager.QueryView;
 import com.marklogic.client.query.RawCombinedQueryDefinition;
 import com.marklogic.client.query.RawQueryByExampleDefinition;
 import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.junit.*;
+import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.xml.sax.SAXException;
@@ -42,24 +45,23 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
-import static org.junit.Assert.*;
 
 public class TestBulkSearchEWithQBE extends AbstractFunctionalTest {
   private static final int BATCH_SIZE = 100;
   private static final String DIRECTORY = "/bulkSearch/";
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpBeforeClass() throws Exception {
     createRESTUserWithPermissions("usr1", "password", getPermissionNode("flexrep-eval", Capability.READ),
         getCollectionNode("http://permission-collections/"), "rest-writer", "rest-reader");
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownAfterClass() throws Exception {
     deleteRESTUser("usr1");
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws KeyManagementException, NoSuchAlgorithmException, Exception {
     // create new connection for each test below
     client = getDatabaseClient("usr1", "password", getConnType());
@@ -68,7 +70,7 @@ public class TestBulkSearchEWithQBE extends AbstractFunctionalTest {
     loadJSONDocuments();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     System.out.println("Running clear script");
     // release client
@@ -77,10 +79,10 @@ public class TestBulkSearchEWithQBE extends AbstractFunctionalTest {
 
   public void validateRecord(DocumentRecord record, Format type) {
 
-    assertNotNull("DocumentRecord should never be null", record);
-    assertNotNull("Document uri should never be null", record.getUri());
-    assertTrue("Document uri should start with " + DIRECTORY, record.getUri().startsWith(DIRECTORY));
-    assertEquals("All records are expected to be in same format", type, record.getFormat());
+    assertNotNull( record);
+    assertNotNull( record.getUri());
+    assertTrue(record.getUri().startsWith(DIRECTORY));
+    assertEquals(type, record.getFormat());
     // System.out.println(record.getMimetype());
 
   }
@@ -177,8 +179,8 @@ public class TestBulkSearchEWithQBE extends AbstractFunctionalTest {
       count = 0;
       page = docMgr.search(qd, pageNo, dh);
       if (pageNo > 1) {
-        assertFalse("Is this first Page", page.isFirstPage());
-        assertTrue("Is page has previous page ?", page.hasPreviousPage());
+        assertFalse(page.isFirstPage());
+        assertTrue(page.hasPreviousPage());
       }
       while (page.hasNext()) {
         DocumentRecord rec = page.next();
@@ -190,14 +192,13 @@ public class TestBulkSearchEWithQBE extends AbstractFunctionalTest {
 
       Document resultDoc = dh.get();
       assertXpathEvaluatesTo("xml", "string(//*[local-name()='result'][last()]//@*[local-name()='format'])", resultDoc);
-      assertEquals("document count", page.size(), count);
-      // assertEquals("Page Number #",pageNo,page.getPageNumber());
+      assertEquals( page.size(), count);
       pageNo = pageNo + page.getPageSize();
     } while (!page.isLastPage() && page.hasContent());
-    assertEquals("page count is 5 ", 5, page.getTotalPages());
-    assertTrue("Page has previous page ?", page.hasPreviousPage());
-    assertEquals("page size", 25, page.getPageSize());
-    assertEquals("document count", 102, page.getTotalSize());
+    assertEquals( 5, page.getTotalPages());
+    assertTrue(page.hasPreviousPage());
+    assertEquals( 25, page.getPageSize());
+    assertEquals( 102, page.getTotalSize());
 
   }
 
@@ -229,8 +230,8 @@ public class TestBulkSearchEWithQBE extends AbstractFunctionalTest {
       count = 0;
       page = docMgr.search(qd, pageNo, sh);
       if (pageNo > 1) {
-        assertFalse("Is this first Page", page.isFirstPage());
-        assertTrue("Is page has previous page ?", page.hasPreviousPage());
+        assertFalse( page.isFirstPage());
+        assertTrue(page.hasPreviousPage());
       }
       while (page.hasNext()) {
         DocumentRecord rec = page.next();
@@ -239,16 +240,15 @@ public class TestBulkSearchEWithQBE extends AbstractFunctionalTest {
         System.out.println(rec.getContent(new StringHandle()).get().toString());
         count++;
       }
-      assertTrue("Page start in results and on page", sh.get().get("start").asLong() == page.getStart());
-      assertEquals("document count", page.size(), count);
-      // assertEquals("Page Number #",pageNo,page.getPageNumber());
+      assertTrue( sh.get().get("start").asLong() == page.getStart());
+      assertEquals( page.size(), count);
       pageNo = pageNo + page.getPageSize();
     } while (!page.isLastPage() && page.hasContent());
 
-    assertEquals("page count is  ", 5, page.getTotalPages());
-    assertTrue("Page has previous page ?", page.hasPreviousPage());
-    assertEquals("page size", 25, page.getPageSize());
-    assertEquals("document count", 102, page.getTotalSize());
+    assertEquals( 5, page.getTotalPages());
+    assertTrue(page.hasPreviousPage());
+    assertEquals( 25, page.getPageSize());
+    assertEquals( 102, page.getTotalSize());
 
   }
 
@@ -298,8 +298,8 @@ public class TestBulkSearchEWithQBE extends AbstractFunctionalTest {
       count = 0;
       page = docMgr.search(qd, pageNo, dh);
       if (pageNo > 1) {
-        assertFalse("Is this first Page", page.isFirstPage());
-        assertTrue("Is page has previous page ?", page.hasPreviousPage());
+        assertFalse( page.isFirstPage());
+        assertTrue( page.hasPreviousPage());
       }
       while (page.hasNext()) {
         DocumentRecord rec = page.next();
@@ -308,15 +308,14 @@ public class TestBulkSearchEWithQBE extends AbstractFunctionalTest {
       }
       Document resultDoc = dh.get();
       assertXpathEvaluatesTo("xml", "string(//*[local-name()='result'][last()]//@*[local-name()='format'])", resultDoc);
-      assertEquals("document count", page.size(), count);
-      // assertEquals("Page Number #",pageNo,page.getPageNumber());
+      assertEquals( page.size(), count);
       pageNo = pageNo + page.getPageSize();
     } while (!page.isLastPage() && page.hasContent());
 
-    assertEquals("page count is  ", 5, page.getTotalPages());
-    assertTrue("Page has previous page ?", page.hasPreviousPage());
-    assertEquals("page size", 25, page.getPageSize());
-    assertEquals("document count", 102, page.getTotalSize());
+    assertEquals( 5, page.getTotalPages());
+    assertTrue( page.hasPreviousPage());
+    assertEquals( 25, page.getPageSize());
+    assertEquals( 102, page.getTotalSize());
 
   }
 
@@ -349,8 +348,8 @@ public class TestBulkSearchEWithQBE extends AbstractFunctionalTest {
       count = 0;
       page = docMgr.search(qd, pageNo, sh);
       if (pageNo > 1) {
-        assertFalse("Is this first Page", page.isFirstPage());
-        assertTrue("Is page has previous page ?", page.hasPreviousPage());
+        assertFalse( page.isFirstPage());
+        assertTrue( page.hasPreviousPage());
       }
       while (page.hasNext()) {
         DocumentRecord rec = page.next();
@@ -358,15 +357,15 @@ public class TestBulkSearchEWithQBE extends AbstractFunctionalTest {
         validateRecord(rec, Format.JSON);
         count++;
       }
-      assertTrue("Page start in results and on page", sh.get().get("start").asLong() == page.getStart());
-      assertEquals("document count", page.size(), count);
+      assertTrue( sh.get().get("start").asLong() == page.getStart());
+      assertEquals( page.size(), count);
       pageNo = pageNo + page.getPageSize();
     } while (!page.isLastPage() && page.hasContent());
     System.out.println(sh.get().toString());
-    assertEquals("page count is  ", 5, page.getTotalPages());
-    assertTrue("Page has previous page ?", page.hasPreviousPage());
-    assertEquals("page size", 25, page.getPageSize());
-    assertEquals("document count", 102, page.getTotalSize());
+    assertEquals( 5, page.getTotalPages());
+    assertTrue( page.hasPreviousPage());
+    assertEquals( 25, page.getPageSize());
+    assertEquals( 102, page.getTotalSize());
 
   }
 
@@ -404,8 +403,8 @@ public class TestBulkSearchEWithQBE extends AbstractFunctionalTest {
       count = 0;
       page = docMgr.search(qd, pageNo, sh);
       if (pageNo > 1) {
-        assertFalse("Is this first Page", page.isFirstPage());
-        assertTrue("Is page has previous page ?", page.hasPreviousPage());
+        assertFalse( page.isFirstPage());
+        assertTrue( page.hasPreviousPage());
       }
       while (page.hasNext()) {
         DocumentRecord rec = page.next();
@@ -415,7 +414,7 @@ public class TestBulkSearchEWithQBE extends AbstractFunctionalTest {
         count++;
       }
 
-      assertEquals("document count", page.size(), count);
+      assertEquals( page.size(), count);
       pageNo = pageNo + page.getPageSize();
     } while (!page.isLastPage() && page.hasContent());
 
@@ -425,12 +424,12 @@ public class TestBulkSearchEWithQBE extends AbstractFunctionalTest {
     JsonNode jnode = null;
     jnode = mapper.readValue(jsonParser, JsonNode.class);
 
-    assertTrue("Page start in results and on page", jnode.get("start").asLong() == page.getStart());
+    assertTrue( jnode.get("start").asLong() == page.getStart());
 
-    assertEquals("page count is  ", 5, page.getTotalPages());
-    assertTrue("Page has previous page ?", page.hasPreviousPage());
-    assertEquals("page size", 25, page.getPageSize());
-    assertEquals("document count", 102, page.getTotalSize());
+    assertEquals( 5, page.getTotalPages());
+    assertTrue(page.hasPreviousPage());
+    assertEquals( 25, page.getPageSize());
+    assertEquals( 102, page.getTotalSize());
     sh.close();
   }
 }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkSearchWithStringQueryDef.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkSearchWithStringQueryDef.java
@@ -29,7 +29,9 @@ import com.marklogic.client.query.MatchLocation;
 import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.query.QueryManager.QueryView;
 import com.marklogic.client.query.StringQueryDefinition;
-import org.junit.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.*;
 import org.xml.sax.SAXException;
 
 import javax.xml.parsers.ParserConfigurationException;
@@ -40,30 +42,30 @@ import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+
 
 public class TestBulkSearchWithStringQueryDef extends AbstractFunctionalTest {
   private static final int BATCH_SIZE = 100;
   private static final String DIRECTORY = "/bulkSearch/";
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpBeforeClass() throws Exception {
     createRESTUserWithPermissions("usr1", "password", getPermissionNode("flexrep-eval", Capability.READ), getCollectionNode("http://permission-collections/"), "rest-writer",
         "rest-reader");
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownAfterClass() throws Exception {
     deleteRESTUser("usr1");
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     // create new connection for each test below
     client = getDatabaseClient("usr1", "password", getConnType());
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     client.release();
   }
@@ -95,10 +97,10 @@ public class TestBulkSearchWithStringQueryDef extends AbstractFunctionalTest {
 
   public void validateRecord(DocumentRecord record, Format type) {
 
-    assertNotNull("DocumentRecord should never be null", record);
-    assertNotNull("Document uri should never be null", record.getUri());
-    assertTrue("Document uri should start with " + DIRECTORY, record.getUri().startsWith(DIRECTORY));
-    assertEquals("All records are expected to be in same format", type, record.getFormat());
+    assertNotNull( record);
+    assertNotNull( record.getUri());
+    assertTrue(record.getUri().startsWith(DIRECTORY));
+    assertEquals( type, record.getFormat());
     // System.out.println(record.getMimetype());
 
   }
@@ -154,37 +156,37 @@ public class TestBulkSearchWithStringQueryDef extends AbstractFunctionalTest {
     docMgr.setPageLength(1);
     docMgr.setSearchView(QueryView.RESULTS);
     docMgr.setNonDocumentFormat(Format.XML);
-    assertEquals("format set on document manager", "XML", docMgr.getNonDocumentFormat().toString());
-    assertEquals("Queryview set on document manager ", "RESULTS", docMgr.getSearchView().toString());
-    assertEquals("Page length ", 1, docMgr.getPageLength());
+    assertEquals( "XML", docMgr.getNonDocumentFormat().toString());
+    assertEquals( "RESULTS", docMgr.getSearchView().toString());
+    assertEquals( 1, docMgr.getPageLength());
     // Search for documents where content has bar and get first result record,
     // get search handle on it
     SearchHandle sh = new SearchHandle();
     DocumentPage page = docMgr.search(qd, 0);
     // test for page methods
-    assertEquals("Number of records", 1, page.size());
-    assertEquals("Starting record in first page ", 1, page.getStart());
-    assertEquals("Total number of estimated results:", 101, page.getTotalSize());
-    assertEquals("Total number of estimated pages :", 101, page.getTotalPages());
+    assertEquals( 1, page.size());
+    assertEquals( 1, page.getStart());
+    assertEquals(101, page.getTotalSize());
+    assertEquals(101, page.getTotalPages());
     // till the issue #78 get fixed
     System.out.println("Is this First page :" + page.isFirstPage() + page.getPageNumber());// this
                                                                                            // is
                                                                                            // bug
     System.out.println("Is this Last page :" + page.isLastPage());
     System.out.println("Is this First page has content:" + page.hasContent());
-    assertTrue("Is this First page :", page.isFirstPage());// this is bug
-    assertFalse("Is this Last page :", page.isLastPage());
-    assertTrue("Is this First page has content:", page.hasContent());
+    assertTrue( page.isFirstPage());// this is bug
+    assertFalse( page.isLastPage());
+    assertTrue( page.hasContent());
     // Need the Issue #75 to be fixed
-    assertFalse("Is first page has previous page ?", page.hasPreviousPage());
+    assertFalse( page.hasPreviousPage());
     //
     long pageNo = 1;
     do {
       count = 0;
       page = docMgr.search(qd, pageNo, sh);
       if (pageNo > 1) {
-        assertFalse("Is this first Page", page.isFirstPage());
-        assertTrue("Is page has previous page ?", page.hasPreviousPage());
+        assertFalse( page.isFirstPage());
+        assertTrue( page.hasPreviousPage());
       }
       while (page.hasNext()) {
         DocumentRecord rec = page.next();
@@ -194,27 +196,26 @@ public class TestBulkSearchWithStringQueryDef extends AbstractFunctionalTest {
         count++;
       }
       MatchDocumentSummary[] mds = sh.getMatchResults();
-      assertEquals("Matched document count", 1, mds.length);
+      assertEquals( 1, mds.length);
       // since we set the query view to get only results, facet count supposed
       // be 0
-      assertEquals("Matched Facet count", 0, sh.getFacetNames().length);
+      assertEquals( 0, sh.getFacetNames().length);
 
-      assertEquals("document count", page.size(), count);
-      // assertEquals("Page Number #",pageNo,page.getPageNumber());
+      assertEquals( page.size(), count);
       pageNo = pageNo + page.getPageSize();
     } while (!page.isLastPage());
-    // assertTrue("page count is 101 ",pageNo == page.getTotalPages());
-    assertTrue("Page has previous page ?", page.hasPreviousPage());
-    assertEquals("page size", 1, page.getPageSize());
-    assertEquals("document count", 101, page.getTotalSize());
+    // assertTrue(pageNo == page.getTotalPages());
+    assertTrue( page.hasPreviousPage());
+    assertEquals( 1, page.getPageSize());
+    assertEquals( 101, page.getTotalSize());
     page = docMgr.search(qd, 102);
-    assertFalse("Page has any records ?", page.hasContent());
+    assertFalse( page.hasContent());
   }
 
   // This test is trying to set the setResponse to JSON on DocumentManager and
   // use search handle which only work with XML
-  @Test(expected = UnsupportedOperationException.class)
-  public void testBulkSearchSQDwithWrongResponseFormat() throws KeyManagementException, NoSuchAlgorithmException, Exception {
+	@Test
+  public void testBulkSearchSQDwithWrongResponseFormat() {
     loadTxtDocuments();
     TextDocumentManager docMgr = client.newTextDocumentManager();
     QueryManager queryMgr = client.newQueryManager();
@@ -222,21 +223,12 @@ public class TestBulkSearchWithStringQueryDef extends AbstractFunctionalTest {
     qd.setCriteria("bar");
     docMgr.setNonDocumentFormat(Format.JSON);
     SearchHandle results = new SearchHandle();
-    DocumentPage page = docMgr.search(qd, 1, results);
-    MatchDocumentSummary[] summaries = results.getMatchResults();
-    for (MatchDocumentSummary summary : summaries) {
-      MatchLocation[] locations = summary.getMatchLocations();
-      for (MatchLocation location : locations) {
-        System.out.println(location.getAllSnippetText());
-        // do something with the snippet text
-      }
-    }
-
+    assertThrows(UnsupportedOperationException.class, () -> docMgr.search(qd, 1, results));
   }
 
   // Testing issue 192
   @Test
-  public void testBulkSearchSQDwithNoResults() throws KeyManagementException, NoSuchAlgorithmException, Exception {
+  public void testBulkSearchSQDwithNoResults() {
     loadTxtDocuments();
     TextDocumentManager docMgr = client.newTextDocumentManager();
     QueryManager queryMgr = client.newQueryManager();
@@ -244,7 +236,7 @@ public class TestBulkSearchWithStringQueryDef extends AbstractFunctionalTest {
     qd.setCriteria("zzzz");
     SearchHandle results = new SearchHandle();
     DocumentPage page = docMgr.search(qd, 1, results);
-    assertFalse("Should return no results", page.hasNext());
+    assertFalse( page.hasNext());
 
   }
 
@@ -271,10 +263,10 @@ public class TestBulkSearchWithStringQueryDef extends AbstractFunctionalTest {
       DocumentRecord rec = page.next();
       validateRecord(rec, Format.TEXT);
       docMgr.readMetadata(rec.getUri(), mh);
-      assertTrue("Records has permissions? ", mh.getPermissions().containsKey("flexrep-eval"));
-      assertTrue("Record has collections ?", mh.getCollections().isEmpty());
+      assertTrue( mh.getPermissions().containsKey("flexrep-eval"));
+      assertTrue( mh.getCollections().isEmpty());
     }
-    assertFalse("Search handle contains", results.get().isEmpty());
+    assertFalse( results.get().isEmpty());
 
   }
 
@@ -296,32 +288,32 @@ public class TestBulkSearchWithStringQueryDef extends AbstractFunctionalTest {
     DocumentPage page = docMgr.search(qd, 1, jh);
 
     // System.out.println(jh.get().toString());
-    assertTrue("Searh response has entry for facets", jh.get().has("facets"));
-    assertFalse("Searh response has entry for results", jh.get().has("results"));
+    assertTrue( jh.get().has("facets"));
+    assertFalse( jh.get().has("results"));
     // Issue 84 is tracking this
-    assertFalse("Searh response has entry for metrics", jh.get().has("metrics"));
+    assertFalse( jh.get().has("metrics"));
 
     docMgr.setSearchView(QueryView.RESULTS);
     page = docMgr.search(qd, 1, jh);
 
-    assertFalse("Searh response has entry for facets", jh.get().has("facets"));
-    assertTrue("Searh response has entry for results", jh.get().has("results"));
-    assertFalse("Searh response has entry for metrics", jh.get().has("metrics"));
-    // Issue 84 is tracking this                                                                     
+    assertFalse( jh.get().has("facets"));
+    assertTrue( jh.get().has("results"));
+    assertFalse( jh.get().has("metrics"));
+    // Issue 84 is tracking this
 
     docMgr.setSearchView(QueryView.METADATA);
     page = docMgr.search(qd, 1, jh);
 
-    assertFalse("Searh response has entry for facets", jh.get().has("facets"));
-    assertFalse("Searh response has entry for results", jh.get().has("results"));
-    assertTrue("Searh response has entry for metrics", jh.get().has("metrics"));
+    assertFalse( jh.get().has("facets"));
+    assertFalse( jh.get().has("results"));
+    assertTrue( jh.get().has("metrics"));
 
     docMgr.setSearchView(QueryView.ALL);
     page = docMgr.search(qd, 1, jh);
 
-    assertTrue("Searh response has entry for facets", jh.get().has("facets"));
-    assertTrue("Searh response has entry for results", jh.get().has("results"));
-    assertTrue("Searh response has entry for metrics", jh.get().has("metrics"));
+    assertTrue( jh.get().has("facets"));
+    assertTrue( jh.get().has("results"));
+    assertTrue( jh.get().has("metrics"));
 
     queryMgr.setView(QueryView.FACETS);
     queryMgr.search(qd, jh);
@@ -365,8 +357,8 @@ public class TestBulkSearchWithStringQueryDef extends AbstractFunctionalTest {
         validateRecord(rec, Format.XML);
         count++;
       }
-      assertTrue("Page has conttent :", page.hasContent());
-      assertEquals("Total search results before transaction rollback are ", "102",
+      assertTrue( page.hasContent());
+      assertEquals( "102",
           results.get().getElementsByTagNameNS("*", "response").item(0).getAttributes().getNamedItem("total").getNodeValue());
       // System.out.println(results.get().getElementsByTagNameNS("*",
       // "response").item(0).getAttributes().getNamedItem("total").getNodeValue());
@@ -380,7 +372,7 @@ public class TestBulkSearchWithStringQueryDef extends AbstractFunctionalTest {
     DocumentPage page = docMgr.search(qd, 1, results);
     System.out.println(this.convertXMLDocumentToString(results.get()));
 
-    assertEquals("Total search results after rollback are ", results.get().getElementsByTagNameNS("*", "response").item(0).getAttributes().getNamedItem("total").getNodeValue(),
+    assertEquals( results.get().getElementsByTagNameNS("*", "response").item(0).getAttributes().getNamedItem("total").getNodeValue(),
         "0");
   }
 }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkSearchWithStrucQueryDef.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkSearchWithStrucQueryDef.java
@@ -31,9 +31,10 @@ import com.marklogic.client.query.*;
 import com.marklogic.client.query.QueryManager.QueryView;
 import com.marklogic.client.type.CtsQueryExpr;
 import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.xml.sax.SAXException;
@@ -51,13 +52,13 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
-import static org.junit.Assert.*;
+
 
 public class TestBulkSearchWithStrucQueryDef extends AbstractFunctionalTest {
 
     private static final int BATCH_SIZE = 100;
     private static final String DIRECTORY = "/bulkSearch/";
-    @BeforeClass
+    @BeforeAll
     public static void setUpBeforeClass() throws Exception {
         createRESTUserWithPermissions("usr1", "password", getPermissionNode("flexrep-eval", Capability.READ), getCollectionNode("http://permission-collections/"), "rest-writer",
                 "rest-reader");
@@ -66,7 +67,7 @@ public class TestBulkSearchWithStrucQueryDef extends AbstractFunctionalTest {
         loadXMLDocuments();
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDownAfterClass() throws Exception {
         deleteRESTUser("usr1");
     }
@@ -96,10 +97,10 @@ public class TestBulkSearchWithStrucQueryDef extends AbstractFunctionalTest {
     }
 
     public void validateRecord(DocumentRecord record, Format type) {
-        assertNotNull("DocumentRecord should never be null", record);
-        assertNotNull("Document uri should never be null", record.getUri());
-        assertTrue("Document uri should start with " + DIRECTORY, record.getUri().startsWith(DIRECTORY));
-        assertEquals("All records are expected to be in same format", type, record.getFormat());
+        assertNotNull( record);
+        assertNotNull( record.getUri());
+        assertTrue(record.getUri().startsWith(DIRECTORY));
+        assertEquals( type, record.getFormat());
     }
 
     public static Document getDocContent(String xmltype) throws IOException, ParserConfigurationException, SAXException
@@ -150,32 +151,32 @@ public class TestBulkSearchWithStrucQueryDef extends AbstractFunctionalTest {
         docMgr.setPageLength(1);
         docMgr.setSearchView(QueryView.RESULTS);
         docMgr.setNonDocumentFormat(Format.XML);
-        assertEquals("format set on document manager", "XML", docMgr.getNonDocumentFormat().toString());
-        assertEquals("Queryview set on document manager ", "RESULTS", docMgr.getSearchView().toString());
-        assertEquals("Page length ", 1, docMgr.getPageLength());
+        assertEquals( "XML", docMgr.getNonDocumentFormat().toString());
+        assertEquals( "RESULTS", docMgr.getSearchView().toString());
+        assertEquals( 1, docMgr.getPageLength());
         // Search for documents where content has bar and get first result record,
         // get search handle on it
         SearchHandle sh = new SearchHandle();
         DocumentPage page = docMgr.search(qd, 0);
         // test for page methods
-        assertEquals("Number of records", 1, page.size());
-        assertEquals("Starting record in first page ", 1, page.getStart());
-        assertEquals("Total number of estimated results:", 102, page.getTotalSize());
-        assertEquals("Total number of estimated pages :", 102, page.getTotalPages());
+        assertEquals( 1, page.size());
+        assertEquals( 1, page.getStart());
+        assertEquals( 102, page.getTotalSize());
+        assertEquals( 102, page.getTotalPages());
         // till the issue #78 get fixed
-        assertTrue("Is this First page :", page.isFirstPage());// this is bug
-        assertFalse("Is this Last page :", page.isLastPage());
-        assertTrue("Is this First page has content:", page.hasContent());
+        assertTrue( page.isFirstPage());// this is bug
+        assertFalse( page.isLastPage());
+        assertTrue( page.hasContent());
         // Need the Issue #75 to be fixed
-        assertFalse("Is first page has previous page ?", page.hasPreviousPage());
+        assertFalse( page.hasPreviousPage());
         //
         long pageNo = 1;
         do {
             count = 0;
             page = docMgr.search(qd, pageNo, sh);
             if (pageNo > 1) {
-                assertFalse("Is this first Page", page.isFirstPage());
-                assertTrue("Is page has previous page ?", page.hasPreviousPage());
+                assertFalse( page.isFirstPage());
+                assertTrue( page.hasPreviousPage());
             }
             while (page.hasNext()) {
                 DocumentRecord rec = page.next();
@@ -185,21 +186,20 @@ public class TestBulkSearchWithStrucQueryDef extends AbstractFunctionalTest {
                 count++;
             }
             MatchDocumentSummary[] mds = sh.getMatchResults();
-            assertEquals("Matched document count", 1, mds.length);
+            assertEquals( 1, mds.length);
             // since we set the query view to get only results, facet count supposed
             // be 0
-            assertEquals("Matched Facet count", 0, sh.getFacetNames().length);
+            assertEquals( 0, sh.getFacetNames().length);
 
-            assertEquals("document count", page.size(), count);
-            // assertEquals("Page Number #",pageNo,page.getPageNumber());
+            assertEquals( page.size(), count);
             pageNo = pageNo + page.getPageSize();
         } while (!page.isLastPage());
 
-        assertTrue("Page has previous page ?", page.hasPreviousPage());
-        assertEquals("page size", 1, page.getPageSize());
-        assertEquals("document count", 102, page.getTotalSize());
+        assertTrue( page.hasPreviousPage());
+        assertEquals( 1, page.getPageSize());
+        assertEquals( 102, page.getTotalSize());
         page = docMgr.search(qd, 103);
-        assertFalse("Page has any records ?", page.hasContent());
+        assertFalse( page.hasContent());
     }
 
     // This test has set response to JSON and pass StringHandle with format as
@@ -225,10 +225,10 @@ public class TestBulkSearchWithStrucQueryDef extends AbstractFunctionalTest {
             DocumentRecord rec = page.next();
             validateRecord(rec, Format.JSON);
             docMgr.readMetadata(rec.getUri(), mh);
-            assertTrue("Records has permissions? ", mh.getPermissions().containsKey("flexrep-eval"));
-            assertTrue("Record has collections ?", mh.getCollections().isEmpty());
+            assertTrue( mh.getPermissions().containsKey("flexrep-eval"));
+            assertTrue( mh.getCollections().isEmpty());
         }
-        assertFalse("Search handle contains", results.get().isEmpty());
+        assertFalse( results.get().isEmpty());
     }
 
     // This test is testing SearchView options and search handle
@@ -246,30 +246,30 @@ public class TestBulkSearchWithStrucQueryDef extends AbstractFunctionalTest {
         JacksonHandle jh = new JacksonHandle();
         docMgr.search(qd, 1, jh);
 
-        assertTrue("Searh response has entry for facets", jh.get().has("facets"));
-        assertFalse("Searh response has entry for facets", jh.get().has("results"));// Issue 84 is tracking this
-        assertFalse("Searh response has entry for facets", jh.get().has("metrics"));
+        assertTrue( jh.get().has("facets"));
+        assertFalse( jh.get().has("results"));// Issue 84 is tracking this
+        assertFalse( jh.get().has("metrics"));
 
         docMgr.setSearchView(QueryView.RESULTS);
         docMgr.search(qd, 1, jh);
 
-        assertFalse("Searh response has entry for facets", jh.get().has("facets"));
-        assertTrue("Searh response has entry for facets", jh.get().has("results"));
-        assertFalse("Searh response has entry for facets", jh.get().has("metrics"));// Issue 84 is tracking this
-        
+        assertFalse( jh.get().has("facets"));
+        assertTrue( jh.get().has("results"));
+        assertFalse( jh.get().has("metrics"));// Issue 84 is tracking this
+
         docMgr.setSearchView(QueryView.METADATA);
         docMgr.search(qd, 1, jh);
 
-        assertFalse("Searh response has entry for facets", jh.get().has("facets"));
-        assertFalse("Searh response has entry for facets", jh.get().has("results"));
-        assertTrue("Searh response has entry for facets", jh.get().has("metrics"));
+        assertFalse( jh.get().has("facets"));
+        assertFalse( jh.get().has("results"));
+        assertTrue( jh.get().has("metrics"));
 
         docMgr.setSearchView(QueryView.ALL);
         docMgr.search(qd, 1, jh);
 
-        assertTrue("Searh response has entry for facets", jh.get().has("facets"));
-        assertTrue("Searh response has entry for facets", jh.get().has("results"));
-        assertTrue("Searh response has entry for facets", jh.get().has("metrics"));
+        assertTrue( jh.get().has("facets"));
+        assertTrue( jh.get().has("results"));
+        assertTrue( jh.get().has("metrics"));
 
         queryMgr.setView(QueryView.FACETS);
         queryMgr.search(qd, jh);
@@ -311,8 +311,8 @@ public class TestBulkSearchWithStrucQueryDef extends AbstractFunctionalTest {
                 validateRecord(rec, Format.XML);
                 count++;
             }
-            assertTrue("Page has conttent :", page.hasContent());
-            assertEquals("Total search results before transaction rollback are ", "102",
+            assertTrue( page.hasContent());
+            assertEquals( "102",
                     results.get().getElementsByTagNameNS("*", "response").item(0).getAttributes().getNamedItem("total").getNodeValue());
             // System.out.println(results.get().getElementsByTagNameNS("*",
             // "response").item(0).getAttributes().getNamedItem("total").getNodeValue());
@@ -324,7 +324,7 @@ public class TestBulkSearchWithStrucQueryDef extends AbstractFunctionalTest {
         }
         docMgr.search(qd, 1, results);
         System.out.println(convertXMLDocumentToString(results.get()));
-        assertEquals("Total search results after rollback are ", results.get().getElementsByTagNameNS("*", "response").item(0).getAttributes().getNamedItem("total").getNodeValue(),
+        assertEquals( results.get().getElementsByTagNameNS("*", "response").item(0).getAttributes().getNamedItem("total").getNodeValue(),
                 "0");
     }
 
@@ -364,12 +364,12 @@ public class TestBulkSearchWithStrucQueryDef extends AbstractFunctionalTest {
                     validateRecord(rec, Format.JSON);
                 }
                 docMgr.readMetadata(rec.getUri(), mh);
-                assertTrue("Records has permissions? ", mh.getPermissions().containsKey("flexrep-eval"));
-                assertFalse("Record has collections ?", mh.getCollections().isEmpty());
+                assertTrue( mh.getPermissions().containsKey("flexrep-eval"));
+                assertFalse( mh.getCollections().isEmpty());
 
             }
             System.out.println(this.convertXMLDocumentToString(dh.get()));
-            assertEquals("Total search results before transaction rollback are ", "204", dh.get().getElementsByTagNameNS("*", "response").item(0).getAttributes().getNamedItem("total")
+            assertEquals( "204", dh.get().getElementsByTagNameNS("*", "response").item(0).getAttributes().getNamedItem("total")
                     .getNodeValue());
             count++;
         }
@@ -405,7 +405,7 @@ public class TestBulkSearchWithStrucQueryDef extends AbstractFunctionalTest {
                 // we don't test for kind because it isn't sent in this case
                 assertEquals(1, extracted.size());
                 Document item1 = extracted.next().getAs(Document.class);
-                assertEquals("This is so foo with a bar 71", item1.getFirstChild().getTextContent());
+                assertEquals( "This is so foo with a bar 71", item1.getFirstChild().getTextContent());
                 continue;
             } else if (Format.JSON == summary.getFormat()) {
                 // we don't test for kind because it isn't sent in this case
@@ -457,7 +457,7 @@ public class TestBulkSearchWithStrucQueryDef extends AbstractFunctionalTest {
                 // TODO:: Bug 33921 also add test to include-with-ancestors
                 assertEquals(0, extracted.size());
                 // Document item1 = extracted.next().getAs(Document.class);
-                // assertEquals("This is so foo with a bar 71",
+                // assertEquals(
                 // item1.getFirstChild().getTextContent());
                 continue;
             } else if (Format.JSON == summary.getFormat()) {
@@ -508,7 +508,7 @@ public class TestBulkSearchWithStrucQueryDef extends AbstractFunctionalTest {
                 // we don't test for kind because it isn't sent in this case
                 assertEquals(1, extracted.size());
                 Document item1 = extracted.next().getAs(Document.class);
-                assertEquals("This is so foo with a bar 71", item1.getFirstChild().getTextContent());
+                assertEquals( "This is so foo with a bar 71", item1.getFirstChild().getTextContent());
                 continue;
             } else if (Format.JSON == summary.getFormat()) {
                 // we don't test for kind because it isn't sent in this case
@@ -558,7 +558,7 @@ public class TestBulkSearchWithStrucQueryDef extends AbstractFunctionalTest {
                 // we don't test for kind because it isn't sent in this case
                 assertEquals(1, extracted.size());
                 Document item1 = extracted.next().getAs(Document.class);
-                assertEquals("This is so foo with a bar 71", item1.getFirstChild().getTextContent());
+                assertEquals( "This is so foo with a bar 71", item1.getFirstChild().getTextContent());
                 continue;
             } else if (Format.JSON == summary.getFormat()) {
                 // we don't test for kind because it isn't sent in this case
@@ -608,7 +608,7 @@ public class TestBulkSearchWithStrucQueryDef extends AbstractFunctionalTest {
                 // we don't test for kind because it isn't sent in this case
                 assertEquals(1, extracted.size());
                 Document item1 = extracted.next().getAs(Document.class);
-                assertEquals("This is so foo with a bar 71", item1.getFirstChild().getTextContent());
+                assertEquals( "This is so foo with a bar 71", item1.getFirstChild().getTextContent());
                 continue;
             } else if (Format.JSON == summary.getFormat()) {
                 // we don't test for kind because it isn't sent in this case
@@ -679,23 +679,23 @@ public class TestBulkSearchWithStrucQueryDef extends AbstractFunctionalTest {
                     validateRecord(rec, Format.JSON);
                 }
                 docMgr.readMetadata(rec.getUri(), mh);
-                assertTrue("Records has permissions? ", mh.getPermissions().containsKey("flexrep-eval"));
-                assertFalse("Record has collections ?", mh.getCollections().isEmpty());
+                assertTrue( mh.getPermissions().containsKey("flexrep-eval"));
+                assertFalse( mh.getCollections().isEmpty());
             }
             count++;
         }
         System.out.println(results.get().toString());
-        assertEquals("Total search results before transaction rollback are ", "204", results.get().get("total").asText());
+        assertEquals( "204", results.get().get("total").asText());
     }
 
     /*
      * Searching for boolean and string in XML element using value query. Purpose:
      * To validate QueryBuilder's new value methods (in 8.0) in XML document using
      * an element.
-     * 
+     *
      * Load a file that has a boolean value in a XML attribute and use query def
      * to search on that boolean value
-     * 
+     *
      * Methods used : value(StructuredQueryBuilder.TextIndex index, boolean)
      * value(StructuredQueryBuilder.TextIndex index, String)
      */
@@ -856,8 +856,8 @@ public class TestBulkSearchWithStrucQueryDef extends AbstractFunctionalTest {
 
         // 1 - Verify that page length from client takes precedence. Both client and
         // persisted options have page length
-        assertEquals("Page Length from client not taken", 3, nPageLen);
-        assertEquals("Summaries Length incorrect", 3, nSummariesLen);
+        assertEquals( 3, nPageLen);
+        assertEquals( 3, nSummariesLen);
 
         String optionsWithoutPageLen = "<search:options>" +
                 "<search:extract-document-data selected=\"exclude\">" +
@@ -878,7 +878,7 @@ public class TestBulkSearchWithStrucQueryDef extends AbstractFunctionalTest {
         System.out.println("Summaries Length is " + nSummariesLenNP);
         // 2 - Verify that without page length from client precedence is for Server
         // options.
-        assertTrue("Page Length from client not taken", nPageLenNP == 10);
+        assertTrue( nPageLenNP == 10);
 
         // 3 - Search with options - Persisted options take precedence
         StringQueryDefinition querydef = queryMgr.newStringDefinition(queryOptionName);
@@ -892,7 +892,7 @@ public class TestBulkSearchWithStrucQueryDef extends AbstractFunctionalTest {
 
         System.out.println("Summaries Length is " + nSummariesLenOpt);
         // Verify that page length from client options takes precedence.
-        assertTrue("Page Length from client not taken", nSummariesLenOpt == 4);
+        assertTrue( nSummariesLenOpt == 4);
 
         // 4 - Search WITHOUT options - Persisted options take precedence
         StringQueryDefinition querydefNoOpts = queryMgr.newStringDefinition();
@@ -906,7 +906,7 @@ public class TestBulkSearchWithStrucQueryDef extends AbstractFunctionalTest {
 
         System.out.println("Summaries Length is " + nSummariesLenNoOpts);
         // Verify that page length from client options takes precedence.
-        assertTrue("Page Length from Server persisted options not taken", nSummariesLenNoOpts == 4);
+        assertTrue( nSummariesLenNoOpts == 4);
     }
 
     /*
@@ -961,7 +961,7 @@ public class TestBulkSearchWithStrucQueryDef extends AbstractFunctionalTest {
         assertNotNull(summaries);
         int nSummariesLen = summaries.length;
         System.out.println("Summaries Length is " + nSummariesLen);
-        assertEquals("Summaries Length incorrect", 5, nSummariesLen);
+        assertEquals( 5, nSummariesLen);
 
         // Make sure we have proper descending sort.
         LinkedHashMap<String, String> descHashMap = new LinkedHashMap<String, String>();
@@ -991,7 +991,7 @@ public class TestBulkSearchWithStrucQueryDef extends AbstractFunctionalTest {
                 fail("unexpected search result:" + summary.getUri());
         }
 
-        assertTrue("Should have summaries returned in descending order.", descHashMap.equals(exptdHashMap));
+        assertTrue( descHashMap.equals(exptdHashMap));
 
         // 2 - Verify that without sort from client, precedence is for Server
         // options
@@ -1011,7 +1011,7 @@ public class TestBulkSearchWithStrucQueryDef extends AbstractFunctionalTest {
         assertNotNull(summariesNoSort);
         int nSummariesNoSortLen = summariesNoSort.length;
         System.out.println("Summaries Length is " + nSummariesNoSortLen);
-        assertEquals("Summaries Length incorrect", 5, nSummariesNoSortLen);
+        assertEquals( 5, nSummariesNoSortLen);
 
         // Make sure we have proper ascending sort.
         LinkedHashMap<String, String> ascHashMap = new LinkedHashMap<String, String>();
@@ -1041,7 +1041,7 @@ public class TestBulkSearchWithStrucQueryDef extends AbstractFunctionalTest {
                 fail("unexpected search result:" + summary.getUri());
         }
         // 2 - Verify server options is used - ascending
-        assertTrue("Should have summaries returned in ascending order.", ascHashMap.equals(exptdAscHashMap));
+        assertTrue( ascHashMap.equals(exptdAscHashMap));
 
         // 3 - Search with options - Persisted options take precedence
         StringQueryDefinition querydef = queryMgr.newStringDefinition(queryOptionName);
@@ -1064,7 +1064,7 @@ public class TestBulkSearchWithStrucQueryDef extends AbstractFunctionalTest {
         }
 
         // 3 - Verify server options is used - ascending
-        assertTrue("Should have summaries returned in ascending order.", WithOptionsAscHashMap.equals(exptdAscHashMap));
+        assertTrue( WithOptionsAscHashMap.equals(exptdAscHashMap));
 
         // 4 - Search without options - Persisted options take precedence
         StringQueryDefinition querydefNoOpts = queryMgr.newStringDefinition(queryOptionName);
@@ -1086,9 +1086,9 @@ public class TestBulkSearchWithStrucQueryDef extends AbstractFunctionalTest {
             }
         }
         // 4 - Verify server options is used - ascending
-        assertTrue("Should have summaries returned in ascending order.", NoOptsAscHashMap.equals(exptdAscHashMap));
+        assertTrue( NoOptsAscHashMap.equals(exptdAscHashMap));
     }
-   
+
     @Test
     public void testStartPageOnQueryManager() throws KeyManagementException, NoSuchAlgorithmException, Exception {
 
@@ -1125,10 +1125,10 @@ public class TestBulkSearchWithStrucQueryDef extends AbstractFunctionalTest {
             int nSummariesLen = summaries1.length;
             System.out.println("Summaries Length is " + nSummariesLen);
 
-            assertEquals("Summaries returned incorrect", 2, nSummariesLen);
+            assertEquals( 2, nSummariesLen);
             long nTotal = results.getTotalResults();
             System.out.println("Total # of results are " + nTotal);
-            assertEquals("Total Length incorrect", 14, nTotal);
+            assertEquals( 14, nTotal);
 
             // Make sure we have proper descending sort.
             LinkedHashMap<String, String> descHashMap = new LinkedHashMap<String, String>();
@@ -1153,7 +1153,7 @@ public class TestBulkSearchWithStrucQueryDef extends AbstractFunctionalTest {
                 else
                     fail("unexpected search result:" + summary.getUri());
             }
-            assertTrue("Should have summaries returned in descending order.", descHashMap.equals(exptdHashMap));
+            assertTrue( descHashMap.equals(exptdHashMap));
 
             t = clientTmp.openTransaction("QM");;
 
@@ -1163,11 +1163,11 @@ public class TestBulkSearchWithStrucQueryDef extends AbstractFunctionalTest {
             nSummariesLen = summaries2.length;
             System.out.println("Summaries Length is " + nSummariesLen);
 
-            assertEquals("Summaries returned incorrect", 2, nSummariesLen);
+            assertEquals( 2, nSummariesLen);
 
             nTotal = results2.getTotalResults();
             System.out.println("Total # of results are " + nTotal);
-            assertEquals("Total Length incorrect", 14, nTotal);
+            assertEquals( 14, nTotal);
 
             // Make sure we have proper descending sort.
             LinkedHashMap<String, String> descHashMap2 = new LinkedHashMap<String, String>();
@@ -1193,7 +1193,7 @@ public class TestBulkSearchWithStrucQueryDef extends AbstractFunctionalTest {
                 else
                     fail("unexpected search result:" + summary.getUri());
             }
-            assertTrue("Should have summaries returned in descending order.", descHashMap2.equals(exptdHashMap2));
+            assertTrue( descHashMap2.equals(exptdHashMap2));
         }
         catch(Exception ex) {
             System.out.println("Exception from method " + ex.getMessage());
@@ -1226,30 +1226,30 @@ public class TestBulkSearchWithStrucQueryDef extends AbstractFunctionalTest {
         docMgr.search(qd, 1, jh);
 
         // System.out.println(jh.get().toString());
-        assertTrue("Searh response has entry for facets", jh.get().has("facets"));
-        assertFalse("Searh response has entry for facets", jh.get().has("results"));// Issue 84 is tracking this
-        assertFalse("Searh response has entry for facets", jh.get().has("metrics"));
+        assertTrue( jh.get().has("facets"));
+        assertFalse( jh.get().has("results"));// Issue 84 is tracking this
+        assertFalse( jh.get().has("metrics"));
 
         docMgr.setSearchView(QueryView.RESULTS);
         docMgr.search(qd, 1, jh);
 
-        assertFalse("Searh response has entry for facets", jh.get().has("facets"));
-        assertTrue("Searh response has entry for facets", jh.get().has("results"));
-        assertFalse("Searh response has entry for facets", jh.get().has("metrics"));// Issue 84 is tracking this
+        assertFalse( jh.get().has("facets"));
+        assertTrue( jh.get().has("results"));
+        assertFalse( jh.get().has("metrics"));// Issue 84 is tracking this
 
         docMgr.setSearchView(QueryView.METADATA);
         docMgr.search(qd, 1, jh);
 
-        assertFalse("Searh response has entry for facets", jh.get().has("facets"));
-        assertFalse("Searh response has entry for facets", jh.get().has("results"));
-        assertTrue("Searh response has entry for facets", jh.get().has("metrics"));
+        assertFalse( jh.get().has("facets"));
+        assertFalse( jh.get().has("results"));
+        assertTrue( jh.get().has("metrics"));
 
         docMgr.setSearchView(QueryView.ALL);
         docMgr.search(qd, 1, jh);
 
-        assertTrue("Searh response has entry for facets", jh.get().has("facets"));
-        assertTrue("Searh response has entry for facets", jh.get().has("results"));
-        assertTrue("Searh response has entry for facets", jh.get().has("metrics"));
+        assertTrue( jh.get().has("facets"));
+        assertTrue( jh.get().has("results"));
+        assertTrue( jh.get().has("metrics"));
 
         queryMgr.setView(QueryView.FACETS);
         queryMgr.search(qd, jh);

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkWriteMetadata1.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkWriteMetadata1.java
@@ -15,7 +15,7 @@
  */
 
 /**
- * 
+ *
  */
 package com.marklogic.client.fastfunctest;
 
@@ -27,7 +27,7 @@ import com.marklogic.client.io.DocumentMetadataHandle.Capability;
 import com.marklogic.client.io.DocumentMetadataHandle.DocumentCollections;
 import com.marklogic.client.io.DocumentMetadataHandle.DocumentPermissions;
 import com.marklogic.client.io.DocumentMetadataHandle.DocumentProperties;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 import javax.xml.transform.Source;
 import javax.xml.transform.dom.DOMSource;
@@ -39,23 +39,24 @@ import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Calendar;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author skottam This test is designed to add default meta data bulk writes
  *         with different types of Managers and different content type like
  *         JSON,text,binary,XMl
- * 
+ *
  *         TextDocumentManager XMLDocumentManager BinaryDocumentManager
  *         JSONDocumentManager GenericDocumentManager
- * 
+ *
  */
 public class TestBulkWriteMetadata1 extends AbstractFunctionalTest {
 
   /**
    * @throws java.lang.Exception
    */
-  @BeforeClass
+  @BeforeAll
   public static void setUpBeforeClass() throws Exception {
     System.out.println("In Setup");
     createRESTUser("app-user", "password", "rest-writer", "rest-reader");
@@ -64,7 +65,7 @@ public class TestBulkWriteMetadata1 extends AbstractFunctionalTest {
   /**
    * @throws java.lang.Exception
    */
-  @AfterClass
+  @AfterAll
   public static void tearDownAfterClass() throws Exception {
     deleteRESTUser("app-user");
   }
@@ -72,7 +73,7 @@ public class TestBulkWriteMetadata1 extends AbstractFunctionalTest {
   /**
    * @throws java.lang.Exception
    */
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     // create new connection for each test below
     client = getDatabaseClient("app-user", "password", getConnType());
@@ -81,7 +82,7 @@ public class TestBulkWriteMetadata1 extends AbstractFunctionalTest {
   /**
    * @throws java.lang.Exception
    */
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     client.release();
   }
@@ -111,32 +112,32 @@ public class TestBulkWriteMetadata1 extends AbstractFunctionalTest {
     System.out.println("Returned properties: " + actualProperties);
     StringBuffer calProperty = new StringBuffer("myCalendar:").append(Calendar.getInstance().get(Calendar.YEAR));
 
-    assertTrue("Document properties difference in size value", actualProperties.contains("size:5"));
-    assertTrue("Document property reviewed not found or not correct", actualProperties.contains("reviewed:true"));
-    assertTrue("Document property myInteger not found or not correct", actualProperties.contains("myInteger:10"));
-    assertTrue("Document property myDecimal not found or not correct", actualProperties.contains("myDecimal:34.56678"));
-    assertTrue("Document property myCalendar not found or not correct", actualProperties.contains(calProperty.toString()));
-    assertTrue("Document property myString not found or not correct", actualProperties.contains("myString:foo"));
+    assertTrue( actualProperties.contains("size:5"));
+    assertTrue( actualProperties.contains("reviewed:true"));
+    assertTrue( actualProperties.contains("myInteger:10"));
+    assertTrue( actualProperties.contains("myDecimal:34.56678"));
+    assertTrue( actualProperties.contains(calProperty.toString()));
+    assertTrue( actualProperties.contains("myString:foo"));
 
     // Permissions
     String actualPermissions = getDocumentPermissionsString(permissions);
     System.out.println("Returned permissions: " + actualPermissions);
 
-    assertTrue("Document permissions difference in size value", actualPermissions.contains("size:5"));
-    assertTrue("Document permissions difference in rest-reader permission", actualPermissions.contains("rest-reader:[READ]"));
-    assertTrue("Document permissions difference in rest-writer permission", actualPermissions.contains("rest-writer:[UPDATE]"));
-    assertTrue("Document permissions difference in app-user permissions",
+    assertTrue( actualPermissions.contains("size:5"));
+    assertTrue( actualPermissions.contains("rest-reader:[READ]"));
+    assertTrue( actualPermissions.contains("rest-writer:[UPDATE]"));
+    assertTrue(
         (actualPermissions.contains("app-user:[UPDATE, READ]") || actualPermissions.contains("app-user:[READ, UPDATE]")));
-    assertTrue("Document permissions difference in harmonized-updater permission", actualPermissions.contains("harmonized-updater:[UPDATE]"));
-    assertTrue("Document permissions difference in harmonized-reader permission", actualPermissions.contains("harmonized-reader:[READ]"));
+    assertTrue( actualPermissions.contains("harmonized-updater:[UPDATE]"));
+    assertTrue( actualPermissions.contains("harmonized-reader:[READ]"));
 
     // Collections
     String actualCollections = getDocumentCollectionsString(collections);
     System.out.println("Returned collections: " + actualCollections);
 
-    assertTrue("Document collections difference in size value", actualCollections.contains("size:2"));
-    assertTrue("my-collection1 not found", actualCollections.contains("my-collection1"));
-    assertTrue("my-collection2 not found", actualCollections.contains("my-collection2"));
+    assertTrue( actualCollections.contains("size:2"));
+    assertTrue( actualCollections.contains("my-collection1"));
+    assertTrue( actualCollections.contains("my-collection2"));
   }
 
   @Test
@@ -182,7 +183,7 @@ public class TestBulkWriteMetadata1 extends AbstractFunctionalTest {
     docMgr.write(writeset);
 
     DocumentPage page = docMgr.read(docId);
-    assertTrue("DocumentPage Size did not return expected value:: returned==  " + page.size(), page.size() == 3);
+    assertEquals(3, page.size());
     while (page.hasNext()) {
       DocumentRecord rec = page.next();
       docMgr.readMetadata(rec.getUri(), mh);

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkWriteMetadata2.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkWriteMetadata2.java
@@ -15,7 +15,7 @@
  */
 
 /**
- * 
+ *
  */
 package com.marklogic.client.fastfunctest;
 
@@ -27,7 +27,9 @@ import com.marklogic.client.io.DocumentMetadataHandle.Capability;
 import com.marklogic.client.io.DocumentMetadataHandle.DocumentCollections;
 import com.marklogic.client.io.DocumentMetadataHandle.DocumentPermissions;
 import com.marklogic.client.io.DocumentMetadataHandle.DocumentProperties;
-import org.junit.*;
+import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 import javax.xml.transform.Source;
 import javax.xml.transform.dom.DOMSource;
@@ -37,8 +39,8 @@ import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Calendar;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+
+
 
 /*
  *         This test is test the DocumentWriteSet function public
@@ -53,14 +55,14 @@ import static org.junit.Assert.assertTrue;
  *         begining has old defaults and later have latest load third set of
  *         documents with defaultset and do a document specific metadata update
  *         and check that is updated.
- * 
+ *
  */
 public class TestBulkWriteMetadata2 extends AbstractFunctionalTest {
 
   /*
    * @throws java.lang.Exception
    */
-  @BeforeClass
+  @BeforeAll
   public static void setUpBeforeClass() throws Exception {
     System.out.println("In Setup");
     createRESTUser("app-user", "password", "rest-writer", "rest-reader");
@@ -72,7 +74,7 @@ public class TestBulkWriteMetadata2 extends AbstractFunctionalTest {
   /*
    * @throws java.lang.Exception
    */
-  @AfterClass
+  @AfterAll
   public static void tearDownAfterClass() throws Exception {
     setMaintainLastModified("java-functest", false);
     deleteRESTUser("app-user");
@@ -82,7 +84,7 @@ public class TestBulkWriteMetadata2 extends AbstractFunctionalTest {
   /*
    * @throws java.lang.Exception
    */
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     // create new connection for each test below
     client = getDatabaseClient("usr1", "password", getConnType());
@@ -91,7 +93,7 @@ public class TestBulkWriteMetadata2 extends AbstractFunctionalTest {
   /*
    * @throws java.lang.Exception
    */
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     client.release();
   }
@@ -121,28 +123,28 @@ public class TestBulkWriteMetadata2 extends AbstractFunctionalTest {
     // "size:5|reviewed:true|myInteger:10|myDecimal:34.56678|myCalendar:2014|myString:foo|";
     String actualProperties = getDocumentPropertiesString(properties);
     boolean result = actualProperties.contains("size:6|");
-    assertTrue("Document properties count", result);
+    assertTrue( result);
 
     // Permissions
     String actualPermissions = getDocumentPermissionsString(permissions);
     System.out.println(actualPermissions);
 
-    assertTrue("Document permissions difference in size value", actualPermissions.contains("size:6"));
-    assertTrue("Document permissions difference in flexrep-eval permission", actualPermissions.contains("flexrep-eval:[READ]"));
-    assertTrue("Document permissions difference in rest-reader permission", actualPermissions.contains("rest-reader:[READ]"));
-    assertTrue("Document permissions difference in rest-writer permission", actualPermissions.contains("rest-writer:[UPDATE]"));
-    assertTrue("Document permissions difference in app-user permissions",
+    assertTrue( actualPermissions.contains("size:6"));
+    assertTrue( actualPermissions.contains("flexrep-eval:[READ]"));
+    assertTrue( actualPermissions.contains("rest-reader:[READ]"));
+    assertTrue( actualPermissions.contains("rest-writer:[UPDATE]"));
+    assertTrue(
         (actualPermissions.contains("app-user:[UPDATE, READ]") || actualPermissions.contains("app-user:[READ, UPDATE]")));
-    assertTrue("Document permissions difference in harmonized-updater permission", actualPermissions.contains("harmonized-updater:[UPDATE]"));
-    assertTrue("Document permissions difference in harmonized-reader permission", actualPermissions.contains("harmonized-reader:[READ]"));
+    assertTrue( actualPermissions.contains("harmonized-updater:[UPDATE]"));
+    assertTrue( actualPermissions.contains("harmonized-reader:[READ]"));
 
     // Collections
     String actualCollections = getDocumentCollectionsString(collections);
     System.out.println(collections);
 
-    assertTrue("Document collections difference in size value", actualCollections.contains("size:2"));
-    assertTrue("my-collection1 not found", actualCollections.contains("my-collection1"));
-    assertTrue("my-collection2 not found", actualCollections.contains("my-collection2"));
+    assertTrue( actualCollections.contains("size:2"));
+    assertTrue( actualCollections.contains("my-collection1"));
+    assertTrue( actualCollections.contains("my-collection2"));
   }
 
   public void validateDefaultMetadata(DocumentMetadataHandle mh) {
@@ -155,23 +157,23 @@ public class TestBulkWriteMetadata2 extends AbstractFunctionalTest {
     String actualProperties = getDocumentPropertiesString(properties);
     boolean result = actualProperties.contains("size:1|");
     System.out.println(actualProperties + result);
-    assertTrue("Document default last modified properties count1?", result);
+    assertTrue( result);
 
     // Permissions
     String actualPermissions = getDocumentPermissionsString(permissions);
 
-    assertTrue("Document permissions difference in size value", actualPermissions.contains("size:5"));
-    assertTrue("Document permissions difference in flexrep-eval permission", actualPermissions.contains("flexrep-eval:[READ]"));
-    assertTrue("Document permissions difference in rest-reader permission", actualPermissions.contains("rest-reader:[READ]"));
-    assertTrue("Document permissions difference in rest-writer permission", actualPermissions.contains("rest-writer:[UPDATE]"));
-    assertTrue("Document permissions difference in harmonized-updater permission", actualPermissions.contains("harmonized-updater:[UPDATE]"));
-    assertTrue("Document permissions difference in harmonized-reader permission", actualPermissions.contains("harmonized-reader:[READ]"));
+    assertTrue( actualPermissions.contains("size:5"));
+    assertTrue( actualPermissions.contains("flexrep-eval:[READ]"));
+    assertTrue( actualPermissions.contains("rest-reader:[READ]"));
+    assertTrue( actualPermissions.contains("rest-writer:[UPDATE]"));
+    assertTrue( actualPermissions.contains("harmonized-updater:[UPDATE]"));
+    assertTrue( actualPermissions.contains("harmonized-reader:[READ]"));
 
     // Collections
     String expectedCollections = "size:1|http://permission-collections/|";
     String actualCollections = getDocumentCollectionsString(collections);
 
-    assertEquals("Document collections difference", expectedCollections, actualCollections);
+    assertEquals( expectedCollections, actualCollections);
   }
 
   @Test
@@ -355,17 +357,17 @@ public class TestBulkWriteMetadata2 extends AbstractFunctionalTest {
     rec = page.next();
     docMgr.readMetadata(rec.getUri(), mh);
     // System.out.println(rec.getUri()+mh.getQuality());
-    assertEquals("default quality", 0, mh.getQuality());
+    assertEquals( 0, mh.getQuality());
     validateDefaultMetadata(mh);
     page = docMgr.read("/2/Pandakarlino.jpg");
     rec = page.next();
     docMgr.readMetadata(rec.getUri(), mh);
-    assertEquals(" quality", 5, mh.getQuality());
+    assertEquals( 5, mh.getQuality());
 
     // Collections - Test corrected for bug fix from 32783
     /*
      * Default collections are applied only in the following cases:
-     * 
+     *
      * Creating a document with single write without specifying collections
      * Creating a document or updating document content with bulk write without
      * specifying collections Resetting collections by deleting all or
@@ -375,17 +377,17 @@ public class TestBulkWriteMetadata2 extends AbstractFunctionalTest {
     String expectedCollections = "size:1|http://permission-collections/|";
     String actualCollections = getDocumentCollectionsString(mh.getCollections());
 
-    assertEquals("Document collections difference", expectedCollections, actualCollections);
+    assertEquals( expectedCollections, actualCollections);
 
     page = docMgr.read("/1/mlfavicon.png");
     rec = page.next();
     docMgr.readMetadata(rec.getUri(), mh);
-    assertEquals("default quality", 0, mh.getQuality());
+    assertEquals( 0, mh.getQuality());
     // System.out.println(rec.getUri()+mh.getCollections().isEmpty());
     expectedCollections = "size:1|collection1|";
     actualCollections = getDocumentCollectionsString(mh.getCollections());
 
-    assertEquals("Document collections difference", expectedCollections, actualCollections);
+    assertEquals( expectedCollections, actualCollections);
 
     page = docMgr.read("/2/mlfavicon.png");
     rec = page.next();
@@ -447,18 +449,18 @@ public class TestBulkWriteMetadata2 extends AbstractFunctionalTest {
     rec = page.next();
     jdm.readMetadata(rec.getUri(), mh);
     validateDefaultMetadata(mh);
-    assertEquals("default quality", 0, mh.getQuality());
+    assertEquals( 0, mh.getQuality());
 
     // Doc2 should use the first batch default metadata, with quality 1
     page = jdm.read("doc2.json");
     rec = page.next();
     jdm.readMetadata(rec.getUri(), mh);
     System.out.print(mh.getCollections().isEmpty());
-    assertEquals("default quality", 1, mh.getQuality());
+    assertEquals( 1, mh.getQuality());
     String expectedCollections = "size:1|http://permission-collections/|";
     String actualCollections = getDocumentCollectionsString(mh.getCollections());
 
-    assertEquals("Document collections difference", expectedCollections, actualCollections);
+    assertEquals( expectedCollections, actualCollections);
 
     // Doc3 should have the system default document quality (0) because quality
     // was not included in the document-specific metadata. It should be in the
@@ -467,8 +469,8 @@ public class TestBulkWriteMetadata2 extends AbstractFunctionalTest {
     page = jdm.read("doc3.json");
     rec = page.next();
     jdm.readMetadata(rec.getUri(), mh);
-    assertEquals("default quality", 0, mh.getQuality());
-    assertEquals("default collection must change", "[mySpecificCollection]", mh.getCollections().toString());
+    assertEquals( 0, mh.getQuality());
+    assertEquals( "[mySpecificCollection]", mh.getCollections().toString());
 
     DocumentMetadataHandle doc3Metadata =
         jdm.readMetadata("doc3.json", new DocumentMetadataHandle());
@@ -476,22 +478,22 @@ public class TestBulkWriteMetadata2 extends AbstractFunctionalTest {
     expectedCollections = "size:1|mySpecificCollection|";
     actualCollections = getDocumentCollectionsString(mh.getCollections());
 
-    assertEquals("Document collections difference", expectedCollections, actualCollections);
+    assertEquals( expectedCollections, actualCollections);
 
     // Doc 4 should also use the 1st batch default metadata, with quality 1
     page = jdm.read("doc4.json");
     rec = page.next();
     jdm.readMetadata(rec.getUri(), mh);
-    assertEquals("default quality", 1, mh.getQuality());
+    assertEquals( 1, mh.getQuality());
     expectedCollections = "size:1|http://permission-collections/|";
     actualCollections = getDocumentCollectionsString(mh.getCollections());
 
-    assertEquals("Document collections difference", expectedCollections, actualCollections);
+    assertEquals( expectedCollections, actualCollections);
     // Doc5 should use the 2nd batch default metadata, with quality 2
     page = jdm.read("doc5.json");
     rec = page.next();
     jdm.readMetadata(rec.getUri(), mh);
-    assertEquals("default quality", 2, mh.getQuality());
+    assertEquals( 2, mh.getQuality());
 
   }
 
@@ -550,18 +552,18 @@ public class TestBulkWriteMetadata2 extends AbstractFunctionalTest {
     page = docMgr.read("/generic/dog.json");
     DocumentRecord rec = page.next();
     docMgr.readMetadata(rec.getUri(), mh);
-    assertEquals("default quality", 10, mh.getQuality());
+    assertEquals( 10, mh.getQuality());
 
     String expectedCollections = "size:1|http://permission-collections/|";
     String actualCollections = getDocumentCollectionsString(mh.getCollections());
 
-    assertEquals("Document collections difference", expectedCollections, actualCollections);
+    assertEquals( expectedCollections, actualCollections);
 
     page = docMgr.read("/generic/foo.xml");
     rec = page.next();
     docMgr.readMetadata(rec.getUri(), mh);
-    assertEquals("default quality", 0, mh.getQuality());
-    assertEquals("default collection must change", "[genericCollection]", mh.getCollections().toString());
+    assertEquals( 0, mh.getQuality());
+    assertEquals( "[genericCollection]", mh.getCollections().toString());
     sh.close();
   }
 }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkWriteMetadatawithRawXML.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkWriteMetadatawithRawXML.java
@@ -24,7 +24,9 @@ import com.marklogic.client.io.DocumentMetadataHandle.Capability;
 import com.marklogic.client.io.DocumentMetadataHandle.DocumentCollections;
 import com.marklogic.client.io.DocumentMetadataHandle.DocumentPermissions;
 import com.marklogic.client.io.DocumentMetadataHandle.DocumentProperties;
-import org.junit.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.*;
 import org.w3c.dom.Document;
 
 import javax.xml.transform.Source;
@@ -38,8 +40,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+
+
 
 /**
  * @author skottam This test is test the DocumentWriteSet function public
@@ -50,14 +52,14 @@ import static org.junit.Assert.assertTrue;
  *         data as default client make a connection with usr1 to do bulk loading
  *         load set of documents where default metadata is set with raw xml or
  *         json documents test disableDefault().
- * 
+ *
  */
 public class TestBulkWriteMetadatawithRawXML extends AbstractFunctionalTest {
 
   /**
    * @throws java.lang.Exception
    */
-  @BeforeClass
+  @BeforeAll
   public static void setUpBeforeClass() throws Exception {
     createRESTUser("app-user", "password", "rest-writer", "rest-reader");
     createRESTUserWithPermissions("usr1", "password", getPermissionNode("flexrep-eval", Capability.READ), getCollectionNode("http://permission-collections/"), "rest-writer",
@@ -67,7 +69,7 @@ public class TestBulkWriteMetadatawithRawXML extends AbstractFunctionalTest {
   /**
    * @throws java.lang.Exception
    */
-  @AfterClass
+  @AfterAll
   public static void tearDownAfterClass() throws Exception {
     deleteRESTUser("app-user");
     deleteRESTUser("usr1");
@@ -76,7 +78,7 @@ public class TestBulkWriteMetadatawithRawXML extends AbstractFunctionalTest {
   /**
    * @throws java.lang.Exception
    */
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     // create new connection for each test below
     client = getDatabaseClient("usr1", "password", getConnType());
@@ -85,7 +87,7 @@ public class TestBulkWriteMetadatawithRawXML extends AbstractFunctionalTest {
   /**
    * @throws java.lang.Exception
    */
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     client.release();
   }
@@ -116,28 +118,28 @@ public class TestBulkWriteMetadatawithRawXML extends AbstractFunctionalTest {
     // "size:5|reviewed:true|myInteger:10|myDecimal:34.56678|myCalendar:2014|myString:foo|";
     String actualProperties = getDocumentPropertiesString(properties);
     boolean result = actualProperties.contains("size:5|");
-    assertTrue("Document properties count", result);
+    assertTrue( result);
 
     // Permissions
     String actualPermissions = getDocumentPermissionsString(permissions);
     System.out.println(actualPermissions);
 
-    assertTrue("Document permissions difference in size value", actualPermissions.contains("size:6"));
-    assertTrue("Document permissions difference in flexrep-eval permission", actualPermissions.contains("flexrep-eval:[READ]"));
-    assertTrue("Document permissions difference in rest-reader permission", actualPermissions.contains("rest-reader:[READ]"));
-    assertTrue("Document permissions difference in rest-writer permission", actualPermissions.contains("rest-writer:[UPDATE]"));
-    assertTrue("Document permissions difference in app-user permissions",
+    assertTrue( actualPermissions.contains("size:6"));
+    assertTrue( actualPermissions.contains("flexrep-eval:[READ]"));
+    assertTrue( actualPermissions.contains("rest-reader:[READ]"));
+    assertTrue( actualPermissions.contains("rest-writer:[UPDATE]"));
+    assertTrue(
         (actualPermissions.contains("app-user:[UPDATE, READ]") || actualPermissions.contains("app-user:[READ, UPDATE]")));
-    assertTrue("Document permissions difference in harmonized-updater permission", actualPermissions.contains("harmonized-updater:[UPDATE]"));
-    assertTrue("Document permissions difference in harmonized-reader permission", actualPermissions.contains("harmonized-reader:[READ]"));
+    assertTrue( actualPermissions.contains("harmonized-updater:[UPDATE]"));
+    assertTrue( actualPermissions.contains("harmonized-reader:[READ]"));
 
     // Collections
     String actualCollections = getDocumentCollectionsString(collections);
     System.out.println(collections);
 
-    assertTrue("Document collections difference in size value", actualCollections.contains("size:2"));
-    assertTrue("my-collection1 not found", actualCollections.contains("my-collection1"));
-    assertTrue("my-collection2 not found", actualCollections.contains("my-collection2"));
+    assertTrue( actualCollections.contains("size:2"));
+    assertTrue( actualCollections.contains("my-collection1"));
+    assertTrue( actualCollections.contains("my-collection2"));
 
   }
 
@@ -152,17 +154,17 @@ public class TestBulkWriteMetadatawithRawXML extends AbstractFunctionalTest {
     String actualPermissions = getDocumentPermissionsString(permissions);
     System.out.println(actualPermissions);
 
-    assertTrue("Document permissions difference in size value", actualPermissions.contains("size:5"));
-    assertTrue("Document permissions difference in flexrep-eval permission", actualPermissions.contains("flexrep-eval:[READ]"));
-    assertTrue("Document permissions difference in rest-reader permission", actualPermissions.contains("rest-reader:[READ]"));
-    assertTrue("Document permissions difference in rest-writer permission", actualPermissions.contains("rest-writer:[UPDATE]"));
-    assertTrue("Document permissions difference in harmonized-updater permission", actualPermissions.contains("harmonized-updater:[UPDATE]"));
-    assertTrue("Document permissions difference in harmonized-reader permission", actualPermissions.contains("harmonized-reader:[READ]"));
+    assertTrue( actualPermissions.contains("size:5"));
+    assertTrue( actualPermissions.contains("flexrep-eval:[READ]"));
+    assertTrue( actualPermissions.contains("rest-reader:[READ]"));
+    assertTrue( actualPermissions.contains("rest-writer:[UPDATE]"));
+    assertTrue( actualPermissions.contains("harmonized-updater:[UPDATE]"));
+    assertTrue( actualPermissions.contains("harmonized-reader:[READ]"));
 
     // Collections
     String actualCollections = getDocumentCollectionsString(collections);
-    assertTrue("Document collections difference in size value", actualCollections.contains("size:1"));
-    assertTrue("my-collection1 not found", actualCollections.contains("http://permission-collections/"));
+    assertTrue( actualCollections.contains("size:1"));
+    assertTrue( actualCollections.contains("http://permission-collections/"));
   }
 
   @Test
@@ -370,7 +372,7 @@ public class TestBulkWriteMetadatawithRawXML extends AbstractFunctionalTest {
     jdm.readMetadata(rec.getUri(), mh);
     System.out.print(mh.getQuality());
     validateDefaultMetadata(mh);
-    assertEquals("default quality", 0, mh.getQuality());
+    assertEquals( 0, mh.getQuality());
 
     // Doc2 should use the first batch default metadata, that has only
     // properties i.e. rest needs to be default to system defaults
@@ -381,9 +383,9 @@ public class TestBulkWriteMetadatawithRawXML extends AbstractFunctionalTest {
     String expectedCollections = "size:1|http://permission-collections/|";
     String actualCollections = getDocumentCollectionsString(mh.getCollections());
 
-    assertEquals("Document collections difference", expectedCollections, actualCollections);
+    assertEquals( expectedCollections, actualCollections);
 
-    assertEquals("default quality", 0, mh.getQuality());
+    assertEquals( 0, mh.getQuality());
 
     // Doc3 should have the system default document quality (0) because quality
     // was not included in the document-specific metadata. It should be in the
@@ -392,20 +394,20 @@ public class TestBulkWriteMetadatawithRawXML extends AbstractFunctionalTest {
     page = jdm.read("doc3.json");
     rec = page.next();
     jdm.readMetadata(rec.getUri(), mh);
-    assertEquals("default quality", 0, mh.getQuality());
-    assertEquals("default collection must change", "[http://Json-Uri-spec-collections/]", mh.getCollections().toString());
+    assertEquals( 0, mh.getQuality());
+    assertEquals( "[http://Json-Uri-spec-collections/]", mh.getCollections().toString());
 
     // Doc 4 should also use the 1st batch default metadata, with quality 1
     page = jdm.read("doc4.json");
     rec = page.next();
     jdm.readMetadata(rec.getUri(), mh);
-    assertEquals("default quality", 0, mh.getQuality());
-    assertTrue("default collections reset", mh.getProperties().containsValue("9"));
+    assertEquals( 0, mh.getQuality());
+    assertTrue( mh.getProperties().containsValue("9"));
     // Doc5 should use the 2nd batch default metadata, with quality 2
     page = jdm.read("doc5.json");
     rec = page.next();
     jdm.readMetadata(rec.getUri(), mh);
-    assertEquals("default quality", 20, mh.getQuality());
+    assertEquals( 20, mh.getQuality());
 
   }
 
@@ -496,17 +498,17 @@ public class TestBulkWriteMetadatawithRawXML extends AbstractFunctionalTest {
     DocumentPage page = docMgr.read("/generic/Sega.jpg");
     DocumentRecord rec = page.next();
     docMgr.readMetadata(rec.getUri(), mh1);
-    assertEquals("default quality", 0, mh1.getQuality());
-    assertTrue("Properties contains value 19", mh1.getProperties().containsValue("19"));
+    assertEquals( 0, mh1.getQuality());
+    assertTrue( mh1.getProperties().containsValue("19"));
 
     page = docMgr.read("/generic/dog.json");
     rec = page.next();
     docMgr.readMetadata(rec.getUri(), mh1);
-    assertEquals("default quality", 10, mh1.getQuality());
+    assertEquals( 10, mh1.getQuality());
     String expectedCollections = "size:1|http://permission-collections/|";
     String actualCollections = getDocumentCollectionsString(mh1.getCollections());
 
-    assertEquals("Document collections difference", expectedCollections, actualCollections);
+    assertEquals( expectedCollections, actualCollections);
 
     page = docMgr.read("/generic/foo1.txt");
     rec = page.next();
@@ -514,24 +516,24 @@ public class TestBulkWriteMetadatawithRawXML extends AbstractFunctionalTest {
     expectedCollections = "size:1|http://permission-collections/|";
     actualCollections = getDocumentCollectionsString(mh1.getCollections());
 
-    assertEquals("Document collections difference", expectedCollections, actualCollections);
+    assertEquals( expectedCollections, actualCollections);
 
-    assertEquals("default quality", 0, mh1.getQuality());
+    assertEquals( 0, mh1.getQuality());
 
     String actualPermissions = mh1.getPermissions().toString();
     System.out.println(actualPermissions);
-    assertTrue("Default permissions must contain flexrep-eval=[READ]",
+    assertTrue(
         actualPermissions.contains("flexrep-eval=[READ]"));
-    assertTrue("Default permissions must contain rest-reader=[READ]",
+    assertTrue(
         actualPermissions.contains("rest-reader=[READ]"));
-    assertTrue("Default permissions must contain rest-writer=[UPDATE]",
+    assertTrue(
         actualPermissions.contains("rest-writer=[UPDATE]"));
 
     page = docMgr.read("/generic/foo.xml");
     rec = page.next();
     docMgr.readMetadata(rec.getUri(), mh1);
-    assertEquals("default quality", 0, mh1.getQuality());
-    assertEquals("default collection must change",
+    assertEquals( 0, mh1.getQuality());
+    assertEquals(
         "[http://Json-Uri-generic-collections/]", mh1.getCollections()
             .toString());
     sh.close();

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkWriteSample1.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkWriteSample1.java
@@ -23,9 +23,10 @@ import com.marklogic.client.ResourceNotFoundException;
 import com.marklogic.client.document.*;
 import com.marklogic.client.functionaltest.Product;
 import com.marklogic.client.io.*;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 import javax.xml.bind.JAXBContext;
@@ -35,11 +36,11 @@ import java.io.*;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 
-import static org.junit.Assert.assertEquals;
+
 
 /*
  * This test is designed to to test simple bulk writes with different types of Managers and different content type like JSON,text,binary,XMl
- * 
+ *
  *  TextDocumentManager
  *  XMLDocumentManager
  *  BinaryDocumentManager
@@ -49,14 +50,14 @@ import static org.junit.Assert.assertEquals;
 
 public class TestBulkWriteSample1 extends AbstractFunctionalTest {
 
-  @Before
+  @BeforeEach
   public void testSetup() throws Exception
   {
     // create new connection for each test below
     client = getDatabaseClient("rest-admin", "x", getConnType());
   }
 
-  @After
+  @AfterEach
   public void testCleanUp() throws Exception
   {
     client.release();
@@ -66,7 +67,7 @@ public class TestBulkWriteSample1 extends AbstractFunctionalTest {
   /*
    * This is cloned in github with tracking bug #27685
    * https://github.com/marklogic/java-client-api/issues/23
-   * 
+   *
    * This test uses StringHandle to load 3 text documents, writes to database
    * using bulk write set. Verified by reading individual documents
    */
@@ -85,9 +86,9 @@ public class TestBulkWriteSample1 extends AbstractFunctionalTest {
 
     docMgr.write(writeset);
 
-    assertEquals("Text document write difference", "This is so foo1", docMgr.read(docId[0], new StringHandle()).get());
-    assertEquals("Text document write difference", "This is so foo2", docMgr.read(docId[1], new StringHandle()).get());
-    assertEquals("Text document write difference", "This is so foo3", docMgr.read(docId[2], new StringHandle()).get());
+    assertEquals( "This is so foo1", docMgr.read(docId[0], new StringHandle()).get());
+    assertEquals( "This is so foo2", docMgr.read(docId[1], new StringHandle()).get());
+    assertEquals( "This is so foo3", docMgr.read(docId[2], new StringHandle()).get());
 
     // Bulk delete on TextDocumentManager
     docMgr.delete(docId[0], docId[1], docId[2]);
@@ -114,11 +115,11 @@ public class TestBulkWriteSample1 extends AbstractFunctionalTest {
     DOMHandle dh = new DOMHandle();
     docMgr.read(docId[0], dh);
 
-    assertEquals("xml document write difference", "This is so foo1", dh.get().getChildNodes().item(0).getTextContent());
+    assertEquals( "This is so foo1", dh.get().getChildNodes().item(0).getTextContent());
     docMgr.read(docId[1], dh);
-    assertEquals("xml document write difference", "This is so foo2", dh.get().getChildNodes().item(0).getTextContent());
+    assertEquals( "This is so foo2", dh.get().getChildNodes().item(0).getTextContent());
     docMgr.read(docId[2], dh);
-    assertEquals("xml document write difference", "This is so foo3", dh.get().getChildNodes().item(0).getTextContent());
+    assertEquals( "This is so foo3", dh.get().getChildNodes().item(0).getTextContent());
 
     // Bulk delete on XMLDocumentManager
     docMgr.delete(docId[0], docId[1], docId[2]);
@@ -128,8 +129,8 @@ public class TestBulkWriteSample1 extends AbstractFunctionalTest {
    * This test uses FileHandle to load 3 binary documents with same URI, writes
    * to database using bulk write set. Expecting an exception.
    */
-  @Test(expected = FailedRequestException.class)
-  public void testWriteMultipleSameBinaryDoc() throws KeyManagementException, NoSuchAlgorithmException, Exception
+  @Test
+  public void testWriteMultipleSameBinaryDoc()
   {
     String docId[] = { "Pandakarlino.jpg", "mlfavicon.png" };
 
@@ -140,9 +141,7 @@ public class TestBulkWriteSample1 extends AbstractFunctionalTest {
     FileHandle handle1 = new FileHandle(file1);
     writeset.add("/1/" + docId[0], handle1.withFormat(Format.BINARY));
     writeset.add("/1/" + docId[0], handle1.withFormat(Format.BINARY));
-
-    docMgr.write(writeset);
-
+    assertThrows(FailedRequestException.class, () -> docMgr.write(writeset));
   }
 
   /*
@@ -176,8 +175,8 @@ public class TestBulkWriteSample1 extends AbstractFunctionalTest {
     docMgr.read("/1/" + docId[1], readHandle2);
     System.out.println(file1.getName() + ":" + fsize1 + " " + readHandle1.get().getName() + ":" + readHandle1.get().length());
     System.out.println(file2.getName() + ":" + fsize2 + " " + readHandle2.get().getName() + ":" + readHandle2.get().length());
-    assertEquals("Size of the  File 1" + docId[0], fsize1, readHandle1.get().length());
-    assertEquals("Size of the  File 1" + docId[1], fsize2, readHandle2.get().length());
+    assertEquals(fsize1, readHandle1.get().length());
+    assertEquals(fsize2, readHandle2.get().length());
 
     // Bulk delete test - Git 284
     String doc0 = "/1/" + docId[0];
@@ -213,9 +212,9 @@ public class TestBulkWriteSample1 extends AbstractFunctionalTest {
     BufferedReader bfr = new BufferedReader(r1.get());
     assertEquals(json1, bfr.readLine());
     docMgr.read(docId[1], r1);
-    assertEquals("Json File Content" + docId[1], json2, new BufferedReader(r1.get()).readLine());
+    assertEquals(json2, new BufferedReader(r1.get()).readLine());
     docMgr.read(docId[2], r1);
-    assertEquals("Json File Content" + docId[2], json3, new BufferedReader(r1.get()).readLine());
+    assertEquals(json3, new BufferedReader(r1.get()).readLine());
     bfr.close();
   }
 
@@ -249,11 +248,11 @@ public class TestBulkWriteSample1 extends AbstractFunctionalTest {
     DOMHandle dh = new DOMHandle();
     docMgr.read(docId[0], dh);
 
-    assertEquals("xml document write difference", "Very cool Iphone", dh.get().getChildNodes().item(0).getChildNodes().item(1).getTextContent());
+    assertEquals( "Very cool Iphone", dh.get().getChildNodes().item(0).getChildNodes().item(1).getTextContent());
     docMgr.read(docId[1], dh);
-    assertEquals("xml document write difference", "Very cool Ipad", dh.get().getChildNodes().item(0).getChildNodes().item(1).getTextContent());
+    assertEquals( "Very cool Ipad", dh.get().getChildNodes().item(0).getChildNodes().item(1).getTextContent());
     docMgr.read(docId[2], dh);
-    assertEquals("xml document write difference", "Very cool Ipod", dh.get().getChildNodes().item(0).getChildNodes().item(1).getTextContent());
+    assertEquals( "Very cool Ipod", dh.get().getChildNodes().item(0).getChildNodes().item(1).getTextContent());
   }
 
   /*
@@ -303,21 +302,21 @@ public class TestBulkWriteSample1 extends AbstractFunctionalTest {
     FileHandle rh = new FileHandle();
 
     docMgr.read("/generic/" + docId[0], rh);
-    assertEquals("Size of the  File /generic/" + docId[0], file1.length(), rh.get().length());
+    assertEquals(file1.length(), rh.get().length());
     System.out.println(rh.get().getName() + ":" + rh.get().length() + "\n");
 
     docMgr.read("/generic/foo.xml", rh);
     BufferedReader br = new BufferedReader(new FileReader(rh.get()));
     br.readLine();
-    assertEquals("xml document write difference", "<foo>This is so foo1</foo>", br.readLine());
+    assertEquals( "<foo>This is so foo1</foo>", br.readLine());
     docMgr.read("/generic/foo1.txt", rh);
     br.close();
     br = new BufferedReader(new FileReader(rh.get()));
-    assertEquals("txt document write difference", foo1, br.readLine());
+    assertEquals( foo1, br.readLine());
     br.close();
     docMgr.read("/generic/dog.json", rh);
     br = new BufferedReader(new FileReader(rh.get()));
-    assertEquals("Json document write difference", "{\"animal\":\"dog\", \"says\":\"woof\"}", br.readLine());
+    assertEquals( "{\"animal\":\"dog\", \"says\":\"woof\"}", br.readLine());
     br.close();
     fis.close();
 
@@ -374,8 +373,8 @@ public class TestBulkWriteSample1 extends AbstractFunctionalTest {
 
   }
 
-  @Test(expected = ResourceNotFoundException.class)
-  public void testJAXBDocsBulkDelete() throws KeyManagementException, NoSuchAlgorithmException, Exception
+	@Test
+  public void testJAXBDocsBulkDelete() throws Exception
   {
     String docId[] = { "/jaxb/iphone.xml", "/jaxb/ipad.xml", "/jaxb/ipod.xml" };
     Product product1 = new Product();
@@ -403,11 +402,11 @@ public class TestBulkWriteSample1 extends AbstractFunctionalTest {
     DOMHandle dh = new DOMHandle();
     docMgr.read(docId[0], dh);
 
-    assertEquals("xml document write difference", "Very cool Iphone", dh.get().getChildNodes().item(0).getChildNodes().item(1).getTextContent());
+    assertEquals( "Very cool Iphone", dh.get().getChildNodes().item(0).getChildNodes().item(1).getTextContent());
     docMgr.read(docId[1], dh);
-    assertEquals("xml document write difference", "Very cool Ipad", dh.get().getChildNodes().item(0).getChildNodes().item(1).getTextContent());
+    assertEquals( "Very cool Ipad", dh.get().getChildNodes().item(0).getChildNodes().item(1).getTextContent());
     docMgr.read(docId[2], dh);
-    assertEquals("xml document write difference", "Very cool Ipod", dh.get().getChildNodes().item(0).getChildNodes().item(1).getTextContent());
+    assertEquals( "Very cool Ipod", dh.get().getChildNodes().item(0).getChildNodes().item(1).getTextContent());
 
     // Bulk delete on XMLDocumentManager
     docMgr.delete(docId[0], docId[1], docId[2]);
@@ -417,6 +416,6 @@ public class TestBulkWriteSample1 extends AbstractFunctionalTest {
 
     // Make sure that bulk delete indeed worked. Should throw
     // ResourceNotFoundException.
-    docMgr.read("/generic/" + docId[0], rhDeleted);
+    assertThrows(ResourceNotFoundException.class, () -> docMgr.read("/generic/" + docId[0], rhDeleted));
   }
 }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkWriteWithTransactions.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkWriteWithTransactions.java
@@ -27,9 +27,10 @@ import com.marklogic.client.io.DocumentMetadataHandle.DocumentPermissions;
 import com.marklogic.client.io.DocumentMetadataHandle.DocumentProperties;
 import com.marklogic.client.io.FileHandle;
 import com.marklogic.client.io.Format;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.File;
 import java.security.KeyManagementException;
@@ -38,7 +39,7 @@ import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+
 
 public class TestBulkWriteWithTransactions extends AbstractFunctionalTest {
 
@@ -46,7 +47,7 @@ public class TestBulkWriteWithTransactions extends AbstractFunctionalTest {
   private static final String DIRECTORY = "/bulkTransacton/";
   private static int ndocCount = 0;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpBeforeClass() throws Exception {
     System.out.println("In Setup");
     createRESTUser("app-user", "password", "rest-writer", "rest-reader", "flexrep-eval");
@@ -56,11 +57,11 @@ public class TestBulkWriteWithTransactions extends AbstractFunctionalTest {
 		  ndocCount = 1;
 	  }
 	  else {
-		  ndocCount = 102; 
+		  ndocCount = 102;
 	  }
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownAfterClass() throws Exception {
     System.out.println("In tear down");
     deleteRESTUser("app-user");
@@ -92,26 +93,26 @@ public class TestBulkWriteWithTransactions extends AbstractFunctionalTest {
     String actualProperties = getDocumentPropertiesString(properties);
     boolean result = actualProperties.contains("size:5|");
 
-    assertTrue("Document properties count", result);
+    assertTrue( result);
 
     // Permissions
     String actualPermissions = getDocumentPermissionsString(permissions);
 
-    assertTrue("Document permissions difference in size value", actualPermissions.contains("size:6"));
-    assertTrue("Document permissions difference in rest-reader permission", actualPermissions.contains("rest-reader:[READ]"));
-    assertTrue("Document permissions difference in rest-writer permission", actualPermissions.contains("rest-writer:[UPDATE]"));
-    assertTrue("Document permissions difference in app-user permissions",
+    assertTrue( actualPermissions.contains("size:6"));
+    assertTrue( actualPermissions.contains("rest-reader:[READ]"));
+    assertTrue( actualPermissions.contains("rest-writer:[UPDATE]"));
+    assertTrue(
         (actualPermissions.contains("app-user:[UPDATE, READ]") || actualPermissions.contains("app-user:[READ, UPDATE]")));
-    assertTrue("Document permissions difference in harmonized-updater permission", actualPermissions.contains("harmonized-updater:[UPDATE]"));
-    assertTrue("Document permissions difference in harmonized-reader permission", actualPermissions.contains("harmonized-reader:[READ]"));
-    
+    assertTrue( actualPermissions.contains("harmonized-updater:[UPDATE]"));
+    assertTrue( actualPermissions.contains("harmonized-reader:[READ]"));
+
     // Collections
     String expectedCollections = "size:2|my-collection1|my-collection2|";
-    String[] actualCollections = getDocumentCollectionsString(collections).split("\\|");    
+    String[] actualCollections = getDocumentCollectionsString(collections).split("\\|");
 
-    assertTrue("Document collections difference", expectedCollections.contains(actualCollections[0]));
-    assertTrue("Document collections difference", expectedCollections.contains(actualCollections[1]));
-    assertTrue("Document collections difference", expectedCollections.contains(actualCollections[2]));
+    assertTrue( expectedCollections.contains(actualCollections[0]));
+    assertTrue( expectedCollections.contains(actualCollections[1]));
+    assertTrue( expectedCollections.contains(actualCollections[2]));
 
   }
 
@@ -126,28 +127,28 @@ public class TestBulkWriteWithTransactions extends AbstractFunctionalTest {
     String actualPermissions = getDocumentPermissionsString(permissions);
     System.out.println("Returned permissions: " + actualPermissions);
 
-    assertTrue("Document permissions difference in size value", actualPermissions.contains("size:5"));
-    assertTrue("Document permissions difference in rest-reader permission", actualPermissions.contains("rest-reader:[READ]"));
-    assertTrue("Document permissions difference in rest-writer permission", actualPermissions.contains("rest-writer:[UPDATE]"));
-    assertTrue("Document permissions difference in flexrep-eval permission", actualPermissions.contains("flexrep-eval:[READ]"));
-    assertTrue("Document permissions difference in harmonized-updater permission", actualPermissions.contains("harmonized-updater:[UPDATE]"));
-    assertTrue("Document permissions difference in harmonized-reader permission", actualPermissions.contains("harmonized-reader:[READ]"));
+    assertTrue( actualPermissions.contains("size:5"));
+    assertTrue( actualPermissions.contains("rest-reader:[READ]"));
+    assertTrue( actualPermissions.contains("rest-writer:[UPDATE]"));
+    assertTrue( actualPermissions.contains("flexrep-eval:[READ]"));
+    assertTrue( actualPermissions.contains("harmonized-updater:[UPDATE]"));
+    assertTrue( actualPermissions.contains("harmonized-reader:[READ]"));
     // Collections
     String expectedCollections = "size:1|http://permission-collections/|";
     String[] actualCollections = getDocumentCollectionsString(collections).split("\\|");
 
-    assertTrue("Document collections difference", expectedCollections.contains(actualCollections[0]));
-    assertTrue("Document collections difference", expectedCollections.contains(actualCollections[1]));
+    assertTrue( expectedCollections.contains(actualCollections[0]));
+    assertTrue( expectedCollections.contains(actualCollections[1]));
 
     // System.out.println(actualPermissions);
   }
 
   public void validateRecord(DocumentRecord record, Format type) {
 
-    assertNotNull("DocumentRecord should never be null", record);
-    assertNotNull("Document uri should never be null", record.getUri());
-    assertTrue("Document uri should start with " + DIRECTORY, record.getUri().startsWith(DIRECTORY));
-    assertEquals("All records are expected to be in same format", type, record.getFormat());
+    assertNotNull( record);
+    assertNotNull( record.getUri());
+    assertTrue(record.getUri().startsWith(DIRECTORY));
+    assertEquals( type, record.getFormat());
   }
 
   /*
@@ -173,7 +174,7 @@ public class TestBulkWriteWithTransactions extends AbstractFunctionalTest {
 				  // Slow down in the cloud env.
 				  System.out.println("count is = " + count);
 			  }
-			  count++;			  
+			  count++;
 		  }
 		  if (count % BATCH_SIZE > 0) {
 			  docMgr.write(writeset, t);
@@ -191,7 +192,7 @@ public class TestBulkWriteWithTransactions extends AbstractFunctionalTest {
 				  DocumentRecord rec = page.next();
 				  validateRecord(rec, Format.XML);
 				  rec.getContent(dh);
-				  assertEquals("Comparing the content :", map.get(rec.getUri()), convertXMLDocumentToString(dh.get()));
+				  assertEquals( map.get(rec.getUri()), convertXMLDocumentToString(dh.get()));
 				  count++;
 				  System.out.println("count is = " + count);
 			  }
@@ -200,7 +201,7 @@ public class TestBulkWriteWithTransactions extends AbstractFunctionalTest {
 			  System.out.println(e.getMessage());
 			  throw e;
 		  }
-		  assertEquals("document count", 102, count);
+		  assertEquals( 102, count);
 	  } catch (Exception e) {
 		  e.printStackTrace();
 	  }
@@ -249,11 +250,11 @@ public class TestBulkWriteWithTransactions extends AbstractFunctionalTest {
 				  DocumentRecord rec = page.next();
 				  validateRecord(rec, Format.XML);
 				  rec.getContent(dh);
-				  assertEquals("Comparing the content :", map.get(rec.getUri()), convertXMLDocumentToString(dh.get()));
+				  assertEquals( map.get(rec.getUri()), convertXMLDocumentToString(dh.get()));
 				  count++;
 			  }
 
-			  assertEquals("document count", 102, count);
+			  assertEquals( 102, count);
 			  t1.rollback();
 			  tstatus = false;
 			  count = 0;
@@ -263,10 +264,10 @@ public class TestBulkWriteWithTransactions extends AbstractFunctionalTest {
 				  DocumentRecord rec = page.next();
 				  validateRecord(rec, Format.XML);
 				  rec.getContent(dh);
-				  assertEquals("Comparing the content :", map.get(rec.getUri()), convertXMLDocumentToString(dh.get()));
+				  assertEquals( map.get(rec.getUri()), convertXMLDocumentToString(dh.get()));
 				  count++;
 			  }
-			  assertEquals("document count", 0, count);
+			  assertEquals( 0, count);
 
 		  } catch (Exception e) {
 			  System.out.println(e.getMessage());
@@ -293,7 +294,7 @@ public class TestBulkWriteWithTransactions extends AbstractFunctionalTest {
 	  int count = 1;
 	  boolean tstatus = true;
 	  System.out.println("Inside testBulkWritewithMetadataTransactionNoCommit");
-	  try {		  
+	  try {
 		  client = getDatabaseClient("usr1", "password", getConnType());
 		  Transaction t1 = client.openTransaction();
 		  try {
@@ -339,12 +340,12 @@ public class TestBulkWriteWithTransactions extends AbstractFunctionalTest {
 				  DocumentRecord rec = page.next();
 				  validateRecord(rec, Format.XML);
 				  rec.getContent(dh);
-				  assertEquals("Comparing the content :", map2.get(rec.getUri()), convertXMLDocumentToString(dh.get()));
+				  assertEquals( map2.get(rec.getUri()), convertXMLDocumentToString(dh.get()));
 				  docMgr.readMetadata(rec.getUri(), mh2, t1);
 				  validateMetadata(mh2);
 				  count++;
 			  }
-			  assertEquals("document count", 102, count);
+			  assertEquals( 102, count);
 			  t1.rollback();
 			  tstatus = false;
 			  count = 0;
@@ -355,12 +356,12 @@ public class TestBulkWriteWithTransactions extends AbstractFunctionalTest {
 				  DocumentRecord rec = page.next();
 				  validateRecord(rec, Format.XML);
 				  rec.getContent(dh);
-				  assertEquals("Comparing the content :", map.get(rec.getUri()), convertXMLDocumentToString(dh.get()));
+				  assertEquals( map.get(rec.getUri()), convertXMLDocumentToString(dh.get()));
 				  docMgr.readMetadata(rec.getUri(), mh2);
 				  validateDefaultMetadata(mh2);
 				  count++;
 			  }
-			  assertEquals("document count", 102, count);
+			  assertEquals( 102, count);
 
 		  } catch (Exception e) {
 			  System.out.println(e.getMessage());
@@ -417,12 +418,12 @@ public class TestBulkWriteWithTransactions extends AbstractFunctionalTest {
         DocumentRecord rec = page.next();
         validateRecord(rec, Format.XML);
         rec.getContent(dh);
-        assertEquals("Comparing the content :", map.get(rec.getUri()), convertXMLDocumentToString(dh.get()));
+        assertEquals( map.get(rec.getUri()), convertXMLDocumentToString(dh.get()));
         dMgr.readMetadata(rec.getUri(), mh2, t1);
         validateMetadata(mh2);
         count++;
       }
-      assertEquals("document count", 102, count);
+      assertEquals( 102, count);
       t1.commit();
       tstatus = false;
 
@@ -445,7 +446,7 @@ public class TestBulkWriteWithTransactions extends AbstractFunctionalTest {
     int count = 1;
     String docId[] = { "Sega-4MB.jpg" };
     System.out.println("Inside testBulkWritewithTransactionCommitTimeOut");
-	  try {		  
+	  try {
 		  client = getDatabaseClient("usr1", "password", getConnType());
     Transaction t = client.openTransaction("timeoutTrans", 1);
     BinaryDocumentManager docMgr = client.newBinaryDocumentManager();
@@ -477,13 +478,13 @@ public class TestBulkWriteWithTransactions extends AbstractFunctionalTest {
       DocumentRecord rec = page.next();
       validateRecord(rec, Format.BINARY);
       rec.getContent(rh);
-      assertEquals("Content length :", file1.length(), rh.get().length());
+      assertEquals( file1.length(), rh.get().length());
       count++;
     }
-    assertEquals("document count", ndocCount, count);
+    assertEquals( ndocCount, count);
 	  }
 	  catch (Exception e) {
-		  e.printStackTrace();		  
+		  e.printStackTrace();
 	  }
 	  finally {
 		  client.release();
@@ -492,7 +493,7 @@ public class TestBulkWriteWithTransactions extends AbstractFunctionalTest {
 
   /*
    * Purpose: To test bulk delete within a transaction.
-   * 
+   *
    * Test bulk insert documents with transaction open and then perform a bulk
    * delete. Read documents before and after delete.
    */
@@ -534,12 +535,12 @@ public class TestBulkWriteWithTransactions extends AbstractFunctionalTest {
         DocumentRecord rec = page.next();
         validateRecord(rec, Format.XML);
         rec.getContent(dh);
-        assertEquals("Comparing the content :", map.get(rec.getUri()),
+        assertEquals( map.get(rec.getUri()),
             convertXMLDocumentToString(dh.get()));
         count++;
       }
 
-      assertEquals("document count", 102, count);
+      assertEquals( 102, count);
       // Perform a bulk delete.
       docMgr.delete(t1, uris);
 
@@ -550,12 +551,12 @@ public class TestBulkWriteWithTransactions extends AbstractFunctionalTest {
         DocumentRecord rec = page.next();
         validateRecord(rec, Format.XML);
         rec.getContent(dh);
-        assertEquals("Comparing the content :", map.get(rec.getUri()),
+        assertEquals( map.get(rec.getUri()),
             convertXMLDocumentToString(dh.get()));
         count++;
       }
       System.out.println("testBulkWriteDeleteWithTransactions document count = " + count);
-      assertEquals("document count", 0, count);
+      assertEquals( 0, count);
 
     } catch (Exception e) {
       System.out.println(e.getMessage());

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkWriteWithTransformations.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkWriteWithTransformations.java
@@ -27,7 +27,7 @@ import com.marklogic.client.io.SourceHandle;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.query.RawCtsQueryDefinition;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Source;
@@ -41,8 +41,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Scanner;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestBulkWriteWithTransformations extends AbstractFunctionalTest {
   private static final int BATCH_SIZE = 100;
@@ -50,20 +50,20 @@ public class TestBulkWriteWithTransformations extends AbstractFunctionalTest {
 
   private static String appServerHostname = null;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpBeforeClass() throws Exception {
     System.out.println("In setup");
     appServerHostname = getRestAppServerHostName();
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownAfterClass() throws Exception {
     System.out.println("In tear down");
     deleteRESTUser("eval-user");
     deleteUserRole("test-eval");
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     // create new connection for each test below
     createUserRolesWithPrevilages("test-eval", "xdbc:eval", "xdbc:eval-in", "xdmp:eval-in", "any-uri", "xdbc:invoke");
@@ -76,7 +76,7 @@ public class TestBulkWriteWithTransformations extends AbstractFunctionalTest {
     }
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     client.release();
   }
@@ -115,15 +115,15 @@ public class TestBulkWriteWithTransformations extends AbstractFunctionalTest {
     docMgr.read(docId[0], dh);
     scanner = new Scanner(dh.get()).useDelimiter("\\Z");
     String readContent = scanner.next();
-    assertTrue("xml document contains firstname", readContent.contains("firstname"));
+    assertTrue( readContent.contains("firstname"));
     docMgr.read(docId[1], dh);
     sc1 = new Scanner(dh.get()).useDelimiter("\\Z");
     readContent = sc1.next();
-    assertTrue("xml document contains firstname", readContent.contains("firstname"));
+    assertTrue( readContent.contains("firstname"));
     docMgr.read(docId[2], dh);
     sc2 = new Scanner(dh.get()).useDelimiter("\\Z");
     readContent = sc2.next();
-    assertTrue("xml document contains firstname", readContent.contains("firstname"));
+    assertTrue( readContent.contains("firstname"));
     }
     catch (Exception e) {
     	e.printStackTrace();
@@ -181,10 +181,10 @@ public class TestBulkWriteWithTransformations extends AbstractFunctionalTest {
     while (page.hasNext()) {
       DocumentRecord rec = page.next();
       rec.getContent(dh);
-      assertTrue("Element has attribure ? :", dh.get().getElementsByTagName("foo").item(0).hasAttributes());
+      assertTrue( dh.get().getElementsByTagName("foo").item(0).hasAttributes());
       count++;
     }
-    assertEquals("document count", 102, count);
+    assertEquals(102, count);
   }
 
   @Test
@@ -236,14 +236,14 @@ public class TestBulkWriteWithTransformations extends AbstractFunctionalTest {
     while (page.hasNext()) {
       DocumentRecord rec = page.next();
       rec.getContent(dh);
-      assertTrue("Element has attribure ? :", dh.get().getElementsByTagName("foo").item(0).hasAttributes());
+      assertTrue( dh.get().getElementsByTagName("foo").item(0).hasAttributes());
       count++;
     }
 
-    assertEquals("Document count", 10, count);
+    assertEquals(10, count);
     DOMHandle readHandle = readDocumentUsingDOMHandle(client, uris[0], "XML");
     attribute = readHandle.get().getDocumentElement().getAttributes().getNamedItem("Land").toString();
-    assertTrue("Attribute value incorrect : ", attribute.contains("Land=\"USA\""));
+    assertTrue( attribute.contains("Land=\"USA\""));
 
     // Do a read transform
     count = 0;
@@ -277,13 +277,13 @@ public class TestBulkWriteWithTransformations extends AbstractFunctionalTest {
     while (pageRd.hasNext()) {
       DocumentRecord recRd = pageRd.next();
       recRd.getContent(dhRd);
-      assertTrue("Element has attribure ? :", dhRd.get().getElementsByTagName("foo").item(0).hasAttributes());
+      assertTrue( dhRd.get().getElementsByTagName("foo").item(0).hasAttributes());
       attribute = dhRd.get().getDocumentElement().getAttributes().getNamedItem("Place").toString();
-      assertTrue("Attribute value incorrect :", attribute.contains("Place=\"England\""));
+      assertTrue( attribute.contains("Place=\"England\""));
       count++;
     }
 
-    assertEquals("Document count", 10, count);
+    assertEquals(10, count);
 
     // Test for multiple Read transforms on same URI.
     ServerTransform transformRd1 = new ServerTransform("add-attr-xquery-transform");
@@ -299,7 +299,7 @@ public class TestBulkWriteWithTransformations extends AbstractFunctionalTest {
     recRd1.getContent(dhRd1);
     attribute = dhRd1.get().getDocumentElement().getAttributes().getNamedItem("Country").toString();
 
-    assertTrue("Attribute value incorrect :", attribute.contains("Country=\"GB\""));
+    assertTrue( attribute.contains("Country=\"GB\""));
 
     // Test for Read and Write transforms on same URI.
     docMgrRd1.setReadTransform(null);
@@ -314,9 +314,9 @@ public class TestBulkWriteWithTransformations extends AbstractFunctionalTest {
     DocumentRecord recRdMul = pageMul.next();
     recRdMul.getContent(dhRdMul);
     attribute = dhRdMul.get().getDocumentElement().getAttributes().getNamedItem("Country").toString();
-    assertTrue("Attribute value incorrect :", attribute.contains("Country=\"GB\""));
+    assertTrue( attribute.contains("Country=\"GB\""));
     attribute = dhRdMul.get().getDocumentElement().getAttributes().getNamedItem("Land").toString();
-    assertTrue("Attribute value incorrect :", attribute.contains("Land=\"USA\""));
+    assertTrue( attribute.contains("Land=\"USA\""));
 
     // Negative test - Use null Transforms
     docMgrRd1.setReadTransform(null);
@@ -331,7 +331,7 @@ public class TestBulkWriteWithTransformations extends AbstractFunctionalTest {
     recRdNull.getContent(dhRdNull);
     String content = dhRdNull.toString();
 
-    assertTrue("Attribute value incorrect :", content.contains("<foo>This is so foo Multiple</foo>"));
+    assertTrue( content.contains("<foo>This is so foo Multiple</foo>"));
 
     // Git Issue 639 - Case 1: Test using documentManager.setReadTransform and passing in a SearchReadHandle
     // to verify it gets transformed .
@@ -360,8 +360,8 @@ public class TestBulkWriteWithTransformations extends AbstractFunctionalTest {
     recSrch.getContent(dhSrch);
     attribute = dhSrch.get().getDocumentElement().getAttributes().getNamedItem("Domicile").toString();
 
-    assertTrue("Transform value incorrect :", attribute.contains("Domicile=\"USA\""));
-    assertTrue("URI value incorrect :", recSrch.getUri().trim().contains("/bulkTransform/MarkLogic9.0.xml"));
+    assertTrue( attribute.contains("Domicile=\"USA\""));
+    assertTrue( recSrch.getUri().trim().contains("/bulkTransform/MarkLogic9.0.xml"));
 
     // Test search() with SearchReadHandle
     // create result handle
@@ -373,8 +373,8 @@ public class TestBulkWriteWithTransformations extends AbstractFunctionalTest {
     recSrchHandle.getContent(resultsDOMHandle);
     attribute = resultsDOMHandle.get().getDocumentElement().getAttributes().getNamedItem("Domicile").toString();
 
-    assertTrue("Transform value incorrect :", attribute.contains("Domicile=\"USA\""));
-    assertTrue("URI value incorrect :", recSrch.getUri().trim().contains("/bulkTransform/MarkLogic9.0.xml"));
+    assertTrue( attribute.contains("Domicile=\"USA\""));
+    assertTrue( recSrch.getUri().trim().contains("/bulkTransform/MarkLogic9.0.xml"));
 
     // Test with documentManager.setReadTransform and queryDefinition.setResponseTransform set to different transforms.
     // Case 1 : Transform applies to same location
@@ -392,8 +392,8 @@ public class TestBulkWriteWithTransformations extends AbstractFunctionalTest {
     System.out.println("DOMHandle multiple Transforms " + dhSrch2.toString());
     attribute = dhSrch2.get().getDocumentElement().getAttributes().getNamedItem("Continent").toString();
 
-    assertTrue("Transform value incorrect :", attribute.contains("Continent=\"North America\""));
-    assertTrue("URI value incorrect :", recSrch.getUri().trim().contains("/bulkTransform/MarkLogic9.0.xml"));
+    assertTrue( attribute.contains("Continent=\"North America\""));
+    assertTrue( recSrch.getUri().trim().contains("/bulkTransform/MarkLogic9.0.xml"));
 
     // Case 2 : Apply different transforms. QueryDef has add element transformation
     // throws java.lang.IllegalStateException
@@ -428,7 +428,7 @@ public class TestBulkWriteWithTransformations extends AbstractFunctionalTest {
     catch(Exception ex /* throws java.lang.IllegalStateException */) {
         actualMsg = ex.getMessage();
     }
-    assertTrue("Exception message incorrect :", actualMsg.contains(strExptdMsg));
+    assertTrue( actualMsg.contains(strExptdMsg));
   }
 
   /*
@@ -482,7 +482,7 @@ public class TestBulkWriteWithTransformations extends AbstractFunctionalTest {
         // Verify rollback on DocumentManager write method with transform.
         tRollback.rollback();
         DocumentPage pageRollback = docMgr.read(uris);
-        assertEquals("Document count is not zero. Transaction did not rollback", 0, pageRollback.size());
+        assertEquals(pageRollback.size(), 0, "Document count is not zero. Transaction did not rollback");
 
         // Perform write with a commit.
         Transaction tCommit = client.openTransaction();
@@ -508,16 +508,16 @@ public class TestBulkWriteWithTransformations extends AbstractFunctionalTest {
         while (page.hasNext()) {
             DocumentRecord rec = page.next();
             rec.getContent(dh);
-            assertTrue("Element has attribure ? :", dh.get().getElementsByTagName("foo").item(0).hasAttributes());
+            assertTrue( dh.get().getElementsByTagName("foo").item(0).hasAttributes());
             verifyAttrValue = dh.get().getElementsByTagName("foo").item(0).getAttributes().getNamedItem("Lang").getNodeValue();
-            assertTrue("Server Transform did not go through ", verifyAttrValue.equalsIgnoreCase("testBulkXQYTransformWithTrans"));
+            assertTrue( verifyAttrValue.equalsIgnoreCase("testBulkXQYTransformWithTrans"));
             count++;
         }
     } catch (Exception e) {
       System.out.println(e.getMessage());
       throw e;
     }
-    assertEquals("document count", 102, count);
+    assertEquals(102, count);
   }
 
 //Refer to BT 52461. Having bulk write with transform (no meta-data on the transform itself) used to throw
@@ -563,10 +563,10 @@ public class TestBulkWriteWithTransformations extends AbstractFunctionalTest {
    while (page.hasNext()) {
      DocumentRecord rec = page.next();
      rec.getContent(dh);
-     assertTrue("Element has attribure ? :", dh.get().getElementsByTagName("foo").item(0).hasAttributes());
+     assertTrue( dh.get().getElementsByTagName("foo").item(0).hasAttributes());
      count++;
    }
-   assertEquals("document count", 102, count);
+   assertEquals(102, count);
  }
 
   @Test
@@ -613,9 +613,9 @@ public class TestBulkWriteWithTransformations extends AbstractFunctionalTest {
     while (page.hasNext()) {
       DocumentRecord rec = page.next();
       rec.getContent(dh);
-      assertTrue("Element has attribure ? :", dh.get().getElementsByTagName("foo").item(0).hasAttributes());
+      assertTrue( dh.get().getElementsByTagName("foo").item(0).hasAttributes());
       count++;
     }
-    assertEquals("document count", 102, count);
+    assertEquals(102, count);
   }
 }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestCRUDModulesDb.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestCRUDModulesDb.java
@@ -24,16 +24,16 @@ import com.marklogic.client.io.BytesHandle;
 import com.marklogic.client.io.FileHandle;
 import com.marklogic.client.io.Format;
 import com.marklogic.client.io.StringHandle;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.File;
 import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+
+
 
 public class TestCRUDModulesDb extends AbstractFunctionalTest {
 
@@ -53,7 +53,7 @@ public class TestCRUDModulesDb extends AbstractFunctionalTest {
 
         // read it back
         String xqueryModuleAsString = libsMgr.read(Path, new StringHandle()).get();
-        assertTrue("module read and read back", xqueryModuleAsString.startsWith("xquery version \"1.0-ml\";"));
+        assertTrue( xqueryModuleAsString.startsWith("xquery version \"1.0-ml\";"));
 
         // write Duplicate XQuery file to the modules database with different
         // content
@@ -61,11 +61,11 @@ public class TestCRUDModulesDb extends AbstractFunctionalTest {
 
         // read it back to check overwritten
         String xqueryModuleAsDuplicateString = libsMgr.read(Path, new StringHandle()).get();
-        assertTrue("module read and read back", xqueryModuleAsDuplicateString.startsWith("xquery version \"1.0-ml\";"));
+        assertTrue( xqueryModuleAsDuplicateString.startsWith("xquery version \"1.0-ml\";"));
 
         // get the list of descriptors
         ExtensionLibraryDescriptor[] descriptors = libsMgr.list();
-        assertEquals("number of modules installed", descriptors.length, 1);
+        assertEquals( descriptors.length, 1);
 
         for (ExtensionLibraryDescriptor descriptor : descriptors) {
             assertEquals(descriptor.getPath(), Path);
@@ -100,15 +100,15 @@ public class TestCRUDModulesDb extends AbstractFunctionalTest {
 
         // read 1st file back
         String xqueryModuleAsString = libsMgr.read(firstPath, new StringHandle()).get();
-        assertTrue("module read and read back", xqueryModuleAsString.startsWith("xquery version \"1.0-ml\";"));
+        assertTrue( xqueryModuleAsString.startsWith("xquery version \"1.0-ml\";"));
 
         // read 2nd file back
         String xqueryModuleAsString1 = libsMgr.read(secondPath, new StringHandle()).get();
-        assertTrue("module read and read back", xqueryModuleAsString1.startsWith("xquery version \"1.0-ml\";"));
+        assertTrue( xqueryModuleAsString1.startsWith("xquery version \"1.0-ml\";"));
 
         // get the list of descriptors
         ExtensionLibraryDescriptor[] descriptors = libsMgr.list();
-        assertEquals("number of modules installed", descriptors.length, 2);
+        assertEquals( descriptors.length, 2);
         assertEquals(descriptors[0].getPath(), firstPath);
         assertEquals(descriptors[1].getPath(), secondPath);
 
@@ -146,7 +146,7 @@ public class TestCRUDModulesDb extends AbstractFunctionalTest {
 
         // get the list of descriptors
         ExtensionLibraryDescriptor[] descriptors = libsMgr.list();
-        assertEquals("number of modules installed", descriptors.length, 1);
+        assertEquals( descriptors.length, 1);
 
         for (ExtensionLibraryDescriptor descriptor : descriptors) {
             assertEquals(descriptor.getPath(), Path);
@@ -179,11 +179,11 @@ public class TestCRUDModulesDb extends AbstractFunctionalTest {
 
         // read it back
         String xqueryModuleAsString = libsMgr.read(Path, new StringHandle()).get();
-        assertTrue("module read and read back", xqueryModuleAsString.startsWith("Copyright (c) 2022 MarkLogic Corporation"));
+        assertTrue( xqueryModuleAsString.startsWith("Copyright (c) 2022 MarkLogic Corporation"));
 
         // get the list of descriptors
         ExtensionLibraryDescriptor[] descriptors = libsMgr.list();
-        assertEquals("number of modules installed", descriptors.length, 1);
+        assertEquals( descriptors.length, 1);
 
         for (ExtensionLibraryDescriptor descriptor : descriptors) {
             assertEquals(descriptor.getPath(), Path);
@@ -221,7 +221,7 @@ public class TestCRUDModulesDb extends AbstractFunctionalTest {
 
         // get the list of descriptors
         ExtensionLibraryDescriptor[] descriptors = libsMgr.list();
-        assertEquals("number of modules installed", descriptors.length, 1);
+        assertEquals( descriptors.length, 1);
 
         for (ExtensionLibraryDescriptor descriptor : descriptors) {
             assertEquals(descriptor.getPath(), Path);
@@ -256,11 +256,11 @@ public class TestCRUDModulesDb extends AbstractFunctionalTest {
         // read it back
 
         String xqueryModuleAsString = libsMgr.read(Path, new StringHandle()).get();
-        assertTrue("module read and read back", xqueryModuleAsString.contains("let $x := (1,2,3,4,5)"));
+        assertTrue( xqueryModuleAsString.contains("let $x := (1,2,3,4,5)"));
 
         // get the list of descriptors
         ExtensionLibraryDescriptor[] descriptors = libsMgr.list();
-        assertEquals("number of modules installed", descriptors.length, 1);
+        assertEquals( descriptors.length, 1);
 
         for (ExtensionLibraryDescriptor descriptor : descriptors) {
             assertEquals(descriptor.getPath(), Path);
@@ -303,11 +303,11 @@ public class TestCRUDModulesDb extends AbstractFunctionalTest {
         // read it back
 
         String xqueryModuleAsString = libsMgr.read(Path, new StringHandle()).get();
-        assertTrue("module read and read back", xqueryModuleAsString.contains("let $x := (1,2,3,4,5)"));
+        assertTrue( xqueryModuleAsString.contains("let $x := (1,2,3,4,5)"));
 
         // get the list of descriptors
         ExtensionLibraryDescriptor[] descriptors = libsMgr.list();
-        assertEquals("number of modules installed", descriptors.length, 1);
+        assertEquals( descriptors.length, 1);
 
         for (ExtensionLibraryDescriptor descriptor : descriptors) {
             descriptor.setPath("/ext/my/path/to/my/new/module.xqy");
@@ -349,7 +349,7 @@ public class TestCRUDModulesDb extends AbstractFunctionalTest {
         // write XQuery file to the modules database
         try {
             libsMgr.write(Path, f);
-            Assert.assertTrue("Exception was not thrown", false);
+            assertTrue( false);
         } catch (IllegalArgumentException e) {
             // Issue 210 logged for meaningful error
             assertEquals("libraryPath (the modules database path under which you install an asset) must begin with /ext/", e.getMessage());
@@ -357,7 +357,7 @@ public class TestCRUDModulesDb extends AbstractFunctionalTest {
         // delete it
         try {
             libsMgr.delete(Path);
-            Assert.assertTrue("Exception was not thrown", false);
+            assertTrue( false);
         } catch (IllegalArgumentException e) {
             assertEquals("libraryPath (the modules database path under which you install an asset) must begin with /ext/", e.getMessage());
         }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestConstraintCombination.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestConstraintCombination.java
@@ -24,8 +24,9 @@ import com.marklogic.client.io.SearchHandle;
 import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.query.StringQueryDefinition;
 import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
@@ -34,12 +35,11 @@ import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 
-import static junit.framework.Assert.assertEquals;
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
 
 public class TestConstraintCombination extends AbstractFunctionalTest {
 
-  @After
+  @AfterEach
   public void testCleanUp() throws Exception
   {
     deleteDocuments(connectAsAdmin());

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestDatabaseAuthentication.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestDatabaseAuthentication.java
@@ -16,21 +16,20 @@
 
 package com.marklogic.client.fastfunctest;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.DatabaseClientFactory;
 import com.marklogic.client.DatabaseClientFactory.SecurityContext;
 import com.marklogic.client.io.InputStreamHandle;
-import com.marklogic.mgmt.resource.appservers.ServerManager;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
 
 /*
  * The tests here run against normal a no SSL enabled REST Server.
@@ -43,12 +42,12 @@ public class TestDatabaseAuthentication extends AbstractFunctionalTest {
   private static String restServerName = "java-functest";
   private String originalServerAuthentication;
 
-  @Before
+  @BeforeEach
   public void before() {
 	  originalServerAuthentication = getServerAuthentication(restServerName);
   }
 
-  @After
+  @AfterEach
   public void teardown() throws Exception {
     setAuthentication(originalServerAuthentication, restServerName);
     setDefaultUser("nobody", restServerName);
@@ -69,7 +68,7 @@ public class TestDatabaseAuthentication extends AbstractFunctionalTest {
       } catch (Exception ex) {
         str.append(ex.getMessage());
       }
-      assertEquals("Write Text difference", "makeSecurityContext should only be called with BASIC or DIGEST Authentication",
+      assertEquals( "makeSecurityContext should only be called with BASIC or DIGEST Authentication",
           str.toString().trim());
     }
   }
@@ -102,7 +101,7 @@ public class TestDatabaseAuthentication extends AbstractFunctionalTest {
 
       String expectedContent = "hello world, welcome to java API";
 
-      assertEquals("Write Text difference", expectedContent.trim(), readContent.trim());
+      assertEquals( expectedContent.trim(), readContent.trim());
 
       // release client
       client.release();

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestDocumentEncoding.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestDocumentEncoding.java
@@ -20,7 +20,8 @@ import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.document.XMLDocumentManager;
 import com.marklogic.client.io.BytesHandle;
 import com.marklogic.client.io.StringHandle;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 import org.w3c.dom.DOMImplementation;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -36,7 +37,7 @@ import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestDocumentEncoding extends AbstractFunctionalTest
 {
@@ -120,7 +121,7 @@ public class TestDocumentEncoding extends AbstractFunctionalTest
     int length2 = docMgr.read("/doc/bar.xml", new BytesHandle()).get().length;
     System.out.println(length2);
 
-    assertEquals("Byte size is not the same", length1, length2);
+    assertEquals(length1, length2);
 
     // **************************
 

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestDocumentFormat.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestDocumentFormat.java
@@ -25,9 +25,10 @@ import com.marklogic.client.io.Format;
 import com.marklogic.client.io.marker.GenericReadHandle;
 import com.marklogic.client.io.marker.GenericWriteHandle;
 import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
@@ -37,12 +38,12 @@ import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+
+
 
 public class TestDocumentFormat extends AbstractFunctionalTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
     // Create a user with minimal privs and test doc exists in a transaction.
     createRESTUser("userInTrans", "x", "rest-writer");
@@ -78,7 +79,7 @@ public class TestDocumentFormat extends AbstractFunctionalTest {
       String expectedUri1 = uri1 + filename;
 
       String docUri1 = docMgr1.exists(expectedUri1, t1).getUri();
-      assertEquals("URI is not found", expectedUri1, docUri1);
+      assertEquals( expectedUri1, docUri1);
       t1.rollback();
     }
     catch(Exception ex) {
@@ -120,7 +121,7 @@ public class TestDocumentFormat extends AbstractFunctionalTest {
 
       String expectedUri2 = uri2 + filename;
       String docUri2 = docMgr2.exists(expectedUri2, t2).getUri();
-      assertEquals("URI is not found", expectedUri2, docUri2);
+      assertEquals( expectedUri2, docUri2);
       t2.rollback();
     }
     catch(Exception ex) {
@@ -161,7 +162,7 @@ public class TestDocumentFormat extends AbstractFunctionalTest {
 
     String expectedUri = uri + filename;
     String docUri = docMgr.exists(expectedUri).getUri();
-    assertEquals("URI is not found", expectedUri, docUri);
+    assertEquals( expectedUri, docUri);
 
     // release the client
     client.release();
@@ -202,7 +203,7 @@ public class TestDocumentFormat extends AbstractFunctionalTest {
     }
 
     boolean isExceptionThrown = exception.contains(expectedException);
-    assertTrue("Exception is not thrown", isExceptionThrown);
+    assertTrue( isExceptionThrown);
 
     // release the client
     client.release();
@@ -237,7 +238,7 @@ public class TestDocumentFormat extends AbstractFunctionalTest {
 
     String expectedUri = uri + filename;
     String docUri = docMgr.exists(expectedUri).getUri();
-    assertEquals("URI is not found", expectedUri, docUri);
+    assertEquals( expectedUri, docUri);
 
     // release the client
     client.release();
@@ -272,7 +273,7 @@ public class TestDocumentFormat extends AbstractFunctionalTest {
 
     String expectedUri = uri + filename;
     String docUri = docMgr.exists(expectedUri).getUri();
-    assertEquals("URI is not found", expectedUri, docUri);
+    assertEquals( expectedUri, docUri);
 
     // release the client
     client.release();
@@ -307,7 +308,7 @@ public class TestDocumentFormat extends AbstractFunctionalTest {
 
     String expectedUri = uri + filename;
     String docUri = docMgr.exists(expectedUri).getUri();
-    assertEquals("URI is not found", expectedUri, docUri);
+    assertEquals( expectedUri, docUri);
 
     // release the client
     client.release();
@@ -342,7 +343,7 @@ public class TestDocumentFormat extends AbstractFunctionalTest {
 
     String expectedUri = uri + filename;
     String docUri = docMgr.exists(expectedUri).getUri();
-    assertEquals("URI is not found", expectedUri, docUri);
+    assertEquals( expectedUri, docUri);
 
     // release the client
     client.release();
@@ -377,7 +378,7 @@ public class TestDocumentFormat extends AbstractFunctionalTest {
 
     String expectedUri = uri + filename;
     String docUri = docMgr.exists(expectedUri).getUri();
-    assertEquals("URI is not found", expectedUri, docUri);
+    assertEquals( expectedUri, docUri);
 
     // release the client
     client.release();
@@ -412,7 +413,7 @@ public class TestDocumentFormat extends AbstractFunctionalTest {
 
     String expectedUri = uri + filename;
     String docUri = docMgr.exists(expectedUri).getUri();
-    assertEquals("URI is not found", expectedUri, docUri);
+    assertEquals( expectedUri, docUri);
 
     // release the client
     client.release();
@@ -447,7 +448,7 @@ public class TestDocumentFormat extends AbstractFunctionalTest {
 
     String expectedUri = uri + filename;
     String docUri = docMgr.exists(expectedUri).getUri();
-    assertEquals("URI is not found", expectedUri, docUri);
+    assertEquals( expectedUri, docUri);
 
     // release the client
     client.release();
@@ -487,7 +488,7 @@ public class TestDocumentFormat extends AbstractFunctionalTest {
       exception = e.toString();
     }
     boolean isExceptionThrown = exception.contains(expectedException);
-    assertTrue("Exception is not thrown", isExceptionThrown);
+    assertTrue( isExceptionThrown);
 
     // release the client
     client.release();
@@ -528,7 +529,7 @@ public class TestDocumentFormat extends AbstractFunctionalTest {
     }
 
     boolean isExceptionThrown = exception.contains(expectedException);
-    assertTrue("Exception is not thrown", isExceptionThrown);
+    assertTrue( isExceptionThrown);
 
     // release the client
     client.release();
@@ -569,7 +570,7 @@ public class TestDocumentFormat extends AbstractFunctionalTest {
     }
 
     boolean isExceptionThrown = exception.contains(expectedException);
-    assertTrue("Exception is not thrown", isExceptionThrown);
+    assertTrue( isExceptionThrown);
 
     // release the client
     client.release();
@@ -604,7 +605,7 @@ public class TestDocumentFormat extends AbstractFunctionalTest {
 
     String expectedUri = uri + filename;
     String docUri = docMgr.exists(expectedUri).getUri();
-    assertEquals("URI is not found", expectedUri, docUri);
+    assertEquals( expectedUri, docUri);
 
     // release the client
     client.release();
@@ -639,7 +640,7 @@ public class TestDocumentFormat extends AbstractFunctionalTest {
 
     String expectedUri = uri + filename;
     String docUri = docMgr.exists(expectedUri).getUri();
-    assertEquals("URI is not found", expectedUri, docUri);
+    assertEquals( expectedUri, docUri);
 
     // release the client
     client.release();
@@ -680,7 +681,7 @@ public class TestDocumentFormat extends AbstractFunctionalTest {
     }
 
     boolean isExceptionThrown = exception.contains(expectedException);
-    assertTrue("Exception is not thrown", isExceptionThrown);
+    assertTrue( isExceptionThrown);
 
     // release the client
     client.release();
@@ -715,7 +716,7 @@ public class TestDocumentFormat extends AbstractFunctionalTest {
 
     String expectedUri = uri + filename;
     String docUri = docMgr.exists(expectedUri).getUri();
-    assertEquals("URI is not found", expectedUri, docUri);
+    assertEquals( expectedUri, docUri);
 
     // release the client
     client.release();
@@ -752,13 +753,13 @@ public class TestDocumentFormat extends AbstractFunctionalTest {
     }
 
     boolean isExceptionThrown = exception.contains(expectedException);
-    assertTrue("Wrong exception", isExceptionThrown);
+    assertTrue( isExceptionThrown);
 
     // release the client
     client.release();
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() throws Exception
   {
     deleteRESTUser("userInTrans");

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestDocumentMimetype.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestDocumentMimetype.java
@@ -20,7 +20,8 @@ import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.document.DocumentManager;
 import com.marklogic.client.io.FileHandle;
 import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 import org.xml.sax.SAXException;
 
 import javax.xml.parsers.ParserConfigurationException;
@@ -28,8 +29,6 @@ import java.io.File;
 import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
-
-import static org.junit.Assert.assertEquals;
 
 public class TestDocumentMimetype extends AbstractFunctionalTest {
 
@@ -62,14 +61,14 @@ public class TestDocumentMimetype extends AbstractFunctionalTest {
 
     String expectedUri = uri + filename;
     String docUri = docMgr.exists(expectedUri).getUri();
-    assertEquals("URI is not found", expectedUri, docUri);
+    assertEquals( expectedUri, docUri);
 
     // read document format
     docMgr.read(docId, handle);
     String format = handle.getFormat().name();
     String expectedFormat = "XML";
 
-    assertEquals("Format does not match", expectedFormat, format);
+    assertEquals( expectedFormat, format);
 
     // release the client
     client.release();
@@ -104,14 +103,14 @@ public class TestDocumentMimetype extends AbstractFunctionalTest {
 
     String expectedUri = uri + filename;
     String docUri = docMgr.exists(expectedUri).getUri();
-    assertEquals("URI is not found", expectedUri, docUri);
+    assertEquals( expectedUri, docUri);
 
     // read document mimetype
     docMgr.read(docId, handle);
     String format = handle.getFormat().name();
     String expectedFormat = "XML";
 
-    assertEquals("Format does not match", expectedFormat, format);
+    assertEquals( expectedFormat, format);
 
     // release the client
     client.release();
@@ -146,14 +145,14 @@ public class TestDocumentMimetype extends AbstractFunctionalTest {
 
     String expectedUri = uri + filename;
     String docUri = docMgr.exists(expectedUri).getUri();
-    assertEquals("URI is not found", expectedUri, docUri);
+    assertEquals( expectedUri, docUri);
 
     // read document mimetype
     docMgr.read(docId, handle);
     String format = handle.getFormat().name();
     String expectedFormat = "XML";
 
-    assertEquals("Format does not match", expectedFormat, format);
+    assertEquals( expectedFormat, format);
 
     // release the client
     client.release();
@@ -188,14 +187,14 @@ public class TestDocumentMimetype extends AbstractFunctionalTest {
 
     String expectedUri = uri + filename;
     String docUri = docMgr.exists(expectedUri).getUri();
-    assertEquals("URI is not found", expectedUri, docUri);
+    assertEquals( expectedUri, docUri);
 
     // read document mimetype
     docMgr.read(docId, handle);
     String format = handle.getFormat().name();
     String expectedFormat = "XML";
 
-    assertEquals("Format does not match", expectedFormat, format);
+    assertEquals( expectedFormat, format);
 
     // release the client
     client.release();
@@ -230,14 +229,14 @@ public class TestDocumentMimetype extends AbstractFunctionalTest {
 
     String expectedUri = uri + filename;
     String docUri = docMgr.exists(expectedUri).getUri();
-    assertEquals("URI is not found", expectedUri, docUri);
+    assertEquals( expectedUri, docUri);
 
     // read document format
     docMgr.read(docId, handle);
     String format = handle.getFormat().name();
     String expectedFormat = "JSON";
 
-    assertEquals("Format does not match", expectedFormat, format);
+    assertEquals( expectedFormat, format);
 
     // release the client
     client.release();
@@ -272,14 +271,14 @@ public class TestDocumentMimetype extends AbstractFunctionalTest {
 
     String expectedUri = uri + filename;
     String docUri = docMgr.exists(expectedUri).getUri();
-    assertEquals("URI is not found", expectedUri, docUri);
+    assertEquals( expectedUri, docUri);
 
     // read document mimetype
     docMgr.read(docId, handle);
     String format = handle.getFormat().name();
     String expectedFormat = "JSON";
 
-    assertEquals("Format does not match", expectedFormat, format);
+    assertEquals( expectedFormat, format);
 
     // release the client
     client.release();
@@ -314,14 +313,14 @@ public class TestDocumentMimetype extends AbstractFunctionalTest {
 
     String expectedUri = uri + filename;
     String docUri = docMgr.exists(expectedUri).getUri();
-    assertEquals("URI is not found", expectedUri, docUri);
+    assertEquals( expectedUri, docUri);
 
     // read document mimetype
     docMgr.read(docId, handle);
     String format = handle.getFormat().name();
     String expectedFormat = "JSON";
 
-    assertEquals("Format does not match", expectedFormat, format);
+    assertEquals( expectedFormat, format);
 
     // release the client
     client.release();
@@ -356,14 +355,14 @@ public class TestDocumentMimetype extends AbstractFunctionalTest {
 
     String expectedUri = uri + filename;
     String docUri = docMgr.exists(expectedUri).getUri();
-    assertEquals("URI is not found", expectedUri, docUri);
+    assertEquals( expectedUri, docUri);
 
     // read document mimetype
     docMgr.read(docId, handle);
     String format = handle.getFormat().name();
     String expectedFormat = "JSON";
 
-    assertEquals("Format does not match", expectedFormat, format);
+    assertEquals( expectedFormat, format);
 
     // release the client
     client.release();
@@ -398,14 +397,14 @@ public class TestDocumentMimetype extends AbstractFunctionalTest {
 
     String expectedUri = uri + filename;
     String docUri = docMgr.exists(expectedUri).getUri();
-    assertEquals("URI is not found", expectedUri, docUri);
+    assertEquals( expectedUri, docUri);
 
     // read document format
     docMgr.read(docId, handle);
     String format = handle.getFormat().name();
     String expectedFormat = "BINARY";
 
-    assertEquals("Format does not match", expectedFormat, format);
+    assertEquals( expectedFormat, format);
 
     // release the client
     client.release();
@@ -440,14 +439,14 @@ public class TestDocumentMimetype extends AbstractFunctionalTest {
 
     String expectedUri = uri + filename;
     String docUri = docMgr.exists(expectedUri).getUri();
-    assertEquals("URI is not found", expectedUri, docUri);
+    assertEquals( expectedUri, docUri);
 
     // read document mimetype
     docMgr.read(docId, handle);
     String format = handle.getFormat().name();
     String expectedFormat = "BINARY";
 
-    assertEquals("Format does not match", expectedFormat, format);
+    assertEquals( expectedFormat, format);
 
     // release the client
     client.release();
@@ -482,14 +481,14 @@ public class TestDocumentMimetype extends AbstractFunctionalTest {
 
     String expectedUri = uri + filename;
     String docUri = docMgr.exists(expectedUri).getUri();
-    assertEquals("URI is not found", expectedUri, docUri);
+    assertEquals( expectedUri, docUri);
 
     // read document mimetype
     docMgr.read(docId, handle);
     String format = handle.getFormat().name();
     String expectedFormat = "BINARY";
 
-    assertEquals("Format does not match", expectedFormat, format);
+    assertEquals( expectedFormat, format);
 
     // release the client
     client.release();
@@ -524,14 +523,14 @@ public class TestDocumentMimetype extends AbstractFunctionalTest {
 
     String expectedUri = uri + filename;
     String docUri = docMgr.exists(expectedUri).getUri();
-    assertEquals("URI is not found", expectedUri, docUri);
+    assertEquals( expectedUri, docUri);
 
     // read document mimetype
     docMgr.read(docId, handle);
     String format = handle.getFormat().name();
     String expectedFormat = "BINARY";
 
-    assertEquals("Format does not match", expectedFormat, format);
+    assertEquals( expectedFormat, format);
 
     // release the client
     client.release();
@@ -566,14 +565,14 @@ public class TestDocumentMimetype extends AbstractFunctionalTest {
 
     String expectedUri = uri + filename;
     String docUri = docMgr.exists(expectedUri).getUri();
-    assertEquals("URI is not found", expectedUri, docUri);
+    assertEquals( expectedUri, docUri);
 
     // read document format
     docMgr.read(docId, handle);
     String format = handle.getFormat().name();
     String expectedFormat = "TEXT";
 
-    assertEquals("Format does not match", expectedFormat, format);
+    assertEquals( expectedFormat, format);
 
     // release the client
     client.release();
@@ -608,14 +607,14 @@ public class TestDocumentMimetype extends AbstractFunctionalTest {
 
     String expectedUri = uri + filename;
     String docUri = docMgr.exists(expectedUri).getUri();
-    assertEquals("URI is not found", expectedUri, docUri);
+    assertEquals( expectedUri, docUri);
 
     // read document mimetype
     docMgr.read(docId, handle);
     String format = handle.getFormat().name();
     String expectedFormat = "TEXT";
 
-    assertEquals("Format does not match", expectedFormat, format);
+    assertEquals( expectedFormat, format);
 
     // release the client
     client.release();
@@ -650,14 +649,14 @@ public class TestDocumentMimetype extends AbstractFunctionalTest {
 
     String expectedUri = uri + filename;
     String docUri = docMgr.exists(expectedUri).getUri();
-    assertEquals("URI is not found", expectedUri, docUri);
+    assertEquals( expectedUri, docUri);
 
     // read document mimetype
     docMgr.read(docId, handle);
     String format = handle.getFormat().name();
     String expectedFormat = "TEXT";
 
-    assertEquals("Format does not match", expectedFormat, format);
+    assertEquals( expectedFormat, format);
 
     // release the client
     client.release();
@@ -692,14 +691,14 @@ public class TestDocumentMimetype extends AbstractFunctionalTest {
 
     String expectedUri = uri + filename;
     String docUri = docMgr.exists(expectedUri).getUri();
-    assertEquals("URI is not found", expectedUri, docUri);
+    assertEquals( expectedUri, docUri);
 
     // read document mimetype
     docMgr.read(docId, handle);
     String format = handle.getFormat().name();
     String expectedFormat = "TEXT";
 
-    assertEquals("Format does not match", expectedFormat, format);
+    assertEquals( expectedFormat, format);
 
     // release the client
     client.release();

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestDoublePrecisionGeoOps.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestDoublePrecisionGeoOps.java
@@ -32,8 +32,9 @@ import com.marklogic.client.query.StructuredQueryBuilder.CoordinateSystem;
 import com.marklogic.client.query.StructuredQueryBuilder.GeospatialOperator;
 import com.marklogic.client.query.StructuredQueryDefinition;
 import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
@@ -45,8 +46,8 @@ import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.util.TreeMap;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+
+
 
 public class TestDoublePrecisionGeoOps extends AbstractFunctionalTest {
 
@@ -55,7 +56,7 @@ public class TestDoublePrecisionGeoOps extends AbstractFunctionalTest {
 
   static DatabaseClient client = null;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception
   {
     // Load all necessary data / docs.
@@ -101,10 +102,10 @@ public class TestDoublePrecisionGeoOps extends AbstractFunctionalTest {
     JsonNode jsonPointNodes = resultJsonNode.path("results");
 
     // Should have 2 nodes returned.
-    assertEquals("Two nodes not returned from testLinestringContainsPoint method ", 2, resultJsonNode.path("total").asInt());
-    assertTrue("URI returned from testLinestringContainsPoint method is incorrect", jsonPointNodes.get(0).path("uri").asText().contains("/Equator-json.json") ||
+    assertEquals( 2, resultJsonNode.path("total").asInt());
+    assertTrue( jsonPointNodes.get(0).path("uri").asText().contains("/Equator-json.json") ||
         jsonPointNodes.get(1).path("uri").asText().contains("/Equator-json.json"));
-    assertTrue("URI returned from testLinestringContainsPoint method is incorrect", jsonPointNodes.get(0).path("uri").asText().contains("/Equator.xml") ||
+    assertTrue( jsonPointNodes.get(0).path("uri").asText().contains("/Equator.xml") ||
         jsonPointNodes.get(1).path("uri").asText().contains("/Equator.xml"));
 
     // Verify snippets returned are correct
@@ -137,7 +138,7 @@ public class TestDoublePrecisionGeoOps extends AbstractFunctionalTest {
         System.out.println("Line desc from XML file is " + linedesc);
 
         // Verify that snippets from qb and read contain the same.
-        assertTrue("Snippets from summary and from XML file are incorrect ", linedesc.contains("Linestring In Equator - South America"));
+        assertTrue( linedesc.contains("Linestring In Equator - South America"));
 
         readDoc = null;
         contentHandle = null;
@@ -151,14 +152,14 @@ public class TestDoublePrecisionGeoOps extends AbstractFunctionalTest {
         System.out.println("Snippet line-desc from JSON file is " + linedesc);
 
         // Verify that snippets from qb and read contain the same.
-        assertTrue("Snippets from summary and from JSON file are incorrect ", linedesc.contains("Json Linestring In Equator - South America"));
+        assertTrue( linedesc.contains("Json Linestring In Equator - South America"));
         jacksonhandle = null;
         resultNode = null;
       }
       // Get the results into the map.
       readMap.put(docUri, linedesc);
     }
-    assertTrue("Result not returned correctly from testLinestringContainsPoint method ", expectedMap.equals(readMap));
+    assertTrue( expectedMap.equals(readMap));
   }
 
   /*
@@ -185,10 +186,10 @@ public class TestDoublePrecisionGeoOps extends AbstractFunctionalTest {
     JsonNode jsonPointNodes = resultNode.path("results");
 
     // Should have 2 nodes returned.
-    assertEquals("Two nodes not returned from testCircleContainsCircle method ", 2, resultNode.path("total").asInt());
-    assertTrue("URI returned from testCircleContainsCircle method is incorrect", jsonPointNodes.get(0).path("uri").asText().contains("/Equator-json.json") ||
+    assertEquals( 2, resultNode.path("total").asInt());
+    assertTrue( jsonPointNodes.get(0).path("uri").asText().contains("/Equator-json.json") ||
         jsonPointNodes.get(1).path("uri").asText().contains("/Equator-json.json"));
-    assertTrue("URI returned from testCircleContainsCircle method is incorrect", jsonPointNodes.get(0).path("uri").asText().contains("/Equator.xml") ||
+    assertTrue( jsonPointNodes.get(0).path("uri").asText().contains("/Equator.xml") ||
         jsonPointNodes.get(1).path("uri").asText().contains("/Equator.xml"));
   }
 
@@ -216,10 +217,10 @@ public class TestDoublePrecisionGeoOps extends AbstractFunctionalTest {
     JsonNode jsonPointNodes = resultNode.path("results");
 
     // Should have 2 nodes returned.
-    assertEquals("Two nodes not returned from testBoxContainsPolygon method ", 2, resultNode.path("total").asInt());
-    assertTrue("URI returned from testBoxContainsPolygon method is incorrect", jsonPointNodes.get(0).path("uri").asText().contains("/Equator-json.json") ||
+    assertEquals( 2, resultNode.path("total").asInt());
+    assertTrue( jsonPointNodes.get(0).path("uri").asText().contains("/Equator-json.json") ||
         jsonPointNodes.get(1).path("uri").asText().contains("/Equator-json.json"));
-    assertTrue("URI returned from testBoxContainsPolygon method is incorrect", jsonPointNodes.get(0).path("uri").asText().contains("/Equator.xml") ||
+    assertTrue( jsonPointNodes.get(0).path("uri").asText().contains("/Equator.xml") ||
         jsonPointNodes.get(1).path("uri").asText().contains("/Equator.xml"));
   }
 
@@ -247,20 +248,20 @@ public class TestDoublePrecisionGeoOps extends AbstractFunctionalTest {
     JsonNode jsonPointNodes = resultNode.path("results");
 
     // Should have 2 nodes returned.
-    assertEquals("Two nodes not returned from testCircleIntersectsPoint method ", 2, resultNode.path("total").asInt());
-    assertTrue("URI returned from testCircleIntersectsPoint method is incorrect", jsonPointNodes.get(0).path("uri").asText().contains("/Equator-json.json") ||
+    assertEquals( 2, resultNode.path("total").asInt());
+    assertTrue( jsonPointNodes.get(0).path("uri").asText().contains("/Equator-json.json") ||
         jsonPointNodes.get(1).path("uri").asText().contains("/Equator-json.json"));
     // Verify match text in either of the two nodes returned. This is the Json
     // Point.
-    assertTrue("Match text returned from testCircleIntersectsPoint method is incorrect", jsonPointNodes.get(0).path("matches")
+    assertTrue( jsonPointNodes.get(0).path("matches")
         .get(0).path("match-text").get(0).path("highlight").asText().contains("6.897 0,-66.09375") ||
         jsonPointNodes.get(1).path("matches")
             .get(0).path("match-text").get(0).path("highlight").asText().contains("6.897 0,-66.09375"));
 
-    assertTrue("URI returned from testCircleIntersectsPoint method is incorrect", jsonPointNodes.get(0).path("uri").asText().contains("/Equator.xml") ||
+    assertTrue( jsonPointNodes.get(0).path("uri").asText().contains("/Equator.xml") ||
         jsonPointNodes.get(1).path("uri").asText().contains("/Equator.xml"));
     // Verify match text in either of the two nodes returned. XML point.
-    assertTrue("Match text returned from testCircleIntersectsPoint method is incorrect", jsonPointNodes.get(0).path("matches")
+    assertTrue( jsonPointNodes.get(0).path("matches")
         .get(0).path("match-text").get(0).path("highlight").asText().contains("6.897 0,-66.09375") ||
         jsonPointNodes.get(1).path("matches")
             .get(0).path("match-text").get(0).path("highlight").asText().contains("6.897 0,-66.09375"));
@@ -299,19 +300,19 @@ public class TestDoublePrecisionGeoOps extends AbstractFunctionalTest {
     JsonNode jsonPointNodes = resultNode.path("results");
 
     // Should have 2 nodes returned.
-    assertEquals("Two nodes not returned from testcircleCoveredByPolygon method ", 2, resultNode.path("total").asInt());
+    assertEquals( 2, resultNode.path("total").asInt());
 
     // Verify match text in either of the two nodes returned. This is the Json
     // Point.
-    assertTrue("Match text returned from testcircleCoveredByPolygon method is incorrect", jsonPointNodes.get(0).path("matches")
+    assertTrue( jsonPointNodes.get(0).path("matches")
         .get(0).path("match-text").get(0).path("highlight").asText().contains("6.897 0,-66.09375") ||
         jsonPointNodes.get(1).path("matches")
             .get(0).path("match-text").get(0).path("highlight").asText().contains("6.897 0,-66.09375"));
 
-    assertTrue("URI returned from testcircleCoveredByPolygon method is incorrect", jsonPointNodes.get(0).path("uri").asText().contains("/Equator.xml") ||
+    assertTrue( jsonPointNodes.get(0).path("uri").asText().contains("/Equator.xml") ||
         jsonPointNodes.get(1).path("uri").asText().contains("/Equator.xml"));
     // Verify match text in either of the two nodes returned. XML point.
-    assertTrue("Match text returned from testcircleCoveredByPolygon method is incorrect", jsonPointNodes.get(0).path("matches")
+    assertTrue( jsonPointNodes.get(0).path("matches")
         .get(0).path("match-text").get(0).path("highlight").asText().contains("6.897 0,-66.09375") ||
         jsonPointNodes.get(1).path("matches")
             .get(0).path("match-text").get(0).path("highlight").asText().contains("6.897 0,-66.09375"));
@@ -344,7 +345,7 @@ public class TestDoublePrecisionGeoOps extends AbstractFunctionalTest {
     JsonNode resultNodeJs = resultsHandleJs.get();
 
     // Should have 2 nodes returned.
-    assertEquals("Two nodes not returned from testBoxCoversPolygon method ", 2, resultNodeJs.path("total").asInt());
+    assertEquals( 2, resultNodeJs.path("total").asInt());
 
     // Verify snippets returned are correct
     SearchHandle resultsHandle = new SearchHandle();
@@ -381,7 +382,7 @@ public class TestDoublePrecisionGeoOps extends AbstractFunctionalTest {
         System.out.println("Snippet from XML file is " + snippetFromRead);
 
         // Verify that snippets from qb and read contain the same.
-        assertTrue("Snippets from summary and from XML file are incorrect ", snippetFromRead.contains(snippetFromSummary));
+        assertTrue( snippetFromRead.contains(snippetFromSummary));
 
         readDoc = null;
         contentHandle = null;
@@ -396,14 +397,14 @@ public class TestDoublePrecisionGeoOps extends AbstractFunctionalTest {
         System.out.println("Snippet from JSON file is " + snippetFromRead);
 
         // Verify that snippets from qb and read contain the same.
-        assertTrue("Snippets from summary and from JSON file are incorrect ", snippetFromRead.contains(snippetFromSummary));
+        assertTrue( snippetFromRead.contains(snippetFromSummary));
         jacksonhandle = null;
         resultNode = null;
       }
       // Get the results into the map.
       readMap.put(docUri, boxdesc);
     }
-    assertTrue("Result not returned correctly from testBoxCoversPolygon method ", expectedMap.equals(readMap));
+    assertTrue( expectedMap.equals(readMap));
   }
 
   /*
@@ -431,7 +432,7 @@ public class TestDoublePrecisionGeoOps extends AbstractFunctionalTest {
     JsonNode resultNode = resultsHandle.get();
 
     // Should have 2 nodes returned.
-    assertEquals("Two nodes not returned from testPolygonCoversBox method ", 2, resultNode.path("total").asInt());
+    assertEquals( 2, resultNode.path("total").asInt());
 
   }
 
@@ -460,7 +461,7 @@ public class TestDoublePrecisionGeoOps extends AbstractFunctionalTest {
     JsonNode resultNodeJs = resultsHandleJs.get();
 
     // Should have 2 nodes returned.
-    assertEquals("Two nodes not returned from testBoxOverlapsCircle method ", 2, resultNodeJs.path("total").asInt());
+    assertEquals( 2, resultNodeJs.path("total").asInt());
 
     // Verify snippets returned are correct
     SearchHandle resultsHandle = new SearchHandle();
@@ -497,7 +498,7 @@ public class TestDoublePrecisionGeoOps extends AbstractFunctionalTest {
         System.out.println("Snippet from XML file is " + snippetFromRead);
 
         // Verify that snippets from qb and read contain the same.
-        assertTrue("Snippets from summary and from XML file are incorrect ", snippetFromRead.contains(snippetFromSummary));
+        assertTrue( snippetFromRead.contains(snippetFromSummary));
 
         readDoc = null;
         contentHandle = null;
@@ -512,14 +513,14 @@ public class TestDoublePrecisionGeoOps extends AbstractFunctionalTest {
         System.out.println("Snippet from JSON file is " + snippetFromRead);
 
         // Verify that snippets from qb and read contain the same.
-        assertTrue("Snippets from summary and from JSON file are incorrect ", snippetFromRead.contains(snippetFromSummary));
+        assertTrue( snippetFromRead.contains(snippetFromSummary));
         jacksonhandle = null;
         resultNode = null;
       }
       // Get the results into the map.
       readMap.put(docUri, boxdesc);
     }
-    assertTrue("Result not returned correctly from testBoxOverlapsCircle method ", expectedMap.equals(readMap));
+    assertTrue( expectedMap.equals(readMap));
   }
 
   /*
@@ -553,7 +554,7 @@ public class TestDoublePrecisionGeoOps extends AbstractFunctionalTest {
     JsonNode resultNodejh = resultsHandlejh.get();
 
     // Should have 20 nodes returned.
-    assertEquals("Twenty nodes not returned from testPolygonCoversBox method ", 20, resultNodejh.path("total").asInt());
+    assertEquals( 20, resultNodejh.path("total").asInt());
   }
 
   /*
@@ -582,7 +583,7 @@ public class TestDoublePrecisionGeoOps extends AbstractFunctionalTest {
     MatchDocumentSummary matches[] = resultsHandle.getMatchResults();
 
     // Should have 18 nodes returned.
-    assertEquals("Eighteen nodes not returned from testBoxDisjointBox method ", 18, matches.length);
+    assertEquals( 18, matches.length);
 
     JSONDocumentManager docMgr = client.newJSONDocumentManager();
     TreeMap<String, String> expectedMap = new TreeMap<String, String>();
@@ -634,7 +635,7 @@ public class TestDoublePrecisionGeoOps extends AbstractFunctionalTest {
       // Get the results into the map.
       readMap.put(docUri, boxDesc);
     }
-    assertTrue("Result not returned correctly from testBoxDisjointBox method ", expectedMap.equals(readMap));
+    assertTrue( expectedMap.equals(readMap));
   }
 
   /*
@@ -664,7 +665,7 @@ public class TestDoublePrecisionGeoOps extends AbstractFunctionalTest {
     JsonNode resultNodejh = resultsHandlejh.get();
 
     // Should have 2 nodes returned.
-    assertEquals("Two nodes not returned from testPointEqualsPoint method ", 2, resultNodejh.path("total").asInt());
+    assertEquals( 2, resultNodejh.path("total").asInt());
 
     // Verify snippets returned are correct
     SearchHandle resultsHandle = new SearchHandle();
@@ -701,7 +702,7 @@ public class TestDoublePrecisionGeoOps extends AbstractFunctionalTest {
         System.out.println("Snippet from XML file is " + snippetFromRead);
 
         // Verify that snippets from qb and read contain the same.
-        assertTrue("Snippets from summary and from XML file are incorrect ", snippetFromRead.contains(snippetFromSummary));
+        assertTrue( snippetFromRead.contains(snippetFromSummary));
 
         readDoc = null;
         contentHandle = null;
@@ -716,14 +717,14 @@ public class TestDoublePrecisionGeoOps extends AbstractFunctionalTest {
         System.out.println("Snippet from JSON file is " + snippetFromRead);
 
         // Verify that snippets from qb and read contain the same.
-        assertTrue("Snippets from summary and from JSON file are incorrect ", snippetFromRead.contains(snippetFromSummary));
+        assertTrue( snippetFromRead.contains(snippetFromSummary));
         jacksonhandle = null;
         resultNode = null;
       }
       // Get the results into the map.
       readMap.put(docUri, pointdesc);
     }
-    assertTrue("Result not returned correctly from testPointEqualsPoint method ", expectedMap.equals(readMap));
+    assertTrue( expectedMap.equals(readMap));
   }
 
   /*
@@ -753,14 +754,14 @@ public class TestDoublePrecisionGeoOps extends AbstractFunctionalTest {
     JsonNode jsonPointNodes = resultNode.path("results");
 
     // Should have 2 nodes returned.
-    assertEquals("Two nodes not returned from testPolygonTouchesPoint method ", 2, resultNode.path("total").asInt());
+    assertEquals( 2, resultNode.path("total").asInt());
 
     String exptdString = "POLYGON((153.65 -8.35,170.57 -26.0,162.52 -52.52,136.0 -56.35,111.0 -51.0,100.89 -26.0,108.18 1.82,136.0 10.26,153.65 -8.35))";
     String polygondesc1 = jsonPointNodes.get(0).path("matches").get(0).path("match-text").get(0).path("highlight").asText();
     String polygondesc2 = jsonPointNodes.get(1).path("matches").get(0).path("match-text").get(0).path("highlight").asText();
 
-    assertTrue("Polygon Node not returned from testPolygonTouchesPoint method ", exptdString.equalsIgnoreCase(polygondesc1));
-    assertTrue("Polygon Node not returned from testPolygonTouchesPoint method ", exptdString.equalsIgnoreCase(polygondesc2));
+    assertTrue( exptdString.equalsIgnoreCase(polygondesc1));
+    assertTrue( exptdString.equalsIgnoreCase(polygondesc2));
   }
 
   /*
@@ -789,7 +790,7 @@ public class TestDoublePrecisionGeoOps extends AbstractFunctionalTest {
     JsonNode resultNodejh = resultsHandlejh.get();
 
     // Should have 2 nodes returned.
-    assertEquals("Two nodes not returned from testCircleWithinBox method ", 2, resultNodejh.path("total").asInt());
+    assertEquals( 2, resultNodejh.path("total").asInt());
 
     // Verify snippets returned are correct
     SearchHandle resultsHandle = new SearchHandle();
@@ -825,7 +826,7 @@ public class TestDoublePrecisionGeoOps extends AbstractFunctionalTest {
         System.out.println("Snippet from XML file is " + snippetFromRead);
 
         // Verify that snippets from qb and read contain the same.
-        assertTrue("Snippets from summary and from XML file are incorrect ", snippetFromRead.contains(snippetFromSummary));
+        assertTrue( snippetFromRead.contains(snippetFromSummary));
 
         readDoc = null;
         contentHandle = null;
@@ -840,14 +841,14 @@ public class TestDoublePrecisionGeoOps extends AbstractFunctionalTest {
         System.out.println("Snippet from JSON file is " + snippetFromRead);
 
         // Verify that snippets from qb and read contain the same.
-        assertTrue("Snippets from summary and from JSON file are incorrect ", snippetFromRead.contains(snippetFromSummary));
+        assertTrue( snippetFromRead.contains(snippetFromSummary));
         jacksonhandle = null;
         resultNode = null;
       }
       // Get the results into the map.
       readMap.put(docUri, circledesc);
     }
-    assertTrue("Result not returned correctly from testCircleWithinBox method ", expectedMap.equals(readMap));
+    assertTrue( expectedMap.equals(readMap));
   }
 
   public static void writeGeoDoubleFilesToDB(DatabaseClient client, String filename, String uri, String type) throws IOException, ParserConfigurationException, SAXException

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestEvalJavaScript.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestEvalJavaScript.java
@@ -28,8 +28,7 @@ import com.marklogic.client.eval.EvalResultIterator;
 import com.marklogic.client.eval.ServerEvaluationCall;
 import com.marklogic.client.io.*;
 import com.marklogic.client.io.DocumentMetadataHandle.Capability;
-import org.junit.*;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.*;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 
@@ -41,22 +40,22 @@ import java.io.StringReader;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /*
- * This test is meant for javascript to 
+ * This test is meant for javascript to
  * verify the eval api can handle all the formats of documents
  * verify eval api can handle all the return types
  * Verify eval takes all kind of variables
  */
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@TestMethodOrder(MethodOrderer.MethodName.class)
 public class TestEvalJavaScript extends AbstractFunctionalTest {
   private static String appServerHostname = null;
   private String dbName = "java-functest";
 
   private DatabaseClient client;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpBeforeClass() throws Exception {
     TestEvalXquery.createUserRolesWithPrevilages("test-js-eval", "xdbc:eval", "xdbc:eval-in", "xdmp:eval-in", "xdmp:invoke-in", "xdmp:invoke", "xdbc:invoke-in", "any-uri",
         "xdbc:invoke");
@@ -64,13 +63,13 @@ public class TestEvalJavaScript extends AbstractFunctionalTest {
     appServerHostname = getRestAppServerHostName();
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownAfterClass() throws Exception {
     TestEvalXquery.deleteRESTUser("eval-userJS");
     TestEvalXquery.deleteUserRole("test-js-eval");
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws KeyManagementException, NoSuchAlgorithmException, Exception {
     int restPort = getRestServerPort();
     client = getDatabaseClientOnDatabase(appServerHostname, restPort, dbName, "eval-userJS", "x", getConnType());
@@ -91,42 +90,41 @@ public class TestEvalJavaScript extends AbstractFunctionalTest {
 
         if (jh.get().isArray()) {
           System.out.println("Type Array :" + jh.get().toString());
-          assertEquals("array value at index 0 ", 1, jh.get().get(0)
+          assertEquals( 1, jh.get().get(0)
               .asInt());
-          assertEquals("array value at index 1 ", 2, jh.get().get(1)
+          assertEquals( 2, jh.get().get(1)
               .asInt());
-          assertEquals("array value at index 2 ", 3, jh.get().get(2)
+          assertEquals( 3, jh.get().get(2)
               .asInt());
         } else if (jh.get().isObject()) {
           System.out.println("Type Object :" + jh.get().toString());
           if (jh.get().has("foo")) {
-            assertNull("this object also has null node", jh.get()
+            assertNull( jh.get()
                 .get("testNull").textValue());
           } else if (jh.get().has("obj")) {
-            assertEquals("Value of the object is ", "value", jh
+            assertEquals( "value", jh
                 .get().get("obj").asText());
           } else {
-            assertFalse("getting a wrong object ", true);
+            fail("getting a wrong object ");
           }
 
         } else if (jh.get().isNumber()) {
           System.out.println("Type Number :" + jh.get().toString());
-          assertEquals("Number value", 1, jh.get().asInt());
+          assertEquals( 1, jh.get().asInt());
         } else if (jh.get().isNull()) {
           System.out.println("Type Null :" + jh.get().toString());
-          assertNull("Returned Null", jh.get().textValue());
+          assertNull( jh.get().textValue());
         } else if (jh.get().isBoolean()) {
           System.out.println("Type boolean :" + jh.get().toString());
-          assertTrue("Boolean value returned false", jh.get()
+          assertTrue( jh.get()
               .asBoolean());
         } else {
           // System.out.println("Running into different types than expected");
-          assertFalse("Running into different types than expected",
-              true);
+          fail("Running into different types than expected");
         }
 
       } else if (er.getType().equals(Type.TEXTNODE)) {
-        assertTrue("document contains",
+        assertTrue(
             er.getAs(String.class).equals("test1"));
         // System.out.println("type txt node :"+er.getAs(String.class));
 
@@ -134,20 +132,20 @@ public class TestEvalJavaScript extends AbstractFunctionalTest {
         FileHandle fh = new FileHandle();
         fh = er.get(fh);
         // System.out.println("type binary :"+fh.get().length());
-        assertEquals("files size", 2, fh.get().length());
+        assertEquals( 2, fh.get().length());
       } else if (er.getType().equals(Type.BOOLEAN)) {
-        assertTrue("Documents exist?", er.getBoolean());
+        assertTrue(er.getBoolean());
         // System.out.println("type boolean:"+er.getBoolean());
       } else if (er.getType().equals(Type.INTEGER)) {
         System.out.println("type Integer: "
             + er.getNumber().longValue());
-        assertEquals("count of documents ", 31, er.getNumber()
+        assertEquals( 31, er.getNumber()
             .intValue());
       } else if (er.getType().equals(Type.STRING)) {
           String str = er.getString();
         // There is git issue 152
         System.out.println("type string: " + str );
-        assertTrue("String?", str.contains("true") || str.contains("xml")
+        assertTrue(str.contains("true") || str.contains("xml")
             || str.contains("31") || str.contains("1.0471975511966"));
 
       } else if (er.getType().equals(Type.NULL)) {
@@ -159,25 +157,24 @@ public class TestEvalJavaScript extends AbstractFunctionalTest {
         // There is git issue 151
         System.out.println("Testing is Others? "
             + er.getAs(String.class));
-        // assertEquals("Returns OTHERs","xdmp:forest-restart#1",er.getString());
 
       } else if (er.getType().equals(Type.ANYURI)) {
         // System.out.println("Testing is AnyUri? "+er.getAs(String.class));
-        assertEquals("Returns me a uri :", "test1.xml",
+        assertEquals( "test1.xml",
             er.getAs(String.class));
 
       } else if (er.getType().equals(Type.DATE)) {
         // System.out.println("Testing is DATE? "+er.getAs(String.class));
-        assertEquals("Returns me a date :", "2002-03-07-07:00",
+        assertEquals( "2002-03-07-07:00",
             er.getAs(String.class));
       } else if (er.getType().equals(Type.DATETIME)) {
         // System.out.println("Testing is DATETIME? "+er.getAs(String.class));
-        assertEquals("Returns me a dateTime :",
+        assertEquals(
             "2010-01-06T18:13:50.874-07:00", er.getAs(String.class));
 
       } else if (er.getType().equals(Type.DECIMAL)) {
         // System.out.println("Testing is Decimal? "+er.getAs(String.class));
-        assertEquals("Returns me a Decimal :", "1.0471975511966",
+        assertEquals( "1.0471975511966",
             er.getAs(String.class));
 
       } else if (er.getType().equals(Type.DOUBLE)) {
@@ -187,64 +184,64 @@ public class TestEvalJavaScript extends AbstractFunctionalTest {
       } else if (er.getType().equals(Type.DURATION)) {
         System.out.println("Testing is Duration? "
             + er.getAs(String.class));
-        // assertEquals("Returns me a Duration :",0.4903562,er.getNumber().floatValue());
+        // assertEquals(0.4903562,er.getNumber().floatValue());
       } else if (er.getType().equals(Type.FLOAT)) {
         // System.out.println("Testing is Float? "+er.getAs(String.class));
         assertEquals(20, er.getNumber().floatValue(), 0);
       } else if (er.getType().equals(Type.GDAY)) {
         // System.out.println("Testing is GDay? "+er.getAs(String.class));
-        assertEquals("Returns me a GDAY :", "---01",
+        assertEquals( "---01",
             er.getAs(String.class));
       } else if (er.getType().equals(Type.GMONTH)) {
         // System.out.println("Testing is GMonth "+er.getAs(String.class));
-        assertEquals("Returns me a GMONTH :", "--01",
+        assertEquals( "--01",
             er.getAs(String.class));
       } else if (er.getType().equals(Type.GMONTHDAY)) {
         // System.out.println("Testing is GMonthDay? "+er.getAs(String.class));
-        assertEquals("Returns me a GMONTHDAY :", "--12-25-14:00",
+        assertEquals( "--12-25-14:00",
             er.getAs(String.class));
       } else if (er.getType().equals(Type.GYEAR)) {
         // System.out.println("Testing is GYear? "+er.getAs(String.class));
-        assertEquals("Returns me a GYEAR :", "2005-12:00",
+        assertEquals( "2005-12:00",
             er.getAs(String.class));
       } else if (er.getType().equals(Type.GYEARMONTH)) {
         // System.out.println("Testing is GYearMonth?1976-02 "+er.getAs(String.class));
-        assertEquals("Returns me a GYEARMONTH :", "1976-02",
+        assertEquals( "1976-02",
             er.getAs(String.class));
       } else if (er.getType().equals(Type.HEXBINARY)) {
         // System.out.println("Testing is HEXBINARY? "+er.getAs(String.class));
-        assertEquals("Returns me a HEXBINARY :", "BEEF",
+        assertEquals( "BEEF",
             er.getAs(String.class));
       } else if (er.getType().equals(Type.QNAME)) {
         // System.out.println("Testing is QNAME integer"+er.getAs(String.class));
-        assertEquals("Returns me a QNAME :", "integer",
+        assertEquals( "integer",
             er.getAs(String.class));
       } else if (er.getType().equals(Type.TIME)) {
         // System.out.println("Testing is TIME? "+er.getAs(String.class));
-        assertEquals("Returns me a TIME :", "10:00:00",
+        assertEquals( "10:00:00",
             er.getAs(String.class));
       } else if (er.getType().equals(Type.ATTRIBUTE)) {
         // System.out.println("Testing is ATTRIBUTE? "+er.getAs(String.class));
-        assertEquals("Returns me a ATTRIBUTE :", "attribute",
+        assertEquals( "attribute",
             er.getAs(String.class));
 
       } else if (er.getType().equals(Type.PROCESSINGINSTRUCTION)) {
         // System.out.println("Testing is ProcessingInstructions? "+er.getAs(String.class));
-        assertEquals("Returns me a PROCESSINGINSTRUCTION :",
+        assertEquals(
             "<?processing instruction?>", er.getAs(String.class));
       } else if (er.getType().equals(Type.COMMENT)) {
         // System.out.println("Testing is Comment node? "+er.getAs(String.class));
-        assertEquals("Returns me a COMMENT :", "<!--comment-->",
+        assertEquals( "<!--comment-->",
             er.getAs(String.class));
       } else if (er.getType().equals(Type.BASE64BINARY)) {
         // System.out.println("Testing is Base64Binary  "+er.getAs(String.class));
-        assertEquals("Returns me a BASE64BINARY :", "DEADBEEF",
+        assertEquals( "DEADBEEF",
             er.getAs(String.class));
       } else {
         System.out
             .println("Got something which is not belongs to anytype we support "
                 + er.getAs(String.class));
-        assertFalse("getting in else part, missing a type  ", true);
+        fail("getting in else part, missing a type  ");
       }
     }
   }
@@ -274,31 +271,31 @@ public class TestEvalJavaScript extends AbstractFunctionalTest {
     boolean response = client.newServerEval().javascript(insertXML).eval()
         .hasNext();
 
-    assertFalse("Insert query return empty sequence", response);
+    assertFalse( response);
     response = client.newServerEval().javascript(insertJSON).eval()
         .hasNext();
 
-    assertFalse("Insert query return empty sequence", response);
+    assertFalse( response);
     response = client.newServerEval().javascript(insertTXT).eval()
         .hasNext();
 
-    assertFalse("Insert query return empty sequence", response);
+    assertFalse( response);
     response = client.newServerEval().javascript(insertBinary).eval()
         .hasNext();
 
-    assertFalse("Insert query return empty sequence", response);
+    assertFalse( response);
     boolean response1 = client.newServerEval().javascript(query1).eval()
         .next().getBoolean();
 
-    assertTrue("Documents exist?", response1);
+    assertTrue(response1);
     int response2 = client.newServerEval().javascript(query2).eval().next()
         .getNumber().intValue();
 
-    assertEquals("count of documents ", 4, response2);
+    assertEquals( 4, response2);
     String response3 = client.newServerEval().javascript(query3)
         .evalAs(String.class);
 
-    assertEquals("Content database?", dbName, response3);
+    assertEquals( dbName, response3);
     ServerEvaluationCall evl = client.newServerEval();
     EvalResultIterator evr = evl.javascript(readDoc).eval();
     while (evr.hasNext()) {
@@ -306,22 +303,21 @@ public class TestEvalJavaScript extends AbstractFunctionalTest {
       if (er.getType().equals(Type.XML)) {
         DOMHandle dh = new DOMHandle();
         dh = er.get(dh);
-        assertEquals("document has content", "<foo>test1</foo>",
+        assertEquals( "<foo>test1</foo>",
             convertXMLDocumentToString(dh.get()));
       } else if (er.getType().equals(Type.JSON)) {
         JacksonHandle jh = new JacksonHandle();
         jh = er.get(jh);
-        assertTrue("document has object?", jh.get().has("test"));
+        assertTrue(jh.get().has("test"));
       } else if (er.getType().equals(Type.TEXTNODE)) {
         assertTrue(
-            "document contains",
             er.getAs(String.class).equals(
                 "This is a text document."));
 
       } else if (er.getType().equals(Type.BINARY)) {
         FileHandle fh = new FileHandle();
         fh = er.get(fh);
-        assertEquals("files size", 2, fh.get().length());
+        assertEquals( 2, fh.get().length());
 
       } else {
         System.out.println("Something went wrong");
@@ -348,20 +344,20 @@ public class TestEvalJavaScript extends AbstractFunctionalTest {
         if (er.getType().equals(Type.XML)) {
           DOMHandle dh = new DOMHandle();
           dh = er.get(dh);
-          assertEquals("document has content", "<foo>test1</foo>",
+          assertEquals( "<foo>test1</foo>",
               convertXMLDocumentToString(dh.get()));
         } else if (er.getType().equals(Type.JSON)) {
           JacksonHandle jh = new JacksonHandle();
           jh = er.get(jh);
-          assertTrue("document has object?", jh.get().has("test"));
+          assertTrue(jh.get().has("test"));
         } else if (er.getType().equals(Type.TEXTNODE)) {
-          assertTrue("document contains", er.getAs(String.class)
+          assertTrue( er.getAs(String.class)
               .equals("This is a text document."));
 
         } else if (er.getType().equals(Type.BINARY)) {
           FileHandle fh = new FileHandle();
           fh = er.get(fh);
-          assertEquals("files size", 2, fh.get().length());
+          assertEquals( 2, fh.get().length());
 
         } else {
           System.out.println("Something went wrong");
@@ -379,20 +375,19 @@ public class TestEvalJavaScript extends AbstractFunctionalTest {
    * Test is intended to test different types of variable passed to Javascript
    * from java and check return types,data types, there is a bug log against
    * REST 30209
-   * 
+   *
    * Expected Result : JS variable myJsonNull in this test has JsonNode object
    * of Type NullNode and its value not null. Hence we expect an Exception from
    * JerseyServices. See Git issue # 317 for further explanation.
    */
-  @Test(expected = IllegalArgumentException.class)
-  public void testJSDifferentVariableTypes() throws KeyManagementException, NoSuchAlgorithmException, Exception {
-	System.out.println("Running testJSDifferentVariableTypes"); 
+	@Test
+  public void testJSDifferentVariableTypes() throws Exception {
+	System.out.println("Running testJSDifferentVariableTypes");
     DocumentBuilder db = DocumentBuilderFactory.newInstance().newDocumentBuilder();
     InputSource is = new InputSource();
     is.setCharacterStream(new StringReader("<foo attr=\"attribute\"><?processing instruction?><!--comment-->test1</foo>"));
     Document doc = db.parse(is);
     System.out.println(this.convertXMLDocumentToString(doc));
-    try {
       String query1 = " var results = [];"
           + "var myString;"
           + "var myBool ;"
@@ -415,19 +410,14 @@ public class TestEvalJavaScript extends AbstractFunctionalTest {
           .addVariableAs("myJsonArray", new ObjectMapper().createArrayNode().add(1).add(2).add(3))
           .addVariableAs("myJsonNull", new ObjectMapper().createObjectNode().nullNode());
       System.out.println(new ObjectMapper().createObjectNode().nullNode().toString());
-      EvalResultIterator evr = evl.eval();
-      this.validateReturnTypes(evr);
-      evr.close();
-    } catch (Exception e) {
-      throw e;
-    }
+      assertThrows(IllegalArgumentException.class, () -> evl.eval());
   }
 
   /*
    * Test is intended to test different types of variable passed to javascript
    * from java and check return types,data types, there is a bug log against
    * REST 30209
-   * 
+   *
    * Expected Result : JS variable myJsonNull in this test has value set to
    * null. See Git issue # 317 for further explanation.
    */
@@ -514,23 +504,13 @@ public class TestEvalJavaScript extends AbstractFunctionalTest {
     }
   }
 
-  @Test(expected = java.lang.IllegalStateException.class)
+  @Test
   public void testMultipleJSfnOnServerEval() {
 	System.out.println("Running testMultipleJSfnOnServerEval");
     String insertQuery = "xdmp.document-insert(\"test1.xml\",<foo>test1</foo>)";
     String query1 = "fn.exists(fn:doc())";
-    String query2 = "fn.count(fn:doc())";
-    String query3 = "xdmp.database-name(xdmp.database())";
-
-    boolean response1 = client.newServerEval().javascript(query1)
-        .javascript(insertQuery).eval().next().getBoolean();
-    System.out.println(response1);
-    int response2 = client.newServerEval().xquery(query2).eval().next()
-        .getNumber().intValue();
-    System.out.println(response2);
-    String response3 = client.newServerEval().xquery(query3)
-        .evalAs(String.class);
-    System.out.println(response3);
+    assertThrows(IllegalStateException.class, () -> client.newServerEval().javascript(query1)
+        .javascript(insertQuery).eval().next().getBoolean());
   }
 
   // Issue 30209 ,external variable passing is not working so I have test cases
@@ -557,7 +537,7 @@ public class TestEvalJavaScript extends AbstractFunctionalTest {
       InputSource is = new InputSource();
       is.setCharacterStream(new StringReader(
           "<foo attr=\"attribute\"><?processing instruction?><!--comment-->test1</foo>"));
-   
+
       ServerEvaluationCall evl = client.newServerEval().modulePath(
           "/data/javascriptQueries.sjs");
 
@@ -567,20 +547,20 @@ public class TestEvalJavaScript extends AbstractFunctionalTest {
         if (er.getType().equals(Type.XML)) {
           DOMHandle dh = new DOMHandle();
           dh = er.get(dh);
-          assertEquals("document has content", "<foo>test1</foo>",
+          assertEquals( "<foo>test1</foo>",
               convertXMLDocumentToString(dh.get()));
         } else if (er.getType().equals(Type.JSON)) {
           JacksonHandle jh = new JacksonHandle();
           jh = er.get(jh);
-          assertTrue("document has object?", jh.get().has("test"));
+          assertTrue(jh.get().has("test"));
         } else if (er.getType().equals(Type.TEXTNODE)) {
-          assertTrue("document contains", er.getAs(String.class)
+          assertTrue( er.getAs(String.class)
               .equals("This is a text document."));
 
         } else if (er.getType().equals(Type.BINARY)) {
           FileHandle fh = new FileHandle();
           fh = er.get(fh);
-          assertEquals("files size", 2, fh.get().length());
+          assertEquals( 2, fh.get().length());
 
         } else {
           System.out.println("Something went wrong");
@@ -596,73 +576,73 @@ public class TestEvalJavaScript extends AbstractFunctionalTest {
       moduleClient.release();
     }
   }
-  
+
   /*
-   * Test is intended to test ServerEvaluationCall.evalAs(Class<T>) closing underlying streams prematurely 
+   * Test is intended to test ServerEvaluationCall.evalAs(Class<T>) closing underlying streams prematurely
    * Git Issue 725
    */
   @Test
   public void testStreamClosingWithEvalAs() throws KeyManagementException, NoSuchAlgorithmException, Exception {
 	  System.out.println("Running testStreamClosingWithEvalAs");
 	  try {
-      String query1 = 
+      String query1 =
            "var phrase = 'MarkLogic Corp';"
           + "var repeat = 10;"
           + "for (var i = 0; i < repeat; i++) {"
           + "phrase += phrase.concat(phrase);"
-          + "}"          
+          + "}"
           + "phrase;";
-      
-      String query2 = 
+
+      String query2 =
               "var phrase2 = 'Java Client API';"
              + "var repeat = 10;"
              + "for (var i = 0; i < repeat; i++) {"
              + "phrase2 += phrase2.concat(phrase2);"
-             + "}"          
+             + "}"
              + "var jsStr = JSON.stringify(phrase2);"
              + "jsStr;";
 
       ServerEvaluationCall evl = client.newServerEval().javascript(query1);
-      
+
       // Using evalAs(String.class)
       String evr = evl.evalAs(String.class);
-      
+
       int nLen = evr.length();
       String firstFiftyChars = evr.substring(0, 50);
       String lastTenChars = evr.substring(evr.length() - 10);
-      
+
       // Make sure we can access results that are greater than 17,400 chars. See Git Issue 725.
       System.out.println("String length is " + nLen);
       System.out.println("First Fifty String output is " + firstFiftyChars);
       System.out.println("Last Ten String output is " + lastTenChars);
-      
-      assertTrue("String length incorrect", nLen==826686);
-      assertTrue("First Fifty String output incorrect ", firstFiftyChars.equalsIgnoreCase("MarkLogic CorpMarkLogic CorpMarkLogic CorpMarkLogi"));
-      assertTrue("Last Ten String output incorrect ", lastTenChars.equalsIgnoreCase("Logic Corp"));
-      
+
+      assertTrue( nLen==826686);
+      assertTrue( firstFiftyChars.equalsIgnoreCase("MarkLogic CorpMarkLogic CorpMarkLogic CorpMarkLogi"));
+      assertTrue( lastTenChars.equalsIgnoreCase("Logic Corp"));
+
       // Using evalAs(JsonNode.class)
       ServerEvaluationCall ev2 = client.newServerEval().javascript(query2);
       JsonNode jNode = ev2.evalAs(JsonNode.class);
-      
+
       String jsonStr = jNode.asText();
       int nJLen = jsonStr.length();
       String firstFiftyCharsJson = jsonStr.substring(0, 50);
       String lastTenCharsJson = jsonStr.substring(jsonStr.length() - 10);
-      
+
       // Make sure we can access results that are greater than 17,400 chars. See Git Issue 725.
       System.out.println("JSON String length is " + nJLen);
       System.out.println("First Fifty String JSON output is " + firstFiftyCharsJson);
       System.out.println("Last Ten String JSON output is " + lastTenCharsJson);
-      
-      assertTrue("JSON String length incorrect", nJLen==885735);
-      assertTrue("First Fifty JSON String output incorrect ", firstFiftyCharsJson.equalsIgnoreCase("Java Client APIJava Client APIJava Client APIJava "));
-      assertTrue("Last Ten JSON String output incorrect ", lastTenCharsJson.equalsIgnoreCase("Client API"));
-      
+
+      assertTrue( nJLen==885735);
+      assertTrue( firstFiftyCharsJson.equalsIgnoreCase("Java Client APIJava Client APIJava Client APIJava "));
+      assertTrue( lastTenCharsJson.equalsIgnoreCase("Client API"));
+
     } catch (Exception e) {
       throw e;
     }
   }
-  
+
   // Making sure that mjs modules can be used in eval.
   @Test
   public void testJavaScriptModules() throws KeyManagementException, NoSuchAlgorithmException, Exception {
@@ -675,7 +655,7 @@ public class TestEvalJavaScript extends AbstractFunctionalTest {
 		  moduleClient = getDatabaseClientOnDatabase(appServerHostname, restPort, ("java-unittest-modules"),
               getAdminUser(), getAdminPassword(), getConnType());
 		  String mjsString = "import sr from '/MarkLogic/jsearch';" +
-	              "var output =" + 
+	              "var output =" +
 	              " sr.documents()" +
 	              "  .where(cts.directoryQuery('/test/words/'))" +
 	              "  .orderBy('city')" +
@@ -695,7 +675,7 @@ public class TestEvalJavaScript extends AbstractFunctionalTest {
 
 		  StringBuilder sb1 = new StringBuilder(
 				  "{" +
-						  "    \"city\": \"london\"," + 
+						  "    \"city\": \"london\"," +
 						  "    \"distance\": 50.4," +
 						  "    \"srchDate\": \"2007-01-01\"," +
 						  "    \"metro\": true," +
@@ -719,7 +699,7 @@ public class TestEvalJavaScript extends AbstractFunctionalTest {
 
 		  StringBuilder sb2 = new StringBuilder(
 				  "{ " +
-						  "    \"city\": \"new york\"," + 
+						  "    \"city\": \"new york\"," +
 						  "    \"distance\": 23.3," +
 						  "    \"srchDate\": \"2006-06-23\"," +
 						  "    \"metro\": true," +
@@ -744,7 +724,7 @@ public class TestEvalJavaScript extends AbstractFunctionalTest {
 
 		  StringBuilder sb3 = new StringBuilder(
 				  "  {" +
-						  "    \"city\": \"new jersey\"," + 
+						  "    \"city\": \"new jersey\"," +
 						  "    \"distance\": 12.9," +
 						  "    \"srchDate\": \"1971-12-23\"," +
 						  "    \"metro\": false," +
@@ -768,7 +748,7 @@ public class TestEvalJavaScript extends AbstractFunctionalTest {
 				  );
 		  StringBuilder sb4 = new StringBuilder(
 				  "<doc>" +
-	              "    <city>beijing</city>" + 
+	              "    <city>beijing</city>" +
 	              "    <distance direction=\"east\">134.5</distance>" +
 	              "    <srchDate>1981-11-09</srchDate>" +
 	              "    <metro rate=\"3\">true</metro>" +
@@ -793,7 +773,7 @@ public class TestEvalJavaScript extends AbstractFunctionalTest {
 				  );
 		  StringBuilder sb5 = new StringBuilder(
 				  "<doc>" +
-	              "    <city>cape town</city>" + 
+	              "    <city>cape town</city>" +
 	              "    <distance direction=\"south\">377.9</distance>" +
 	              "    <srchDate>1999-04-22</srchDate>" +
 	              "    <metro rate=\"2\">true</metro>" +
@@ -828,16 +808,16 @@ public class TestEvalJavaScript extends AbstractFunctionalTest {
 
 		  // Using evalAs(JsonNode.class)
 		  JsonNode jNode = evl.evalAs(JsonNode.class);
-		  
-		  assertTrue("Module Eval incorrect", jNode.get("results").get(0).get("uri").asText()
+
+		  assertTrue( jNode.get("results").get(0).get("uri").asText()
 				                              .equalsIgnoreCase("/test/words/wd4.xml"));
-		  assertTrue("Module Eval incorrect", jNode.get("results").get(1).get("uri").asText()
+		  assertTrue( jNode.get("results").get(1).get("uri").asText()
                   .equalsIgnoreCase("/test/words/wd5.xml"));
-		  assertTrue("Module Eval incorrect", jNode.get("results").get(2).get("uri").asText()
+		  assertTrue( jNode.get("results").get(2).get("uri").asText()
                   .equalsIgnoreCase("/test/words/wd1.json"));
-		  assertTrue("Module Eval incorrect", jNode.get("results").get(3).get("uri").asText()
+		  assertTrue( jNode.get("results").get(3).get("uri").asText()
                   .equalsIgnoreCase("/test/words/wd3.json"));
-		  assertTrue("Module Eval incorrect", jNode.get("results").get(4).get("uri").asText()
+		  assertTrue( jNode.get("results").get(4).get("uri").asText()
                   .equalsIgnoreCase("/test/words/wd2.json"));
 
 	  } catch (Exception e) {

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestEvalXquery.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestEvalXquery.java
@@ -18,6 +18,7 @@ package com.marklogic.client.fastfunctest;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.FailedRequestException;
 import com.marklogic.client.document.DocumentManager;
 import com.marklogic.client.eval.EvalResult;
 import com.marklogic.client.eval.EvalResult.Type;
@@ -25,7 +26,7 @@ import com.marklogic.client.eval.EvalResultIterator;
 import com.marklogic.client.eval.ServerEvaluationCall;
 import com.marklogic.client.io.*;
 import com.marklogic.client.io.DocumentMetadataHandle.Capability;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 
@@ -39,34 +40,34 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Date;
 import java.util.TimeZone;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /*
- * This test is meant for xquery to 
+ * This test is meant for xquery to
  * verify the eval api can handle all the formats of documents
  * verify eval api can handle all the return types
  * Verify eval takes all kind of variable with name spaces
  */
 public class TestEvalXquery extends AbstractFunctionalTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpBeforeClass() throws Exception {
     TestEvalXquery.createUserRolesWithPrevilages("test-eval", "xdbc:eval", "any-uri", "xdbc:invoke");
     TestEvalXquery.createRESTUser("eval-user", "x", "test-eval");
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownAfterClass() throws Exception {
     TestEvalXquery.deleteRESTUser("eval-user");
     TestEvalXquery.deleteUserRole("test-eval");
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws KeyManagementException, NoSuchAlgorithmException, Exception {
     client = getDatabaseClient("eval-user", "x", getConnType());
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     client.release();
   }
@@ -84,38 +85,38 @@ public class TestEvalXquery extends AbstractFunctionalTest {
         dh = er.get(dh);
         if (dh.get().getDocumentElement().hasChildNodes()) {
           // System.out.println("Type XML  :"+convertXMLDocumentToString(dh.get()));
-          assertEquals("document has content", "<foo attr=\"attribute\"><?processing instruction?><!--comment-->test1</foo>", convertXMLDocumentToString(dh.get()));
+          assertEquals( "<foo attr=\"attribute\"><?processing instruction?><!--comment-->test1</foo>", convertXMLDocumentToString(dh.get()));
         } else {
-          assertEquals("element node ", "<test1/>", convertXMLDocumentToString(dh.get()));
+          assertEquals( "<test1/>", convertXMLDocumentToString(dh.get()));
         }
       }
       else if (er.getType().equals(Type.JSON)) {
         JacksonHandle jh = new JacksonHandle();
         jh = er.get(jh);
         // System.out.println("Type JSON :"+jh.get().toString());
-        assertTrue("document has object?", jh.get().has("test"));
+        assertTrue( jh.get().has("test"));
       }
       else if (er.getType().equals(Type.TEXTNODE)) {
-        assertTrue("document contains", er.getAs(String.class).equals("test1"));
+        assertTrue( er.getAs(String.class).equals("test1"));
         // System.out.println("type txt node :"+er.getAs(String.class));
 
       } else if (er.getType().equals(Type.BINARY)) {
         FileHandle fh = new FileHandle();
         fh = er.get(fh);
         // System.out.println("type binary :"+fh.get().length());
-        assertEquals("files size", 2, fh.get().length());
+        assertEquals( 2, fh.get().length());
       } else if (er.getType().equals(Type.BOOLEAN)) {
-        assertTrue("Documents exist?", er.getBoolean());
+        assertTrue( er.getBoolean());
         // System.out.println("type boolean:"+er.getBoolean());
       }
       else if (er.getType().equals(Type.INTEGER)) {
         // System.out.println("type Integer: "+er.getNumber().longValue());
-        assertEquals("count of documents ", 31, er.getNumber().intValue());
+        assertEquals( 31, er.getNumber().intValue());
       }
       else if (er.getType().equals(Type.STRING)) {
         // There is git issue 152
           String str = er.getString();
-        assertEquals("String?", "xml", str);
+        assertEquals( "xml", str);
         System.out.println("type string: " + str);
       } else if (er.getType().equals(Type.NULL)) {
         // There is git issue 151
@@ -124,24 +125,24 @@ public class TestEvalXquery extends AbstractFunctionalTest {
       } else if (er.getType().equals(Type.OTHER)) {
         // There is git issue 151
         // System.out.println("Testing is Others? "+er.getAs(String.class));
-        assertTrue("Returns OTHERs", er.getString().contains("PT0S"));
+        assertTrue( er.getString().contains("PT0S"));
 
       } else if (er.getType().equals(Type.ANYURI)) {
         // System.out.println("Testing is AnyUri? "+er.getAs(String.class));
-        assertEquals("Returns me a uri :", "test1.xml", er.getAs(String.class));
+        assertEquals( "test1.xml", er.getAs(String.class));
 
       } else if (er.getType().equals(Type.DATE)) {
         // Adjusted this to ignore timezone
         String val = er.getAs(String.class);
-        assertTrue("Unexpected value: " + val, val.startsWith("2002-03-07"));
+        assertTrue(val.startsWith("2002-03-07"));
       } else if (er.getType().equals(Type.DATETIME)) {
         // Adjusted this to ignore timezone
         String val = er.getAs(String.class);
-        assertTrue("Unexpected value: " + val, val.startsWith("2010-01-06T"));
-        assertTrue("Unexpected value: " + val, val.contains(":13:50.873"));
+        assertTrue(val.startsWith("2010-01-06T"));
+        assertTrue(val.contains(":13:50.873"));
       } else if (er.getType().equals(Type.DECIMAL)) {
         // System.out.println("Testing is Decimal? "+er.getAs(String.class));
-        assertEquals("Returns me a Decimal :", "10.5", er.getAs(String.class));
+        assertEquals( "10.5", er.getAs(String.class));
 
       } else if (er.getType().equals(Type.DOUBLE)) {
         // System.out.println("Testing is Double? "+er.getAs(String.class));
@@ -149,51 +150,51 @@ public class TestEvalXquery extends AbstractFunctionalTest {
 
       } else if (er.getType().equals(Type.DURATION)) {
         System.out.println("Testing is Duration? " + er.getAs(String.class));
-        // assertEquals("Returns me a Duration :",0.4903562,er.getNumber().floatValue());
+        // assertEquals(0.4903562,er.getNumber().floatValue());
       } else if (er.getType().equals(Type.FLOAT)) {
         // System.out.println("Testing is Float? "+er.getAs(String.class));
         assertEquals(20, er.getNumber().floatValue(), 0);
       } else if (er.getType().equals(Type.GDAY)) {
         // System.out.println("Testing is GDay? "+er.getAs(String.class));
-        assertEquals("Returns me a GDAY :", "---01", er.getAs(String.class));
+        assertEquals( "---01", er.getAs(String.class));
       } else if (er.getType().equals(Type.GMONTH)) {
         // System.out.println("Testing is GMonth "+er.getAs(String.class));
-        assertEquals("Returns me a GMONTH :", "--01", er.getAs(String.class));
+        assertEquals( "--01", er.getAs(String.class));
       } else if (er.getType().equals(Type.GMONTHDAY)) {
         // System.out.println("Testing is GMonthDay? "+er.getAs(String.class));
-        assertEquals("Returns me a GMONTHDAY :", "--12-25-14:00", er.getAs(String.class));
+        assertEquals( "--12-25-14:00", er.getAs(String.class));
       } else if (er.getType().equals(Type.GYEAR)) {
         // System.out.println("Testing is GYear? "+er.getAs(String.class));
-        assertEquals("Returns me a GYEAR :", "2005-12:00", er.getAs(String.class));
+        assertEquals( "2005-12:00", er.getAs(String.class));
       } else if (er.getType().equals(Type.GYEARMONTH)) {
         // System.out.println("Testing is GYearMonth?1976-02 "+er.getAs(String.class));
-        assertEquals("Returns me a GYEARMONTH :", "1976-02", er.getAs(String.class));
+        assertEquals( "1976-02", er.getAs(String.class));
       } else if (er.getType().equals(Type.HEXBINARY)) {
         // System.out.println("Testing is HEXBINARY? "+er.getAs(String.class));
-        assertEquals("Returns me a HEXBINARY :", "BEEF", er.getAs(String.class));
+        assertEquals( "BEEF", er.getAs(String.class));
       } else if (er.getType().equals(Type.QNAME)) {
           String str = er.getString();
         // System.out.println("Testing is QNAME integer"+er.getAs(String.class));
-        assertTrue("Returns me a QNAME :", str.contains("integer") || str.contains("fn:empty"));
+        assertTrue( str.contains("integer") || str.contains("fn:empty"));
       } else if (er.getType().equals(Type.TIME)) {
         // System.out.println("Testing is TIME? "+er.getAs(String.class));
-        assertEquals("Returns me a TIME :", "10:00:00", er.getAs(String.class));
+        assertEquals( "10:00:00", er.getAs(String.class));
       } else if (er.getType().equals(Type.ATTRIBUTE)) {
         // System.out.println("Testing is ATTRIBUTE? "+er.getAs(String.class));
-        assertEquals("Returns me a ATTRIBUTE :", "attribute", er.getAs(String.class));
+        assertEquals( "attribute", er.getAs(String.class));
 
       } else if (er.getType().equals(Type.PROCESSINGINSTRUCTION)) {
         // System.out.println("Testing is ProcessingInstructions? "+er.getAs(String.class));
-        assertEquals("Returns me a PROCESSINGINSTRUCTION :", "<?processing instruction?>", er.getAs(String.class));
+        assertEquals( "<?processing instruction?>", er.getAs(String.class));
       } else if (er.getType().equals(Type.COMMENT)) {
         // System.out.println("Testing is Comment node? "+er.getAs(String.class));
-        assertEquals("Returns me a COMMENT :", "<!--comment-->", er.getAs(String.class));
+        assertEquals( "<!--comment-->", er.getAs(String.class));
       } else if (er.getType().equals(Type.BASE64BINARY)) {
         // System.out.println("Testing is Base64Binary  "+er.getAs(String.class));
-        assertEquals("Returns me a BASE64BINARY :", "DEADBEEF", er.getAs(String.class));
+        assertEquals( "DEADBEEF", er.getAs(String.class));
       } else {
         System.out.println("Got something which is not belongs to anytype we support " + er.getAs(String.class));
-        assertFalse("getting in else part, missing a type  ", true);
+        fail("getting in else part, missing a type  ");
       }
     }
     evr.close();
@@ -214,25 +215,25 @@ public class TestEvalXquery extends AbstractFunctionalTest {
 
     boolean response = client.newServerEval().xquery(insertXML).eval().hasNext();
     // System.out.printlnln(response);
-    assertFalse("Insert query return empty sequence", response);
+    assertFalse( response);
     response = client.newServerEval().xquery(insertJSON).eval().hasNext();
     // System.out.printlnln(response);
-    assertFalse("Insert query return empty sequence", response);
+    assertFalse( response);
     response = client.newServerEval().xquery(insertTXT).eval().hasNext();
     // System.out.printlnln(response);
-    assertFalse("Insert query return empty sequence", response);
+    assertFalse( response);
     response = client.newServerEval().xquery(insertBinary).eval().hasNext();
     // System.out.printlnln(response);
-    assertFalse("Insert query return empty sequence", response);
+    assertFalse( response);
     boolean response1 = client.newServerEval().xquery(query1).eval().next().getBoolean();
     // System.out.printlnln(response1);
-    assertTrue("Documents exist?", response1);
+    assertTrue( response1);
     int response2 = client.newServerEval().xquery(query2).eval().next().getNumber().intValue();
     // System.out.printlnln(response2);
-    assertEquals("count of documents ", 4, response2);
+    assertEquals( 4, response2);
     String response3 = client.newServerEval().xquery(query3).evalAs(String.class);
     // System.out.printlnln(response3);
-    assertEquals("Content database?", "java-functest", response3);
+    assertEquals( "java-functest", response3);
     ServerEvaluationCall evl = client.newServerEval();
     EvalResultIterator evr = evl.xquery(readDoc).eval();
     while (evr.hasNext())
@@ -241,20 +242,20 @@ public class TestEvalXquery extends AbstractFunctionalTest {
       if (er.getType().equals(Type.XML)) {
         DOMHandle dh = new DOMHandle();
         dh = er.get(dh);
-        assertEquals("document has content", "<foo>test1</foo>", convertXMLDocumentToString(dh.get()));
+        assertEquals( "<foo>test1</foo>", convertXMLDocumentToString(dh.get()));
       }
       else if (er.getType().equals(Type.JSON)) {
         JacksonHandle jh = new JacksonHandle();
         jh = er.get(jh);
-        assertTrue("document has object?", jh.get().has("test"));
+        assertTrue( jh.get().has("test"));
       }
       else if (er.getType().equals(Type.TEXTNODE)) {
-        assertTrue("document contains", er.getAs(String.class).equals("This is a text document."));
+        assertTrue( er.getAs(String.class).equals("This is a text document."));
 
       } else if (er.getType().equals(Type.BINARY)) {
         FileHandle fh = new FileHandle();
         fh = er.get(fh);
-        assertEquals("files size", 2, fh.get().length());
+        assertEquals( 2, fh.get().length());
 
       } else {
         System.out.println("Something went wrong");
@@ -340,95 +341,75 @@ public class TestEvalXquery extends AbstractFunctionalTest {
 
           if (jh.get().isArray()) {
             // System.out.println("Type Array :"+jh.get().toString());
-            assertEquals("array value at index 0 ", 1, jh.get().get(0).asInt());
-            assertEquals("array value at index 1 ", 2, jh.get().get(1).asInt());
-            assertEquals("array value at index 2 ", 3, jh.get().get(2).asInt());
+            assertEquals( 1, jh.get().get(0).asInt());
+            assertEquals( 2, jh.get().get(1).asInt());
+            assertEquals( 3, jh.get().get(2).asInt());
           }
           else if (jh.get().isObject()) {
             System.out.println("Type Object :" + jh.get().toString());
             if (jh.get().has("foo")) {
-              assertNull("this object also has null node", jh.get().get("testNull").textValue());
+              assertNull( jh.get().get("testNull").textValue());
             } else if (jh.get().has("obj"))
             {
-              assertEquals("Value of the object is ", "value", jh.get().get("obj").asText());
+              assertEquals( "value", jh.get().get("obj").asText());
             } else {
-              assertFalse("getting a wrong object ", true);
+              fail("getting a wrong object ");
             }
 
           }
           else if (jh.get().isNumber()) {
             // System.out.println("Type Number :"+jh.get().toString());
-            assertEquals("Number value", 1, jh.get().asInt());
+            assertEquals( 1, jh.get().asInt());
           }
           else if (jh.get().isNull()) {
             // System.out.println("Type Null :"+jh.get().toString());
-            assertNull("Returned Null", jh.get().textValue());
+            assertNull( jh.get().textValue());
           }
           else if (jh.get().isBoolean()) {
             // System.out.println("Type boolean :"+jh.get().toString());
-            assertTrue("Boolean value returned false", jh.get().asBoolean());
+            assertTrue( jh.get().asBoolean());
           }
           else {
             // System.out.println("Running into different types than expected");
-            assertFalse("Running into different types than expected", true);
+            fail("Running into different types than expected");
           }
 
         }
         else if (er.getType().equals(Type.TEXTNODE)) {
-          assertTrue("document contains", er.getAs(String.class).contains("s"));
+          assertTrue( er.getAs(String.class).contains("s"));
           // System.out.println("type txt node :"+er.getAs(String.class));
         } else {
           System.out.println("No corresponding type found for :" + er.getType());
         }
       }
       evr.close();
-      
+
     } catch (Exception e) {
       throw e;
     }
   }
 
-  @Test(expected = java.lang.IllegalStateException.class)
+	@Test
   public void testMultipleXqueryfnOnServerEval() {
     String insertQuery = "xdmp:document-insert(\"test1.xml\",<foo>test1</foo>)";
     String query1 = "fn:exists(fn:doc())";
-    String query2 = "fn:count(fn:doc())";
-    String query3 = "xdmp:database-name(xdmp:database())";
-
-    boolean response1 = client.newServerEval().xquery(query1).xquery(insertQuery).eval().next().getBoolean();
-    System.out.println(response1);
-    int response2 = client.newServerEval().xquery(query2).eval().next().getNumber().intValue();
-    System.out.println(response2);
-    String response3 = client.newServerEval().xquery(query3).evalAs(String.class);
-    System.out.println(response3);
+    assertThrows(IllegalStateException.class, () ->
+		client.newServerEval().xquery(query1).xquery(insertQuery).eval().next().getBoolean());
   }
 
   // Issue 156 exist for this, have test cases where you can pass, element node,
   // text node, binary node as an external variable
-  @Test(expected = com.marklogic.client.FailedRequestException.class)
-  public void testXqueryWithExtVarAsNode() throws KeyManagementException, NoSuchAlgorithmException, Exception {
+	@Test
+  public void testXqueryWithExtVarAsNode() throws Exception {
     DocumentBuilder db = DocumentBuilderFactory.newInstance().newDocumentBuilder();
     InputSource is = new InputSource();
     is.setCharacterStream(new StringReader("<foo attr=\"attribute\"><?processing instruction?> <!--comment-->test1</foo>"));
     Document doc = db.parse(is);
-    try {
       String query1 = "declare variable $myXmlNode as node() external;"
           + "document{ xdmp:unquote($myXmlNode) }";
       ServerEvaluationCall evl = client.newServerEval().xquery(query1);
       evl.addVariableAs("myXmlNode", new DOMHandle(doc));
-      EvalResultIterator evr = evl.eval();
-      while (evr.hasNext())
-      {
-        EvalResult er = evr.next();
-        DOMHandle dh = new DOMHandle();
-        dh = er.get(dh);
-        // System.out.println("Type XML  :"+convertXMLDocumentToString(dh.get()));
-        assertEquals("document has content", "<foo attr=\"attribute\"><?processing instruction?><!--comment-->test1</foo>", convertXMLDocumentToString(dh.get()));
-      }
-      evr.close();
-    } catch (Exception e) {
-      throw e;
-    }
+      assertThrows(FailedRequestException.class, () -> evl.eval());
   }
 
   // Issue 156 , have test cases where you can pass, element node, text node,

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestFieldConstraint.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestFieldConstraint.java
@@ -18,14 +18,15 @@ package com.marklogic.client.fastfunctest;
 
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.io.SearchHandle;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 
-import static org.junit.Assert.assertEquals;
+
 
 public class TestFieldConstraint extends AbstractFunctionalTest {
   static String filenames[] = { "bbq1.xml", "bbq2.xml", "bbq3.xml", "bbq4.xml", "bbq5.xml" };
@@ -33,7 +34,7 @@ public class TestFieldConstraint extends AbstractFunctionalTest {
   private static String dbName = "FieldConstraintDB";
   private static String[] fNames = { "FieldConstraintDB-1" };
 
-  @After
+  @AfterEach
   public void testCleanUp() throws Exception
   {
     deleteDocuments(connectAsAdmin());
@@ -59,12 +60,12 @@ public class TestFieldConstraint extends AbstractFunctionalTest {
     // search result
     String matchResult = "Matched " + resultsHandle.getTotalResults();
     String expectedMatchResult = "Matched 1";
-    assertEquals("Match results difference", expectedMatchResult, matchResult);
+    assertEquals( expectedMatchResult, matchResult);
 
     String result = returnSearchResult(resultsHandle);
     String expectedResult = "|Matched 3 locations in /field-constraint/bbq3.xml";
 
-    assertEquals("Results difference", expectedResult, result);
+    assertEquals( expectedResult, result);
 
     // release client
     client.release();

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestHandles.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestHandles.java
@@ -22,10 +22,10 @@ import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.DatabaseClientFactory;
 import com.marklogic.client.io.*;
 import org.custommonkey.xmlunit.XMLUnit;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -40,27 +40,27 @@ import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 
 import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestHandles extends AbstractFunctionalTest {
 
     private static String dbName = "java-functest";
     private static String appServerHostname = null;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() throws Exception {
         createUserRolesWithPrevilages("test-eval", "xdbc:eval", "xdbc:eval-in", "xdmp:eval-in", "any-uri", "xdbc:invoke");
         createRESTUser("eval-user", "x", "test-eval", "rest-admin", "rest-writer", "rest-reader");
         appServerHostname = getRestAppServerHostName();
     }
 
-    @After
+    @AfterEach
     public void testCleanUp() throws Exception {
         deleteDocuments(connectAsAdmin());
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDown() throws Exception {
         deleteRESTUser("eval-user");
         deleteUserRole("test-eval");
@@ -123,9 +123,9 @@ public class TestHandles extends AbstractFunctionalTest {
         }
 
         String expectedException = "com.marklogic.client.ResourceNotFoundException: Local message: Could not read non-existent document. Server Message: RESTAPI-NODOCUMENT: (err:FOER0000) Resource or document does not exist:  category: content message: /write-xml-domhandle/xml-original-test.xml";
-        assertEquals("Document is not deleted", expectedException, exception);
+        assertEquals( expectedException, exception);
 
-        // assertFalse("Document is not deleted", isDocumentExist(client, uri +
+        // assertFalse( isDocumentExist(client, uri +
         // filename, "XML"));
 
         // release client
@@ -152,7 +152,7 @@ public class TestHandles extends AbstractFunctionalTest {
         // String readContent = contentHandle.get().toString();
         String readContent = new String(fileRead);
         String expectedContent = "hello world, welcome to java API";
-        assertEquals("Write Text difference", expectedContent.trim(), readContent.trim());
+        assertEquals( expectedContent.trim(), readContent.trim());
 
         // UPDATE the doc
         // acquire the content for update
@@ -168,13 +168,13 @@ public class TestHandles extends AbstractFunctionalTest {
         String readContentUpdate = new String(fileReadUpdate);
         String expectedContentUpdate = "hello world, welcome to java API after new updates";
 
-        assertEquals("Write Text difference", expectedContentUpdate.trim(), readContentUpdate.toString().trim());
+        assertEquals( expectedContentUpdate.trim(), readContentUpdate.toString().trim());
 
         // delete the document
         deleteDocument(client, uri + filename, "Text");
 
         // read the deleted document
-        // assertFalse("Document is not deleted", isDocumentExist(client, uri +
+        // assertFalse( isDocumentExist(client, uri +
         // filename, "Text"));
 
         String exception = "";
@@ -185,7 +185,7 @@ public class TestHandles extends AbstractFunctionalTest {
         }
 
         String expectedException = "com.marklogic.client.ResourceNotFoundException: Local message: Could not read non-existent document. Server Message: RESTAPI-NODOCUMENT: (err:FOER0000) Resource or document does not exist:  category: content message: /write-text-Byteshandle/text-original.txt";
-        assertEquals("Document is not deleted", expectedException, exception);
+        assertEquals( expectedException, exception);
 
         // release client
         client.release();
@@ -215,7 +215,7 @@ public class TestHandles extends AbstractFunctionalTest {
         // get expected contents
         JsonNode expectedContent = expectedJSONDocument(filename);
 
-        assertTrue("Write JSON document difference", readContent.equals(expectedContent));
+        assertTrue( readContent.equals(expectedContent));
 
         // update the doc
         // acquire the content for update
@@ -231,13 +231,13 @@ public class TestHandles extends AbstractFunctionalTest {
 
         // get expected contents
         JsonNode expectedContentUpdate = expectedJSONDocument(updateFilename);
-        assertTrue("Write JSON document difference", readContentUpdate.equals(expectedContentUpdate));
+        assertTrue( readContentUpdate.equals(expectedContentUpdate));
 
         // delete the document
         deleteDocument(client, uri + filename, "JSON");
 
         // read the deleted document
-        // assertFalse("Document is not deleted", isDocumentExist(client, uri +
+        // assertFalse( isDocumentExist(client, uri +
         // filename, "JSON"));
 
         String exception = "";
@@ -248,7 +248,7 @@ public class TestHandles extends AbstractFunctionalTest {
         }
 
         String expectedException = "com.marklogic.client.ResourceNotFoundException: Local message: Could not read non-existent document. Server Message: RESTAPI-NODOCUMENT: (err:FOER0000) Resource or document does not exist:  category: content message: /write-json-Byteshandle/json-original.json";
-        assertEquals("Document is not deleted", expectedException, exception);
+        assertEquals( expectedException, exception);
 
         // release client
         client.release();
@@ -276,7 +276,7 @@ public class TestHandles extends AbstractFunctionalTest {
         long size = getBinarySizeFromByte(fileRead);
         long expectedSize = 34543;
 
-        assertEquals("Binary size difference", expectedSize, size);
+        assertEquals( expectedSize, size);
 
         // update the doc
         // acquire the content for update
@@ -293,13 +293,13 @@ public class TestHandles extends AbstractFunctionalTest {
         long sizeUpdate = getBinarySizeFromByte(fileReadUpdate);
         // long expectedSizeUpdate = 3290;
         long expectedSizeUpdate = 3322;
-        assertEquals("Binary size difference", expectedSizeUpdate, sizeUpdate);
+        assertEquals( expectedSizeUpdate, sizeUpdate);
 
         // delete the document
         deleteDocument(client, uri + filename, "Binary");
 
         // read the deleted document
-        // assertFalse("Document is not deleted", isDocumentExist(client, uri +
+        // assertFalse( isDocumentExist(client, uri +
         // filename, "Binary"));
 
         String exception = "";
@@ -309,7 +309,7 @@ public class TestHandles extends AbstractFunctionalTest {
             exception = e.toString();
         }
         String expectedException = "com.marklogic.client.ResourceNotFoundException: Local message: Could not read non-existent document. Server Message: RESTAPI-NODOCUMENT: (err:FOER0000) Resource or document does not exist:  category: content message: /write-bin-Bytehandle/Pandakarlino.jpg";
-        assertEquals("Document is not deleted", expectedException, exception);
+        assertEquals( expectedException, exception);
 
         // release client
         client.release();
@@ -341,13 +341,13 @@ public class TestHandles extends AbstractFunctionalTest {
         // get xml document for expected result
         Document expectedDoc = expectedXMLDocument(filename);
 
-        assertEquals("First Node incorrect in input doc", readDoc.getFirstChild().getNodeName().trim(), "food");
-        assertEquals("First Node attribute incorrect in input doc", readDoc.getFirstChild().getAttributes().item(0).getNodeValue().trim(), "en");
-        assertEquals("Child Node value incorrect in input doc", readDoc.getChildNodes().item(0).getTextContent().trim(), "noodle");
+        assertEquals( readDoc.getFirstChild().getNodeName().trim(), "food");
+        assertEquals( readDoc.getFirstChild().getAttributes().item(0).getNodeValue().trim(), "en");
+        assertEquals( readDoc.getChildNodes().item(0).getTextContent().trim(), "noodle");
 
-        assertEquals("First Node incorrect in output doc", expectedDoc.getFirstChild().getNodeName().trim(), "food");
-        assertEquals("First Node attribute incorrect in output doc", expectedDoc.getFirstChild().getAttributes().item(0).getNodeValue().trim(), "en");
-        assertEquals("Child Node value incorrect in output doc", expectedDoc.getChildNodes().item(0).getTextContent().trim(), "noodle");
+        assertEquals( expectedDoc.getFirstChild().getNodeName().trim(), "food");
+        assertEquals( expectedDoc.getFirstChild().getAttributes().item(0).getNodeValue().trim(), "en");
+        assertEquals( expectedDoc.getChildNodes().item(0).getTextContent().trim(), "noodle");
 
         // update the doc
         // acquire the content for update
@@ -359,9 +359,9 @@ public class TestHandles extends AbstractFunctionalTest {
 
         Document readDocUpdate = updateHandle.get();
 
-        assertEquals("First Node incorrect in output doc", readDocUpdate.getFirstChild().getNodeName().trim(), "food");
-        assertEquals("First Node attribute incorrect in output doc", readDocUpdate.getFirstChild().getAttributes().item(0).getNodeValue().trim(), "en");
-        assertEquals("Child Node value incorrect in output doc", readDocUpdate.getChildNodes().item(0).getTextContent().trim(), "fried noodle");
+        assertEquals( readDocUpdate.getFirstChild().getNodeName().trim(), "food");
+        assertEquals( readDocUpdate.getFirstChild().getAttributes().item(0).getNodeValue().trim(), "en");
+        assertEquals( readDocUpdate.getChildNodes().item(0).getTextContent().trim(), "fried noodle");
 
         // delete the document
         deleteDocument(client, uri + filename, "XML");
@@ -376,7 +376,7 @@ public class TestHandles extends AbstractFunctionalTest {
 
         String expectedException = "Could not read non-existent document";
         boolean documentIsDeleted = exception.contains(expectedException);
-        assertTrue("Document is not deleted", documentIsDeleted);
+        assertTrue( documentIsDeleted);
 
         // release client
         client.release();
@@ -446,7 +446,7 @@ public class TestHandles extends AbstractFunctionalTest {
         }
         String expectedException = "Could not read non-existent document";
         boolean documentIsDeleted = exception.contains(expectedException);
-        assertTrue("Document is not deleted", documentIsDeleted);
+        assertTrue( documentIsDeleted);
 
         // release client
         client.release();
@@ -475,7 +475,7 @@ public class TestHandles extends AbstractFunctionalTest {
 
         String expectedContent = "hello world, welcome to java API";
 
-        assertEquals("Write Text difference", expectedContent.trim(), readContent.trim());
+        assertEquals( expectedContent.trim(), readContent.trim());
 
         // update the doc
         // acquire the content for update
@@ -492,13 +492,13 @@ public class TestHandles extends AbstractFunctionalTest {
 
         String expectedContentUpdate = "hello world, welcome to java API after new updates";
 
-        assertEquals("Write Text difference", expectedContentUpdate.trim(), readContentUpdate.toString().trim());
+        assertEquals( expectedContentUpdate.trim(), readContentUpdate.toString().trim());
 
         // delete the document
         deleteDocument(client, uri + filename, "Text");
 
         // read the deleted document
-        // assertFalse("Document is not deleted", isDocumentExist(client, uri +
+        // assertFalse( isDocumentExist(client, uri +
         // filename, "Text"));
 
         String exception = "";
@@ -510,7 +510,7 @@ public class TestHandles extends AbstractFunctionalTest {
         //
         String expectedException = "Could not read non-existent document";
         boolean documentIsDeleted = exception.contains(expectedException);
-        assertTrue("Document is not deleted", documentIsDeleted);
+        assertTrue( documentIsDeleted);
 
         // release client
         client.release();
@@ -542,7 +542,7 @@ public class TestHandles extends AbstractFunctionalTest {
         // get expected contents
         JsonNode expectedContent = expectedJSONDocument(filename);
 
-        assertTrue("Write JSON document difference", readContent.equals(expectedContent));
+        assertTrue( readContent.equals(expectedContent));
 
         // update the doc
         // acquire the content for update
@@ -560,13 +560,13 @@ public class TestHandles extends AbstractFunctionalTest {
         // get expected contents
         JsonNode expectedContentUpdate = expectedJSONDocument(updateFilename);
 
-        assertTrue("Write JSON document difference", readContentUpdate.equals(expectedContentUpdate));
+        assertTrue( readContentUpdate.equals(expectedContentUpdate));
 
         // delete the document
         deleteDocument(client, uri + filename, "JSON");
 
         // read the deleted document
-        // assertFalse("Document is not deleted", isDocumentExist(client, uri +
+        // assertFalse( isDocumentExist(client, uri +
         // filename, "JSON"));
 
         String exception = "";
@@ -578,7 +578,7 @@ public class TestHandles extends AbstractFunctionalTest {
 
         String expectedException = "Could not read non-existent document";
         boolean documentIsDeleted = exception.contains(expectedException);
-        assertTrue("Document is not deleted", documentIsDeleted);
+        assertTrue( documentIsDeleted);
 
         // release client
         client.release();
@@ -608,7 +608,7 @@ public class TestHandles extends AbstractFunctionalTest {
         long size = fileRead.length();
         long expectedSize = 34543;
 
-        assertEquals("Binary size difference", expectedSize, size);
+        assertEquals( expectedSize, size);
 
         // update the doc
         // acquire the content for update
@@ -625,13 +625,13 @@ public class TestHandles extends AbstractFunctionalTest {
         long sizeUpdate = fileReadUpdate.length();
         long expectedSizeUpdate = 3322;
 
-        assertEquals("Binary size difference", expectedSizeUpdate, sizeUpdate);
+        assertEquals( expectedSizeUpdate, sizeUpdate);
 
         // delete the document
         deleteDocument(client, uri + filename, "Binary");
 
         // read the deleted document
-        // assertFalse("Document is not deleted", isDocumentExist(client, uri +
+        // assertFalse( isDocumentExist(client, uri +
         // filename, "Binary"));
 
         String exception = "";
@@ -643,7 +643,7 @@ public class TestHandles extends AbstractFunctionalTest {
 
         String expectedException = "Could not read non-existent document";
         boolean documentIsDeleted = exception.contains(expectedException);
-        assertTrue("Document is not deleted", documentIsDeleted);
+        assertTrue( documentIsDeleted);
 
         // release client
         client.release();
@@ -715,7 +715,7 @@ public class TestHandles extends AbstractFunctionalTest {
 
         String expectedException = "Could not read non-existent document";
         boolean documentIsDeleted = exception.contains(expectedException);
-        assertTrue("Document is not deleted", documentIsDeleted);
+        assertTrue( documentIsDeleted);
 
         // release client
         contentHandle.close();
@@ -788,7 +788,7 @@ public class TestHandles extends AbstractFunctionalTest {
 
         String expectedException = "Could not read non-existent document";
         boolean documentIsDeleted = exception.contains(expectedException);
-        assertTrue("Document is not deleted", documentIsDeleted);
+        assertTrue( documentIsDeleted);
 
         // release client
         client.release();
@@ -817,7 +817,7 @@ public class TestHandles extends AbstractFunctionalTest {
 
         String expectedContent = "hello world, welcome to java API";
 
-        assertEquals("Write Text difference", expectedContent.trim(), readContent.trim());
+        assertEquals( expectedContent.trim(), readContent.trim());
 
         // update the doc
         // acquire the content for update
@@ -834,13 +834,13 @@ public class TestHandles extends AbstractFunctionalTest {
 
         String expectedContentUpdate = "hello world, welcome to java API after new updates";
 
-        assertEquals("Write Text difference", expectedContentUpdate.trim(), readContentUpdate.toString().trim());
+        assertEquals( expectedContentUpdate.trim(), readContentUpdate.toString().trim());
 
         // delete the document
         deleteDocument(client, uri + filename, "Text");
 
         // read the deleted document
-        // assertFalse("Document is not deleted", isDocumentExist(client, uri +
+        // assertFalse( isDocumentExist(client, uri +
         // filename, "Text"));
 
         String exception = "";
@@ -852,7 +852,7 @@ public class TestHandles extends AbstractFunctionalTest {
 
         String expectedException = "Could not read non-existent document";
         boolean documentIsDeleted = exception.contains(expectedException);
-        assertTrue("Document is not deleted", documentIsDeleted);
+        assertTrue( documentIsDeleted);
 
         // release client
         client.release();
@@ -883,7 +883,7 @@ public class TestHandles extends AbstractFunctionalTest {
         // get expected contents
         JsonNode expectedContent = expectedJSONDocument(filename);
 
-        assertTrue("Write JSON document difference", readContent.equals(expectedContent));
+        assertTrue( readContent.equals(expectedContent));
 
         // update the doc
         // acquire the content for update
@@ -901,13 +901,13 @@ public class TestHandles extends AbstractFunctionalTest {
         // get expected contents
         JsonNode expectedContentUpdate = expectedJSONDocument(updateFilename);
 
-        assertTrue("Write JSON document difference", readContentUpdate.equals(expectedContentUpdate));
+        assertTrue( readContentUpdate.equals(expectedContentUpdate));
 
         // delete the document
         deleteDocument(client, uri + filename, "JSON");
 
         // read the deleted document
-        // assertFalse("Document is not deleted", isDocumentExist(client, uri +
+        // assertFalse( isDocumentExist(client, uri +
         // filename, "JSON"));
 
         String exception = "";
@@ -919,7 +919,7 @@ public class TestHandles extends AbstractFunctionalTest {
 
         String expectedException = "Could not read non-existent document";
         boolean documentIsDeleted = exception.contains(expectedException);
-        assertTrue("Document is not deleted", documentIsDeleted);
+        assertTrue( documentIsDeleted);
 
         // release client
         client.release();
@@ -948,7 +948,7 @@ public class TestHandles extends AbstractFunctionalTest {
         int size = getBinarySize(fileRead);
         int expectedSize = 34543;
 
-        assertEquals("Binary size difference", expectedSize, size);
+        assertEquals( expectedSize, size);
 
         // update the doc
         // acquire the content for update
@@ -965,13 +965,13 @@ public class TestHandles extends AbstractFunctionalTest {
         int sizeUpdate = getBinarySize(fileReadUpdate);
         int expectedSizeUpdate = 3322;
 
-        assertEquals("Binary size difference", expectedSizeUpdate, sizeUpdate);
+        assertEquals( expectedSizeUpdate, sizeUpdate);
 
         // delete the document
         deleteDocument(client, uri + filename, "Binary");
 
         // read the deleted document
-        // assertFalse("Document is not deleted", isDocumentExist(client, uri +
+        // assertFalse( isDocumentExist(client, uri +
         // filename, "Binary"));
 
         String exception = "";
@@ -983,7 +983,7 @@ public class TestHandles extends AbstractFunctionalTest {
 
         String expectedException = "Could not read non-existent document";
         boolean documentIsDeleted = exception.contains(expectedException);
-        assertTrue("Document is not deleted", documentIsDeleted);
+        assertTrue( documentIsDeleted);
 
         // release client
         client.release();
@@ -1052,7 +1052,7 @@ public class TestHandles extends AbstractFunctionalTest {
 
         String expectedException = "Could not read non-existent document";
         boolean documentIsDeleted = exception.contains(expectedException);
-        assertTrue("Document is not deleted", documentIsDeleted);
+        assertTrue( documentIsDeleted);
 
         // release client
         client.release();
@@ -1081,7 +1081,7 @@ public class TestHandles extends AbstractFunctionalTest {
 
         String expectedContent = "hello world, welcome to java API";
 
-        assertEquals("Write Text difference", expectedContent.trim(), readContent.trim());
+        assertEquals( expectedContent.trim(), readContent.trim());
 
         // update the doc
         // acquire the content for update
@@ -1098,7 +1098,7 @@ public class TestHandles extends AbstractFunctionalTest {
 
         String expectedContentUpdate = "hello world, welcome to java API after new updates";
 
-        assertEquals("Write Text difference", expectedContentUpdate.trim(), readContentUpdate.toString().trim());
+        assertEquals( expectedContentUpdate.trim(), readContentUpdate.toString().trim());
 
         // delete the document
         deleteDocument(client, uri + filename, "Text");
@@ -1113,7 +1113,7 @@ public class TestHandles extends AbstractFunctionalTest {
 
         String expectedException = "Could not read non-existent document";
         boolean documentIsDeleted = exception.contains(expectedException);
-        assertTrue("Document is not deleted", documentIsDeleted);
+        assertTrue( documentIsDeleted);
 
         // release client
         client.release();
@@ -1144,7 +1144,7 @@ public class TestHandles extends AbstractFunctionalTest {
         // get expected contents
         JsonNode expectedContent = expectedJSONDocument(filename);
 
-        assertTrue("Write JSON document difference", readContent.equals(expectedContent));
+        assertTrue( readContent.equals(expectedContent));
 
         // update the doc
         // acquire the content for update
@@ -1162,13 +1162,13 @@ public class TestHandles extends AbstractFunctionalTest {
         // get expected contents
         JsonNode expectedContentUpdate = expectedJSONDocument(updateFilename);
 
-        assertTrue("Write JSON document difference", readContentUpdate.equals(expectedContentUpdate));
+        assertTrue( readContentUpdate.equals(expectedContentUpdate));
 
         // delete the document
         deleteDocument(client, uri + filename, "JSON");
 
         // read the deleted document
-        // assertFalse("Document is not deleted", isDocumentExist(client, uri +
+        // assertFalse( isDocumentExist(client, uri +
         // filename, "JSON"));
 
         String exception = "";
@@ -1180,7 +1180,7 @@ public class TestHandles extends AbstractFunctionalTest {
 
         String expectedException = "Could not read non-existent document";
         boolean documentIsDeleted = exception.contains(expectedException);
-        assertTrue("Document is not deleted", documentIsDeleted);
+        assertTrue( documentIsDeleted);
 
         // release client
         client.release();
@@ -1209,7 +1209,7 @@ public class TestHandles extends AbstractFunctionalTest {
         int size = getBinarySize(fileRead);
         int expectedSize = 34543;
 
-        assertEquals("Binary size difference", expectedSize, size);
+        assertEquals( expectedSize, size);
 
         // update the doc
         // acquire the content for update
@@ -1226,7 +1226,7 @@ public class TestHandles extends AbstractFunctionalTest {
         int sizeUpdate = getBinarySize(fileReadUpdate);
         int expectedSizeUpdate = 3322;
 
-        assertEquals("Binary size difference", expectedSizeUpdate, sizeUpdate);
+        assertEquals( expectedSizeUpdate, sizeUpdate);
 
         // delete the document
         deleteDocument(client, uri + filename, "Binary");
@@ -1241,7 +1241,7 @@ public class TestHandles extends AbstractFunctionalTest {
 
         String expectedException = "Could not read non-existent document";
         boolean documentIsDeleted = exception.contains(expectedException);
-        assertTrue("Document is not deleted", documentIsDeleted);
+        assertTrue( documentIsDeleted);
 
         // release client
         client.release();
@@ -1315,7 +1315,7 @@ public class TestHandles extends AbstractFunctionalTest {
 
         String expectedException = "Could not read non-existent document";
         boolean documentIsDeleted = exception.contains(expectedException);
-        assertTrue("Document is not deleted", documentIsDeleted);
+        assertTrue( documentIsDeleted);
 
         // release the client
         client.release();
@@ -1344,7 +1344,7 @@ public class TestHandles extends AbstractFunctionalTest {
 
         String readContent = convertReaderToString(fileRead);
 
-        assertEquals("Write Text document difference", expectedContent, readContent);
+        assertEquals( expectedContent, readContent);
 
         // update the doc
         // acquire the content for update
@@ -1361,7 +1361,7 @@ public class TestHandles extends AbstractFunctionalTest {
 
         String expectedContentUpdate = "hello world, welcome to java API after new updates";
 
-        assertEquals("Update Text document difference", expectedContentUpdate, readContentUpdate);
+        assertEquals( expectedContentUpdate, readContentUpdate);
 
         // delete the document
         deleteDocument(client, uri + filename, "Text");
@@ -1376,7 +1376,7 @@ public class TestHandles extends AbstractFunctionalTest {
 
         String expectedException = "Could not read non-existent document";
         boolean documentIsDeleted = exception.contains(expectedException);
-        assertTrue("Document is not deleted", documentIsDeleted);
+        assertTrue( documentIsDeleted);
 
         // release the client
         client.release();
@@ -1407,7 +1407,7 @@ public class TestHandles extends AbstractFunctionalTest {
         // get expected contents
         JsonNode expectedContent = expectedJSONDocument(filename);
 
-        assertTrue("Write JSON document difference", readContent.equals(expectedContent));
+        assertTrue( readContent.equals(expectedContent));
 
         // update the doc
         // acquire the content for update
@@ -1424,7 +1424,7 @@ public class TestHandles extends AbstractFunctionalTest {
         // get expected contents
         JsonNode expectedContentUpdate = expectedJSONDocument(updateFilename);
 
-        assertTrue("Write JSON document difference", readContentUpdate.equals(expectedContentUpdate));
+        assertTrue( readContentUpdate.equals(expectedContentUpdate));
 
         // delete the document
         deleteDocument(client, uri + filename, "JSON");
@@ -1439,7 +1439,7 @@ public class TestHandles extends AbstractFunctionalTest {
 
         String expectedException = "Could not read non-existent document";
         boolean documentIsDeleted = exception.contains(expectedException);
-        assertTrue("Document is not deleted", documentIsDeleted);
+        assertTrue( documentIsDeleted);
 
         // release the client
         client.release();
@@ -1510,7 +1510,7 @@ public class TestHandles extends AbstractFunctionalTest {
 
         String expectedException = "Could not read non-existent document";
         boolean documentIsDeleted = exception.contains(expectedException);
-        assertTrue("Document is not deleted", documentIsDeleted);
+        assertTrue( documentIsDeleted);
 
         // release client
         contentHandle.close();
@@ -1580,7 +1580,7 @@ public class TestHandles extends AbstractFunctionalTest {
         }
 
         String expectedException = "com.marklogic.client.ResourceNotFoundException: Local message: Could not read non-existent document. Server Message: RESTAPI-NODOCUMENT: (err:FOER0000) Resource or document does not exist:  category: content message: /write-xml-string/xml-original-test.xml";
-        assertEquals("Document is not deleted", expectedException, exception);
+        assertEquals( expectedException, exception);
 
         // release client
         client.release();
@@ -1609,7 +1609,7 @@ public class TestHandles extends AbstractFunctionalTest {
 
         String expectedContent = "hello world, welcome to java API";
 
-        assertEquals("Write Text difference", expectedContent.trim(), readContent.trim());
+        assertEquals( expectedContent.trim(), readContent.trim());
 
         // update the doc
         // acquire the content for update
@@ -1626,7 +1626,7 @@ public class TestHandles extends AbstractFunctionalTest {
 
         String expectedContentUpdate = "hello world, welcome to java API after new updates";
 
-        assertEquals("Write Text difference", expectedContentUpdate.trim(), readContentUpdate.toString().trim());
+        assertEquals( expectedContentUpdate.trim(), readContentUpdate.toString().trim());
 
         // delete the document
         deleteDocument(client, uri + filename, "Text");
@@ -1639,7 +1639,7 @@ public class TestHandles extends AbstractFunctionalTest {
         }
 
         String expectedException = "com.marklogic.client.ResourceNotFoundException: Local message: Could not read non-existent document. Server Message: RESTAPI-NODOCUMENT: (err:FOER0000) Resource or document does not exist:  category: content message: /write-text-stringhandle/text-original.txt";
-        assertEquals("Document is not deleted", expectedException, exception);
+        assertEquals( expectedException, exception);
 
         // release client
         client.release();
@@ -1669,7 +1669,7 @@ public class TestHandles extends AbstractFunctionalTest {
         // get expected contents
         JsonNode expectedContent = expectedJSONDocument(filename);
 
-        assertTrue("Write JSON document difference", readContent.equals(expectedContent));
+        assertTrue( readContent.equals(expectedContent));
 
         // update the doc
         // acquire the content for update
@@ -1687,7 +1687,7 @@ public class TestHandles extends AbstractFunctionalTest {
         // get expected contents
         JsonNode expectedContentUpdate = expectedJSONDocument(updateFilename);
 
-        assertTrue("Write JSON document difference", readContentUpdate.equals(expectedContentUpdate));
+        assertTrue( readContentUpdate.equals(expectedContentUpdate));
 
         // delete the document
         deleteDocument(client, uri + filename, "JSON");
@@ -1700,7 +1700,7 @@ public class TestHandles extends AbstractFunctionalTest {
         }
 
         String expectedException = "com.marklogic.client.ResourceNotFoundException: Local message: Could not read non-existent document. Server Message: RESTAPI-NODOCUMENT: (err:FOER0000) Resource or document does not exist:  category: content message: /write-json-stringhandle/json-original.json";
-        assertEquals("Document is not deleted", expectedException, exception);
+        assertEquals( expectedException, exception);
 
         // release client
         client.release();
@@ -1791,7 +1791,7 @@ public class TestHandles extends AbstractFunctionalTest {
 
         String expectedException = "Could not read non-existent document";
         boolean documentIsDeleted = exception.contains(expectedException);
-        assertTrue("Document is not deleted", documentIsDeleted);
+        assertTrue( documentIsDeleted);
 
         // release the client
         client.release();
@@ -1824,7 +1824,7 @@ public class TestHandles extends AbstractFunctionalTest {
         Document expectedDoc = expectedXMLDocument(filename);
         String expectedContent = convertXMLDocumentToString(expectedDoc);
         expectedContent = "null" + expectedContent.substring(expectedContent.indexOf("<name>") + 6, expectedContent.indexOf("</name>"));
-        assertEquals("Write XML difference", expectedContent, readContent);
+        assertEquals( expectedContent, readContent);
 
         // delete the document
         deleteDocument(client, uri + filename, "XML");
@@ -1838,7 +1838,7 @@ public class TestHandles extends AbstractFunctionalTest {
 
         String expectedException = "Could not read non-existent document";
         boolean documentIsDeleted = exception.contains(expectedException);
-        assertTrue("Document is not deleted", documentIsDeleted);
+        assertTrue( documentIsDeleted);
 
         // release the client
         client.release();

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestJSResourceExtensions.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestJSResourceExtensions.java
@@ -30,14 +30,16 @@ import com.marklogic.client.io.InputStreamHandle;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.util.RequestParameters;
-import org.junit.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.*;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.io.FileInputStream;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+
 
 public class TestJSResourceExtensions extends AbstractFunctionalTest {
   ResourceExtensionsManager resourceMgr;
@@ -100,7 +102,7 @@ public class TestJSResourceExtensions extends AbstractFunctionalTest {
     public String putJSON(String docUri) {
       RequestParameters params = new RequestParameters();
       params.add("uri", docUri);
-      
+
       String input = "{\"argument1\":\"hello\", \"argument2\":\"Earth\", \"content\":\"This is a JSON document\", \"response\":[200, \"OK\"], \"outputTypes\":\"application/json\"}";
       StringHandle readHandle = new StringHandle();
       // call the service
@@ -120,19 +122,19 @@ public class TestJSResourceExtensions extends AbstractFunctionalTest {
     }
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpBeforeClass() throws Exception {
     createUserRolesWithPrevilages("test-eval", "xdbc:eval", "xdbc:eval-in", "xdmp:value", "xdmp:eval", "xdmp:eval-in", "any-uri", "xdbc:invoke");
     createRESTUser("eval-user", "x", "test-eval", "rest-admin", "rest-writer", "rest-reader", "rest-extension-user");
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownAfterClass() throws Exception {
     deleteRESTUser("eval-user");
     deleteUserRole("test-eval");
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
 
     int restPort = getRestServerPort();
@@ -154,7 +156,7 @@ public class TestJSResourceExtensions extends AbstractFunctionalTest {
     resourceMgr.writeServices("simpleJSResourceModule", handle, resextMetadata, getParams);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     resourceMgr.deleteServices("simpleJSResourceModule");
     client.release();
@@ -166,8 +168,8 @@ public class TestJSResourceExtensions extends AbstractFunctionalTest {
     JacksonHandle jh = new JacksonHandle();
     resourceMgr.listServices(jh);
 
-    assertEquals("Format on Handle", "JSON", jh.getFormat().name());
-    assertEquals("Mime Type on Handle", "application/json", jh.getMimetype());
+    assertEquals( "JSON", jh.getFormat().name());
+    assertEquals( "application/json", jh.getMimetype());
 
     String expectedList = "{\"resources\":{\"resource\":[{\"name\":\"simpleJSResourceModule\", \"source-format\":\"javascript\", \"description\":\"Testing resource extension for java script\", \"version\":\"1.0\", \"title\":\"BasicJSTest\", \"methods\":{\"method\":[{\"method-name\":\"get\", \"parameter\":[{\"parameter-name\":\"my-uri\", \"parameter-type\":\"xs:string?\"}]}, {\"method-name\":\"post\"}, {\"method-name\":\"put\"}, {\"method-name\":\"delete\"}]}, \"resource-source\":\"/v1/resources/simpleJSResourceModule\"}]}}";
     JSONAssert.assertEquals(expectedList, jh.get().toString(), false);
@@ -201,7 +203,7 @@ public class TestJSResourceExtensions extends AbstractFunctionalTest {
     JacksonHandle jh2 = new JacksonHandle();
     jh.set(jh2.getMapper().readTree(tjs.getJSON("helloJS0.json")));
 
-    assertEquals("Total documents loaded are", 150, jh.get().get("document-count").intValue());
+    assertEquals( 150, jh.get().get("document-count").intValue());
 
     String expAftrPut = "{\"argument1\":\"hello\", \"argument2\":\"Earth\", \"content\":\"This is a JSON document\", \"array\":[1, 2, 3], \"response\":[200, \"OK\"], \"outputTypes\":\"application/json\"}";
     String expected = "{\"argument1\":\"helloJS.json\", \"argument2\":\"Earth\", \"database-name\":\"" + client.getDatabase() + "\", \"document-count\":0, \"content\":\"This is a JSON document\", \"document-content\":null, \"response\":[200, \"OK\"], \"outputTypes\":[\"application/json\"]}";

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestJacksonAnnotationsTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestJacksonAnnotationsTest.java
@@ -25,19 +25,19 @@ import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.DocumentMetadataHandle.Capability;
 import com.marklogic.client.pojo.PojoRepository;
 import com.marklogic.client.pojo.annotation.Id;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Calendar;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /*
  * This test is designed to to test available Jackson Annotations.
  * Separate POJO classes with aJackson annotation will be used.
- * refer to each static class for further description of its purpose. 
+ * refer to each static class for further description of its purpose.
  */
 
 public class TestJacksonAnnotationsTest extends AbstractFunctionalTest {
@@ -47,10 +47,10 @@ public class TestJacksonAnnotationsTest extends AbstractFunctionalTest {
   /*
    * This class is similar to the SmallArtifact class. It is used to test
    * Jackson Annotation
-   * 
+   *
    * @JsonIgnoreProperties on inventory field. The field is ignored at class
    * level.
-   * 
+   *
    * Class member name has been annotated with @Id. Expected result: Field
    * inventory should not be serialized.
    */
@@ -90,9 +90,9 @@ public class TestJacksonAnnotationsTest extends AbstractFunctionalTest {
   /*
    * This class is similar to the IgnoreProperties class. It is used to test
    * Jackson Annotation
-   * 
+   *
    * @JsonIgnore on inventory field. The field is ignored at field level.
-   * 
+   *
    * Class member name has been annotated with @Id. Expected result: Field
    * inventory should not be serialized.
    */
@@ -133,9 +133,9 @@ public class TestJacksonAnnotationsTest extends AbstractFunctionalTest {
   /*
    * This class is similar to the IgnoreProperties class. It is used to test
    * Jackson Annotation
-   * 
+   *
    * @JsonProperty on different fields.
-   * 
+   *
    * Class member name has been annotated with @Id. property to serialize when
    * applied to getter method. property to de-serialize when applied to setter
    * method. Expected result: Id field is not serialized / de-serialized.
@@ -197,10 +197,10 @@ public class TestJacksonAnnotationsTest extends AbstractFunctionalTest {
   /*
    * This class is similar to the JsonPropertyCheck class. It is used to test
    * Jackson Annotation
-   * 
+   *
    * @JsonValue on a method whose return String value is used to produce JSON
    * value serialization.
-   * 
+   *
    * Class member name has been annotated with @Id. property to serialize when
    * applied to getter method. property to de-serialize when applied to setter
    * method. Expected result: Id field is not serialized / de-serialized.
@@ -272,7 +272,7 @@ public class TestJacksonAnnotationsTest extends AbstractFunctionalTest {
     return lTemp == -1 ? -1 : lTemp;
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws KeyManagementException, NoSuchAlgorithmException, Exception {
     client = getDatabaseClient("rest-admin", "x", getConnType());
   }
@@ -298,24 +298,23 @@ public class TestJacksonAnnotationsTest extends AbstractFunctionalTest {
    * This method is used when there is a need to validate IgnoreProperties.
    */
   public void validateIgnoreProperties(IgnoreProperties artifact, long temp) {
-    assertNotNull("Artifact object should never be Null", artifact);
-    assertNotNull("Id should never be Null", artifact.id);
-    assertEquals("Id of the object is ", temp, artifact.getId());
-    assertEquals("Name of the object is ", "IgnoreProperties",
-        artifact.getName());
-    assertEquals("Inventory of the object is ", 0, artifact.getInventory());
+    assertNotNull(artifact);
+    assertNotNull(artifact.id);
+    assertEquals(temp, artifact.getId());
+    assertEquals( "IgnoreProperties", artifact.getName());
+    assertEquals(0, artifact.getInventory());
   }
 
   /*
    * This method is used when there is a need to validate IgnoreFields.
    */
   public void validateIgnoreFields(IgnoreFields artifact, long temp) {
-    assertNotNull("Artifact object should never be Null", artifact);
-    assertNotNull("Id should never be Null", artifact.id);
-    assertEquals("Id of the object is ", temp, artifact.getId());
-    assertEquals("Name of the object is ", "IgnoreFields",
+    assertNotNull( artifact);
+    assertNotNull( artifact.id);
+    assertEquals( temp, artifact.getId());
+    assertEquals( "IgnoreFields",
         artifact.getName());
-    assertEquals("Inventory of the object is ", 0, artifact.getInventory());
+    assertEquals( 0, artifact.getInventory());
   }
 
   /*
@@ -323,14 +322,14 @@ public class TestJacksonAnnotationsTest extends AbstractFunctionalTest {
    * field is not serialized and hence its default return value should be 0
    */
   public void validateJsonPropertyCheck(JsonPropertyCheck artifact, long temp) {
-    assertNotNull("Artifact object should never be Null", artifact);
-    assertNotNull("Id should never be Null", artifact.id);
-    assertEquals("Id of the object is ", 0, artifact.getId());
-    assertEquals("Name of the object is ", "JsonProperty",
+    assertNotNull( artifact);
+    assertNotNull( artifact.id);
+    assertEquals( 0, artifact.getId());
+    assertEquals( "JsonProperty",
         artifact.getName());
-    assertEquals("Batch Name of the object is ", "Batch One",
+    assertEquals( "Batch One",
         artifact.getBatch());
-    assertEquals("Inventory of the object is ", 1000,
+    assertEquals( 1000,
         artifact.getInventory());
   }
 
@@ -368,7 +367,7 @@ public class TestJacksonAnnotationsTest extends AbstractFunctionalTest {
    * instance. Uses IgnoreProperties class which has @Id on the name methods.
    * Test result expectations are: Mapper's write should not contain field -
    * inventory.
-   * 
+   *
    * Test method testPOJOJsonIgnoreProperties does a database store and then a
    * read back and in that the Java Default 0 is read back into the object.
    */
@@ -416,7 +415,7 @@ public class TestJacksonAnnotationsTest extends AbstractFunctionalTest {
    * Purpose : This test is to validate @JsonIgnore with valid POJO instance.
    * Uses IgnoreFields class which has @Id on the name methods. Test result
    * expectations are: Mapper's write should not contain field - inventory.
-   * 
+   *
    * Test method testPOJOJsonIgnoreFields does a database store and then a read
    * back and in that the Java Default 0 is read back into the object.
    */
@@ -435,7 +434,7 @@ public class TestJacksonAnnotationsTest extends AbstractFunctionalTest {
    * Purpose : This test is to validate @JsonProperty with valid POJO. Uses
    * JsonPropertyCheck class which has @Id on the name methods. Test result
    * expectations are: Java Default 0L is read back into the object.
-   * 
+   *
    * Field id is not annotation. Its Getter/Setter are also not annotated. Hence
    * that field is not serialized nor de-serialized.
    */
@@ -469,7 +468,7 @@ public class TestJacksonAnnotationsTest extends AbstractFunctionalTest {
    * Purpose : This test is to validate @JsonIgnore with valid POJO instance.
    * Uses JsonPropertyCheck class which has @Id on the name methods. Test result
    * expectations are: Mapper's write should not contain field - id.
-   * 
+   *
    * Test method testPOJOJsonIgnoreFields does a database store and then a read
    * back and in that the Java Default 0 is read back into the object.
    */

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestJacksonDateTimeFormat.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestJacksonDateTimeFormat.java
@@ -27,8 +27,9 @@ import com.marklogic.client.io.Format;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.pojo.PojoRepository;
 import com.marklogic.client.pojo.annotation.Id;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.security.KeyManagementException;
@@ -36,11 +37,11 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Calendar;
 import java.util.TimeZone;
 
-import static org.junit.Assert.*;
+
 
 /*
  * Purpose : To test the date-time data type.
- * 
+ *
  */
 
 public class TestJacksonDateTimeFormat extends AbstractFunctionalTest {
@@ -173,7 +174,7 @@ public class TestJacksonDateTimeFormat extends AbstractFunctionalTest {
     this.artifactId = artifactId;
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws KeyManagementException, NoSuchAlgorithmException, Exception {
     client = getDatabaseClient("rest-admin", "x", getConnType());
   }
@@ -236,21 +237,21 @@ public class TestJacksonDateTimeFormat extends AbstractFunctionalTest {
     System.out.println("Argumnt : " + datetime.toString());
     System.out.println("Jackson POJO : " + artifact.getExpiryDate().toString());
 
-    assertNotNull("Artifact object should never be Null", artifact);
-    assertNotNull("Id should never be Null", artifact.id);
-    assertEquals("Id of the object is ", longId, artifact.getId());
-    assertEquals("Name of the object is ", artifactName, artifact.getName());
-    assertEquals("Inventory of the object is ", 1000, artifact.getInventory());
-    assertEquals("Company name of the object is ", artifactName, artifact.getManufacturer().getName());
-    assertEquals("Web site of the object is ", "http://www.acme.com", artifact.getManufacturer().getWebsite());
+    assertNotNull( artifact);
+    assertNotNull( artifact.id);
+    assertEquals( longId, artifact.getId());
+    assertEquals( artifactName, artifact.getName());
+    assertEquals( 1000, artifact.getInventory());
+    assertEquals( artifactName, artifact.getManufacturer().getName());
+    assertEquals( "http://www.acme.com", artifact.getManufacturer().getWebsite());
     // Validate the calendar object's field, instead of object or string
     // comparisions.
-    assertEquals("Expiry date: MONTH ", datetime.get(Calendar.MONTH), artifact.getExpiryDate().get(Calendar.MONTH));
-    assertEquals("Expiry date: DAY_OF_MONTH ", datetime.get(Calendar.DAY_OF_MONTH), artifact.getExpiryDate().get(Calendar.DAY_OF_MONTH));
-    assertEquals("Expiry date: YEAR ", datetime.get(Calendar.YEAR), artifact.getExpiryDate().get(Calendar.YEAR));
-    assertEquals("Expiry date: HOUR ", datetime.get(Calendar.HOUR), artifact.getExpiryDate().get(Calendar.HOUR));
-    assertEquals("Expiry date: MINUTE ", datetime.get(Calendar.MINUTE), artifact.getExpiryDate().get(Calendar.MINUTE));
-    assertEquals("Expiry date: SECOND ", datetime.get(Calendar.SECOND), artifact.getExpiryDate().get(Calendar.SECOND));
+    assertEquals( datetime.get(Calendar.MONTH), artifact.getExpiryDate().get(Calendar.MONTH));
+    assertEquals(datetime.get(Calendar.DAY_OF_MONTH), artifact.getExpiryDate().get(Calendar.DAY_OF_MONTH));
+    assertEquals( datetime.get(Calendar.YEAR), artifact.getExpiryDate().get(Calendar.YEAR));
+    assertEquals( datetime.get(Calendar.HOUR), artifact.getExpiryDate().get(Calendar.HOUR));
+    assertEquals( datetime.get(Calendar.MINUTE), artifact.getExpiryDate().get(Calendar.MINUTE));
+    assertEquals( datetime.get(Calendar.SECOND), artifact.getExpiryDate().get(Calendar.SECOND));
     assertEquals(-87.966, artifact.getManufacturer().getLongitude(), 0.00);
     assertEquals(41.998, artifact.getManufacturer().getLatitude(), 0.00);
   }
@@ -263,21 +264,21 @@ public class TestJacksonDateTimeFormat extends AbstractFunctionalTest {
     System.out.println("Argumnt : " + datetime.toString());
     System.out.println("Jackson POJO : " + artifact.getExpiryDate().toString());
 
-    assertNotNull("Artifact object should never be Null", artifact);
-    assertNotNull("Id should never be Null", artifact.id);
-    assertEquals("Id of the object is ", longId, artifact.getId());
-    assertEquals("Name of the object is ", artifactName, artifact.getName());
-    assertEquals("Inventory of the object is ", 1000, artifact.getInventory());
-    assertEquals("Company name of the object is ", artifactName, artifact.getManufacturer().getName());
-    assertEquals("Web site of the object is ", "http://www.acme.com", artifact.getManufacturer().getWebsite());
+    assertNotNull( artifact);
+    assertNotNull( artifact.id);
+    assertEquals( longId, artifact.getId());
+    assertEquals( artifactName, artifact.getName());
+    assertEquals( 1000, artifact.getInventory());
+    assertEquals( artifactName, artifact.getManufacturer().getName());
+    assertEquals( "http://www.acme.com", artifact.getManufacturer().getWebsite());
     // Validate the calendar object's field, instead of object or string
     // comparisions.
-    assertEquals("Expiry date: MONTH ", datetime.get(Calendar.MONTH), artifact.getExpiryDate().get(Calendar.MONTH));
-    assertEquals("Expiry date: DAY_OF_MONTH ", datetime.get(Calendar.DAY_OF_MONTH), artifact.getExpiryDate().get(Calendar.DAY_OF_MONTH));
-    assertEquals("Expiry date: YEAR ", datetime.get(Calendar.YEAR), artifact.getExpiryDate().get(Calendar.YEAR));
-    assertEquals("Expiry date: HOUR ", datetime.get(Calendar.HOUR), artifact.getExpiryDate().get(Calendar.HOUR));
-    assertEquals("Expiry date: MINUTE ", datetime.get(Calendar.MINUTE), artifact.getExpiryDate().get(Calendar.MINUTE));
-    assertEquals("Expiry date: SECOND ", datetime.get(Calendar.SECOND), artifact.getExpiryDate().get(Calendar.SECOND));
+    assertEquals( datetime.get(Calendar.MONTH), artifact.getExpiryDate().get(Calendar.MONTH));
+    assertEquals(datetime.get(Calendar.DAY_OF_MONTH), artifact.getExpiryDate().get(Calendar.DAY_OF_MONTH));
+    assertEquals( datetime.get(Calendar.YEAR), artifact.getExpiryDate().get(Calendar.YEAR));
+    assertEquals( datetime.get(Calendar.HOUR), artifact.getExpiryDate().get(Calendar.HOUR));
+    assertEquals( datetime.get(Calendar.MINUTE), artifact.getExpiryDate().get(Calendar.MINUTE));
+    assertEquals( datetime.get(Calendar.SECOND), artifact.getExpiryDate().get(Calendar.SECOND));
     assertEquals(-87.966, artifact.getManufacturer().getLongitude(), 0.00);
     assertEquals(41.998, artifact.getManufacturer().getLatitude(), 0.00);
   }
@@ -361,16 +362,16 @@ public class TestJacksonDateTimeFormat extends AbstractFunctionalTest {
     // Introduce a wait for the document to be deleted.
     try {
       artifact = pojoReposProducts.read(calTime);
-      assertFalse("Test Expecting exception", true);
+      assertFalse( true);
     } catch (ResourceNotFoundException e) {
-      assertTrue("expected exception", true);
+      assertTrue( true);
     } catch (Exception e) {
-      assertFalse("Test got unexpected", true);
+      assertFalse( true);
     }
     // Validate the artifact read back.
     // long count = pojoReposProducts.count();
     //
-    // assertEquals("Artifact with calendar as Id found - Delete did not work",0,
+    // assertEquals(0,
     // count);
   }
 

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestLinkResultDocuments.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestLinkResultDocuments.java
@@ -23,7 +23,7 @@ import com.marklogic.client.query.MatchDocumentSummary;
 import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.query.StringQueryDefinition;
 import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xml.sax.SAXException;
 
 import javax.xml.parsers.ParserConfigurationException;
@@ -32,8 +32,7 @@ import java.io.File;
 import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
-
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestLinkResultDocuments extends AbstractFunctionalTest {
 
@@ -79,7 +78,7 @@ public class TestLinkResultDocuments extends AbstractFunctionalTest {
       System.out.println(result.getPath() + ": Path");
       System.out.println(result.getFormat() + ": Format");
       System.out.println(result.getUri() + ": Uri");
-      assertTrue("Uri is Wrong", result.getPath().contains("/mime-type/constraint4.json") || result.getPath().contains("/mime-type/constraint4.xml"));
+      assertTrue( result.getPath().contains("/mime-type/constraint4.json") || result.getPath().contains("/mime-type/constraint4.xml"));
     }
 
     XMLStreamReaderHandle shandle = queryMgr.search(querydef, new XMLStreamReaderHandle());

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestMetadata.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestMetadata.java
@@ -28,9 +28,10 @@ import com.marklogic.client.io.Format;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.io.marker.DocumentPatchHandle;
 import org.json.JSONException;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 import javax.xml.bind.JAXBException;
@@ -43,11 +44,11 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Calendar;
 import java.util.Scanner;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestMetadata extends AbstractFunctionalTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception
   {
     createRoleWithNodeUpdate("elsrole", "xdbc:eval", "xdbc:eval-in", "xdmp:eval-in", "any-uri", "xdbc:invoke");
@@ -102,39 +103,39 @@ public class TestMetadata extends AbstractFunctionalTest {
     String actualProperties = getDocumentPropertiesString(properties);
     System.out.println("Returned properties: " + actualProperties);
 
-    assertTrue("Document properties difference in size value", actualProperties.contains("size:5"));
-    assertTrue("Document property reviewed not found or not correct", actualProperties.contains("reviewed:true"));
-    assertTrue("Document property myInteger not found or not correct", actualProperties.contains("myInteger:10"));
-    assertTrue("Document property myDecimal not found or not correct", actualProperties.contains("myDecimal:34.56678"));
-    assertTrue("Document property myCalendar not found or not correct", actualProperties.contains(calProperty.toString()));
-    assertTrue("Document property myString not found or not correct", actualProperties.contains("myString:foo"));
+    assertTrue( actualProperties.contains("size:5"));
+    assertTrue( actualProperties.contains("reviewed:true"));
+    assertTrue( actualProperties.contains("myInteger:10"));
+    assertTrue( actualProperties.contains("myDecimal:34.56678"));
+    assertTrue( actualProperties.contains(calProperty.toString()));
+    assertTrue( actualProperties.contains("myString:foo"));
 
     // Permissions
     String actualPermissions = getDocumentPermissionsString(permissions);
     System.out.println("Returned permissions: " + actualPermissions);
 
-    assertTrue("Document permissions difference in size value", actualPermissions.contains("size:5"));
-    assertTrue("Document permissions difference in harmonized-updater permission", actualPermissions.contains("harmonized-updater:[UPDATE]"));
-    assertTrue("Document permissions difference in harmonized-reader permission", actualPermissions.contains("harmonized-reader:[READ]"));
-    assertTrue("Document permissions difference in rest-reader permission", actualPermissions.contains("rest-reader:[READ]"));
-    assertTrue("Document permissions difference in rest-writer permission", actualPermissions.contains("rest-writer:[UPDATE]"));
-    assertTrue("Document permissions difference in app-user permissions",
+    assertTrue( actualPermissions.contains("size:5"));
+    assertTrue( actualPermissions.contains("harmonized-updater:[UPDATE]"));
+    assertTrue( actualPermissions.contains("harmonized-reader:[READ]"));
+    assertTrue( actualPermissions.contains("rest-reader:[READ]"));
+    assertTrue( actualPermissions.contains("rest-writer:[UPDATE]"));
+    assertTrue(
         (actualPermissions.contains("app-user:[UPDATE, READ]") || actualPermissions.contains("app-user:[READ, UPDATE]")));
 
     // Collections
     String actualCollections = getDocumentCollectionsString(collections);
     System.out.println("Returned collections: " + actualCollections);
 
-    assertTrue("Document collections difference in size value", actualCollections.contains("size:2"));
-    assertTrue("my-collection1 not found", actualCollections.contains("another-collection"));
-    assertTrue("my-collection2 not found", actualCollections.contains("my-collection"));
+    assertTrue( actualCollections.contains("size:2"));
+    assertTrue( actualCollections.contains("another-collection"));
+    assertTrue( actualCollections.contains("my-collection"));
 
     // Test MetaData Values
-    assertTrue("key=Name not found in metadata", metadatavalues.containsKey("Name"));
-    assertTrue("value=kiran not found in metadata", metadatavalues.containsValue("kiran"));
-    assertTrue("key=Name not found in metadata", metadatavalues.containsKey("Company"));
-    assertTrue("value=kiran not found in metadata", metadatavalues.containsValue("MarkLogic"));
-    assertFalse("NO metadat keyvalues found", metadatavalues.isEmpty());
+    assertTrue( metadatavalues.containsKey("Name"));
+    assertTrue( metadatavalues.containsValue("kiran"));
+    assertTrue( metadatavalues.containsKey("Company"));
+    assertTrue( metadatavalues.containsValue("MarkLogic"));
+    assertFalse( metadatavalues.isEmpty());
     // Update MetaData Values
     metadataHandle.getMetadataValues().remove("Name");
     metadataHandle.getMetadataValues().replace("Company", "MarkLogic", "marklogicians");
@@ -144,12 +145,12 @@ public class TestMetadata extends AbstractFunctionalTest {
     writeDocumentUsingBytesHandle(client, filename, "/write-bin-byteshandle-metadata/", metadataHandle, "Binary");
     readMetadataHandle = readMetadataFromDocument(client, "/write-bin-byteshandle-metadata/" + filename, "Binary");
     metadatavalues = readMetadataHandle.getMetadataValues();
-    assertTrue("key=HQ not found in metadata", metadatavalues.containsKey("HQ"));
-    assertTrue("value=USACA not found in metadata", metadatavalues.containsValue("USACA"));
-    assertFalse("key=Name found after removing it", metadatavalues.containsKey("Name"));
-    assertFalse("key=MarkLogic found after removing it", metadatavalues.containsValue("MarkLogic"));
-    assertTrue("value=marklogicians not found in metadata", metadatavalues.containsValue("marklogicians"));
-    assertFalse("value=SanCarlos found after removing it", metadatavalues.containsValue("SanCarlos"));
+    assertTrue( metadatavalues.containsKey("HQ"));
+    assertTrue( metadatavalues.containsValue("USACA"));
+    assertFalse( metadatavalues.containsKey("Name"));
+    assertFalse( metadatavalues.containsValue("MarkLogic"));
+    assertTrue( metadatavalues.containsValue("marklogicians"));
+    assertFalse( metadatavalues.containsValue("SanCarlos"));
 
     // patch MetaData Values
     XMLDocumentManager docManager = client.newXMLDocumentManager();
@@ -163,9 +164,9 @@ public class TestMetadata extends AbstractFunctionalTest {
     readMetadataHandle = docManager.readMetadata("/write-bin-byteshandle-metadata/" + filename, readMetadataHandle);
     metadatavalues = readMetadataHandle.getMetadataValues();
     BytesHandle contentHandle = new BytesHandle();
-    assertTrue("value=test-patch not found in metadata", metadatavalues.containsValue("test-patch"));
-    assertTrue("value=15 not found in metadata", metadatavalues.containsValue("15"));
-    assertFalse("key=HQ found after removing it", metadatavalues.containsKey("HQ"));
+    assertTrue(metadatavalues.containsValue("test-patch"));
+    assertTrue( metadatavalues.containsValue("15"));
+    assertFalse( metadatavalues.containsKey("HQ"));
 
     // read metadata values using BinaryDocumentManager ReadAs
     DocumentMetadataHandle metaHandle = new DocumentMetadataHandle();
@@ -174,8 +175,8 @@ public class TestMetadata extends AbstractFunctionalTest {
     docman.readAs("/write-bin-byteshandle-metadata/" + filename, metaHandle, byte[].class);
     docman.read("/write-bin-byteshandle-metadata/" + filename, readmetadata, contentHandle, 0, 100);
     metadatavalues = metaHandle.getMetadataValues();
-    assertTrue(" metadata doesnot contain expected string test-patch", metadatavalues.containsValue("test-patch"));
-    assertTrue(" metadata doesnot contain expected string test-patch", metadatavalues.containsValue("test-patch"));
+    assertTrue(metadatavalues.containsValue("test-patch"));
+    assertTrue(metadatavalues.containsValue("test-patch"));
 
     // release the client
     client.release();
@@ -201,7 +202,7 @@ public class TestMetadata extends AbstractFunctionalTest {
     Scanner scanner = null;
     String readContent;
     File file = null;
-    
+
 	try {
 		file = new File("src/test/java/com/marklogic/client/functionaltest/data/" + filename);
 		fis = new FileInputStream(file);
@@ -223,11 +224,11 @@ public class TestMetadata extends AbstractFunctionalTest {
       metadataHandle.getMetadataValues().add("keyTrx1", "valueTrx1");
       docMgr.writeMetadata(docId, metadataHandle, t1);
       docMgr.readMetadata(docId, readMetadataHandle, t1);
-      assertTrue(" metadata doesnot contain expected string valueTrx1", metadatavalues.containsValue("valueTrx1"));
+      assertTrue( metadatavalues.containsValue("valueTrx1"));
       t1.rollback();
       docMgr.readMetadata(docId, readMetadataHandle);
       metadatavalues = readMetadataHandle.getMetadataValues();
-      assertFalse(" metadata  contains unexpected string valueTrx1", metadatavalues.containsValue("valueTrx1"));
+      assertFalse( metadatavalues.containsValue("valueTrx1"));
 
       // Trx with metadata values commit scenario
       t2 = client.openTransaction();
@@ -235,11 +236,11 @@ public class TestMetadata extends AbstractFunctionalTest {
       DocumentDescriptor desc = docMgr.create(template, metadataHandle, contentHandle, t2);
       String docId1 = desc.getUri();
       docMgr.read(docId1, readMetadataHandle, contentHandle, t2);
-      assertTrue(" metadata doesnot contain expected string valueTrx2", metadatavalues.containsValue("valueTrx2"));
+      assertTrue( metadatavalues.containsValue("valueTrx2"));
       t2.commit();
       docMgr.readAs(docId1, readMetadataHandle, String.class);
       metadatavalues = readMetadataHandle.getMetadataValues();
-      assertTrue(" metadata doesnot contains  string 'valueTrx2' after trx commit", metadatavalues.containsValue("valueTrx2"));
+      assertTrue(metadatavalues.containsValue("valueTrx2"));
       waitForPropertyPropagate();
 
       t1 = t2 = null;
@@ -301,36 +302,36 @@ public class TestMetadata extends AbstractFunctionalTest {
     String actualProperties = getDocumentPropertiesString(properties);
     System.out.println("Returned properties: " + actualProperties);
 
-    assertTrue("Document properties difference in size value", actualProperties.contains("size:6"));
-    assertTrue("Document property reviewed not found or not correct", actualProperties.contains("reviewed:true"));
-    assertTrue("Document property myInteger not found or not correct", actualProperties.contains("myInteger:10"));
-    assertTrue("Document property myDecimal not found or not correct", actualProperties.contains("myDecimal:34.56678"));
-    assertTrue("Document property myCalendar not found or not correct", actualProperties.contains(calProperty.toString()));
-    assertTrue("Document property emptyProperty not found or not correct", actualProperties.contains("emptyProperty:null"));
+    assertTrue( actualProperties.contains("size:6"));
+    assertTrue( actualProperties.contains("reviewed:true"));
+    assertTrue( actualProperties.contains("myInteger:10"));
+    assertTrue( actualProperties.contains("myDecimal:34.56678"));
+    assertTrue( actualProperties.contains(calProperty.toString()));
+    assertTrue( actualProperties.contains("emptyProperty:null"));
 
     // Permissions
     String actualPermissions = getDocumentPermissionsString(permissions);
     System.out.println("Returned permissions: " + actualPermissions);
 
-    assertTrue("Document permissions difference in size value", actualPermissions.contains("size:5"));
-    assertTrue("Document permissions difference in harmonized-updater permission", actualPermissions.contains("harmonized-updater:[UPDATE]"));
-    assertTrue("Document permissions difference in harmonized-reader permission", actualPermissions.contains("harmonized-reader:[READ]"));
-    assertTrue("Document permissions difference in rest-reader permission", actualPermissions.contains("rest-reader:[READ]"));
-    assertTrue("Document permissions difference in rest-writer permission", actualPermissions.contains("rest-writer:[UPDATE]"));
-    assertTrue("Document permissions difference in app-user permissions",
+    assertTrue( actualPermissions.contains("size:5"));
+    assertTrue( actualPermissions.contains("harmonized-updater:[UPDATE]"));
+    assertTrue( actualPermissions.contains("harmonized-reader:[READ]"));
+    assertTrue( actualPermissions.contains("rest-reader:[READ]"));
+    assertTrue( actualPermissions.contains("rest-writer:[UPDATE]"));
+    assertTrue(
         (actualPermissions.contains("app-user:[UPDATE, READ]") || actualPermissions.contains("app-user:[READ, UPDATE]")));
 
     // Collections
     String actualCollections = getDocumentCollectionsString(collections);
     System.out.println("Returned collections: " + actualCollections);
 
-    assertTrue("Document collections difference in size value", actualCollections.contains("size:2"));
-    assertTrue("my-collection1 not found", actualCollections.contains("another-collection"));
-    assertTrue("my-collection2 not found", actualCollections.contains("my-collection"));
+    assertTrue( actualCollections.contains("size:2"));
+    assertTrue( actualCollections.contains("another-collection"));
+    assertTrue( actualCollections.contains("my-collection"));
 
     // Write into empty props and read again.
     DocumentMetadataHandle metadataHandle1 = new DocumentMetadataHandle();
-    
+
     DocumentProperties properties1 = metadataHandle1.getProperties();
     properties1.put("emptyProperty", "Not Empty");
     writeDocumentUsingStringHandle(client, filename, "/write-text-stringhandle-metadata/", metadataHandle1, "Text");
@@ -346,7 +347,7 @@ public class TestMetadata extends AbstractFunctionalTest {
     // Properties
     String actualProperties1 = getDocumentPropertiesString(propertiesRead1);
     System.out.println("Returned properties: " + actualProperties1);
-    assertTrue("Document property emptyProperty not found or not correct", actualProperties1.contains("emptyProperty:Not Empty"));
+    assertTrue( actualProperties1.contains("emptyProperty:Not Empty"));
     // release the client
     client.release();
   }
@@ -399,35 +400,35 @@ public class TestMetadata extends AbstractFunctionalTest {
     String actualProperties = getDocumentPropertiesString(properties);
     System.out.println("Returned properties: " + actualProperties);
 
-    assertTrue("Document properties difference in size value", actualProperties.contains("size:5"));
-    assertTrue("Document property reviewed not found or not correct", actualProperties.contains("reviewed:true"));
-    assertTrue("Document property myInteger not found or not correct", actualProperties.contains("myInteger:10"));
-    assertTrue("Document property myDecimal not found or not correct", actualProperties.contains("myDecimal:34.56678"));
-    assertTrue("Document property myCalendar not found or not correct", actualProperties.contains(calProperty.toString()));
-    assertTrue("Document property myString not found or not correct", actualProperties.contains("myString:foo"));
+    assertTrue( actualProperties.contains("size:5"));
+    assertTrue( actualProperties.contains("reviewed:true"));
+    assertTrue( actualProperties.contains("myInteger:10"));
+    assertTrue( actualProperties.contains("myDecimal:34.56678"));
+    assertTrue( actualProperties.contains(calProperty.toString()));
+    assertTrue( actualProperties.contains("myString:foo"));
 
     // Permissions
     String actualPermissions = getDocumentPermissionsString(permissions);
     System.out.println("Returned permissions: " + actualPermissions);
 
-    assertTrue("Document permissions difference in size value", actualPermissions.contains("size:5"));
-    assertTrue("Document permissions difference in harmonized-updater permission", actualPermissions.contains("harmonized-updater:[UPDATE]"));
-    assertTrue("Document permissions difference in harmonized-reader permission", actualPermissions.contains("harmonized-reader:[READ]"));
-    assertTrue("Document permissions difference in rest-reader permission", actualPermissions.contains("rest-reader:[READ]"));
-    assertTrue("Document permissions difference in rest-writer permission", actualPermissions.contains("rest-writer:[UPDATE]"));
-    assertTrue("Document permissions difference in app-user permissions",
+    assertTrue( actualPermissions.contains("size:5"));
+    assertTrue( actualPermissions.contains("harmonized-updater:[UPDATE]"));
+    assertTrue( actualPermissions.contains("harmonized-reader:[READ]"));
+    assertTrue( actualPermissions.contains("rest-reader:[READ]"));
+    assertTrue( actualPermissions.contains("rest-writer:[UPDATE]"));
+    assertTrue(
         (actualPermissions.contains("app-user:[UPDATE, READ]") || actualPermissions.contains("app-user:[READ, UPDATE]")));
 
     // Collections
     String actualCollections = getDocumentCollectionsString(collections);
     System.out.println("Returned collections: " + actualCollections);
 
-    assertTrue("Document collections difference in size value", actualCollections.contains("size:2"));
-    assertTrue("my-collection1 not found", actualCollections.contains("another-collection"));
-    assertTrue("my-collection2 not found", actualCollections.contains("my-collection"));
+    assertTrue( actualCollections.contains("size:2"));
+    assertTrue( actualCollections.contains("another-collection"));
+    assertTrue( actualCollections.contains("my-collection"));
 
     // metadata Values
-    assertTrue("key1 does not exist in metadata values", metadatavalues.containsKey("key1"));
+    assertTrue( metadatavalues.containsKey("key1"));
 
     // release the client
     client.release();
@@ -478,35 +479,35 @@ public class TestMetadata extends AbstractFunctionalTest {
     String actualProperties = getDocumentPropertiesString(properties);
     System.out.println("Returned properties: " + actualProperties);
 
-    assertTrue("Document properties difference in size value", actualProperties.contains("size:5"));
-    assertTrue("Document property reviewed not found or not correct", actualProperties.contains("reviewed:true"));
-    assertTrue("Document property myInteger not found or not correct", actualProperties.contains("myInteger:10"));
-    assertTrue("Document property myDecimal not found or not correct", actualProperties.contains("myDecimal:34.56678"));
-    assertTrue("Document property myCalendar not found or not correct", actualProperties.contains(calProperty.toString()));
-    assertTrue("Document property myString not found or not correct", actualProperties.contains("myString:foo"));
+    assertTrue( actualProperties.contains("size:5"));
+    assertTrue( actualProperties.contains("reviewed:true"));
+    assertTrue( actualProperties.contains("myInteger:10"));
+    assertTrue( actualProperties.contains("myDecimal:34.56678"));
+    assertTrue( actualProperties.contains(calProperty.toString()));
+    assertTrue( actualProperties.contains("myString:foo"));
 
     // Permissions
     String actualPermissions = getDocumentPermissionsString(permissions);
     System.out.println("Returned permissions: " + actualPermissions);
 
-    assertTrue("Document permissions difference in size value", actualPermissions.contains("size:5"));
-    assertTrue("Document permissions difference in harmonized-updater permission", actualPermissions.contains("harmonized-updater:[UPDATE]"));
-    assertTrue("Document permissions difference in harmonized-reader permission", actualPermissions.contains("harmonized-reader:[READ]"));
-    assertTrue("Document permissions difference in rest-reader permission", actualPermissions.contains("rest-reader:[READ]"));
-    assertTrue("Document permissions difference in rest-writer permission", actualPermissions.contains("rest-writer:[UPDATE]"));
-    assertTrue("Document permissions difference in app-user permissions",
+    assertTrue( actualPermissions.contains("size:5"));
+    assertTrue( actualPermissions.contains("harmonized-updater:[UPDATE]"));
+    assertTrue( actualPermissions.contains("harmonized-reader:[READ]"));
+    assertTrue( actualPermissions.contains("rest-reader:[READ]"));
+    assertTrue( actualPermissions.contains("rest-writer:[UPDATE]"));
+    assertTrue(
         (actualPermissions.contains("app-user:[UPDATE, READ]") || actualPermissions.contains("app-user:[READ, UPDATE]")));
 
     // Collections
     String actualCollections = getDocumentCollectionsString(collections);
     System.out.println("Returned collections: " + actualCollections);
 
-    assertTrue("Document collections difference in size value", actualCollections.contains("size:2"));
-    assertTrue("my-collection1 not found", actualCollections.contains("another-collection"));
-    assertTrue("my-collection2 not found", actualCollections.contains("my-collection"));
+    assertTrue( actualCollections.contains("size:2"));
+    assertTrue( actualCollections.contains("another-collection"));
+    assertTrue( actualCollections.contains("my-collection"));
 
     // Metadata values
-    assertTrue("Documentdoes not contain metadatvalue::value22", metadatavalues.containsValue("value22"));
+    assertTrue( metadatavalues.containsValue("value22"));
 
     // release the client
     client.release();
@@ -543,7 +544,7 @@ public class TestMetadata extends AbstractFunctionalTest {
     String expectedProperties = "size:1|{http://www.example.com}foo:bar|";
     String actualProperties = getDocumentPropertiesString(properties);
     System.out.println(actualProperties);
-    assertEquals("Document properties difference", expectedProperties, actualProperties);
+    assertEquals( expectedProperties, actualProperties);
 
     // release the client
     client.release();
@@ -588,9 +589,9 @@ public class TestMetadata extends AbstractFunctionalTest {
       String actualPermissions = getDocumentPermissionsString(permissions);
       System.out.println("Returned permissions: " + actualPermissions);
 
-      assertTrue("Document collections difference in size value", actualCollections.contains("size:0"));
-      assertTrue("Document permissions difference in rest-reader permission", actualPermissions.contains("rest-reader:[READ]"));
-      assertTrue("Document permissions difference in rest-reader permission", actualPermissions.contains("rest-writer:[UPDATE]"));
+      assertTrue( actualCollections.contains("size:0"));
+      assertTrue( actualPermissions.contains("rest-reader:[READ]"));
+      assertTrue( actualPermissions.contains("rest-writer:[UPDATE]"));
 
       DocumentMetadataPatchBuilder patchBldr = docMgr.newPatchBuilder(Format.JSON);
 
@@ -625,25 +626,25 @@ public class TestMetadata extends AbstractFunctionalTest {
       String patchPermStr = getDocumentPermissionsString(afterPatchperms);
       System.out.println("After patch permissions: " + patchPermStr);
 
-      assertTrue("Document collections difference in size value", patchCollStr.contains("size:2"));
-      assertTrue("JSONPatch1 not found", patchCollStr.contains("JSONPatch1"));
-      assertTrue("JSONPatch3 not found", patchCollStr.contains("JSONPatch3"));
+      assertTrue( patchCollStr.contains("size:2"));
+      assertTrue( patchCollStr.contains("JSONPatch1"));
+      assertTrue( patchCollStr.contains("JSONPatch3"));
 
-      assertTrue("Document permissions difference in size value", patchPermStr.contains("size:5"));
-      assertTrue("Document permissions difference in harmonized-updater permission", actualPermissions.contains("harmonized-updater:[UPDATE]"));
-      assertTrue("Document permissions difference in harmonized-reader permission", actualPermissions.contains("harmonized-reader:[READ]"));
-      assertTrue("Document permissions difference in rest-reader permission", patchPermStr.contains("rest-reader:[READ]"));
-      assertTrue("Document permissions difference in rest-reader permission", patchPermStr.contains("rest-writer:[UPDATE]"));
+      assertTrue( patchPermStr.contains("size:5"));
+      assertTrue( actualPermissions.contains("harmonized-updater:[UPDATE]"));
+      assertTrue( actualPermissions.contains("harmonized-reader:[READ]"));
+      assertTrue( patchPermStr.contains("rest-reader:[READ]"));
+      assertTrue( patchPermStr.contains("rest-writer:[UPDATE]"));
 
       // Should contain elsrole
-      assertTrue("Document permissions difference for role els-role1", patchPermStr.contains("elsrole"));
+      assertTrue( patchPermStr.contains("elsrole"));
       // Verify elsrole capability
       String[] elsPerms = patchPermStr.split("elsrole:\\[")[1].split("\\]")[0].split(",");
-      assertTrue("Document permissions difference in rest-writer permission - first permission",
+      assertTrue(
           elsPerms[0].contains("NODE-UPDATE") || elsPerms[1].contains("NODE-UPDATE") || elsPerms[2].contains("NODE-UPDATE"));
-      assertTrue("Document permissions difference in rest-writer permission - second permission",
+      assertTrue(
           elsPerms[0].contains("EXECUTE") || elsPerms[1].contains("EXECUTE") || elsPerms[2].contains("EXECUTE"));
-      assertTrue("Document permissions difference in rest-writer permission - third permission",
+      assertTrue(
           elsPerms[0].contains("READ") || elsPerms[1].contains("READ") || elsPerms[2].contains("READ"));
 
       // Now use elsrole to do an document update
@@ -684,24 +685,24 @@ public class TestMetadata extends AbstractFunctionalTest {
       String patchCollStr2 = getDocumentCollectionsString(afterPatchcollTwo);
       System.out.println("ELS collections: " + patchCollStr2);
 
-      assertTrue("Document collections difference in size value", patchCollStr2.contains("size:3"));
-      assertTrue("Document collections difference in size value", patchCollStr2.contains("JSONPatch1"));
-      assertTrue("Document collections difference in size value", patchCollStr2.contains("JSONPatch3"));
-      assertTrue("Document collections difference in size value", patchCollStr2.contains("NodeUpdate"));
+      assertTrue( patchCollStr2.contains("size:3"));
+      assertTrue( patchCollStr2.contains("JSONPatch1"));
+      assertTrue( patchCollStr2.contains("JSONPatch3"));
+      assertTrue( patchCollStr2.contains("NodeUpdate"));
 
       // Permissions
       String patchPermStr2 = getDocumentPermissionsString(afterPatchpermsTwo);
       System.out.println("ELS permissions: " + patchPermStr2);
 
       // Should contain elsrole
-      assertTrue("Document permissions difference for role els-role1", patchPermStr2.contains("elsrole"));
+      assertTrue( patchPermStr2.contains("elsrole"));
       // Verify elsrole capability
       String[] elsPerms2 = patchPermStr2.split("elsrole:\\[")[1].split("\\]")[0].split(",");
-      assertTrue("Document permissions difference in rest-writer permission - first permission",
+      assertTrue(
           elsPerms2[0].contains("NODE-UPDATE") || elsPerms2[1].contains("NODE-UPDATE") || elsPerms2[2].contains("NODE-UPDATE"));
-      assertTrue("Document permissions difference in rest-writer permission - second permission",
+      assertTrue(
           elsPerms2[0].contains("EXECUTE") || elsPerms2[1].contains("EXECUTE") || elsPerms2[2].contains("EXECUTE"));
-      assertTrue("Document permissions difference in rest-writer permission - third permission",
+      assertTrue(
           elsPerms2[0].contains("READ") || elsPerms2[1].contains("READ") || elsPerms2[2].contains("READ"));
     } catch (Exception ex) {
       System.out.println(ex.getMessage());
@@ -714,7 +715,7 @@ public class TestMetadata extends AbstractFunctionalTest {
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() throws Exception
   {
     deleteRESTUser("elsuser");

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestMetadataXML.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestMetadataXML.java
@@ -20,7 +20,8 @@ import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.document.XMLDocumentManager;
 import com.marklogic.client.io.DOMHandle;
 import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
@@ -30,7 +31,7 @@ import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
-import static org.junit.Assert.assertTrue;
+
 
 public class TestMetadataXML extends AbstractFunctionalTest {
 
@@ -158,11 +159,11 @@ public class TestMetadataXML extends AbstractFunctionalTest {
       exception = e.toString();
     }
 
-    // assertEquals("Could write metadata with forbidden user",
+    // assertEquals(
     // expectedException, exception);
 
     boolean exceptionIsThrown = exception.contains(expectedException);
-    assertTrue("Exception is not thrown", exceptionIsThrown);
+    assertTrue( exceptionIsThrown);
 
     // release the clients
     client1.release();

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestMultithreading.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestMultithreading.java
@@ -27,8 +27,9 @@ import com.marklogic.client.functionaltest.ThreadWrite;
 import com.marklogic.client.io.Format;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.StringHandle;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,14 +37,14 @@ import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+
+
 
 public class TestMultithreading extends AbstractFunctionalTest {
 
   private static final Logger logger = LoggerFactory.getLogger(TestMultithreading.class);
 
-  @After
+  @AfterEach
   public void testCleanUp() throws Exception {
     deleteDocuments(connectAsAdmin());
   }
@@ -67,13 +68,13 @@ public class TestMultithreading extends AbstractFunctionalTest {
     for (int i = 1; i <= 5; i++) {
       String expectedUri = "/multithread-content-A/filename" + i + ".txt";
       String docUri = docMgr.exists("/multithread-content-A/filename" + i + ".txt").getUri();
-      assertEquals("URI is not found", expectedUri, docUri);
+      assertEquals( expectedUri, docUri);
     }
 
     for (int i = 1; i <= 5; i++) {
       String expectedUri = "/multithread-content-B/filename" + i + ".txt";
       String docUri = docMgr.exists("/multithread-content-B/filename" + i + ".txt").getUri();
-      assertEquals("URI is not found", expectedUri, docUri);
+      assertEquals( expectedUri, docUri);
     }
 
     // release client
@@ -114,9 +115,9 @@ public class TestMultithreading extends AbstractFunctionalTest {
     t5.join();
 
     long totalAllDocumentsReturned = ts1.totalAllResults + ts2.totalAllResults + ts3.totalAllResults + ts4.totalAllResults + ts5.totalAllResults;
-    assertTrue("Documents count is incorrect", totalAllDocumentsReturned == 750);
+    assertTrue( totalAllDocumentsReturned == 750);
   }
-  
+
   @Test
   public void testDeadlockInMultiStmt() throws KeyManagementException, NoSuchAlgorithmException, InterruptedException, IOException
   {
@@ -147,56 +148,56 @@ public class TestMultithreading extends AbstractFunctionalTest {
 		  }
 	  }, "t1");
 	  th1.setDaemon(false);
-	  
-	  final Thread th2 = new Thread(() -> {        
+
+	  final Thread th2 = new Thread(() -> {
 		  try {
 			  client.newXMLDocumentManager().write(docId, new StringHandle("<doc><t>Original Modified by t2</t></doc>").withFormat(Format.XML), t2);
 			  logger.info("Committing t2");
-			  t2.commit();            
+			  t2.commit();
 		  } catch (Exception ex) {
 			  logger.info("Rollback t2");
 			  t2.rollback();
 		  }
 	  }, "t2");
-	  th2.setDaemon(false);	  
-	  
-	  final Thread th3 = new Thread(() -> {        
+	  th2.setDaemon(false);
+
+	  final Thread th3 = new Thread(() -> {
 		  try {
 			  client.newXMLDocumentManager().write(docId, new StringHandle("<doc><t>Original Modified by t3</t></doc>").withFormat(Format.XML), t3);
 			  logger.info("Committing t3");
-			  t3.commit();            
+			  t3.commit();
 		  } catch (Exception ex) {
 			  logger.info("Rollback t3");
 			  t3.rollback();
 		  }
 	  }, "t3");
 	  th3.setDaemon(false);
-	  
-	  final Thread th4 = new Thread(() -> {        
+
+	  final Thread th4 = new Thread(() -> {
 		  try {
 			  client.newXMLDocumentManager().write(docId, new StringHandle("<doc><t>Original Modified by t4</t></doc>").withFormat(Format.XML), t4);
 			  logger.info("Committing t4");
-			  t4.commit();            
+			  t4.commit();
 		  } catch (Exception ex) {
 			  logger.info("Rollback t4");
 			  t4.rollback();
 		  }
 	  }, "t4");
 	  th4.setDaemon(false);
-	  
-	  final Thread th5 = new Thread(() -> {        
+
+	  final Thread th5 = new Thread(() -> {
 		  try {
 			  client.newXMLDocumentManager().write(docId, new StringHandle("<doc><t>Original Modified by t5</t></doc>").withFormat(Format.XML), t5);
 			  logger.info("Committing t5");
-			  t5.commit();            
+			  t5.commit();
 		  } catch (Exception ex) {
 			  logger.info("Rollback t5");
 			  t5.rollback();
 		  }
 	  }, "t5");
 	  th5.setDaemon(false);
-	 
-	  final Thread th6 = new Thread(() -> {        
+
+	  final Thread th6 = new Thread(() -> {
 		  try {
 			  client.newXMLDocumentManager().write(docId, new StringHandle("<doc><t>Original Modified by t6</t></doc>").withFormat(Format.XML), t6);
 			  logger.info("Committing t6");
@@ -205,14 +206,14 @@ public class TestMultithreading extends AbstractFunctionalTest {
 			  JsonNode node = jh.get();
 			  System.out.println("Read status from t6 is " + node.asText());
 			  //Thread.sleep(15000);
-			  t6.commit();            
+			  t6.commit();
 		  } catch (Exception ex) {
 			  logger.info("Rollback t6");
 			  t6.rollback();
 		  }
 	  }, "t6");
 	  th6.setDaemon(false);
-	  
+
 	  th2.start();
 	  th1.start();
 	  th4.start();
@@ -228,7 +229,7 @@ public class TestMultithreading extends AbstractFunctionalTest {
 
 	  StringHandle strHdle2 = docMgr.read(docId, new StringHandle());
 	  System.out.println(strHdle2.get().toString());
-	  
+
 	  if (th1.isAlive()) {th1.join(5000);}
 	  if (th2.isAlive()) {th2.join(5000);}
 	  if (th3.isAlive()) {th3.join(5000);}

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestNamespaces.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestNamespaces.java
@@ -25,7 +25,7 @@ import com.marklogic.client.document.XMLDocumentManager;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.util.EditableNamespaceContext;
 import com.marklogic.client.util.RequestLogger;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.namespace.NamespaceContext;
 import java.io.IOException;
@@ -33,8 +33,8 @@ import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Collection;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestNamespaces extends AbstractFunctionalTest {
 
@@ -61,26 +61,26 @@ public class TestNamespaces extends AbstractFunctionalTest {
 
     NamespaceContext nsContext = nsMgr.readAll();
 
-    assertEquals("Prefix is not equal", "foo", nsContext.getPrefix("http://example.com"));
-    assertEquals("Namespace URI is not equal", "http://example.com", nsContext.getNamespaceURI("foo"));
+    assertEquals( "foo", nsContext.getPrefix("http://example.com"));
+    assertEquals( "http://example.com", nsContext.getNamespaceURI("foo"));
 
     // update prefix
     nsMgr.updatePrefix("foo", "http://exampleupdated.com");
     nsContext = nsMgr.readAll();
-    assertEquals("Updated Namespace URI is not equal", "http://exampleupdated.com", nsContext.getNamespaceURI("foo"));
+    assertEquals( "http://exampleupdated.com", nsContext.getNamespaceURI("foo"));
 
     // stop logging
     nsMgr.stopLogging();
 
     String expectedLogContentMax = "9223372036854775807";
-    assertEquals("Content log is not equal", expectedLogContentMax, Long.toString(logger.getContentMax()));
+    assertEquals( expectedLogContentMax, Long.toString(logger.getContentMax()));
 
     // delete prefix
     nsMgr.deletePrefix("foo");
-    assertTrue("Namespace URI is not deleted", nsMgr.readPrefix("foo") == null);
+    assertTrue( nsMgr.readPrefix("foo") == null);
 
     nsMgr.deleteAll();
-    assertTrue("Namespace URI is not deleted", nsMgr.readPrefix("foo") == null);
+    assertTrue( nsMgr.readPrefix("foo") == null);
 
     // release client
     client.release();
@@ -107,21 +107,21 @@ public class TestNamespaces extends AbstractFunctionalTest {
     // set default namespace
     nsMgr.updatePrefix("defaultns", "http://baz.com");
     String defaultNsUri = nsMgr.readPrefix("defaultns");
-    assertEquals("Default NS is wrong", "http://baz.com", defaultNsUri);
+    assertEquals( "http://baz.com", defaultNsUri);
 
     // delete namespace
     nsMgr.deletePrefix("baz");
     nsMgr.readAll();
 
     // get default namespace
-    assertEquals("Default NS is wrong", "http://baz.com", nsMgr.readPrefix("defaultns"));
+    assertEquals( "http://baz.com", nsMgr.readPrefix("defaultns"));
 
     nsMgr.deleteAll();
     nsMgr.readAll();
-    assertTrue("Namespace URI is not deleted", nsMgr.readPrefix("ns1") == null);
-    assertTrue("Namespace URI is not deleted", nsMgr.readPrefix("ns2") == null);
-    assertTrue("Namespace URI is not deleted", nsMgr.readPrefix("ns3") == null);
-    assertTrue("Namespace URI is not deleted", nsMgr.readPrefix("defaultns") == null);
+    assertTrue( nsMgr.readPrefix("ns1") == null);
+    assertTrue( nsMgr.readPrefix("ns2") == null);
+    assertTrue( nsMgr.readPrefix("ns3") == null);
+    assertTrue( nsMgr.readPrefix("defaultns") == null);
 
     // release client
     client.release();
@@ -145,7 +145,7 @@ public class TestNamespaces extends AbstractFunctionalTest {
 
     // get namespaces
     Collection<String> nameSpaceCollection = patchBldr.getNamespaces().getAllPrefixes();
-    assertEquals("getNamespace failed ", false, nameSpaceCollection.isEmpty());
+    assertEquals(false, nameSpaceCollection.isEmpty());
     for (String prefix : nameSpaceCollection) {
       System.out.println("Prefixes : " + prefix);
       System.out.println(patchBldr.getNamespaces().getNamespaceURI(prefix));
@@ -158,7 +158,7 @@ public class TestNamespaces extends AbstractFunctionalTest {
         + "\n Next xs : " + patchBldr.getNamespaces().getNamespaceURI("xs") + "\n Next xsi : " + patchBldr.getNamespaces().getNamespaceURI("xsi") + "\n Next rapi : "
         + patchBldr.getNamespaces().getNamespaceURI("rapi") + "\n Next new : " + patchBldr.getNamespaces().getNamespaceURI("new"));
     String content = docMgr.read(docId, new StringHandle()).get();
-    assertTrue("setNamespace didn't worked", patchBldr.getNamespaces().getNamespaceURI("new").contains("www.marklogic.com"));
+    assertTrue(patchBldr.getNamespaces().getNamespaceURI("new").contains("www.marklogic.com"));
     System.out.println(content);
 
     // release client

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticEnhancements.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticEnhancements.java
@@ -23,16 +23,15 @@ import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.row.RowManager;
 import com.marklogic.client.type.PlanColumn;
 import com.marklogic.client.type.PlanPrefixer;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class TestOpticEnhancements extends AbstractFunctionalTest {
 
@@ -41,7 +40,7 @@ public class TestOpticEnhancements extends AbstractFunctionalTest {
   private static Map<String, Object>[] storeInformation = new HashMap[4];
   private static Map<String, Object>[] internetSales = new HashMap[4];
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
     removeFieldIndices();
   // Install the TDE templates into schemadbName DB
@@ -195,7 +194,7 @@ public class TestOpticEnhancements extends AbstractFunctionalTest {
     internetSales[3] = row;
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown() {
     restoreFieldIndices();
   }
@@ -238,19 +237,19 @@ public class TestOpticEnhancements extends AbstractFunctionalTest {
       JsonNode jsonBindingsNodes = jacksonHandle.get().path("rows");
       //System.out.println(jsonBindingsNodes);
       // Should have 7 nodes returned.
-      assertEquals("Seven nodes not returned from testRedactRegexJoinInner method", 7, jsonBindingsNodes.size());
+      assertEquals( 7, jsonBindingsNodes.size());
       JsonNode node = jsonBindingsNodes.path(0);
-      assertEquals("Row 1 rowId value incorrect", "1", node.path("rowId").path("value").asText());
-      assertEquals("Row 1 desc value incorrect", "ball", node.path("desc").path("value").asText());
-      assertEquals("Row 1 colorDesc value incorrect", "RED", node.path("colorDesc").path("value").asText());
+      assertEquals( "1", node.path("rowId").path("value").asText());
+      assertEquals( "ball", node.path("desc").path("value").asText());
+      assertEquals( "RED", node.path("colorDesc").path("value").asText());
       node = jsonBindingsNodes.path(3);
-      assertEquals("Row 4 rowId value incorrect", "4", node.path("rowId").path("value").asText());
-      assertEquals("Row 4 desc value incorrect", "hoop", node.path("desc").path("value").asText());
-      assertEquals("Row 4 colorDesc value incorrect", "RED", node.path("colorDesc").path("value").asText());
+      assertEquals( "4", node.path("rowId").path("value").asText());
+      assertEquals( "hoop", node.path("desc").path("value").asText());
+      assertEquals( "RED", node.path("colorDesc").path("value").asText());
       node = jsonBindingsNodes.path(4);
-      assertEquals("Row 5 colorDesc value incorrect", "h=O=", node.path("desc").path("value").asText());
+      assertEquals( "h=O=", node.path("desc").path("value").asText());
       node = jsonBindingsNodes.path(6);
-      assertEquals("Row 7 colorDesc value incorrect", "rameObsolatefMain", node.path("desc").path("value").asText());
+      assertEquals( "rameObsolatefMain", node.path("desc").path("value").asText());
     }
 
   @Test
@@ -290,11 +289,11 @@ public class TestOpticEnhancements extends AbstractFunctionalTest {
     rowMgr.resultDoc(output, jacksonHandle);
     JsonNode jsonBindingsNodes = jacksonHandle.get().path("rows");
     //System.out.println(jsonBindingsNodes);
-    assertEquals("Two node not returned from testRedactDatetime method", 2, jsonBindingsNodes.size());
-    assertEquals("Row 1 id value incorrect", "1", jsonBindingsNodes.path(0).path("id").path("value").asText());
-    assertEquals("Row 1 date value incorrect", "Month=05 Day=12/xx 00:00:00", jsonBindingsNodes.path(0).path("date").path("value").asText());
-    assertEquals("Row 2 id value incorrect", "2", jsonBindingsNodes.path(1).path("id").path("value").asText());
-    assertEquals("Row 2 date value incorrect", "Month=04 Day=02/xx 00:00:00", jsonBindingsNodes.path(1).path("date").path("value").asText());
+    assertEquals( 2, jsonBindingsNodes.size());
+    assertEquals( "1", jsonBindingsNodes.path(0).path("id").path("value").asText());
+    assertEquals( "Month=05 Day=12/xx 00:00:00", jsonBindingsNodes.path(0).path("date").path("value").asText());
+    assertEquals( "2", jsonBindingsNodes.path(1).path("id").path("value").asText());
+    assertEquals( "Month=04 Day=02/xx 00:00:00", jsonBindingsNodes.path(1).path("date").path("value").asText());
   }
 
   @Test
@@ -342,16 +341,16 @@ public class TestOpticEnhancements extends AbstractFunctionalTest {
     Pattern patternMaster = Pattern.compile("[a-z][A-Z][0-9]");
     Pattern patternDetail = Pattern.compile("[a-z]");
 
-    assertEquals("Six node not returned from testMaskDeterministic method", 6, jsonBindingsNodes.size());
+    assertEquals( 6, jsonBindingsNodes.size());
 
     String rowOneMasterName = jsonBindingsNodes.path(0).path("MasterName").path("value").asText();
     String rowOneDetailName = jsonBindingsNodes.path(0).path("DetailName").path("value").asText();
-    assertEquals("Row 1 masterName mask length incorrect", 33, rowOneMasterName.length());
-    assertTrue("Row 1 masterName mask incorrect", patternMaster.matcher(rowOneMasterName).find());
-    assertEquals("Row 1 detailName mask length incorrect", 10, rowOneDetailName.length());
-    assertTrue("Row 1 detailName mask incorrect", patternDetail.matcher(rowOneDetailName).find());
+    assertEquals( 33, rowOneMasterName.length());
+    assertTrue( patternMaster.matcher(rowOneMasterName).find());
+    assertEquals( 10, rowOneDetailName.length());
+    assertTrue( patternDetail.matcher(rowOneDetailName).find());
 
-    assertEquals("Row 1 amount incorrect", "10.01", jsonBindingsNodes.path(0).path("opticFunctionalTest.detail.amount").path("value").asText());
+    assertEquals( "10.01", jsonBindingsNodes.path(0).path("opticFunctionalTest.detail.amount").path("value").asText());
   }
 
   @Test
@@ -385,14 +384,14 @@ public class TestOpticEnhancements extends AbstractFunctionalTest {
     Pattern patternColorId = Pattern.compile("[a-z]");
 
     // Should have 7 nodes returned.
-    assertEquals("Seven nodes not returned from testRedactRegexJoinInner method", 7, jsonBindingsNodes.size());
+    assertEquals( 7, jsonBindingsNodes.size());
     JsonNode node = jsonBindingsNodes.path(0);
     String rowOneDescName = jsonBindingsNodes.path(0).path("desc").path("value").asText();
-    assertTrue("Row 1 desc mask incorrect", patternDesc.matcher(rowOneDescName).find());
+    assertTrue( patternDesc.matcher(rowOneDescName).find());
 
     node = jsonBindingsNodes.path(3);
     String rowFourcolorId = jsonBindingsNodes.path(0).path("colorId").path("value").asText();
-    assertTrue("Row 4 color Id mask incorrect", patternColorId.matcher(rowFourcolorId).find());
+    assertTrue( patternColorId.matcher(rowFourcolorId).find());
   }
 
   @Test
@@ -458,22 +457,22 @@ public class TestOpticEnhancements extends AbstractFunctionalTest {
     Pattern patternAge = Pattern.compile("(\\d)+,(\\d)+");
 
     // Should have 2 nodes returned.
-    assertEquals("Two nodes not returned from testJoinInnerWithCondition method ", 2, jsonBindingsNodes.size());
+    assertEquals( 2, jsonBindingsNodes.size());
     JsonNode first = jsonBindingsNodes.path(0);
 
     String rowOneTeamName = jsonBindingsNodes.path(0).path("TeamName").path("value").asText();
     String rowOnePlayerAge = jsonBindingsNodes.path(0).path("PlayerAge").path("value").asText();
 
-    assertEquals("Row 1 PlayerName value incorrect", "Josh Ream", first.path("PlayerName").path("value").asText());
-    assertTrue("Row 1  Team value mask incorrect",  patternName.matcher(rowOneTeamName).find());
-    assertTrue("Row 1 PlayerAge mask incorrect", patternAge.matcher(rowOnePlayerAge).find());
+    assertEquals( "Josh Ream", first.path("PlayerName").path("value").asText());
+    assertTrue(  patternName.matcher(rowOneTeamName).find());
+    assertTrue( patternAge.matcher(rowOnePlayerAge).find());
 
     JsonNode second = jsonBindingsNodes.path(1);
     String rowTwoTeamName = jsonBindingsNodes.path(1).path("TeamName").path("value").asText();
     String rowTwoPlayerAge = jsonBindingsNodes.path(1).path("PlayerAge").path("value").asText();
 
-    assertEquals("Row 2 PlayerName value incorrect", "John Doe", second.path("PlayerName").path("value").asText());
-    assertTrue("Row 2  Team value mask value incorrect",  patternName.matcher(rowTwoTeamName).find());
-    assertTrue("Row 2 PlayerAge mask incorrect", patternAge.matcher(rowTwoPlayerAge).find());
+    assertEquals( "John Doe", second.path("PlayerName").path("value").asText());
+    assertTrue(  patternName.matcher(rowTwoTeamName).find());
+    assertTrue( patternAge.matcher(rowTwoPlayerAge).find());
   }
 }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnCtsQuery.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnCtsQuery.java
@@ -26,8 +26,9 @@ import com.marklogic.client.row.RowManager;
 import com.marklogic.client.row.RowRecord;
 import com.marklogic.client.row.RowSet;
 import com.marklogic.client.type.*;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 import org.xml.sax.SAXException;
 
 import javax.xml.parsers.ParserConfigurationException;
@@ -38,11 +39,9 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
-import static org.junit.Assert.*;
-
 public class TestOpticOnCtsQuery extends AbstractFunctionalTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
       // Install the TDE templates
       // loadFileToDB(client, filename, docURI, collection, document format)
@@ -81,7 +80,7 @@ public class TestOpticOnCtsQuery extends AbstractFunctionalTest {
    * jsonPropertyWordQuery on fromViews. plan1 uses fromView plan2 use fromView
    */
   @Test
-  public void testJsonPropertyWordQuery() throws KeyManagementException, NoSuchAlgorithmException, IOException, SAXException, ParserConfigurationException
+  public void testJsonPropertyWordQuery()
   {
     System.out.println("In testJsonPropertyWordQuery method");
 
@@ -104,16 +103,16 @@ public class TestOpticOnCtsQuery extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get();
 
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
-    assertTrue("Number of Elements after plan execution is incorrect. Should be 3", 3 == jsonBindingsNodes.size());
-    assertEquals("Row 1 opticFunctionalTest4.detail4.id value incorrect", "100", jsonBindingsNodes.path(0).path("opticFunctionalTest4.detail4.id").path("value").asText());
-    assertEquals("Row 1 opticFunctionalTest4.master4.name value incorrect", "Master 100", jsonBindingsNodes.path(0).path("opticFunctionalTest4.master4.name").path("value")
+    assertTrue( 3 == jsonBindingsNodes.size());
+    assertEquals( "100", jsonBindingsNodes.path(0).path("opticFunctionalTest4.detail4.id").path("value").asText());
+    assertEquals( "Master 100", jsonBindingsNodes.path(0).path("opticFunctionalTest4.master4.name").path("value")
         .asText());
-    assertEquals("Row 2 opticFunctionalTest4.detail4.name value incorrect", "Detail 200", jsonBindingsNodes.path(1).path("opticFunctionalTest4.detail4.name").path("value")
+    assertEquals( "Detail 200", jsonBindingsNodes.path(1).path("opticFunctionalTest4.detail4.name").path("value")
         .asText());
-    assertEquals("Row 2 opticFunctionalTest4.master4.date value incorrect", "2016-04-02", jsonBindingsNodes.path(1).path("opticFunctionalTest4.master4.date").path("value")
+    assertEquals( "2016-04-02", jsonBindingsNodes.path(1).path("opticFunctionalTest4.master4.date").path("value")
         .asText());
-    assertEquals("Row 3 opticFunctionalTest4.detail4.amount value incorrect", "72.9", jsonBindingsNodes.path(2).path("opticFunctionalTest4.detail4.amount").path("value").asText());
-    assertEquals("Row 3 opticFunctionalTest4.detail4.color value incorrect", "yellow", jsonBindingsNodes.path(2).path("opticFunctionalTest4.detail4.color").path("value").asText());
+    assertEquals( "72.9", jsonBindingsNodes.path(2).path("opticFunctionalTest4.detail4.amount").path("value").asText());
+    assertEquals( "yellow", jsonBindingsNodes.path(2).path("opticFunctionalTest4.detail4.color").path("value").asText());
   }
 
   /*
@@ -135,7 +134,7 @@ public class TestOpticOnCtsQuery extends AbstractFunctionalTest {
      * p.cts.jsonPropertyReference("date")); index1.put("distance",
      * p.cts.jsonPropertyReference("distance")); index1.put("point",
      * p.cts.jsonPropertyReference("latLonPoint"));
-     * 
+     *
      * Map<String, CtsReferenceExpr>index2 = new HashMap<String,
      * CtsReferenceExpr>(); index2.put("uri2", p.cts.uriReference());
      * index2.put("cityName", p.cts.jsonPropertyReference("cityName"));
@@ -146,26 +145,26 @@ public class TestOpticOnCtsQuery extends AbstractFunctionalTest {
      * // plan2 - fromLexicons ModifyPlan plan2 = p.fromLexicons(index2,
      * "myTeam", p.fragmentIdCol("fragId2"),
      * p.cts.jsonPropertyValueQuery("cityTeam", p.xs.string("yankee")));
-     * 
+     *
      * ModifyPlan output2 = plan1.joinInner(plan2)
      * .where(p.eq(p.viewCol("myCity", "city"), p.col("cityName")))
      * .orderBy(p.asc(p.col("date")));
-     * 
+     *
      * JacksonHandle jacksonHandle = new JacksonHandle();
      * jacksonHandle.setMimetype("application/json"); rowMgr.resultDoc(output2,
      * jacksonHandle); JsonNode jsonResults = jacksonHandle.get();
-     * 
+     *
      * JsonNode jsonBindingsNodes = jsonResults.path("rows");
-     * 
+     *
      * assertTrue(
      * "Number of Elements after plan execution is incorrect. Should be 1", 1 ==
      * jsonBindingsNodes.size());
-     * assertEquals("Row 1 myCity.city value incorrect", "new york",
+     * assertEquals( "new york",
      * jsonBindingsNodes.path(0).path("myCity.city").path("value").asText());
-     * assertEquals("Row 1 myCity.point value incorrect",
+     * assertEquals(
      * "40.709999,-74.009995",
      * jsonBindingsNodes.path(0).path("myCity.point").path("value").asText());
-     * assertEquals("Row 1 myTeam.uri2 value incorrect",
+     * assertEquals(
      * "/optic/lexicon/test/city2.json",
      * jsonBindingsNodes.path(0).path("myTeam.uri2").path("value").asText());
      */
@@ -179,7 +178,7 @@ public class TestOpticOnCtsQuery extends AbstractFunctionalTest {
   public void testJsonPropertyGeospatialQuery() throws KeyManagementException, NoSuchAlgorithmException, IOException, SAXException, ParserConfigurationException
   {/*
     * System.out.println("In testJsonPropertyGeospatialQuery method");
-    * 
+    *
     * // Create a new Plan. RowManager rowMgr = client.newRowManager();
     * PlanBuilder p = rowMgr.newPlanBuilder(); Map<String,
     * CtsReferenceExpr>index1 = new HashMap<String, CtsReferenceExpr>();
@@ -189,37 +188,37 @@ public class TestOpticOnCtsQuery extends AbstractFunctionalTest {
     * p.cts.jsonPropertyReference("date")); index1.put("distance",
     * p.cts.jsonPropertyReference("distance")); index1.put("point",
     * p.cts.jsonPropertyReference("latLonPoint"));
-    * 
+    *
     * Map<String, CtsReferenceExpr>index2 = new HashMap<String,
     * CtsReferenceExpr>(); index2.put("uri2", p.cts.uriReference());
     * index2.put("cityName", p.cts.jsonPropertyReference("cityName"));
     * index2.put("cityTeam", p.cts.jsonPropertyReference("cityTeam"));
-    * 
+    *
     * // plan1 - fromLexicons PlanSystemColumn fIdCol1 =
     * p.fragmentIdCol("fragId1"); PlanSystemColumn fIdCol2 =
     * p.fragmentIdCol("fragId2"); QualifiedPlan plan1 = p.fromLexicons(index1,
     * "myCity", fIdCol1, p.cts.jsonPropertyGeospatialQuery("latLonPoint",
     * p.cts.box(49.16, -13.41, 60.85, 1.76))); // plan2 - fromLexicons
     * QualifiedPlan plan2 = p.fromLexicons(index2, "myTeam", fIdCol2, null);
-    * 
+    *
     * ModifyPlan output = plan1.joinInner(plan2) .where(p.eq(p.viewCol("myCity",
     * "city"), p.col("cityName"))) .orderBy(p.asc(p.col("date")));
-    * 
+    *
     * JacksonHandle jacksonHandle = new JacksonHandle();
     * jacksonHandle.setMimetype("application/json");
-    * 
+    *
     * rowMgr.resultDoc(output, jacksonHandle); JsonNode jsonResults =
     * jacksonHandle.get();
-    * 
+    *
     * JsonNode jsonBindingsNodes = jsonResults.path("rows");
     * assertTrue("Number of Elements after plan execution is incorrect. Should be 1"
     * , 1 == jsonBindingsNodes.size());
-    * assertEquals("Row 1 myCity.city value incorrect", "london",
+    * assertEquals( "london",
     * jsonBindingsNodes.path(0).path("myCity.city").path("value").asText());
-    * assertEquals("Row 1 myCity.uri1 value incorrect",
+    * assertEquals(
     * "/optic/lexicon/test/doc1.json",
     * jsonBindingsNodes.path(0).path("myCity.uri1").path("value").asText());
-    * assertEquals("Row 1 myTeam.uri2 value incorrect",
+    * assertEquals(
     * "/optic/lexicon/test/city1.json",
     * jsonBindingsNodes.path(0).path("myTeam.uri2").path("value").asText());
     */
@@ -233,44 +232,44 @@ public class TestOpticOnCtsQuery extends AbstractFunctionalTest {
   public void testWordQueryPropertyValueQueryFromViews() throws KeyManagementException, NoSuchAlgorithmException, IOException, SAXException, ParserConfigurationException
   {/*
     * System.out.println("In testWordQueryPropertyValueQueryFromViews method");
-    * 
+    *
     * // Create a new Plan. RowManager rowMgr = client.newRowManager();
     * PlanBuilder p = rowMgr.newPlanBuilder(); PlanPrefixer bb =
     * p.prefixer("http://marklogic.com/baseball/players");
-    * 
+    *
     * // plan1 - fromView ModifyPlan plan1 = p.fromView("opticFunctionalTest4",
     * "detail4", null, null, p.cts.jsonPropertyValueQuery("id",
     * p.xs.string("600")) ); // plan2 - fromView ModifyPlan plan2 =
     * p.fromView("opticFunctionalTest4", "master4", null, null,
     * p.cts.wordQuery("Master 100") );
-    * 
+    *
     * ModifyPlan output = plan1.joinInner(plan2,
     * p.on(p.schemaCol("opticFunctionalTest4", "detail4", "masterId"),
     * p.schemaCol("opticFunctionalTest4", "master4", "id")))
     * .orderBy(p.schemaCol("opticFunctionalTest4", "detail4", "id"));
-    * 
+    *
     * JacksonHandle jacksonHandle = new JacksonHandle();
     * jacksonHandle.setMimetype("application/json");
-    * 
+    *
     * rowMgr.resultDoc(output, jacksonHandle); JsonNode jsonResults =
     * jacksonHandle.get();
-    * 
+    *
     * JsonNode jsonBindingsNodes = jsonResults.path("rows");
     * assertTrue("Number of Elements after plan execution is incorrect. Should be 3"
     * , 3 == jsonBindingsNodes.size());
-    * assertEquals("Row 1 opticFunctionalTest4.detail4.id value incorrect",
+    * assertEquals(
     * "400",
     * jsonBindingsNodes.path(0).path("opticFunctionalTest4.detail4.id").path
     * ("value").asText());
-    * assertEquals("Row 1 opticFunctionalTest4.master4.name value incorrect",
+    * assertEquals(
     * "Master 200",
     * jsonBindingsNodes.path(0).path("opticFunctionalTest4.master4.name"
     * ).path("value").asText());
-    * assertEquals("Row 3 opticFunctionalTest4.detail4.id value incorrect",
+    * assertEquals(
     * "600",
     * jsonBindingsNodes.path(2).path("opticFunctionalTest4.detail4.id").path
     * ("value").asText());
-    * assertEquals("Row 3 opticFunctionalTest4.master4.name value incorrect",
+    * assertEquals(
     * "Master 100",
     * jsonBindingsNodes.path(2).path("opticFunctionalTest4.master4.name"
     * ).path("value").asText());
@@ -320,10 +319,10 @@ public class TestOpticOnCtsQuery extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get();
 
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
-    assertEquals("Unexpected result: " + jsonBindingsNodes.toPrettyString(), 1, jsonBindingsNodes.size());
-    assertEquals("Row 1 myCity.city value incorrect", "london", jsonBindingsNodes.path(0).path("myCity.city").path("value").asText());
-    assertEquals("Row 1 myCity.uri1 value incorrect", "/optic/lexicon/test/doc1.json", jsonBindingsNodes.path(0).path("myCity.uri1").path("value").asText());
-    assertEquals("Row 1 myTeam.uri2 value incorrect", "/optic/lexicon/test/city1.json", jsonBindingsNodes.path(0).path("myTeam.uri2").path("value").asText());
+    assertEquals(1, jsonBindingsNodes.size(), "Unexpected result: " + jsonBindingsNodes.toPrettyString());
+    assertEquals("london", jsonBindingsNodes.path(0).path("myCity.city").path("value").asText());
+    assertEquals("/optic/lexicon/test/doc1.json", jsonBindingsNodes.path(0).path("myCity.uri1").path("value").asText());
+    assertEquals("/optic/lexicon/test/city1.json", jsonBindingsNodes.path(0).path("myTeam.uri2").path("value").asText());
   }
 
   /*
@@ -368,8 +367,8 @@ public class TestOpticOnCtsQuery extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
     System.out.println("Results are " + jsonBindingsNodes.toString());
 
-    assertEquals("Number of Elements after plan execution is incorrect: " + jsonBindingsNodes.toPrettyString(), 1, jsonBindingsNodes.size());
-    assertEquals("Row 1 myCity.city value incorrect", "new york", jsonBindingsNodes.path(0).path("myCity.city").path("value").asText());
+    assertEquals(1, jsonBindingsNodes.size(), "Number of Elements after plan execution is incorrect: " + jsonBindingsNodes.toPrettyString());
+    assertEquals("new york", jsonBindingsNodes.path(0).path("myCity.city").path("value").asText());
   }
 
   /*
@@ -406,12 +405,12 @@ public class TestOpticOnCtsQuery extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get();
 
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
-    assertTrue("Number of Elements after plan execution is incorrect. Should be 3", 3 == jsonBindingsNodes.size());
-    assertEquals("Row 1 opticFunctionalTest4.detail4.id value incorrect", "400", jsonBindingsNodes.path(0).path("opticFunctionalTest4.detail4.id").path("value").asText());
-    assertEquals("Row 1 opticFunctionalTest4.master4.name value incorrect", "Master 200", jsonBindingsNodes.path(0).path("opticFunctionalTest4.master4.name").path("value")
+    assertTrue( 3 == jsonBindingsNodes.size());
+    assertEquals( "400", jsonBindingsNodes.path(0).path("opticFunctionalTest4.detail4.id").path("value").asText());
+    assertEquals( "Master 200", jsonBindingsNodes.path(0).path("opticFunctionalTest4.master4.name").path("value")
         .asText());
-    assertEquals("Row 3 opticFunctionalTest4.detail4.id value incorrect", "600", jsonBindingsNodes.path(2).path("opticFunctionalTest4.detail4.id").path("value").asText());
-    assertEquals("Row 3 opticFunctionalTest4.master4.name value incorrect", "Master 100", jsonBindingsNodes.path(2).path("opticFunctionalTest4.master4.name").path("value")
+    assertEquals( "600", jsonBindingsNodes.path(2).path("opticFunctionalTest4.detail4.id").path("value").asText());
+    assertEquals( "Master 100", jsonBindingsNodes.path(2).path("opticFunctionalTest4.master4.name").path("value")
         .asText());
   }
 
@@ -464,19 +463,19 @@ public class TestOpticOnCtsQuery extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get();
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
     boolean isML11OrHigher = MarkLogicVersion.getMarkLogicVersion(client).getMajor() >= 11;
-    assertTrue("Number of Elements after plan execution is incorrect. Should be 3", 3 == jsonBindingsNodes.size());
-    assertEquals("Row 1 myCity.city value incorrect", "beijing", jsonBindingsNodes.path(0).path("myCity.city").path("value").asText());
-    assertEquals("Row 1 myCity.point value incorrect", toWKT(isML11OrHigher, "39.900002,116.4"), jsonBindingsNodes.path(0).path("myCity.point").path("value").asText());
-    assertEquals("Row 2 myCity.city value incorrect", "cape town", jsonBindingsNodes.path(1).path("myCity.city").path("value").asText());
-    assertEquals("Row 2 myCity.point value incorrect", toWKT(isML11OrHigher, "-33.91,18.42"), jsonBindingsNodes.path(1).path("myCity.point").path("value").asText());
-    assertEquals("Row 3 myCity.city value incorrect", "london", jsonBindingsNodes.path(2).path("myCity.city").path("value").asText());
-    assertEquals("Row 3 myCity.point value incorrect", toWKT(isML11OrHigher, "51.5,-0.12"), jsonBindingsNodes.path(2).path("myCity.point").path("value").asText());
+    assertTrue( 3 == jsonBindingsNodes.size());
+    assertEquals( "beijing", jsonBindingsNodes.path(0).path("myCity.city").path("value").asText());
+    assertEquals( toWKT(isML11OrHigher, "39.900002,116.4"), jsonBindingsNodes.path(0).path("myCity.point").path("value").asText());
+    assertEquals( "cape town", jsonBindingsNodes.path(1).path("myCity.city").path("value").asText());
+    assertEquals( toWKT(isML11OrHigher, "-33.91,18.42"), jsonBindingsNodes.path(1).path("myCity.point").path("value").asText());
+    assertEquals( "london", jsonBindingsNodes.path(2).path("myCity.city").path("value").asText());
+    assertEquals( toWKT(isML11OrHigher, "51.5,-0.12"), jsonBindingsNodes.path(2).path("myCity.point").path("value").asText());
 
     // Verify exported string with QNAME - with random checks
-    assertTrue("Function not available fromLexicons in exported plan", str.contains("\"fn\":\"from-lexicons\""));
-    assertTrue("Function not available fromLexicons in exported plan",
+    assertTrue( str.contains("\"fn\":\"from-lexicons\""));
+    assertTrue(
         str.contains("\"fn\":\"fragment-id-col\", \"args\":[{\"ns\":\"xs\", \"fn\":\"string\", \"args\":[\"fragId1\"]"));
-    assertTrue("Function not available fromLexicons in exported plan", str.contains("\"fn\":\"QName\", \"args\":[\"metro\"]"));
+	  assertTrue(str.contains("\"fn\":\"QName\", \"args\":[\"metro\"]"));
   }
 
   private String toWKT(boolean isML11OrHigher, String latLon) {
@@ -534,7 +533,7 @@ public class TestOpticOnCtsQuery extends AbstractFunctionalTest {
         System.out.println("Exception message is " + strNull.toString());
      }
      // Should have NullPointerException.
-    assertTrue("Exceptions not found", strNull.toString().contains("null"));
+    assertTrue( strNull.toString().contains("null"));
   }
 
   /*
@@ -580,12 +579,12 @@ public class TestOpticOnCtsQuery extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get();
 
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
-    assertTrue("Number of Elements after plan execution is incorrect. Should be 3", 3 == jsonBindingsNodes.size());
-    assertEquals("Row 1 opticFunctionalTest4.detail4.id value incorrect", "400", jsonBindingsNodes.path(0).path("opticFunctionalTest4.detail4.id").path("value").asText());
-    assertEquals("Row 1 opticFunctionalTest4.master4.name value incorrect", "Master 200", jsonBindingsNodes.path(0).path("opticFunctionalTest4.master4.name").path("value")
+    assertTrue( 3 == jsonBindingsNodes.size());
+    assertEquals( "400", jsonBindingsNodes.path(0).path("opticFunctionalTest4.detail4.id").path("value").asText());
+    assertEquals( "Master 200", jsonBindingsNodes.path(0).path("opticFunctionalTest4.master4.name").path("value")
         .asText());
-    assertEquals("Row 3 opticFunctionalTest4.detail4.id value incorrect", "600", jsonBindingsNodes.path(2).path("opticFunctionalTest4.detail4.id").path("value").asText());
-    assertEquals("Row 3 opticFunctionalTest4.master4.name value incorrect", "Master 100", jsonBindingsNodes.path(2).path("opticFunctionalTest4.master4.name").path("value")
+    assertEquals( "600", jsonBindingsNodes.path(2).path("opticFunctionalTest4.detail4.id").path("value").asText());
+    assertEquals( "Master 100", jsonBindingsNodes.path(2).path("opticFunctionalTest4.master4.name").path("value")
         .asText());
   }
 
@@ -627,7 +626,7 @@ public class TestOpticOnCtsQuery extends AbstractFunctionalTest {
 
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
     // Make sure that nested and queries do not blow up the plan.
-    assertTrue("Number of Elements after plan execution is incorrect. Should be 6", 6 == jsonBindingsNodes.size());
+    assertTrue( 6 == jsonBindingsNodes.size());
   }
 
   /*
@@ -660,18 +659,18 @@ public class TestOpticOnCtsQuery extends AbstractFunctionalTest {
     while (rowItr.hasNext()) {
       rCount++;
       record = rowItr.next();
-      assertTrue("Element 1 RowSet Iterator value incorrect", record.getInt("score") > 0);
-      assertEquals("Element 1 RowSet Iterator value incorrect", 100, record.getInt("masterId"));
-      assertEquals("Element 1 RowSet Iterator value incorrect", "white", record.getString("color"));
-      assertEquals("Element 1 RowSet Iterator value incorrect", "Detail 600", record.getString("name"));
-      assertEquals("Element 1 RowSet Iterator value incorrect", 600, record.getInt("id"));
-      assertEquals("Element 1 RowSet Iterator value incorrect", "/optic/view/test/masterDetail5.json", record.getString("uri"));
+      assertTrue( record.getInt("score") > 0);
+      assertEquals(100, record.getInt("masterId"));
+      assertEquals("white", record.getString("color"));
+      assertEquals("Detail 600", record.getString("name"));
+      assertEquals(600, record.getInt("id"));
+      assertEquals("/optic/view/test/masterDetail5.json", record.getString("uri"));
     }
     if (rCount == 0) {
       fail("Could not traverse Iterator<RowRecord> in testfromSearch method");
     }
     else {
-      assertEquals("Incorrect count of records", 1, rCount);
+      assertEquals(1, rCount);
     }
   }
 
@@ -731,13 +730,13 @@ public class TestOpticOnCtsQuery extends AbstractFunctionalTest {
       score = record.getContainer("score").asInt();
 
       System.out.println("Results " + record.toString());
-      assertTrue("Element score RowSet Iterator value incorrect", score > 0);
-      assertEquals("Element masterId of RowSet incorrect", masterid[rCount], record.getInt("opticFunctionalTest.detail.masterId"));
-      assertEquals("Element detailId of RowSet incorrect", detailid[rCount], record.getInt("opticFunctionalTest.detail.id"));
+      assertTrue( score > 0);
+      assertEquals(masterid[rCount], record.getInt("opticFunctionalTest.detail.masterId"));
+      assertEquals(detailid[rCount], record.getInt("opticFunctionalTest.detail.id"));
 
-      assertEquals("Element color of RowSet incorrect", color[rCount], record.getString("opticFunctionalTest.detail.color"));
-      assertEquals("Element name of RowSet incorrect", detname[rCount], record.getString("opticFunctionalTest.detail.name"));
-      assertEquals("Element color of RowSet incorrect", amount[rCount], record.getDouble("opticFunctionalTest.detail.amount"), 0.0);
+      assertEquals(color[rCount], record.getString("opticFunctionalTest.detail.color"));
+      assertEquals(detname[rCount], record.getString("opticFunctionalTest.detail.name"));
+      assertEquals(amount[rCount], record.getDouble("opticFunctionalTest.detail.amount"), 0.0);
 
       rCount++;
     }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnFromSparql.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnFromSparql.java
@@ -25,17 +25,17 @@ import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.row.RowManager;
 import com.marklogic.client.semantics.GraphManager;
 import com.marklogic.client.semantics.RDFMimeTypes;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 import org.xml.sax.SAXException;
 
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.File;
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
 
 public class TestOpticOnFromSparql extends AbstractFunctionalTest {
 
@@ -47,19 +47,19 @@ public class TestOpticOnFromSparql extends AbstractFunctionalTest {
   private JsonNode jsonBindingsNodes;
   private JsonNode node;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() throws Exception {
         removeFieldIndices();
         loadGraphToDB(client, "people.ttl", "/optic/sparql/test/people.ttl");
         loadGraphToDB(client, "companies_100.ttl", "/optic/sparql/test/companies.ttl");
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDown() {
         restoreFieldIndices();
     }
 
-  @Before
+  @BeforeEach
   public void setUpBeforTest() {
 
 	  rowMgr = client.newRowManager();
@@ -67,11 +67,11 @@ public class TestOpticOnFromSparql extends AbstractFunctionalTest {
 	  jacksonHandle.setMimetype("application/json");
 
   }
-  
+
 
   /**
    * Write graph
-   * 
+   *
    * @param client
    * @param filename
    * @param uri
@@ -92,7 +92,7 @@ public class TestOpticOnFromSparql extends AbstractFunctionalTest {
     // create a handle on the content
     FileHandle handle = new FileHandle(file).withMimetype(RDFMimeTypes.TURTLE);
     handle.set(file);
-    
+
     gmgr.setDefaultMimetype(RDFMimeTypes.TURTLE);
     gmgr.writeAs(
     		uri, handle);
@@ -100,14 +100,14 @@ public class TestOpticOnFromSparql extends AbstractFunctionalTest {
     System.out.println("Write " + uri + " to database");
   }
 
-  
+
   /*
    * 1) Test simple sparql select 2) Test simple sparql select with limit 3) Test simple sparql select with offsetLimit
    * 4) Test simple sparql select with offsetLimit 5) Test simple sparql select with offset 6) Test sparql select with multiple triple patterns
    * 7) Test sparql select with multiple triple patterns with condition 8) Test sparql select with order by
-   * 9) Test sparql aggregate on count 10) 
+   * 9) Test sparql aggregate on count 10)
    */
-  
+
   // Test 1
   @Test
   public void testSimpleSparqlSelect() throws Exception
@@ -121,10 +121,10 @@ public class TestOpticOnFromSparql extends AbstractFunctionalTest {
 	    rowMgr.resultDoc(plan1, jacksonHandle);
 	    jsonBindingsNodes = jacksonHandle.get().path("rows");
 	    node = jsonBindingsNodes.path(0);
-	    assertEquals(" nodes not returned from testSimpleSparqlSelect method", 22, jsonBindingsNodes.size());
-	    assertEquals("Row 1 rowId value incorrect", "http://people.org/person1", node.path("s").path("value").asText());
+	    assertEquals( 22, jsonBindingsNodes.size());
+	    assertEquals( "http://people.org/person1", node.path("s").path("value").asText());
   }
-  
+
   //Test 2
   @Test
   public void testSimpleSparqlSelectWithLimit() throws Exception
@@ -138,10 +138,10 @@ public class TestOpticOnFromSparql extends AbstractFunctionalTest {
     rowMgr.resultDoc(plan1, jacksonHandle);
     jsonBindingsNodes = jacksonHandle.get().path("rows");
     node = jsonBindingsNodes.path(0);
-    assertEquals(" nodes not returned from testSimpleSparqlSelectWithLimit method", 10, jsonBindingsNodes.size());
-    assertEquals("Row 1 rowId value incorrect", "http://people.org/person1", node.path("s").path("value").asText());
+    assertEquals( 10, jsonBindingsNodes.size());
+    assertEquals( "http://people.org/person1", node.path("s").path("value").asText());
   }
-  
+
 //Test 3
   @Test
   public void testSimpleSparqlSelectWithOffsetLimit_1() throws Exception
@@ -155,9 +155,9 @@ public class TestOpticOnFromSparql extends AbstractFunctionalTest {
     rowMgr.resultDoc(plan1, jacksonHandle);
     jsonBindingsNodes = jacksonHandle.get().path("rows");
     node = jsonBindingsNodes.path(0);
-    assertEquals(" nodes not returned from testSimpleSparqlSelectWithOffsetLimit_1 method", 15, jsonBindingsNodes.size()); 
+    assertEquals(15, jsonBindingsNodes.size());
   }
-  
+
 //Test 4
   @Test
   public void testSimpleSparqlSelectWithOffsetLimit_2() throws Exception
@@ -171,9 +171,9 @@ public class TestOpticOnFromSparql extends AbstractFunctionalTest {
     rowMgr.resultDoc(plan1, jacksonHandle);
     jsonBindingsNodes = jacksonHandle.get().path("rows");
     node = jsonBindingsNodes.path(0);
-    assertEquals(" nodes not returned from testSimpleSparqlSelectWithOffsetLimit_2 method", 11, jsonBindingsNodes.size()); 
+    assertEquals(11, jsonBindingsNodes.size());
   }
-  
+
 //Test 5
   @Test
   public void testSimpleSparqlSelectWithOffset() throws Exception
@@ -187,385 +187,385 @@ public class TestOpticOnFromSparql extends AbstractFunctionalTest {
     rowMgr.resultDoc(plan1, jacksonHandle);
     jsonBindingsNodes = jacksonHandle.get().path("rows");
     node = jsonBindingsNodes.path(0);
-    assertEquals(" nodes not returned from testSimpleSparqlSelectWithOffset method", 7, jsonBindingsNodes.size()); 
+    assertEquals( 7, jsonBindingsNodes.size());
   }
-  
+
 //Test 6
   @Test
   public void testSimpleSparqlSelectWithMultipleTriplePattern() throws Exception
   {
-	selectStmt = "PREFIX foaf: <http://xmlns.com/foaf/0.1/>\r\n" + 
-			"PREFIX ppl:  <http://people.org/>\r\n" + 
-			"          SELECT *\r\n" + 
-			"          WHERE {\r\n" + 
-			"            ?person foaf:name ?name .\r\n" + 
-			"            ?person <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .\r\n" + 
+	selectStmt = "PREFIX foaf: <http://xmlns.com/foaf/0.1/>\r\n" +
+			"PREFIX ppl:  <http://people.org/>\r\n" +
+			"          SELECT *\r\n" +
+			"          WHERE {\r\n" +
+			"            ?person foaf:name ?name .\r\n" +
+			"            ?person <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .\r\n" +
 			"          }";
     plan1 = p.fromSparql(selectStmt).limit(5);
     rowMgr.resultDoc(plan1, jacksonHandle);
     jsonBindingsNodes = jacksonHandle.get().path("rows");
     node = jsonBindingsNodes.path(0);
-    assertEquals(" nodes not returned from testSimpleSparqlSelectWithMultipleTriplePattern method", 5, jsonBindingsNodes.size()); 
-    assertEquals("Row 1 rowId value incorrect", "http://people.org/person1", node.path("person").path("value").asText());
-    assertEquals("Row 1 rowId value incorrect", "Person 1", node.path("name").path("value").asText());
-    assertEquals("Row 1 rowId value incorrect", "http://people.org/Person", node.path("type").path("value").asText());
+    assertEquals( 5, jsonBindingsNodes.size());
+    assertEquals( "http://people.org/person1", node.path("person").path("value").asText());
+    assertEquals( "Person 1", node.path("name").path("value").asText());
+    assertEquals( "http://people.org/Person", node.path("type").path("value").asText());
   }
-  
+
 //Test 7
   @Test
   public void testSimpleSparqlSelectWithMultipleTriplePatternWithCondition() throws Exception
   {
-	selectStmt = "PREFIX foaf: <http://xmlns.com/foaf/0.1/>\r\n" + 
-			"PREFIX ppl:  <http://people.org/>\r\n" + 
-			"SELECT ?personA ?personB\r\n" + 
-			"WHERE {\r\n" + 
-			"?personB foaf:name 'Person 7' .\r\n" + 
-			"?personA foaf:knows ?personB\r\n" + 
+	selectStmt = "PREFIX foaf: <http://xmlns.com/foaf/0.1/>\r\n" +
+			"PREFIX ppl:  <http://people.org/>\r\n" +
+			"SELECT ?personA ?personB\r\n" +
+			"WHERE {\r\n" +
+			"?personB foaf:name 'Person 7' .\r\n" +
+			"?personA foaf:knows ?personB\r\n" +
 			"}";
     plan1 = p.fromSparql(selectStmt);
     rowMgr.resultDoc(plan1, jacksonHandle);
     jsonBindingsNodes = jacksonHandle.get().path("rows");
     node = jsonBindingsNodes.path(0);
-    assertEquals(" nodes not returned from testSimpleSparqlSelectWithMultipleTriplePatternWithCondition method", 1, jsonBindingsNodes.size()); 
-    assertEquals("Row 1 rowId value incorrect", "http://people.org/person1", node.path("personA").path("value").asText());
-    assertEquals("Row 1 rowId value incorrect", "http://people.org/person7", node.path("personB").path("value").asText());
+    assertEquals( 1, jsonBindingsNodes.size());
+    assertEquals( "http://people.org/person1", node.path("personA").path("value").asText());
+    assertEquals( "http://people.org/person7", node.path("personB").path("value").asText());
   }
-  
+
 //Test 8
   @Test
   public void testSimpleSparqlSelectWithOrderBy() throws Exception
   {
-	selectStmt = "PREFIX foaf: <http://xmlns.com/foaf/0.1/>\r\n" + 
-			"PREFIX ppl:  <http://people.org/>\r\n" + 
-			"SELECT *\r\n" + 
-			"WHERE {\r\n" + 
-			"?person foaf:name ?name .\r\n" + 
-			"?person <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .\r\n" + 
-			"}\r\n" + 
+	selectStmt = "PREFIX foaf: <http://xmlns.com/foaf/0.1/>\r\n" +
+			"PREFIX ppl:  <http://people.org/>\r\n" +
+			"SELECT *\r\n" +
+			"WHERE {\r\n" +
+			"?person foaf:name ?name .\r\n" +
+			"?person <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .\r\n" +
+			"}\r\n" +
 			"ORDER BY ?name";
     plan1 = p.fromSparql(selectStmt).limit(15).offset(11);
     rowMgr.resultDoc(plan1, jacksonHandle);
     jsonBindingsNodes = jacksonHandle.get().path("rows");
     node = jsonBindingsNodes.path(0);
-    assertEquals(" nodes not returned from testSimpleSparqlSelectWithOrderBy method", 4, jsonBindingsNodes.size()); 
-    assertEquals("Row 1 rowId value incorrect", "http://people.org/person2", node.path("person").path("value").asText());
-    assertEquals("Row 1 rowId value incorrect", "Person 2", node.path("name").path("value").asText());
-    assertEquals("Row 1 rowId value incorrect", "http://people.org/Person", node.path("type").path("value").asText());
+    assertEquals( 4, jsonBindingsNodes.size());
+    assertEquals( "http://people.org/person2", node.path("person").path("value").asText());
+    assertEquals( "Person 2", node.path("name").path("value").asText());
+    assertEquals( "http://people.org/Person", node.path("type").path("value").asText());
     node = jsonBindingsNodes.path(3);
-    assertEquals("Row 1 rowId value incorrect", "http://people.org/person4", node.path("person").path("value").asText());
-    assertEquals("Row 1 rowId value incorrect", "Person 4", node.path("name").path("value").asText());
-    assertEquals("Row 1 rowId value incorrect", "http://people.org/Person", node.path("type").path("value").asText());
+    assertEquals( "http://people.org/person4", node.path("person").path("value").asText());
+    assertEquals( "Person 4", node.path("name").path("value").asText());
+    assertEquals( "http://people.org/Person", node.path("type").path("value").asText());
   }
-  
+
 //Test 9
   @Test
   public void testSimpleSparqlSelectWithAggregateCount() throws Exception
   {
-	selectStmt = "PREFIX demov: <http://demo/verb#>\r\n" + 
-			"PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>\r\n" + 
-			"SELECT (COUNT(?industry) AS ?total)\r\n" + 
-			"FROM </optic/sparql/test/companies.ttl>\r\n" + 
-			"WHERE {\r\n" + 
-			"?company a vcard:Organization .\r\n" + 
-			"?company demov:industry ?industry .\r\n" + 
-			"?company demov:industry 'Industrial Goods'\r\n" + 
+	selectStmt = "PREFIX demov: <http://demo/verb#>\r\n" +
+			"PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>\r\n" +
+			"SELECT (COUNT(?industry) AS ?total)\r\n" +
+			"FROM </optic/sparql/test/companies.ttl>\r\n" +
+			"WHERE {\r\n" +
+			"?company a vcard:Organization .\r\n" +
+			"?company demov:industry ?industry .\r\n" +
+			"?company demov:industry 'Industrial Goods'\r\n" +
 			"}";
     plan1 = p.fromSparql(selectStmt);
     rowMgr.resultDoc(plan1, jacksonHandle);
     jsonBindingsNodes = jacksonHandle.get().path("rows");
     node = jsonBindingsNodes.path(0);
-    assertEquals(" nodes not returned from testSimpleSparqlSelectWithAggregateCount method", 1, jsonBindingsNodes.size()); 
-    assertEquals(" nodes not returned from testSimpleSparqlSelectWithAggregateCount method", "15", node.path("total").path("value").asText()); 
+    assertEquals( 1, jsonBindingsNodes.size());
+    assertEquals( "15", node.path("total").path("value").asText());
   }
-  
+
 //Test 9
   @Test
   public void testSimpleSparqlSelectWithAggregateDistinctCount() throws Exception
   {
-	selectStmt = "PREFIX demov: <http://demo/verb#>\r\n" + 
-			"PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>\r\n" + 
-			"SELECT (COUNT( DISTINCT ?industry) AS ?total_industries)\r\n" + 
-			"FROM </optic/sparql/test/companies.ttl>\r\n" + 
-			"WHERE {\r\n" + 
-			"?company demov:industry ?industry .\r\n" + 
+	selectStmt = "PREFIX demov: <http://demo/verb#>\r\n" +
+			"PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>\r\n" +
+			"SELECT (COUNT( DISTINCT ?industry) AS ?total_industries)\r\n" +
+			"FROM </optic/sparql/test/companies.ttl>\r\n" +
+			"WHERE {\r\n" +
+			"?company demov:industry ?industry .\r\n" +
 			"}";
     plan1 = p.fromSparql(selectStmt);
     rowMgr.resultDoc(plan1, jacksonHandle);
     jsonBindingsNodes = jacksonHandle.get().path("rows");
     node = jsonBindingsNodes.path(0);
-    assertEquals(" nodes not returned from testSimpleSparqlSelectWithAggregateDistinctCount method", 1, jsonBindingsNodes.size()); 
-    assertEquals(" nodes not returned from testSimpleSparqlSelectWithAggregateDistinctCount method", "6", node.path("total_industries").path("value").asText()); 
+    assertEquals( 1, jsonBindingsNodes.size());
+    assertEquals( "6", node.path("total_industries").path("value").asText());
   }
-  
+
 //Test 10
   @Test
   public void testSimpleSparqlSelectWithAggregateSum() throws Exception
   {
-	selectStmt = "PREFIX demov: <http://demo/verb#>\r\n" + 
-			"PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>\r\n" + 
-			"SELECT ( SUM (?sales) AS ?sum_sales )\r\n" + 
-			"FROM </optic/sparql/test/companies.ttl>\r\n" + 
-			"WHERE {\r\n" + 
-			"?company a vcard:Organization .\r\n" + 
-			"?company demov:sales ?sales\r\n" + 
+	selectStmt = "PREFIX demov: <http://demo/verb#>\r\n" +
+			"PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>\r\n" +
+			"SELECT ( SUM (?sales) AS ?sum_sales )\r\n" +
+			"FROM </optic/sparql/test/companies.ttl>\r\n" +
+			"WHERE {\r\n" +
+			"?company a vcard:Organization .\r\n" +
+			"?company demov:sales ?sales\r\n" +
 			"}";
     plan1 = p.fromSparql(selectStmt);
     rowMgr.resultDoc(plan1, jacksonHandle);
     jsonBindingsNodes = jacksonHandle.get().path("rows");
     node = jsonBindingsNodes.path(0);
-    assertEquals(" nodes not returned from testSimpleSparqlSelectWithAggregateSum method", 1, jsonBindingsNodes.size()); 
-    assertEquals(" nodes not returned from testSimpleSparqlSelectWithAggregateSum method", "19318588272", node.path("sum_sales").path("value").asText()); 
+    assertEquals( 1, jsonBindingsNodes.size());
+    assertEquals( "19318588272", node.path("sum_sales").path("value").asText());
   }
-  
+
 //Test 11
   @Test
   public void testSimpleSparqlSelectWithAggregateSumWithBind() throws Exception
   {
-	selectStmt = "PREFIX demov: <http://demo/verb#>\r\n" + 
-			"PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>\r\n" + 
-			"SELECT DISTINCT ?industry (SUM(?sales) as ?total_sales) ?country\r\n" + 
-			"FROM </optic/sparql/test/companies.ttl>\r\n" + 
-			"WHERE {\r\n" + 
-			"?company a vcard:Organization .\r\n" + 
-			"?company demov:sales ?sales .\r\n" + 
-			"?company demov:industry 'Other' .\r\n" + 
-			"?company vcard:hasAddress/vcard:country-name 'USA' .\r\n" + 
-			"BIND (vcard:hasAddress/vcard:country-name as ?country)\r\n" + 
-			"BIND (demov:industry as ?industry)\r\n" + 
+	selectStmt = "PREFIX demov: <http://demo/verb#>\r\n" +
+			"PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>\r\n" +
+			"SELECT DISTINCT ?industry (SUM(?sales) as ?total_sales) ?country\r\n" +
+			"FROM </optic/sparql/test/companies.ttl>\r\n" +
+			"WHERE {\r\n" +
+			"?company a vcard:Organization .\r\n" +
+			"?company demov:sales ?sales .\r\n" +
+			"?company demov:industry 'Other' .\r\n" +
+			"?company vcard:hasAddress/vcard:country-name 'USA' .\r\n" +
+			"BIND (vcard:hasAddress/vcard:country-name as ?country)\r\n" +
+			"BIND (demov:industry as ?industry)\r\n" +
 			"}";
     plan1 = p.fromSparql(selectStmt);
     rowMgr.resultDoc(plan1, jacksonHandle);
     jsonBindingsNodes = jacksonHandle.get().path("rows");
     node = jsonBindingsNodes.path(0);
-    assertEquals(" nodes not returned from testSimpleSparqlSelectWithAggregateSumWithBind method", 1, jsonBindingsNodes.size()); 
-    assertEquals(" nodes not returned from testSimpleSparqlSelectWithAggregateSumWithBind method", "1647852766", node.path("total_sales").path("value").asText()); 
+    assertEquals( 1, jsonBindingsNodes.size());
+    assertEquals( "1647852766", node.path("total_sales").path("value").asText());
   }
-  
+
 //Test 12
   @Test
   public void testSimpleSparqlSelectWithAggregateGroupBy() throws Exception
   {
-	selectStmt = "PREFIX demov: <http://demo/verb#>\r\n" + 
-			"PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>\r\n" + 
-			"SELECT ?industry (SUM (?sales) AS ?sum_sales )\r\n" + 
-			"FROM </optic/sparql/test/companies.ttl>\r\n" + 
-			"WHERE {\r\n" + 
-			"?company a vcard:Organization .\r\n" + 
-			"?company demov:sales ?sales .\r\n" + 
-			"?company demov:industry ?industry\r\n" + 
-			"}\r\n" + 
-			"GROUP BY ?industry\r\n" + 
+	selectStmt = "PREFIX demov: <http://demo/verb#>\r\n" +
+			"PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>\r\n" +
+			"SELECT ?industry (SUM (?sales) AS ?sum_sales )\r\n" +
+			"FROM </optic/sparql/test/companies.ttl>\r\n" +
+			"WHERE {\r\n" +
+			"?company a vcard:Organization .\r\n" +
+			"?company demov:sales ?sales .\r\n" +
+			"?company demov:industry ?industry\r\n" +
+			"}\r\n" +
+			"GROUP BY ?industry\r\n" +
 			"ORDER BY ?sum_sales";
     plan1 = p.fromSparql(selectStmt);
     rowMgr.resultDoc(plan1, jacksonHandle);
     jsonBindingsNodes = jacksonHandle.get().path("rows");
     node = jsonBindingsNodes.path(0);
-    assertEquals(" nodes not returned from testSimpleSparqlSelectWithAggregateGroupBy method", 6, jsonBindingsNodes.size()); 
-    assertEquals("Row 1 rowId value incorrect", "Retail/Wholesale", node.path("industry").path("value").asText());
-    assertEquals("Row 1 rowId value incorrect", "1255159206", node.path("sum_sales").path("value").asText());
+    assertEquals( 6, jsonBindingsNodes.size());
+    assertEquals( "Retail/Wholesale", node.path("industry").path("value").asText());
+    assertEquals( "1255159206", node.path("sum_sales").path("value").asText());
     node = jsonBindingsNodes.path(5);
-    assertEquals("Row 1 rowId value incorrect", "Healthcare/Life Sciences", node.path("industry").path("value").asText());
-    assertEquals("Row 1 rowId value incorrect", "6141852782", node.path("sum_sales").path("value").asText());
+    assertEquals( "Healthcare/Life Sciences", node.path("industry").path("value").asText());
+    assertEquals( "6141852782", node.path("sum_sales").path("value").asText());
   }
-  
+
 //Test 13
   @Test
   public void testSimpleSparqlSelectWithAggregateGroupByWithMin() throws Exception
   {
-	selectStmt = "PREFIX demov: <http://demo/verb#>\r\n" + 
-			"PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>\r\n" + 
-			"SELECT ?country (MIN (?sales) AS ?min_sales )\r\n" + 
-			"FROM </optic/sparql/test/companies.ttl>\r\n" + 
-			"WHERE {\r\n" + 
-			"?company a vcard:Organization .\r\n" + 
-			"?company demov:sales ?sales .\r\n" + 
-			"?company vcard:hasAddress [ vcard:country-name ?country ]\r\n" + 
-			"}\r\n" + 
-			"GROUP BY ?country\r\n" + 
+	selectStmt = "PREFIX demov: <http://demo/verb#>\r\n" +
+			"PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>\r\n" +
+			"SELECT ?country (MIN (?sales) AS ?min_sales )\r\n" +
+			"FROM </optic/sparql/test/companies.ttl>\r\n" +
+			"WHERE {\r\n" +
+			"?company a vcard:Organization .\r\n" +
+			"?company demov:sales ?sales .\r\n" +
+			"?company vcard:hasAddress [ vcard:country-name ?country ]\r\n" +
+			"}\r\n" +
+			"GROUP BY ?country\r\n" +
 			"ORDER BY ASC( ?min_sales ) ?country";
     plan1 = p.fromSparql(selectStmt);
     rowMgr.resultDoc(plan1, jacksonHandle);
     jsonBindingsNodes = jacksonHandle.get().path("rows");
     node = jsonBindingsNodes.path(0);
-    assertEquals(" nodes not returned from testSimpleSparqlSelectWithAggregateGroupBy method", 8, jsonBindingsNodes.size()); 
-    assertEquals("Row 1 rowId value incorrect", "China", node.path("country").path("value").asText());
-    assertEquals("Row 1 rowId value incorrect", "8", node.path("min_sales").path("value").asText());
+    assertEquals( 8, jsonBindingsNodes.size());
+    assertEquals( "China", node.path("country").path("value").asText());
+    assertEquals( "8", node.path("min_sales").path("value").asText());
     node = jsonBindingsNodes.path(7);
-    assertEquals("Row 1 rowId value incorrect", "USA", node.path("country").path("value").asText());
-    assertEquals("Row 1 rowId value incorrect", "10000000", node.path("min_sales").path("value").asText());
+    assertEquals( "USA", node.path("country").path("value").asText());
+    assertEquals( "10000000", node.path("min_sales").path("value").asText());
   }
-  
+
 //Test 14
   @Test
   public void testSimpleSparqlSelectWithAggregateGroupByWithQualifier() throws Exception
   {
-	selectStmt = "PREFIX demov: <http://demo/verb#>\r\n" + 
-			"PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>\r\n" + 
-			"SELECT ?industry (SUM (?sales) AS ?sum_sales )\r\n" + 
-			"FROM </optic/sparql/test/companies.ttl>\r\n" + 
-			"WHERE {\r\n" + 
-			"?company a vcard:Organization .\r\n" + 
-			"?company demov:sales ?sales .\r\n" + 
-			"?company demov:industry ?industry\r\n" + 
-			"}\r\n" + 
-			"GROUP BY ?industry\r\n" + 
+	selectStmt = "PREFIX demov: <http://demo/verb#>\r\n" +
+			"PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>\r\n" +
+			"SELECT ?industry (SUM (?sales) AS ?sum_sales )\r\n" +
+			"FROM </optic/sparql/test/companies.ttl>\r\n" +
+			"WHERE {\r\n" +
+			"?company a vcard:Organization .\r\n" +
+			"?company demov:sales ?sales .\r\n" +
+			"?company demov:industry ?industry\r\n" +
+			"}\r\n" +
+			"GROUP BY ?industry\r\n" +
 			"ORDER BY ?sum_sales";
     plan1 = p.fromSparql(selectStmt, "MySPARQL");
     rowMgr.resultDoc(plan1, jacksonHandle);
     jsonBindingsNodes = jacksonHandle.get().path("rows");
     node = jsonBindingsNodes.path(0);
-    assertEquals(" nodes not returned from testSimpleSparqlSelectWithAggregateGroupByWithQualifier method", 6, jsonBindingsNodes.size()); 
-    assertEquals("Row 1 rowId value incorrect", "Retail/Wholesale", node.path("MySPARQL.industry").path("value").asText());
-    assertEquals("Row 1 rowId value incorrect", "1255159206", node.path("MySPARQL.sum_sales").path("value").asText());
+    assertEquals( 6, jsonBindingsNodes.size());
+    assertEquals( "Retail/Wholesale", node.path("MySPARQL.industry").path("value").asText());
+    assertEquals( "1255159206", node.path("MySPARQL.sum_sales").path("value").asText());
     node = jsonBindingsNodes.path(5);
-    assertEquals("Row 1 rowId value incorrect", "Healthcare/Life Sciences", node.path("MySPARQL.industry").path("value").asText());
-    assertEquals("Row 1 rowId value incorrect", "6141852782", node.path("MySPARQL.sum_sales").path("value").asText());
+    assertEquals( "Healthcare/Life Sciences", node.path("MySPARQL.industry").path("value").asText());
+    assertEquals( "6141852782", node.path("MySPARQL.sum_sales").path("value").asText());
   }
-  
-/*  
+
+/*
 //Test 15
   @Test
   public void testSimpleSparqlSelectWithAggregateGroupByWithKeyVaue() throws Exception
   {
-	selectStmt = "PREFIX demov: <http://demo/verb#>\r\n" + 
-			"PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>\r\n" + 
-			"SELECT ?country (MIN (?sales) AS ?min_sales )\r\n" + 
-			"FROM </optic/sparql/test/companies.ttl>\r\n" + 
-			"WHERE {\r\n" + 
-			"?company a vcard:Organization .\r\n" + 
-			"?company demov:sales ?sales .\r\n" + 
-			"?company vcard:hasAddress [ vcard:country-name ?country ]\r\n" + 
-			"}\r\n" + 
-			"GROUP BY ?country\r\n" + 
+	selectStmt = "PREFIX demov: <http://demo/verb#>\r\n" +
+			"PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>\r\n" +
+			"SELECT ?country (MIN (?sales) AS ?min_sales )\r\n" +
+			"FROM </optic/sparql/test/companies.ttl>\r\n" +
+			"WHERE {\r\n" +
+			"?company a vcard:Organization .\r\n" +
+			"?company demov:sales ?sales .\r\n" +
+			"?company vcard:hasAddress [ vcard:country-name ?country ]\r\n" +
+			"}\r\n" +
+			"GROUP BY ?country\r\n" +
 			"ORDER BY ASC( ?min_sales ) ?country";
     plan1 = p.fromSparql(selectStmt, "qualifier");
     rowMgr.resultDoc(plan1, jacksonHandle);
     jsonBindingsNodes = jacksonHandle.get().path("rows");
     node = jsonBindingsNodes.path(0);
-    assertEquals(" nodes not returned from testSimpleSparqlSelectWithAggregateGroupByWithKeyValue method", 8, jsonBindingsNodes.size()); 
-    assertEquals("Row 1 rowId value incorrect", "China", node.path("country").path("value").asText());
-    assertEquals("Row 1 rowId value incorrect", "8", node.path("min_sales").path("value").asText());
+    assertEquals( 8, jsonBindingsNodes.size());
+    assertEquals( "China", node.path("country").path("value").asText());
+    assertEquals( "8", node.path("min_sales").path("value").asText());
     node = jsonBindingsNodes.path(7);
-    assertEquals("Row 1 rowId value incorrect", "USA", node.path("country").path("value").asText());
-    assertEquals("Row 1 rowId value incorrect", "10000000", node.path("min_sales").path("value").asText());
+    assertEquals( "USA", node.path("country").path("value").asText());
+    assertEquals( "10000000", node.path("min_sales").path("value").asText());
   }
  */
-  
+
 //Test 16
   @Test
   public void testSimpleSparqlSelectWithAggregateGroupByWithNullQualifier() throws Exception
   {
-	selectStmt = "PREFIX demov: <http://demo/verb#>\r\n" + 
-			"PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>\r\n" + 
-			"SELECT ?country (MIN (?sales) AS ?min_sales )\r\n" + 
-			"FROM </optic/sparql/test/companies.ttl>\r\n" + 
-			"WHERE {\r\n" + 
-			"?company a vcard:Organization .\r\n" + 
-			"?company demov:sales ?sales .\r\n" + 
-			"?company vcard:hasAddress [ vcard:country-name ?country ]\r\n" + 
-			"}\r\n" + 
-			"GROUP BY ?country\r\n" + 
+	selectStmt = "PREFIX demov: <http://demo/verb#>\r\n" +
+			"PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>\r\n" +
+			"SELECT ?country (MIN (?sales) AS ?min_sales )\r\n" +
+			"FROM </optic/sparql/test/companies.ttl>\r\n" +
+			"WHERE {\r\n" +
+			"?company a vcard:Organization .\r\n" +
+			"?company demov:sales ?sales .\r\n" +
+			"?company vcard:hasAddress [ vcard:country-name ?country ]\r\n" +
+			"}\r\n" +
+			"GROUP BY ?country\r\n" +
 			"ORDER BY ASC( ?min_sales ) ?country";
     plan1 = p.fromSparql(selectStmt, null);
     rowMgr.resultDoc(plan1, jacksonHandle);
     jsonBindingsNodes = jacksonHandle.get().path("rows");
     node = jsonBindingsNodes.path(0);
-    assertEquals(" nodes not returned from testSimpleSparqlSelectWithAggregateGroupByWithKeyValue method", 8, jsonBindingsNodes.size()); 
-    assertEquals("Row 1 rowId value incorrect", "China", node.path("country").path("value").asText());
-    assertEquals("Row 1 rowId value incorrect", "8", node.path("min_sales").path("value").asText());
+    assertEquals( 8, jsonBindingsNodes.size());
+    assertEquals( "China", node.path("country").path("value").asText());
+    assertEquals( "8", node.path("min_sales").path("value").asText());
     node = jsonBindingsNodes.path(7);
-    assertEquals("Row 1 rowId value incorrect", "USA", node.path("country").path("value").asText());
-    assertEquals("Row 1 rowId value incorrect", "10000000", node.path("min_sales").path("value").asText());
+    assertEquals( "USA", node.path("country").path("value").asText());
+    assertEquals( "10000000", node.path("min_sales").path("value").asText());
   }
-  
+
 //Test 17
   @Test
   public void testSimpleSparqlSelectWithOpticOperations() throws Exception
   {
-	selectStmt = "PREFIX foaf: <http://xmlns.com/foaf/0.1/>\r\n" + 
-			"PREFIX ppl:  <http://people.org/>\r\n" + 
-			"SELECT ?s ?o\r\n" + 
+	selectStmt = "PREFIX foaf: <http://xmlns.com/foaf/0.1/>\r\n" +
+			"PREFIX ppl:  <http://people.org/>\r\n" +
+			"SELECT ?s ?o\r\n" +
 			"WHERE { ?s foaf:knows ?o }";
     plan1 = p.fromSparql(selectStmt).orderBy(p.desc("o"));
     rowMgr.resultDoc(plan1, jacksonHandle);
     jsonBindingsNodes = jacksonHandle.get().path("rows");
     node = jsonBindingsNodes.path(0);
-    assertEquals(" nodes not returned from testSimpleSparqlSelectWithOpticOperations method", 22, jsonBindingsNodes.size()); 
-    assertEquals("Row 1 rowId value incorrect", "http://people.org/person9", node.path("o").path("value").asText());
+    assertEquals( 22, jsonBindingsNodes.size());
+    assertEquals( "http://people.org/person9", node.path("o").path("value").asText());
     node = jsonBindingsNodes.path(1);
-    assertEquals("Row 1 rowId value incorrect", "http://people.org/person8", node.path("o").path("value").asText());
+    assertEquals( "http://people.org/person8", node.path("o").path("value").asText());
     node = jsonBindingsNodes.path(21);
-    assertEquals("Row 1 rowId value incorrect", "http://people.org/person10", node.path("o").path("value").asText());
+    assertEquals( "http://people.org/person10", node.path("o").path("value").asText());
   }
-  
+
 /*
 //Test 18
   @Test
   public void testSimpleSparqlSelectWithOpticWhere() throws Exception
   {
-	selectStmt = "PREFIX demov: <http://demo/verb#>\r\n" + 
-			"PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>\r\n" + 
-			"SELECT ?country (MIN (?sales) AS ?min_sales )\r\n" + 
-			"FROM </optic/sparql/test/companies.ttl>\r\n" + 
-			"WHERE {\r\n" + 
-			"?company a vcard:Organization .\r\n" + 
-			"?company demov:sales ?sales .\r\n" + 
-			"?company vcard:hasAddress [ vcard:country-name ?country ]\r\n" + 
-			"}\r\n" + 
-			"GROUP BY ?country\r\n" + 
+	selectStmt = "PREFIX demov: <http://demo/verb#>\r\n" +
+			"PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>\r\n" +
+			"SELECT ?country (MIN (?sales) AS ?min_sales )\r\n" +
+			"FROM </optic/sparql/test/companies.ttl>\r\n" +
+			"WHERE {\r\n" +
+			"?company a vcard:Organization .\r\n" +
+			"?company demov:sales ?sales .\r\n" +
+			"?company vcard:hasAddress [ vcard:country-name ?country ]\r\n" +
+			"}\r\n" +
+			"GROUP BY ?country\r\n" +
 			"ORDER BY ASC( ?min_sales ) ?country";
     plan1 = p.fromSparql(selectStmt).where(p.eq(p.col("min_sales"), p.)));
     rowMgr.resultDoc(plan1, jacksonHandle);
     jsonBindingsNodes = jacksonHandle.get().path("rows");
     node = jsonBindingsNodes.path(0);
-    assertEquals(" nodes not returned from testSimpleSparqlSelectWithOpticOperations method", 22, jsonBindingsNodes.size()); 
-    assertEquals("Row 1 rowId value incorrect", "http://people.org/person9", node.path("o").path("value").asText());
+    assertEquals( 22, jsonBindingsNodes.size());
+    assertEquals( "http://people.org/person9", node.path("o").path("value").asText());
     node = jsonBindingsNodes.path(1);
-    assertEquals("Row 1 rowId value incorrect", "http://people.org/person8", node.path("o").path("value").asText());
+    assertEquals( "http://people.org/person8", node.path("o").path("value").asText());
     node = jsonBindingsNodes.path(21);
-    assertEquals("Row 1 rowId value incorrect", "http://people.org/person10", node.path("o").path("value").asText());
+    assertEquals( "http://people.org/person10", node.path("o").path("value").asText());
   }
 */
-  
+
 //Test 19
   @Test
   public void testSimpleSparqlSelectWithOpticSQLAndQualifier() throws Exception
   {
-	selectStmt = "PREFIX demov: <http://demo/verb#>\r\n" + 
-			"PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>\r\n" + 
-			"SELECT ?industry (SUM (?sales) AS ?sum_sales )\r\n" + 
-			"FROM </optic/sparql/test/companies.ttl>\r\n" + 
-			"WHERE {\r\n" + 
-			"?company a vcard:Organization .\r\n" + 
-			"?company demov:sales ?sales .\r\n" + 
-			"?company demov:industry ?industry\r\n" + 
-			"}\r\n" + 
-			"GROUP BY ?industry\r\n" + 
+	selectStmt = "PREFIX demov: <http://demo/verb#>\r\n" +
+			"PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>\r\n" +
+			"SELECT ?industry (SUM (?sales) AS ?sum_sales )\r\n" +
+			"FROM </optic/sparql/test/companies.ttl>\r\n" +
+			"WHERE {\r\n" +
+			"?company a vcard:Organization .\r\n" +
+			"?company demov:sales ?sales .\r\n" +
+			"?company demov:industry ?industry\r\n" +
+			"}\r\n" +
+			"GROUP BY ?industry\r\n" +
 			"ORDER BY ?sum_sales";
     plan1 = p.fromSparql(selectStmt, "MySPARQL").where(p.sqlCondition("MySPARQL.industry LIKE" + "\'Re%\'")).select(p.viewCol("MySPARQL", "industry"), p.as("mySales", p.viewCol("MySPARQL", "sum_sales")));
     rowMgr.resultDoc(plan1, jacksonHandle);
     jsonBindingsNodes = jacksonHandle.get().path("rows");
     node = jsonBindingsNodes.path(0);
-    assertEquals(" nodes not returned from testSimpleSparqlSelectWithOpticSQLAndQualifier method", 1, jsonBindingsNodes.size()); 
-    assertEquals("Row 1 rowId value incorrect", "Retail/Wholesale", node.path("MySPARQL.industry").path("value").asText());
-    assertEquals("Row 1 rowId value incorrect", "1255159206", node.path("mySales").path("value").asText());
+    assertEquals( 1, jsonBindingsNodes.size());
+    assertEquals( "Retail/Wholesale", node.path("MySPARQL.industry").path("value").asText());
+    assertEquals( "1255159206", node.path("mySales").path("value").asText());
   }
-  
-/*  
+
+/*
 //Test 20
   @Test
   public void testSimpleSparqlSelectWithOpticAndQualifier() throws Exception
   {
-	selectStmt = "PREFIX demov: <http://demo/verb#>\r\n" + 
-			"PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>\r\n" + 
-			"SELECT ?industry (SUM (?sales) AS ?sum_sales )\r\n" + 
-			"FROM </optic/sparql/test/companies.ttl>\r\n" + 
-			"WHERE {\r\n" + 
-			"?company a vcard:Organization .\r\n" + 
-			"?company demov:sales ?sales .\r\n" + 
-			"?company demov:industry ?industry\r\n" + 
-			"}\r\n" + 
-			"GROUP BY ?industry\r\n" + 
+	selectStmt = "PREFIX demov: <http://demo/verb#>\r\n" +
+			"PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>\r\n" +
+			"SELECT ?industry (SUM (?sales) AS ?sum_sales )\r\n" +
+			"FROM </optic/sparql/test/companies.ttl>\r\n" +
+			"WHERE {\r\n" +
+			"?company a vcard:Organization .\r\n" +
+			"?company demov:sales ?sales .\r\n" +
+			"?company demov:industry ?industry\r\n" +
+			"}\r\n" +
+			"GROUP BY ?industry\r\n" +
 			"ORDER BY ?sum_sales";
     plan1 = p.fromSparql(selectStmt, "MySPARQL").select(p.viewCol("MySPARQL", "industry"), p.as("doubleSales", p.viewCol("MySPARQL", "sum_sales")),
     		p.as("discount", p.viewCol("MySPARQL", "sum_sales")));
@@ -574,32 +574,32 @@ public class TestOpticOnFromSparql extends AbstractFunctionalTest {
     rowMgr.resultDoc(plan1, jacksonHandle);
     jsonBindingsNodes = jacksonHandle.get().path("rows");
     node = jsonBindingsNodes.path(0);
-    assertEquals(" nodes not returned from testSimpleSparqlSelectWithOpticSQLAndQualifier method", 6, jsonBindingsNodes.size()); 
-    assertEquals("Row 1 rowId value incorrect", "Retail/Wholesale", node.path("MySPARQL.industry").path("value").asText());
-    assertEquals("Row 1 rowId value incorrect", "2510318412", node.path("doubleSales").path("value").asText());
-    assertEquals("Row 1 rowId value incorrect", "125515920.6", node.path("discount").path("value").asText());
+    assertEquals( 6, jsonBindingsNodes.size());
+    assertEquals( "Retail/Wholesale", node.path("MySPARQL.industry").path("value").asText());
+    assertEquals( "2510318412", node.path("doubleSales").path("value").asText());
+    assertEquals( "125515920.6", node.path("discount").path("value").asText());
   }
 */
-  
- /* 
+
+ /*
 //Test 21
   @Test
   public void testSimpleSparqlSelectWithLiteralPlaceholder() throws Exception
   {
-	selectStmt = "PREFIX foaf: <http://xmlns.com/foaf/0.1/>\r\n" + 
-			"PREFIX ppl:  <http://people.org/>\r\n" + 
-			"SELECT ?personA ?personB\r\n" + 
-			"WHERE {\r\n" + 
-			"?personB foaf:name @placeholderName .\r\n" + 
-			"?personA foaf:knows ?personB\r\n" + 
+	selectStmt = "PREFIX foaf: <http://xmlns.com/foaf/0.1/>\r\n" +
+			"PREFIX ppl:  <http://people.org/>\r\n" +
+			"SELECT ?personA ?personB\r\n" +
+			"WHERE {\r\n" +
+			"?personB foaf:name @placeholderName .\r\n" +
+			"?personA foaf:knows ?personB\r\n" +
 			"}";
     plan1 = p.fromSparql(selectStmt, null, "");
     rowMgr.resultDoc(plan1, jacksonHandle);
     jsonBindingsNodes = jacksonHandle.get().path("rows");
     node = jsonBindingsNodes.path(0);
-    assertEquals(" nodes not returned from testSimpleSparqlSelectWithLiteralPlaceholder method", 1, jsonBindingsNodes.size()); 
-    assertEquals("Row 1 rowId value incorrect", "Retail/Wholesale", node.path("MySPARQL.industry").path("value").asText());
-    assertEquals("Row 1 rowId value incorrect", "1255159206", node.path("mySales").path("value").asText());
+    assertEquals( 1, jsonBindingsNodes.size());
+    assertEquals( "Retail/Wholesale", node.path("MySPARQL.industry").path("value").asText());
+    assertEquals( "1255159206", node.path("mySales").path("value").asText());
   }
 */
 }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnLexicons.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnLexicons.java
@@ -31,18 +31,17 @@ import com.marklogic.client.row.RowSet;
 import com.marklogic.client.type.CtsReferenceExpr;
 import com.marklogic.client.type.PlanColumn;
 import com.marklogic.client.type.PlanSystemColumn;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
-import static org.junit.Assert.*;
-
 public class TestOpticOnLexicons extends AbstractFunctionalTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception
   {
     // Install the TDE templates
@@ -108,7 +107,7 @@ public class TestOpticOnLexicons extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get();
 
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
-    assertTrue("Number of Elements after plan execution is incorrect. Should be 4", 4 == jsonBindingsNodes.size());
+    assertTrue( 4 == jsonBindingsNodes.size());
     // Verify first node.
     Iterator<JsonNode> nameNodesItr = jsonBindingsNodes.elements();
 
@@ -117,32 +116,32 @@ public class TestOpticOnLexicons extends AbstractFunctionalTest {
     jsonNameNode = nameNodesItr.next();
     // Verify result values are ordered by date. We will verify all elements
     // here.
-    assertEquals("Element 1 (city) in Column Strings incorrect", "beijing", jsonNameNode.path("city").path("value").asText());
-    assertEquals("Element 1 (popularity) in Column Strings incorrect", "5", jsonNameNode.path("popularity").path("value").asText());
-    assertEquals("Element 1 (date) in Column Strings incorrect", "1981-11-09", jsonNameNode.path("date").path("value").asText());
-    assertEquals("Element 1 (distance) in Column Strings incorrect", "134.5", jsonNameNode.path("distance").path("value").asText());
-    assertEquals("Element 1 (point) in Column Strings incorrect", toWKT("39.900002,116.4"), jsonNameNode.path("point").path("value").asText());
+    assertEquals("beijing", jsonNameNode.path("city").path("value").asText());
+    assertEquals("5", jsonNameNode.path("popularity").path("value").asText());
+    assertEquals("1981-11-09", jsonNameNode.path("date").path("value").asText());
+    assertEquals("134.5", jsonNameNode.path("distance").path("value").asText());
+    assertEquals(toWKT("39.900002,116.4"), jsonNameNode.path("point").path("value").asText());
 
     jsonNameNode = nameNodesItr.next();
-    assertEquals("Element 2 (city) in Column Strings incorrect", "cape town", jsonNameNode.path("city").path("value").asText());
-    assertEquals("Element 2 (popularity) in Column Strings incorrect", "3", jsonNameNode.path("popularity").path("value").asText());
-    assertEquals("Element 2 (date) in Column Strings incorrect", "1999-04-22", jsonNameNode.path("date").path("value").asText());
-    assertEquals("Element 2 (distance) in Column Strings incorrect", "377.9", jsonNameNode.path("distance").path("value").asText());
-    assertEquals("Element 2 (point) in Column Strings incorrect", toWKT("-33.91,18.42"), jsonNameNode.path("point").path("value").asText());
+    assertEquals("cape town", jsonNameNode.path("city").path("value").asText());
+    assertEquals("3", jsonNameNode.path("popularity").path("value").asText());
+    assertEquals("1999-04-22", jsonNameNode.path("date").path("value").asText());
+    assertEquals("377.9", jsonNameNode.path("distance").path("value").asText());
+    assertEquals(toWKT("-33.91,18.42"), jsonNameNode.path("point").path("value").asText());
 
     jsonNameNode = nameNodesItr.next();
-    assertEquals("Element 3 (city) in Column Strings incorrect", "new york", jsonNameNode.path("city").path("value").asText());
-    assertEquals("Element 3 (popularity) in Column Strings incorrect", "5", jsonNameNode.path("popularity").path("value").asText());
-    assertEquals("Element 3 (date) in Column Strings incorrect", "2006-06-23", jsonNameNode.path("date").path("value").asText());
-    assertEquals("Element 3 (distance) in Column Strings incorrect", "23.3", jsonNameNode.path("distance").path("value").asText());
-    assertEquals("Element 3 (point) in Column Strings incorrect", toWKT("40.709999,-74.009995"), jsonNameNode.path("point").path("value").asText());
+    assertEquals("new york", jsonNameNode.path("city").path("value").asText());
+    assertEquals("5", jsonNameNode.path("popularity").path("value").asText());
+    assertEquals("2006-06-23", jsonNameNode.path("date").path("value").asText());
+    assertEquals("23.3", jsonNameNode.path("distance").path("value").asText());
+    assertEquals(toWKT("40.709999,-74.009995"), jsonNameNode.path("point").path("value").asText());
 
     jsonNameNode = nameNodesItr.next();
-    assertEquals("Element 4 (city) in Column Strings incorrect", "london", jsonNameNode.path("city").path("value").asText());
-    assertEquals("Element 4 (popularity) in Column Strings incorrect", "5", jsonNameNode.path("popularity").path("value").asText());
-    assertEquals("Element 4 (date) in Column Strings incorrect", "2007-01-01", jsonNameNode.path("date").path("value").asText());
-    assertEquals("Element 4 (distance) in Column Strings incorrect", "50.4", jsonNameNode.path("distance").path("value").asText());
-    assertEquals("Element 4 (point) in Column Strings incorrect", toWKT("51.5,-0.12"), jsonNameNode.path("point").path("value").asText());
+    assertEquals("london", jsonNameNode.path("city").path("value").asText());
+    assertEquals("5", jsonNameNode.path("popularity").path("value").asText());
+    assertEquals("2007-01-01", jsonNameNode.path("date").path("value").asText());
+    assertEquals("50.4", jsonNameNode.path("distance").path("value").asText());
+    assertEquals(toWKT("51.5,-0.12"), jsonNameNode.path("point").path("value").asText());
 
     System.out.println("Bindings after execution of Plan 1 is" + jsonBindingsNodes);
 
@@ -159,7 +158,7 @@ public class TestOpticOnLexicons extends AbstractFunctionalTest {
     JsonNode jsonResults2 = jacksonHandle2.get();
 
     JsonNode jsonBindingsNodes2 = jsonResults2.path("rows");
-    assertTrue("Number of Elements after plan execution is incorrect. Should be 3", 3 == jsonBindingsNodes2.size());
+    assertTrue( 3 == jsonBindingsNodes2.size());
 
     // use strings on select
     ExportablePlan plan3 = p.fromLexicons(indexes)
@@ -174,7 +173,7 @@ public class TestOpticOnLexicons extends AbstractFunctionalTest {
     JsonNode jsonResults3 = jacksonHandle3.get();
 
     JsonNode jsonBindingsNodes3 = jsonResults3.path("rows");
-    assertTrue("Number of Elements after plan execution is incorrect. Should be 3", 3 == jsonBindingsNodes3.size());
+    assertTrue( 3 == jsonBindingsNodes3.size());
   }
 
   /*
@@ -225,42 +224,42 @@ public class TestOpticOnLexicons extends AbstractFunctionalTest {
     rowMgr.resultDoc(plan3, strHandle);
 
     JsonNode jsonInnerDocNodes = jsonResults.path("rows");
-    assertTrue("Number of Elements after plan execution is incorrect. Should be 5", 5 == jsonInnerDocNodes.size());
+    assertTrue( 5 == jsonInnerDocNodes.size());
     // Verify first result
-    assertEquals("Element 1 (myCity) in date incorrect", "1971-12-23", jsonInnerDocNodes.get(0).path("myCity.date").path("value").asText());
-    assertEquals("Element 1 (myCity) in URI1 incorrect", "/optic/lexicon/test/doc3.json", jsonInnerDocNodes.get(0).path("myCity.uri1").path("value").asText());
-    assertEquals("Element 1 (myCity) in distance incorrect", "12.9", jsonInnerDocNodes.get(0).path("myCity.distance").path("value").asText());
-    assertEquals("Element 1 (myCity) in city incorrect", "new jersey", jsonInnerDocNodes.get(0).path("myCity.city").path("value").asText());
-    assertEquals("Element 1 (myCity) in popularity incorrect", "2", jsonInnerDocNodes.get(0).path("myCity.popularity").path("value").asText());
-    assertEquals("Element 1 (myCity) in point incorrect", toWKT("40.720001,-74.07"), jsonInnerDocNodes.get(0).path("myCity.point").path("value").asText());
+    assertEquals("1971-12-23", jsonInnerDocNodes.get(0).path("myCity.date").path("value").asText());
+    assertEquals("/optic/lexicon/test/doc3.json", jsonInnerDocNodes.get(0).path("myCity.uri1").path("value").asText());
+    assertEquals("12.9", jsonInnerDocNodes.get(0).path("myCity.distance").path("value").asText());
+    assertEquals("new jersey", jsonInnerDocNodes.get(0).path("myCity.city").path("value").asText());
+    assertEquals("2", jsonInnerDocNodes.get(0).path("myCity.popularity").path("value").asText());
+    assertEquals(toWKT("40.720001,-74.07"), jsonInnerDocNodes.get(0).path("myCity.point").path("value").asText());
 
-    assertEquals("Element 1 (myTeam) in URI2 incorrect", "/optic/lexicon/test/city3.json", jsonInnerDocNodes.get(0).path("myTeam.uri2").path("value").asText());
-    assertEquals("Element 1 (myTeam) in city incorrect", "new jersey", jsonInnerDocNodes.get(0).path("myTeam.cityName").path("value").asText());
-    assertEquals("Element 1 (myTeam) in team incorrect", "nets", jsonInnerDocNodes.get(0).path("myTeam.cityTeam").path("value").asText());
+    assertEquals("/optic/lexicon/test/city3.json", jsonInnerDocNodes.get(0).path("myTeam.uri2").path("value").asText());
+    assertEquals("new jersey", jsonInnerDocNodes.get(0).path("myTeam.cityName").path("value").asText());
+    assertEquals("nets", jsonInnerDocNodes.get(0).path("myTeam.cityTeam").path("value").asText());
 
-    assertEquals("Element 1 (doc) in city incorrect", "new jersey", jsonInnerDocNodes.get(0).path("doc").path("value").path("cityName").asText());
-    assertEquals("Element 1 (doc) in population incorrect", "3000000", jsonInnerDocNodes.get(0).path("doc").path("value").path("cityPopulation").asText());
-    assertEquals("Element 1 (doc) in team incorrect", "nets", jsonInnerDocNodes.get(0).path("doc").path("value").path("cityTeam").asText());
+    assertEquals("new jersey", jsonInnerDocNodes.get(0).path("doc").path("value").path("cityName").asText());
+    assertEquals("3000000", jsonInnerDocNodes.get(0).path("doc").path("value").path("cityPopulation").asText());
+    assertEquals("nets", jsonInnerDocNodes.get(0).path("doc").path("value").path("cityTeam").asText());
 
-    assertEquals("Element 2 (myCity) in date incorrect", "1981-11-09", jsonInnerDocNodes.get(1).path("myCity.date").path("value").asText());
-    assertEquals("Element 3 (myCity) in date incorrect", "1999-04-22", jsonInnerDocNodes.get(2).path("myCity.date").path("value").asText());
-    assertEquals("Element 4 (myCity) in date incorrect", "2006-06-23", jsonInnerDocNodes.get(3).path("myCity.date").path("value").asText());
+    assertEquals("1981-11-09", jsonInnerDocNodes.get(1).path("myCity.date").path("value").asText());
+    assertEquals("1999-04-22", jsonInnerDocNodes.get(2).path("myCity.date").path("value").asText());
+    assertEquals("2006-06-23", jsonInnerDocNodes.get(3).path("myCity.date").path("value").asText());
 
     // Verify last result, since records are ordered.
-    assertEquals("Element 5 (myCity) in date incorrect", "2007-01-01", jsonInnerDocNodes.get(4).path("myCity.date").path("value").asText());
-    assertEquals("Element 5 (myCity) in URI1 incorrect", "/optic/lexicon/test/doc1.json", jsonInnerDocNodes.get(4).path("myCity.uri1").path("value").asText());
-    assertEquals("Element 5 (myCity) in distance incorrect", "50.4", jsonInnerDocNodes.get(4).path("myCity.distance").path("value").asText());
-    assertEquals("Element 5 (myCity) in city incorrect", "london", jsonInnerDocNodes.get(4).path("myCity.city").path("value").asText());
-    assertEquals("Element 5 (myCity) in popularity incorrect", "5", jsonInnerDocNodes.get(4).path("myCity.popularity").path("value").asText());
-    assertEquals("Element 5 (myCity) in point incorrect", toWKT("51.5,-0.12"), jsonInnerDocNodes.get(4).path("myCity.point").path("value").asText());
+    assertEquals("2007-01-01", jsonInnerDocNodes.get(4).path("myCity.date").path("value").asText());
+    assertEquals("/optic/lexicon/test/doc1.json", jsonInnerDocNodes.get(4).path("myCity.uri1").path("value").asText());
+    assertEquals("50.4", jsonInnerDocNodes.get(4).path("myCity.distance").path("value").asText());
+    assertEquals("london", jsonInnerDocNodes.get(4).path("myCity.city").path("value").asText());
+    assertEquals("5", jsonInnerDocNodes.get(4).path("myCity.popularity").path("value").asText());
+    assertEquals(toWKT("51.5,-0.12"), jsonInnerDocNodes.get(4).path("myCity.point").path("value").asText());
 
-    assertEquals("Element 5 (myTeam) in URI2 incorrect", "/optic/lexicon/test/city1.json", jsonInnerDocNodes.get(4).path("myTeam.uri2").path("value").asText());
-    assertEquals("Element 5 (myTeam) in city incorrect", "london", jsonInnerDocNodes.get(4).path("myTeam.cityName").path("value").asText());
-    assertEquals("Element 5 (myTeam) in team incorrect", "arsenal", jsonInnerDocNodes.get(4).path("myTeam.cityTeam").path("value").asText());
+    assertEquals("/optic/lexicon/test/city1.json", jsonInnerDocNodes.get(4).path("myTeam.uri2").path("value").asText());
+    assertEquals("london", jsonInnerDocNodes.get(4).path("myTeam.cityName").path("value").asText());
+    assertEquals("arsenal", jsonInnerDocNodes.get(4).path("myTeam.cityTeam").path("value").asText());
 
-    assertEquals("Element 5 (doc) in city incorrect", "london", jsonInnerDocNodes.get(4).path("doc").path("value").path("cityName").asText());
-    assertEquals("Element 5 (doc) in population incorrect", "2000000", jsonInnerDocNodes.get(4).path("doc").path("value").path("cityPopulation").asText());
-    assertEquals("Element 5 (doc) in team incorrect", "arsenal", jsonInnerDocNodes.get(4).path("doc").path("value").path("cityTeam").asText());
+    assertEquals("london", jsonInnerDocNodes.get(4).path("doc").path("value").path("cityName").asText());
+    assertEquals("2000000", jsonInnerDocNodes.get(4).path("doc").path("value").path("cityPopulation").asText());
+    assertEquals("arsenal", jsonInnerDocNodes.get(4).path("doc").path("value").path("cityTeam").asText());
 
     // Validate RowRecord.
     // Validate the document content, Kind and MimeType.
@@ -273,17 +272,17 @@ public class TestOpticOnLexicons extends AbstractFunctionalTest {
     assertNotNull(recordRow.toString());
     String debugRR = recordRow.toString().trim();
 
-    assertTrue("Debug Info incorrect", debugRR.contains("myCity.date:{kind: \"ATOMIC_VALUE\", type: \"xs:date\", value: \"1971-12-23\"}"));
-    assertTrue("Debug Info incorrect", debugRR.contains("myCity.uri1:{kind: \"ATOMIC_VALUE\", type: \"xs:string\", value: \"/optic/lexicon/test/doc3.json\""));
-    assertTrue("Debug Info incorrect", debugRR.contains("myCity.distance:{kind: \"ATOMIC_VALUE\", type: \"xs:double\", value: 12.9}"));
-    assertTrue("Debug Info incorrect", debugRR.contains("myCity.point:{kind: \"ATOMIC_VALUE\", type: \"http://marklogic.com/cts#point\", value: \"" + toWKT("40.720001,-74.07") + "\"}"));
+    assertTrue( debugRR.contains("myCity.date:{kind: \"ATOMIC_VALUE\", type: \"xs:date\", value: \"1971-12-23\"}"));
+    assertTrue( debugRR.contains("myCity.uri1:{kind: \"ATOMIC_VALUE\", type: \"xs:string\", value: \"/optic/lexicon/test/doc3.json\""));
+    assertTrue( debugRR.contains("myCity.distance:{kind: \"ATOMIC_VALUE\", type: \"xs:double\", value: 12.9}"));
+    assertTrue( debugRR.contains("myCity.point:{kind: \"ATOMIC_VALUE\", type: \"http://marklogic.com/cts#point\", value: \"" + toWKT("40.720001,-74.07") + "\"}"));
 
-    assertEquals("Element 1 (myCity) in date incorrect", "1971-12-23", recordRow.getString("myCity.date"));
-    assertEquals("Element 1 (myCity) in URI1 incorrect", "/optic/lexicon/test/doc3.json", recordRow.getString("myCity.uri1"));
-    assertEquals(12.9, recordRow.getFloat("myCity.distance"), 0.1);
-    assertEquals("Element 1 (myCity) in city incorrect", "new jersey", recordRow.getString("myCity.city"));
-    assertEquals("Element 1 (myCity) in popularity incorrect", 2, recordRow.getInt("myCity.popularity"));
-    assertEquals("Element 1 (myCity) in point incorrect", toWKT("40.720001,-74.07"), recordRow.getString("myCity.point"));
+	  assertEquals("1971-12-23", recordRow.getString("myCity.date"));
+	  assertEquals("/optic/lexicon/test/doc3.json", recordRow.getString("myCity.uri1"));
+	  assertEquals(12.9, recordRow.getFloat("myCity.distance"), 0.1);
+	  assertEquals("new jersey", recordRow.getString("myCity.city"));
+    assertEquals(2, recordRow.getInt("myCity.popularity"));
+    assertEquals(toWKT("40.720001,-74.07"), recordRow.getString("myCity.point"));
 
     // Use a handle different from Jackson.
     StringHandle strDocHandle = new StringHandle();
@@ -291,16 +290,16 @@ public class TestOpticOnLexicons extends AbstractFunctionalTest {
     String docAsaString = strDocHandle.get();
 
     // Validate the document returned.
-    assertTrue("Document does not have correct cityName value", docAsaString.contains("new jersey"));
-    assertTrue("Document does not have cityname field", docAsaString.contains("cityName"));
-    assertTrue("Document does not have correct cityName value", docAsaString.contains("3000000"));
-    assertTrue("Document does not have cityname field", docAsaString.contains("cityPopulation"));
-    assertTrue("Document does not have correct cityName value", docAsaString.contains("nets"));
-    assertTrue("Document does not have cityname field", docAsaString.contains("cityTeam"));
+    assertTrue( docAsaString.contains("new jersey"));
+    assertTrue( docAsaString.contains("cityName"));
+    assertTrue( docAsaString.contains("3000000"));
+    assertTrue( docAsaString.contains("cityPopulation"));
+    assertTrue( docAsaString.contains("nets"));
+    assertTrue( docAsaString.contains("cityTeam"));
 
     // Validate the format and Mime-type.
-    assertTrue("Document format incorrect", recordRow.getContentFormat("doc") == Format.JSON);
-    assertTrue("Document Mime-type incorrect", recordRow.getContentMimetype("doc").contains("application/json"));
+    assertTrue( recordRow.getContentFormat("doc") == Format.JSON);
+    assertTrue( recordRow.getContentMimetype("doc").contains("application/json"));
   }
 
   /*
@@ -340,19 +339,19 @@ public class TestOpticOnLexicons extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get();
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
     // Should have 5 nodes returned.
-    assertEquals("Five nodes not returned from testJoinInnerKeymatchDateSort method ", 5, jsonBindingsNodes.size());
+    assertEquals( 5, jsonBindingsNodes.size());
     JsonNode first = jsonBindingsNodes.path(0);
-    assertEquals("Row 1 myCity.city value incorrect", "new jersey", first.path("myCity.city").path("value").asText());
-    assertEquals("Row 1 myCity.date value incorrect", "1971-12-23", first.path("myCity.date").path("value").asText());
-    assertEquals("Row 1 myTeam.cityName value incorrect", "new jersey", first.path("myTeam.cityName").path("value").asText());
-    assertEquals("Row 1 myTeam.cityTeam value incorrect", "nets", first.path("myTeam.cityTeam").path("value").asText());
-    assertEquals("Row 1 myTeam.uri2 value incorrect", "/optic/lexicon/test/city3.json", first.path("myTeam.uri2").path("value").asText());
+    assertEquals( "new jersey", first.path("myCity.city").path("value").asText());
+    assertEquals( "1971-12-23", first.path("myCity.date").path("value").asText());
+    assertEquals( "new jersey", first.path("myTeam.cityName").path("value").asText());
+    assertEquals( "nets", first.path("myTeam.cityTeam").path("value").asText());
+    assertEquals( "/optic/lexicon/test/city3.json", first.path("myTeam.uri2").path("value").asText());
     JsonNode five = jsonBindingsNodes.path(4);
-    assertEquals("Row 5 myCity.city value incorrect", "london", five.path("myCity.city").path("value").asText());
-    assertEquals("Row 5 myCity.date value incorrect", "2007-01-01", five.path("myCity.date").path("value").asText());
-    assertEquals("Row 5 myTeam.cityName value incorrect", "london", five.path("myTeam.cityName").path("value").asText());
-    assertEquals("Row 5 myTeam.cityTeam value incorrect", "arsenal", five.path("myTeam.cityTeam").path("value").asText());
-    assertEquals("Row 5 myTeam.uri2 value incorrect", "/optic/lexicon/test/city1.json", five.path("myTeam.uri2").path("value").asText());
+    assertEquals( "london", five.path("myCity.city").path("value").asText());
+    assertEquals( "2007-01-01", five.path("myCity.date").path("value").asText());
+    assertEquals( "london", five.path("myTeam.cityName").path("value").asText());
+    assertEquals( "arsenal", five.path("myTeam.cityTeam").path("value").asText());
+    assertEquals( "/optic/lexicon/test/city1.json", five.path("myTeam.uri2").path("value").asText());
 
     PlanColumn uriCol1 = p.col("uri1");
     PlanColumn cityCol = p.col("city");
@@ -377,26 +376,26 @@ public class TestOpticOnLexicons extends AbstractFunctionalTest {
     jsonResults = jacksonHandle.get();
     jsonBindingsNodes = jsonResults.path("rows");
     // Should have 5 nodes returned.
-    assertEquals("Five nodes not returned from testJoinInnerKeymatchDateSort method ", 5, jsonBindingsNodes.size());
+    assertEquals( 5, jsonBindingsNodes.size());
     JsonNode node = jsonBindingsNodes.path(0);
-    assertEquals("Row 1 myCity.city value incorrect", "cape town", node.path("myCity.city").path("value").asText());
-    assertEquals("Row 1 myCity.distance value incorrect", "377.9", node.path("myCity.distance").path("value").asText());
-    assertEquals("Row 1 myTeam.cityName value incorrect", "cape town", node.path("myTeam.cityName").path("value").asText());
-    assertEquals("Row 1 myTeam.cityTeam value incorrect", "pirates", node.path("myTeam.cityTeam").path("value").asText());
-    assertEquals("Row 1 myCity.popularity value incorrect", "3", node.path("myCity.popularity").path("value").asText());
+    assertEquals( "cape town", node.path("myCity.city").path("value").asText());
+    assertEquals( "377.9", node.path("myCity.distance").path("value").asText());
+    assertEquals( "cape town", node.path("myTeam.cityName").path("value").asText());
+    assertEquals( "pirates", node.path("myTeam.cityTeam").path("value").asText());
+    assertEquals( "3", node.path("myCity.popularity").path("value").asText());
 
     node = jsonBindingsNodes.path(1);
-    assertEquals("Row 2 myCity.city value incorrect", "beijing", node.path("myCity.city").path("value").asText());
-    assertEquals("Row 2 myCity.distance value incorrect", "134.5", node.path("myCity.distance").path("value").asText());
-    assertEquals("Row 2 myTeam.cityName value incorrect", "beijing", node.path("myTeam.cityName").path("value").asText());
-    assertEquals("Row 2 myTeam.cityTeam value incorrect", "ducks", node.path("myTeam.cityTeam").path("value").asText());
-    assertEquals("Row 2 myCity.popularity value incorrect", "5", node.path("myCity.popularity").path("value").asText());
+    assertEquals( "beijing", node.path("myCity.city").path("value").asText());
+    assertEquals( "134.5", node.path("myCity.distance").path("value").asText());
+    assertEquals( "beijing", node.path("myTeam.cityName").path("value").asText());
+    assertEquals( "ducks", node.path("myTeam.cityTeam").path("value").asText());
+    assertEquals( "5", node.path("myCity.popularity").path("value").asText());
     node = jsonBindingsNodes.path(4);
-    assertEquals("Row 5 myCity.city value incorrect", "london", node.path("myCity.city").path("value").asText());
-    assertEquals("Row 5 myCity.distance value incorrect", "50.4", node.path("myCity.distance").path("value").asText());
-    assertEquals("Row 5 myTeam.cityName value incorrect", "london", node.path("myTeam.cityName").path("value").asText());
-    assertEquals("Row 5 myTeam.cityTeam value incorrect", "arsenal", node.path("myTeam.cityTeam").path("value").asText());
-    assertEquals("Row 5 myCity.popularity value incorrect", "5", node.path("myCity.popularity").path("value").asText());
+    assertEquals( "london", node.path("myCity.city").path("value").asText());
+    assertEquals( "50.4", node.path("myCity.distance").path("value").asText());
+    assertEquals( "london", node.path("myTeam.cityName").path("value").asText());
+    assertEquals( "arsenal", node.path("myTeam.cityTeam").path("value").asText());
+    assertEquals( "5", node.path("myCity.popularity").path("value").asText());
 
     // TEST 4 - join inner with condition, joinInnerDoc and xpath
 
@@ -416,24 +415,24 @@ public class TestOpticOnLexicons extends AbstractFunctionalTest {
     jsonResults = jacksonHandle.get();
     jsonBindingsNodes = jsonResults.path("rows");
     // Should have 4 nodes returned.
-    assertEquals("Four nodes not returned from testJoinInnerKeymatchDateSort method ", 4, jsonBindingsNodes.size());
+    assertEquals( 4, jsonBindingsNodes.size());
     node = jsonBindingsNodes.path(0);
-    assertEquals("Row 1 myCity.city value incorrect", "beijing", node.path("myCity.city").path("value").asText());
-    assertEquals("Row 1 myCity.distance value incorrect", "134.5", node.path("myCity.distance").path("value").asText());
-    assertEquals("Row 1 myTeam.cityName value incorrect", "beijing", node.path("myTeam.cityName").path("value").asText());
-    assertEquals("Row 1 myTeam.cityTeam value incorrect", "ducks", node.path("myTeam.cityTeam").path("value").asText());
-    assertEquals("Row 1 myCity.popularity value incorrect", "5", node.path("myCity.popularity").path("value").asText());
-    assertEquals("Row 1 myCity.point value incorrect", toWKT("39.900002,116.4"), node.path("myCity.point").path("value").asText());
-    assertEquals("Row 1 nodes value incorrect", "39.9", node.path("nodes").path("value").asText());
+    assertEquals( "beijing", node.path("myCity.city").path("value").asText());
+    assertEquals( "134.5", node.path("myCity.distance").path("value").asText());
+    assertEquals( "beijing", node.path("myTeam.cityName").path("value").asText());
+    assertEquals( "ducks", node.path("myTeam.cityTeam").path("value").asText());
+    assertEquals( "5", node.path("myCity.popularity").path("value").asText());
+    assertEquals( toWKT("39.900002,116.4"), node.path("myCity.point").path("value").asText());
+    assertEquals( "39.9", node.path("nodes").path("value").asText());
 
     node = jsonBindingsNodes.path(3);
-    assertEquals("Row 4 myCity.city value incorrect", "new jersey", node.path("myCity.city").path("value").asText());
-    assertEquals("Row 4 myCity.distance value incorrect", "12.9", node.path("myCity.distance").path("value").asText());
-    assertEquals("Row 4 myTeam.cityName value incorrect", "new jersey", node.path("myTeam.cityName").path("value").asText());
-    assertEquals("Row 4 myTeam.cityTeam value incorrect", "nets", node.path("myTeam.cityTeam").path("value").asText());
-    assertEquals("Row 4 myCity.popularity value incorrect", "2", node.path("myCity.popularity").path("value").asText());
-    assertEquals("Row 4 myCity.point value incorrect", toWKT("40.720001,-74.07"), node.path("myCity.point").path("value").asText());
-    assertEquals("Row 4 nodes value incorrect", "40.72", node.path("nodes").path("value").asText());
+    assertEquals( "new jersey", node.path("myCity.city").path("value").asText());
+    assertEquals( "12.9", node.path("myCity.distance").path("value").asText());
+    assertEquals( "new jersey", node.path("myTeam.cityName").path("value").asText());
+    assertEquals( "nets", node.path("myTeam.cityTeam").path("value").asText());
+    assertEquals( "2", node.path("myCity.popularity").path("value").asText());
+    assertEquals( toWKT("40.720001,-74.07"), node.path("myCity.point").path("value").asText());
+    assertEquals( "40.72", node.path("nodes").path("value").asText());
 
     // TEST 20 - join inner with joinInnerDoc and xpath
     ExportablePlan innerJoinInnerDocXPath = plan1.joinInner(plan2)
@@ -457,27 +456,27 @@ public class TestOpticOnLexicons extends AbstractFunctionalTest {
     jsonBindingsNodes = jsonResults.path("rows");
 
     // Should have 5 nodes returned.
-    assertEquals("Five nodes not returned from testJoinInnerKeymatchDateSort method ", 5, jsonBindingsNodes.size());
+    assertEquals( 5, jsonBindingsNodes.size());
 
     node = jsonBindingsNodes.path(0);
-    assertEquals("Row 1 myCity.city value incorrect", "new jersey", node.path("myCity.city").path("value").asText());
-    assertEquals("Row 1 myCity.distance value incorrect", "12.9", node.path("myCity.distance").path("value").asText());
-    assertEquals("Row 1 myTeam.cityName value incorrect", "new jersey", node.path("myTeam.cityName").path("value").asText());
-    assertEquals("Row 1 myTeam.cityTeam value incorrect", "nets", node.path("myTeam.cityTeam").path("value").asText());
-    assertEquals("Row 1 myCity.popularity value incorrect", "2", node.path("myCity.popularity").path("value").asText());
-    assertEquals("Row 1 myCity.point value incorrect", toWKT("40.720001,-74.07"), node.path("myCity.point").path("value").asText());
-    assertEquals("Row 1 myCity.uri1 value incorrect", "/optic/lexicon/test/doc3.json", node.path("myCity.uri1").path("value").asText());
-    assertEquals("Row 1 myTeam.uri2 value incorrect", "/optic/lexicon/test/city3.json", node.path("myTeam.uri2").path("value").asText());
+    assertEquals( "new jersey", node.path("myCity.city").path("value").asText());
+    assertEquals( "12.9", node.path("myCity.distance").path("value").asText());
+    assertEquals( "new jersey", node.path("myTeam.cityName").path("value").asText());
+    assertEquals( "nets", node.path("myTeam.cityTeam").path("value").asText());
+    assertEquals( "2", node.path("myCity.popularity").path("value").asText());
+    assertEquals( toWKT("40.720001,-74.07"), node.path("myCity.point").path("value").asText());
+    assertEquals( "/optic/lexicon/test/doc3.json", node.path("myCity.uri1").path("value").asText());
+    assertEquals( "/optic/lexicon/test/city3.json", node.path("myTeam.uri2").path("value").asText());
 
     node = jsonBindingsNodes.path(4);
-    assertEquals("Row 5 myCity.city value incorrect", "london", node.path("myCity.city").path("value").asText());
-    assertEquals("Row 5 myCity.distance value incorrect", "50.4", node.path("myCity.distance").path("value").asText());
-    assertEquals("Row 5 myTeam.cityName value incorrect", "london", node.path("myTeam.cityName").path("value").asText());
-    assertEquals("Row 5 myTeam.cityTeam value incorrect", "arsenal", node.path("myTeam.cityTeam").path("value").asText());
-    assertEquals("Row 5 myCity.popularity value incorrect", "5", node.path("myCity.popularity").path("value").asText());
-    assertEquals("Row 5 myCity.point value incorrect", toWKT("51.5,-0.12"), node.path("myCity.point").path("value").asText());
-    assertEquals("Row 5 myCity.uri1 value incorrect", "/optic/lexicon/test/doc1.json", node.path("myCity.uri1").path("value").asText());
-    assertEquals("Row 5 myTeam.uri2 value incorrect", "/optic/lexicon/test/city1.json", node.path("myTeam.uri2").path("value").asText());
+    assertEquals( "london", node.path("myCity.city").path("value").asText());
+    assertEquals( "50.4", node.path("myCity.distance").path("value").asText());
+    assertEquals( "london", node.path("myTeam.cityName").path("value").asText());
+    assertEquals( "arsenal", node.path("myTeam.cityTeam").path("value").asText());
+    assertEquals( "5", node.path("myCity.popularity").path("value").asText());
+    assertEquals( toWKT("51.5,-0.12"), node.path("myCity.point").path("value").asText());
+    assertEquals( "/optic/lexicon/test/doc1.json", node.path("myCity.uri1").path("value").asText());
+    assertEquals( "/optic/lexicon/test/city1.json", node.path("myTeam.uri2").path("value").asText());
   }
 
   /*
@@ -514,13 +513,13 @@ public class TestOpticOnLexicons extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get();
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
     // Should have 4 nodes returned.
-    assertEquals("Four nodes not returned from testPreparePlan method ", 4, jsonBindingsNodes.size());
+    assertEquals( 4, jsonBindingsNodes.size());
     JsonNode first = jsonBindingsNodes.path(0);
-    assertEquals("Row 1 myCity.city value incorrect", "beijing", first.path("myCity.city").path("value").asText());
-    assertEquals("Row 1 myCity.point value incorrect", toWKT("39.900002,116.4"), first.path("myCity.point").path("value").asText());
+    assertEquals( "beijing", first.path("myCity.city").path("value").asText());
+    assertEquals( toWKT("39.900002,116.4"), first.path("myCity.point").path("value").asText());
     first = jsonBindingsNodes.path(3);
-    assertEquals("Row 4 myCity.city value incorrect", "new york", first.path("myCity.city").path("value").asText());
-    assertEquals("Row 4 myCity.point value incorrect", toWKT("40.709999,-74.009995"), first.path("myCity.point").path("value").asText());
+    assertEquals( "new york", first.path("myCity.city").path("value").asText());
+    assertEquals( toWKT("40.709999,-74.009995"), first.path("myCity.point").path("value").asText());
 
     // prepare = 2
     PreparePlan output2 = plan1.where(p.gt(popCol, p.xs.intVal(2)))
@@ -534,13 +533,13 @@ public class TestOpticOnLexicons extends AbstractFunctionalTest {
     jsonResults = jacksonHandle.get();
     jsonBindingsNodes = jsonResults.path("rows");
     // Should have 4 nodes returned.
-    assertEquals("Four nodes not returned from testPreparePlan method ", 4, jsonBindingsNodes.size());
+    assertEquals( 4, jsonBindingsNodes.size());
     first = jsonBindingsNodes.path(0);
-    assertEquals("Row 1 myCity.city value incorrect", "beijing", first.path("myCity.city").path("value").asText());
-    assertEquals("Row 1 myCity.point value incorrect", toWKT("39.900002,116.4"), first.path("myCity.point").path("value").asText());
+    assertEquals( "beijing", first.path("myCity.city").path("value").asText());
+    assertEquals( toWKT("39.900002,116.4"), first.path("myCity.point").path("value").asText());
     first = jsonBindingsNodes.path(3);
-    assertEquals("Row 4 myCity.city value incorrect", "new york", first.path("myCity.city").path("value").asText());
-    assertEquals("Row 4 myCity.point value incorrect", toWKT("40.709999,-74.009995"), first.path("myCity.point").path("value").asText());
+    assertEquals( "new york", first.path("myCity.city").path("value").asText());
+    assertEquals( toWKT("40.709999,-74.009995"), first.path("myCity.point").path("value").asText());
 
     // prepare = 5
     PreparePlan output3 = plan1.where(p.gt(popCol, p.xs.intVal(2)))
@@ -554,13 +553,13 @@ public class TestOpticOnLexicons extends AbstractFunctionalTest {
     jsonResults = jacksonHandle.get();
     jsonBindingsNodes = jsonResults.path("rows");
     // Should have 4 nodes returned.
-    assertEquals("Four nodes not returned from testPreparePlan method ", 4, jsonBindingsNodes.size());
+    assertEquals( 4, jsonBindingsNodes.size());
     first = jsonBindingsNodes.path(0);
-    assertEquals("Row 1 myCity.city value incorrect", "beijing", first.path("myCity.city").path("value").asText());
-    assertEquals("Row 1 myCity.point value incorrect", toWKT("39.900002,116.4"), first.path("myCity.point").path("value").asText());
+    assertEquals( "beijing", first.path("myCity.city").path("value").asText());
+    assertEquals( toWKT("39.900002,116.4"), first.path("myCity.point").path("value").asText());
     first = jsonBindingsNodes.path(3);
-    assertEquals("Row 4 myCity.city value incorrect", "new york", first.path("myCity.city").path("value").asText());
-    assertEquals("Row 4 myCity.point value incorrect", toWKT("40.709999,-74.009995"), first.path("myCity.point").path("value").asText());
+    assertEquals( "new york", first.path("myCity.city").path("value").asText());
+    assertEquals( toWKT("40.709999,-74.009995"), first.path("myCity.point").path("value").asText());
 
     // prepare = -3
     PreparePlan output4 = plan1.where(p.gt(popCol, p.xs.intVal(2)))
@@ -578,8 +577,8 @@ public class TestOpticOnLexicons extends AbstractFunctionalTest {
       System.out.println("Exception message is " + str.toString());
     }
     // Should have XDMP-OPTION exceptions.
-    assertTrue("Exceptions not found", str.toString().contains("XDMP-OPTION"));
-    assertTrue("Exceptions not found", str.toString().contains("Invalid option \"optimize=-3\""));
+    assertTrue( str.toString().contains("XDMP-OPTION"));
+    assertTrue( str.toString().contains("Invalid option \"optimize=-3\""));
   }
 
   /*
@@ -626,27 +625,27 @@ public class TestOpticOnLexicons extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get();
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
     // Should have 5 nodes returned.
-    assertEquals("Five nodes not returned from testJoinInnerWithSystemCol method ", 5, jsonBindingsNodes.size());
+    assertEquals( 5, jsonBindingsNodes.size());
     JsonNode node = jsonBindingsNodes.path(0);
 
-    assertEquals("Row 1 myCity.city value incorrect", "new jersey", node.path("myCity.city").path("value").asText());
-    assertEquals("Row 1 myCity.distance value incorrect", "12.9", node.path("myCity.distance").path("value").asText());
-    assertEquals("Row 1 myTeam.cityName value incorrect", "new jersey", node.path("myTeam.cityName").path("value").asText());
-    assertEquals("Row 1 myTeam.cityTeam value incorrect", "nets", node.path("myTeam.cityTeam").path("value").asText());
-    assertEquals("Row 1 myCity.popularity value incorrect", "2", node.path("myCity.popularity").path("value").asText());
-    assertEquals("Row 1 myCity.point value incorrect", toWKT("40.720001,-74.07"), node.path("myCity.point").path("value").asText());
-    assertEquals("Row 1 myCity.uri1 value incorrect", "/optic/lexicon/test/doc3.json", node.path("myCity.uri1").path("value").asText());
-    assertEquals("Row 1 myTeam.uri2 value incorrect", "/optic/lexicon/test/city3.json", node.path("myTeam.uri2").path("value").asText());
+    assertEquals( "new jersey", node.path("myCity.city").path("value").asText());
+    assertEquals( "12.9", node.path("myCity.distance").path("value").asText());
+    assertEquals( "new jersey", node.path("myTeam.cityName").path("value").asText());
+    assertEquals( "nets", node.path("myTeam.cityTeam").path("value").asText());
+    assertEquals( "2", node.path("myCity.popularity").path("value").asText());
+    assertEquals( toWKT("40.720001,-74.07"), node.path("myCity.point").path("value").asText());
+    assertEquals( "/optic/lexicon/test/doc3.json", node.path("myCity.uri1").path("value").asText());
+    assertEquals( "/optic/lexicon/test/city3.json", node.path("myTeam.uri2").path("value").asText());
 
     node = jsonBindingsNodes.path(4);
-    assertEquals("Row 5 myCity.city value incorrect", "london", node.path("myCity.city").path("value").asText());
-    assertEquals("Row 5 myCity.distance value incorrect", "50.4", node.path("myCity.distance").path("value").asText());
-    assertEquals("Row 5 myTeam.cityName value incorrect", "london", node.path("myTeam.cityName").path("value").asText());
-    assertEquals("Row 5 myTeam.cityTeam value incorrect", "arsenal", node.path("myTeam.cityTeam").path("value").asText());
-    assertEquals("Row 5 myCity.popularity value incorrect", "5", node.path("myCity.popularity").path("value").asText());
-    assertEquals("Row 5 myCity.point value incorrect", toWKT("51.5,-0.12"), node.path("myCity.point").path("value").asText());
-    assertEquals("Row 5 myCity.uri1 value incorrect", "/optic/lexicon/test/doc1.json", node.path("myCity.uri1").path("value").asText());
-    assertEquals("Row 5 myTeam.uri2 value incorrect", "/optic/lexicon/test/city1.json", node.path("myTeam.uri2").path("value").asText());
+    assertEquals( "london", node.path("myCity.city").path("value").asText());
+    assertEquals( "50.4", node.path("myCity.distance").path("value").asText());
+    assertEquals( "london", node.path("myTeam.cityName").path("value").asText());
+    assertEquals( "arsenal", node.path("myTeam.cityTeam").path("value").asText());
+    assertEquals( "5", node.path("myCity.popularity").path("value").asText());
+    assertEquals( toWKT("51.5,-0.12"), node.path("myCity.point").path("value").asText());
+    assertEquals( "/optic/lexicon/test/doc1.json", node.path("myCity.uri1").path("value").asText());
+    assertEquals( "/optic/lexicon/test/city1.json", node.path("myTeam.uri2").path("value").asText());
   }
 
   /*
@@ -684,21 +683,21 @@ public class TestOpticOnLexicons extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get();
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
     // Should have 4 nodes returned.
-    assertEquals("Four nodes not returned from testPreparedPlanMultipleOrderBy method", 4, jsonBindingsNodes.size());
+    assertEquals( 4, jsonBindingsNodes.size());
     JsonNode node = jsonBindingsNodes.path(0);
-    assertEquals("Row 1 myCity.city value incorrect", "cape town", node.path("myCity.city").path("value").asText());
-    assertEquals("Row 1 myCity.popularity value incorrect", "3", node.path("myCity.popularity").path("value").asText());
+    assertEquals( "cape town", node.path("myCity.city").path("value").asText());
+    assertEquals( "3", node.path("myCity.popularity").path("value").asText());
     node = jsonBindingsNodes.path(1);
-    assertEquals("Row 2 myCity.popularity value incorrect", "5", node.path("myCity.popularity").path("value").asText());
+    assertEquals( "5", node.path("myCity.popularity").path("value").asText());
     node = jsonBindingsNodes.path(3);
-    assertEquals("Row 4 myCity.popularity value incorrect", "5", node.path("myCity.popularity").path("value").asText());
-    assertEquals("Row 4 myCity.date value incorrect", "1981-11-09", node.path("myCity.date").path("value").asText());
+    assertEquals( "5", node.path("myCity.popularity").path("value").asText());
+    assertEquals( "1981-11-09", node.path("myCity.date").path("value").asText());
 
     StringHandle strHandle = new StringHandle();
     // Export the plan.
     String str = preparedPlan.export(strHandle).get();
-    assertTrue("Function not available fromLexicons in exported plan", str.contains("\"fn\":\"from-lexicons\""));
-    assertTrue("Prepare from fromLexicons not in exported plan", str.contains("\"fn\":\"prepare\""));
+    assertTrue( str.contains("\"fn\":\"from-lexicons\""));
+    assertTrue( str.contains("\"fn\":\"prepare\""));
   }
 
   /*
@@ -757,17 +756,17 @@ public class TestOpticOnLexicons extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get();
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
     // Should have 5 nodes returned.
-    assertEquals("Five nodes not returned from testConditionalFromJoinDoc method ", 5, jsonBindingsNodes.size());
+    assertEquals( 5, jsonBindingsNodes.size());
 
     JsonNode node = jsonBindingsNodes.path(0);
-    assertEquals("Row 1 myCity.city value incorrect", "london", node.path("myCity.city").path("value").asText());
-    assertEquals("Row 1 myTeam.cityName value incorrect", "london", node.path("myTeam.cityName").path("value").asText());
-    assertEquals("Row 1 myTeam.cityTeam value incorrect", "arsenal", node.path("myTeam.cityTeam").path("value").asText());
+    assertEquals( "london", node.path("myCity.city").path("value").asText());
+    assertEquals( "london", node.path("myTeam.cityName").path("value").asText());
+    assertEquals( "arsenal", node.path("myTeam.cityTeam").path("value").asText());
 
     node = jsonBindingsNodes.path(4);
-    assertEquals("Row 5 myCity.city value incorrect", "cape town", node.path("myCity.city").path("value").asText());
-    assertEquals("Row 5 myTeam.cityName value incorrect", "cape town", node.path("myTeam.cityName").path("value").asText());
-    assertEquals("Row 5 myTeam.cityTeam value incorrect", "pirates", node.path("myTeam.cityTeam").path("value").asText());
+    assertEquals( "cape town", node.path("myCity.city").path("value").asText());
+    assertEquals( "cape town", node.path("myTeam.cityName").path("value").asText());
+    assertEquals( "pirates", node.path("myTeam.cityTeam").path("value").asText());
   }
 
   /*
@@ -808,22 +807,22 @@ public class TestOpticOnLexicons extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get();
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
     // Should have 5 nodes returned.
-    assertEquals("Five nodes not returned from testJoinInnerKeymatchDateSort method ", 5, jsonBindingsNodes.size());
+    assertEquals( 5, jsonBindingsNodes.size());
 
     JsonNode node = jsonBindingsNodes.path(0);
-    assertEquals("Row 1 myCity.city value incorrect", "new jersey", node.path("myCity.city").path("value").asText());
-    assertEquals("Row 1 myCity.date value incorrect", "1971-12-23", node.path("myCity.date").path("value").asText());
-    assertEquals("Row 1 myCity.distance value incorrect", "12.9", node.path("myCity.distance").path("value").asText());
+    assertEquals( "new jersey", node.path("myCity.city").path("value").asText());
+    assertEquals( "1971-12-23", node.path("myCity.date").path("value").asText());
+    assertEquals( "12.9", node.path("myCity.distance").path("value").asText());
 
     node = jsonBindingsNodes.path(1);
-    assertEquals("Row 2 myCity.city value incorrect", "beijing", node.path("myCity.city").path("value").asText());
-    assertEquals("Row 2 myCity.date value incorrect", "1981-11-09", node.path("myCity.date").path("value").asText());
-    assertEquals("Row 2 myCity.distance value incorrect", "134.5", node.path("myCity.distance").path("value").asText());
+    assertEquals( "beijing", node.path("myCity.city").path("value").asText());
+    assertEquals( "1981-11-09", node.path("myCity.date").path("value").asText());
+    assertEquals( "134.5", node.path("myCity.distance").path("value").asText());
 
     node = jsonBindingsNodes.path(4);
-    assertEquals("Row 5 myCity.city value incorrect", "london", node.path("myCity.city").path("value").asText());
-    assertEquals("Row 5 myCity.date value incorrect", "2007-01-01", node.path("myCity.date").path("value").asText());
-    assertEquals("Row 5 myCity.distance value incorrect", "50.4", node.path("myCity.distance").path("value").asText());
+    assertEquals( "london", node.path("myCity.city").path("value").asText());
+    assertEquals( "2007-01-01", node.path("myCity.date").path("value").asText());
+    assertEquals( "50.4", node.path("myCity.distance").path("value").asText());
   }
 
   /*
@@ -863,8 +862,8 @@ public class TestOpticOnLexicons extends AbstractFunctionalTest {
       System.out.println("Exception message is " + str.toString());
     }
     // Should have SQL-NOCOLUMN exceptions.
-    assertTrue("Exceptions not found", str.toString().contains("SQL-NOCOLUMN"));
-    assertTrue("Exceptions not found", str.toString().contains("Column not found: date_invalid"));
+    assertTrue( str.toString().contains("SQL-NOCOLUMN"));
+    assertTrue( str.toString().contains("Column not found: date_invalid"));
   }
 
   /*
@@ -904,7 +903,7 @@ public class TestOpticOnLexicons extends AbstractFunctionalTest {
       System.out.println("Exception message is " + str.toString());
     }
     // Should have SQL-NOCOLUMN exceptions.
-    assertTrue("Exceptions not found",
+    assertTrue(
         str.toString().contains("XDMP-ELEMRIDXNOTFOUND: cts.jsonPropertyReference(\"city_invalid\") -- No  element range index for city_invalid collation"));
   }
 
@@ -951,8 +950,8 @@ public class TestOpticOnLexicons extends AbstractFunctionalTest {
       System.out.println("Exception message is " + str.toString());
     }
     // Should have SQL-NOCOLUMN exceptions.
-    assertTrue("Exceptions not found", str.toString().contains("SQL-NOCOLUMN"));
-    assertTrue("Exceptions not found", str.toString().contains("Column not found: myCity_invalid.city"));
+    assertTrue( str.toString().contains("SQL-NOCOLUMN"));
+    assertTrue( str.toString().contains("Column not found: myCity_invalid.city"));
   }
 
   /*
@@ -998,8 +997,8 @@ public class TestOpticOnLexicons extends AbstractFunctionalTest {
       System.out.println("Exception message is " + str.toString());
     }
     // Should have SQL-NOCOLUMN exceptions.
-    assertTrue("Exceptions not found", str.toString().contains("SQL-NOCOLUMN"));
-    assertTrue("Exceptions not found", str.toString().contains("Column not found: invalid_view.city"));
+    assertTrue( str.toString().contains("SQL-NOCOLUMN"));
+    assertTrue( str.toString().contains("Column not found: invalid_view.city"));
   }
 
   /*
@@ -1040,8 +1039,8 @@ public class TestOpticOnLexicons extends AbstractFunctionalTest {
       System.out.println("Exception message is " + str.toString());
     }
     // Should have SQL-NOCOLUMN exceptions.
-    assertTrue("Exceptions not found", str.toString().contains("SQL-NOCOLUMN"));
-    assertTrue("Exceptions not found", str.toString().contains("Column not found: /foo/bar"));
+    assertTrue( str.toString().contains("SQL-NOCOLUMN"));
+    assertTrue( str.toString().contains("Column not found: /foo/bar"));
 
     // null uri on join inner doc
     try {
@@ -1053,7 +1052,7 @@ public class TestOpticOnLexicons extends AbstractFunctionalTest {
       System.out.println("Exception message is " + str.toString());
     }
     // Should have java.lang.IllegalArgumentException exceptions.
-    assertTrue("Exceptions not found", str.toString().contains("sourceCol parameter for joinDoc() cannot be null"));
+    assertTrue( str.toString().contains("sourceCol parameter for joinDoc() cannot be null"));
 
     // invalid doc on join inner doc
     try {
@@ -1064,8 +1063,8 @@ public class TestOpticOnLexicons extends AbstractFunctionalTest {
       str.append(ex.getMessage());
     }
     // Should have SQL-NOCOLUMN exceptions.
-    assertTrue("Exceptions not found", str.toString().contains("SQL-NOCOLUMN"));
-    assertTrue("Exceptions not found", str.toString().contains("Column not found: {foo: bar}"));
+    assertTrue( str.toString().contains("SQL-NOCOLUMN"));
+    assertTrue( str.toString().contains("Column not found: {foo: bar}"));
   }
 
   /*
@@ -1124,13 +1123,13 @@ public class TestOpticOnLexicons extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get();
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
     // Should have 3 nodes returned.
-    assertEquals("Three nodes not returned from testJoinInnerKeymatchDateSort method ", 3, jsonBindingsNodes.size());
+    assertEquals( 3, jsonBindingsNodes.size());
     JsonNode first = jsonBindingsNodes.path(0);
-    assertEquals("Row 1 myCity.city value incorrect", "london", first.path("myCity.city").path("value").asText());
-    assertEquals("Row 1 Unnamed Node value incorrect", "51.5", first.path("nodes").path("value").asText());
+    assertEquals( "london", first.path("myCity.city").path("value").asText());
+    assertEquals( "51.5", first.path("nodes").path("value").asText());
     JsonNode third = jsonBindingsNodes.path(2);
-    assertEquals("Row 3 myCity.city value incorrect", "new jersey", third.path("myCity.city").path("value").asText());
-    assertEquals("Row 3 Unnamed Node value incorrect", "40.72", third.path("nodes").path("value").asText());
+    assertEquals( "new jersey", third.path("myCity.city").path("value").asText());
+    assertEquals( "40.72", third.path("nodes").path("value").asText());
   }
 
   /*
@@ -1196,10 +1195,10 @@ public class TestOpticOnLexicons extends AbstractFunctionalTest {
     System.out.println(finalPlan.exportAs(ObjectNode.class).toPrettyString());
     JsonNode rows = rowMgr.resultDoc(finalPlan, new JacksonHandle()).get().path("rows");
     // Should have 1 node returned.
-    assertEquals("One node not returned from testJoinInnerKeymatchDateSort method ", 1, rows.size());
+    assertEquals( 1, rows.size());
     JsonNode first = rows.path(0);
-    assertEquals("Row 1 myCity.city value incorrect", "london", first.path("myCity.city").path("value").asText());
-    assertEquals("Row 1 Unnamed Node value incorrect", "Two recent discoveries indicate probable very early settlements near the Thames", first.path("nodes").path("value").asText());
+    assertEquals( "london", first.path("myCity.city").path("value").asText());
+    assertEquals( "Two recent discoveries indicate probable very early settlements near the Thames", first.path("nodes").path("value").asText());
   }
 
   /*
@@ -1260,9 +1259,9 @@ public class TestOpticOnLexicons extends AbstractFunctionalTest {
     rowMgr.resultDoc(UnnamedNodes, jacksonHandle);
     JsonNode jsonResults = jacksonHandle.get();
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
-    assertEquals("Expected 1 node: " + jsonBindingsNodes.toPrettyString(), 1, jsonBindingsNodes.size());
+    assertEquals(1, jsonBindingsNodes.size(), "Expected 1 node: " + jsonBindingsNodes.toPrettyString());
     JsonNode first = jsonBindingsNodes.path(0);
-    assertEquals("Row 1 myCity.city value incorrect", "new jersey", first.path("myCity.city").path("value").asText());
+    assertEquals( "new jersey", first.path("myCity.city").path("value").asText());
   }
 
 }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnLiterals.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnLiterals.java
@@ -28,9 +28,9 @@ import com.marklogic.client.type.PlanAggregateColSeq;
 import com.marklogic.client.type.PlanColumn;
 import com.marklogic.client.type.PlanExprColSeq;
 import com.marklogic.client.type.PlanValueOption;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 import org.xml.sax.SAXException;
 
 import javax.xml.parsers.ParserConfigurationException;
@@ -43,8 +43,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.*;
-
 public class TestOpticOnLiterals extends AbstractFunctionalTest {
 
   private static Map<String, Object>[] literals1 = new HashMap[5];
@@ -52,7 +50,7 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
   private static Map<String, Object>[] storeInformation = new HashMap[4];
   private static Map<String, Object>[] internetSales = new HashMap[4];
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception
   {
     // Install the TDE templates
@@ -209,15 +207,15 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodes = jacksonHandle.get().path("rows");
 
     // Should have 4 nodes returned.
-    assertEquals("Four nodes not returned from testJoinInner method", 4, jsonBindingsNodes.size());
+    assertEquals(4, jsonBindingsNodes.size());
     JsonNode node = jsonBindingsNodes.path(0);
-    assertEquals("Row 1 rowId value incorrect", "1", node.path("rowId").path("value").asText());
-    assertEquals("Row 1 desc value incorrect", "ball", node.path("desc").path("value").asText());
-    assertEquals("Row 1 colorDesc value incorrect", "red", node.path("colorDesc").path("value").asText());
+    assertEquals( "1", node.path("rowId").path("value").asText());
+    assertEquals( "ball", node.path("desc").path("value").asText());
+    assertEquals( "red", node.path("colorDesc").path("value").asText());
     node = jsonBindingsNodes.path(3);
-    assertEquals("Row 4 rowId value incorrect", "4", node.path("rowId").path("value").asText());
-    assertEquals("Row 4 desc value incorrect", "hoop", node.path("desc").path("value").asText());
-    assertEquals("Row 4 colorDesc value incorrect", "red", node.path("colorDesc").path("value").asText());
+    assertEquals( "4", node.path("rowId").path("value").asText());
+    assertEquals( "hoop", node.path("desc").path("value").asText());
+    assertEquals( "red", node.path("colorDesc").path("value").asText());
 
     // Join inner with qualifier
     ModifyPlan plan3 = p.fromLiterals(literals1, "table1");
@@ -231,13 +229,13 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
     rowMgr.resultDoc(outputQualifier, jacksonHandle);
     jsonBindingsNodes = jacksonHandle.get().path("rows");
     node = jsonBindingsNodes.path(3);
-    assertEquals("Row 1 table1.rowId value incorrect", "1", node.path("table1.rowId").path("value").asText());
-    assertEquals("Row 1 table1.desc value incorrect", "ball", node.path("table1.desc").path("value").asText());
-    assertEquals("Row 1 table2.colorDesc value incorrect", "red", node.path("table2.colorDesc").path("value").asText());
+    assertEquals( "1", node.path("table1.rowId").path("value").asText());
+    assertEquals( "ball", node.path("table1.desc").path("value").asText());
+    assertEquals( "red", node.path("table2.colorDesc").path("value").asText());
     node = jsonBindingsNodes.path(0);
-    assertEquals("Row 4 table1.rowId value incorrect", "4", node.path("table1.rowId").path("value").asText());
-    assertEquals("Row 4 table1.desc value incorrect", "hoop", node.path("table1.desc").path("value").asText());
-    assertEquals("Row 4 table2.colorDesc value incorrect", "red", node.path("table2.colorDesc").path("value").asText());
+    assertEquals( "4", node.path("table1.rowId").path("value").asText());
+    assertEquals( "hoop", node.path("table1.desc").path("value").asText());
+    assertEquals( "red", node.path("table2.colorDesc").path("value").asText());
 
     // Test join and multiple order by
     ModifyPlan plan5 = p.fromLiterals(literals1, "myItem");
@@ -256,19 +254,19 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
     rowMgr.resultDoc(outputMultiOrder, jacksonHandle);
     jsonBindingsNodes = jacksonHandle.get().path("rows");
     // Should have 4 nodes returned.
-    assertEquals("Four nodes not returned from testJoinInner method - multiple order by", 4, jsonBindingsNodes.size());
+    assertEquals( 4, jsonBindingsNodes.size());
     node = jsonBindingsNodes.path(0);
-    assertEquals("Row 1 myItem.desc value incorrect", "ball", node.path("myItem.desc").path("value").asText());
-    assertEquals("Row 1 myColor.colorId value incorrect", "1", node.path("myColor.colorId").path("value").asText());
+    assertEquals( "ball", node.path("myItem.desc").path("value").asText());
+    assertEquals( "1", node.path("myColor.colorId").path("value").asText());
     node = jsonBindingsNodes.path(1);
-    assertEquals("Row 2 myItem.desc value incorrect", "box", node.path("myItem.desc").path("value").asText());
-    assertEquals("Row 2 myColor.colorId value incorrect", "1", node.path("myColor.colorId").path("value").asText());
+    assertEquals( "box", node.path("myItem.desc").path("value").asText());
+    assertEquals( "1", node.path("myColor.colorId").path("value").asText());
     node = jsonBindingsNodes.path(2);
-    assertEquals("Row 3 myItem.desc value incorrect", "hoop", node.path("myItem.desc").path("value").asText());
-    assertEquals("Row 3 myColor.colorId value incorrect", "1", node.path("myColor.colorId").path("value").asText());
+    assertEquals( "hoop", node.path("myItem.desc").path("value").asText());
+    assertEquals( "1", node.path("myColor.colorId").path("value").asText());
     node = jsonBindingsNodes.path(3);
-    assertEquals("Row 4 myItem.desc value incorrect", "square", node.path("myItem.desc").path("value").asText());
-    assertEquals("Row 4 myColor.colorId value incorrect", "2", node.path("myColor.colorId").path("value").asText());
+    assertEquals( "square", node.path("myItem.desc").path("value").asText());
+    assertEquals( "2", node.path("myColor.colorId").path("value").asText());
 
     // Test multple inner joins
     Map<String, Object>[] literals3 = new HashMap[4];
@@ -307,23 +305,23 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
     rowMgr.resultDoc(outputMultiJoin, jacksonHandle);
     jsonBindingsNodes = jacksonHandle.get().path("rows");
     // Should have 4 nodes returned.
-    assertEquals("Four nodes not returned from testJoinInner method - multiple joins", 4, jsonBindingsNodes.size());
+    assertEquals( 4, jsonBindingsNodes.size());
     node = jsonBindingsNodes.path(0);
-    assertEquals("Row 1 myItem.desc value incorrect", "ball", node.path("myItem.desc").path("value").asText());
-    assertEquals("Row 1 myColor.colorId value incorrect", "1", node.path("myColor.colorId").path("value").asText());
-    assertEquals("Row 1 myRef.ref value incorrect", "rose", node.path("myRef.ref").path("value").asText());
+    assertEquals( "ball", node.path("myItem.desc").path("value").asText());
+    assertEquals( "1", node.path("myColor.colorId").path("value").asText());
+    assertEquals( "rose", node.path("myRef.ref").path("value").asText());
     node = jsonBindingsNodes.path(1);
-    assertEquals("Row 2 myItem.desc value incorrect", "box", node.path("myItem.desc").path("value").asText());
-    assertEquals("Row 2 myColor.colorId value incorrect", "1", node.path("myColor.colorId").path("value").asText());
-    assertEquals("Row 2 myRef.ref value incorrect", "rose", node.path("myRef.ref").path("value").asText());
+    assertEquals( "box", node.path("myItem.desc").path("value").asText());
+    assertEquals( "1", node.path("myColor.colorId").path("value").asText());
+    assertEquals( "rose", node.path("myRef.ref").path("value").asText());
     node = jsonBindingsNodes.path(2);
-    assertEquals("Row 3 myItem.desc value incorrect", "hoop", node.path("myItem.desc").path("value").asText());
-    assertEquals("Row 3 myColor.colorId value incorrect", "1", node.path("myColor.colorId").path("value").asText());
-    assertEquals("Row 3 myRef.ref value incorrect", "rose", node.path("myRef.ref").path("value").asText());
+    assertEquals( "hoop", node.path("myItem.desc").path("value").asText());
+    assertEquals( "1", node.path("myColor.colorId").path("value").asText());
+    assertEquals( "rose", node.path("myRef.ref").path("value").asText());
     node = jsonBindingsNodes.path(3);
-    assertEquals("Row 4 myItem.desc value incorrect", "square", node.path("myItem.desc").path("value").asText());
-    assertEquals("Row 4 myColor.colorId value incorrect", "2", node.path("myColor.colorId").path("value").asText());
-    assertEquals("Row 4 myRef.ref value incorrect", "water", node.path("myRef.ref").path("value").asText());
+    assertEquals( "square", node.path("myItem.desc").path("value").asText());
+    assertEquals( "2", node.path("myColor.colorId").path("value").asText());
+    assertEquals( "water", node.path("myRef.ref").path("value").asText());
   }
 
   /*
@@ -352,19 +350,19 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodes = jacksonHandle.get().path("rows");
 
     // Should have 5 nodes returned.
-    assertEquals("Five nodes not returned from testJoinLeftOuter method", 5, jsonBindingsNodes.size());
+    assertEquals( 5, jsonBindingsNodes.size());
     JsonNode node = jsonBindingsNodes.path(0);
-    assertEquals("Row 1 rowId value incorrect", "1", node.path("rowId").path("value").asText());
-    assertEquals("Row 1 desc value incorrect", "ball", node.path("desc").path("value").asText());
-    assertEquals("Row 1 colorDesc value incorrect", "red", node.path("colorDesc").path("value").asText());
+    assertEquals( "1", node.path("rowId").path("value").asText());
+    assertEquals( "ball", node.path("desc").path("value").asText());
+    assertEquals( "red", node.path("colorDesc").path("value").asText());
     node = jsonBindingsNodes.path(3);
-    assertEquals("Row 4 rowId value incorrect", "4", node.path("rowId").path("value").asText());
-    assertEquals("Row 4 desc value incorrect", "hoop", node.path("desc").path("value").asText());
-    assertEquals("Row 4 colorDesc value incorrect", "red", node.path("colorDesc").path("value").asText());
+    assertEquals( "4", node.path("rowId").path("value").asText());
+    assertEquals( "hoop", node.path("desc").path("value").asText());
+    assertEquals( "red", node.path("colorDesc").path("value").asText());
     node = jsonBindingsNodes.path(4);
-    assertEquals("Row 5 rowId value incorrect", "5", node.path("rowId").path("value").asText());
-    assertEquals("Row 5 desc value incorrect", "circle", node.path("desc").path("value").asText());
-    assertFalse("Row 5 colorDesc should be null", node.path("colorDesc").isNull());
+    assertEquals( "5", node.path("rowId").path("value").asText());
+    assertEquals( "circle", node.path("desc").path("value").asText());
+    assertFalse(node.path("colorDesc").isNull());
     // To verify issue 1055.
     FileHandle fh = new FileHandle();
     rowMgr.resultDoc(output, fh);
@@ -375,11 +373,11 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
     JsonNode fromFile = mapper.readTree(file).path("rows");
     System.out.println(fileContents);
 
-    assertEquals("Five nodes not returned from testJoinLeftOuter method", 5, fromFile.size());
+    assertEquals( 5, fromFile.size());
     JsonNode nodeFile = fromFile.path(0);
-    assertEquals("Row 1 rowId value incorrect", "1", nodeFile.path("rowId").path("value").asText());
-    assertEquals("Row 1 desc value incorrect", "ball", nodeFile.path("desc").path("value").asText());
-    assertEquals("Row 1 colorDesc value incorrect", "red", nodeFile.path("colorDesc").path("value").asText());
+    assertEquals( "1", nodeFile.path("rowId").path("value").asText());
+    assertEquals( "ball", nodeFile.path("desc").path("value").asText());
+    assertEquals( "red", nodeFile.path("colorDesc").path("value").asText());
   }
 
   /*
@@ -406,16 +404,16 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodes = jacksonHandle.get().path("rows");
 
     // Should have 3 nodes returned.
-    assertEquals("Three nodes not returned from testJoinLeftOuter method", 3, jsonBindingsNodes.size());
+    assertEquals( 3, jsonBindingsNodes.size());
     JsonNode node = jsonBindingsNodes.path(0);
-    assertEquals("Row 1 colorId value incorrect", "1", node.path("colorId").path("value").asText());
-    assertEquals("Row 1 new_color_id value incorrect", "1", node.path("new_color_id").path("value").asText());
+    assertEquals( "1", node.path("colorId").path("value").asText());
+    assertEquals("1", node.path("new_color_id").path("value").asText());
     node = jsonBindingsNodes.path(1);
-    assertEquals("Row 2 colorId value incorrect", "2", node.path("colorId").path("value").asText());
-    assertEquals("Row 2 new_color_id value incorrect", "2", node.path("new_color_id").path("value").asText());
+    assertEquals( "2", node.path("colorId").path("value").asText());
+    assertEquals("2", node.path("new_color_id").path("value").asText());
     node = jsonBindingsNodes.path(2);
-    assertEquals("Row 3 colorId value incorrect", "5", node.path("colorId").path("value").asText());
-    assertEquals("Row 3 new_color_id value incorrect", "5", node.path("new_color_id").path("value").asText());
+    assertEquals( "5", node.path("colorId").path("value").asText());
+    assertEquals("5", node.path("new_color_id").path("value").asText());
   }
 
   /*
@@ -446,17 +444,17 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodes = jacksonHandle.get().path("rows");
 
     // Should have 2 nodes returned.
-    assertEquals("Two nodes not returned from testOffsetAndLimit method", 2, jsonBindingsNodes.size());
+    assertEquals( 2, jsonBindingsNodes.size());
     JsonNode node = jsonBindingsNodes.path(0);
-    assertEquals("Row 1 rowId value incorrect", "3", node.path("rowId").path("value").asText());
-    assertEquals("Row 1 desc value incorrect", "box", node.path("desc").path("value").asText());
-    assertEquals("Row 1 colorId value incorrect", "1", node.path("colorId").path("value").asText());
-    assertEquals("Row 1 colorDesc value incorrect", "red", node.path("colorDesc").path("value").asText());
+    assertEquals( "3", node.path("rowId").path("value").asText());
+    assertEquals( "box", node.path("desc").path("value").asText());
+    assertEquals( "1", node.path("colorId").path("value").asText());
+    assertEquals( "red", node.path("colorDesc").path("value").asText());
     node = jsonBindingsNodes.path(1);
-    assertEquals("Row 2 rowId value incorrect", "4", node.path("rowId").path("value").asText());
-    assertEquals("Row 2 desc value incorrect", "hoop", node.path("desc").path("value").asText());
-    assertEquals("Row 2 colorId value incorrect", "1", node.path("colorId").path("value").asText());
-    assertEquals("Row 2 colorDesc value incorrect", "red", node.path("colorDesc").path("value").asText());
+    assertEquals( "4", node.path("rowId").path("value").asText());
+    assertEquals( "hoop", node.path("desc").path("value").asText());
+    assertEquals( "1", node.path("colorId").path("value").asText());
+    assertEquals( "red", node.path("colorDesc").path("value").asText());
 
     // limit with 0 length
     ModifyPlan outputLimit = plan1.joinInner(plan2)
@@ -473,8 +471,8 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
       System.out.println("Exception message is " + str.toString());
     }
     // Should have OPTIC-INVALARGS exceptions.
-    assertTrue("Exceptions not found", str.toString().contains("OPTIC-INVALARGS"));
-    assertTrue("Exceptions not found", str.toString().contains("Invalid arguments: limit must be a positive number: 0"));
+    assertTrue( str.toString().contains("OPTIC-INVALARGS"));
+    assertTrue( str.toString().contains("Invalid arguments: limit must be a positive number: 0"));
   }
 
   /*
@@ -526,33 +524,33 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodes = jacksonHandle.get().path("rows");
 
     // Should have 4 nodes returned.
-    assertEquals("Four nodes not returned from testArithmeticExpression method", 4, jsonBindingsNodes.size());
+    assertEquals( 4, jsonBindingsNodes.size());
     JsonNode node = jsonBindingsNodes.path(0);
 
-    assertEquals("Row 1 rowId value incorrect", "1", node.path("rowId").path("value").asText());
-    assertEquals("Row 1 colorDesc value incorrect", "red", node.path("colorDesc").path("value").asText());
+    assertEquals( "1", node.path("rowId").path("value").asText());
+    assertEquals( "red", node.path("colorDesc").path("value").asText());
 
-    assertEquals("Row 1 added value incorrect", "12", node.path("added").path("value").asText());
-    assertEquals("Row 1 subtracted value incorrect", "0", node.path("subtracted").path("value").asText());
-    assertEquals("Row 1 divided value incorrect", "1", node.path("divided").path("value").asText());
-    assertEquals("Row 1 multiplied value incorrect", "0.600000023841858", node.path("multiplied").path("value").asText());
-    assertEquals("Row 1 caseExpr value incorrect", "foo", node.path("caseExpr").path("value").asText());
+    assertEquals( "12", node.path("added").path("value").asText());
+    assertEquals( "0", node.path("subtracted").path("value").asText());
+    assertEquals( "1", node.path("divided").path("value").asText());
+    assertEquals( "0.600000023841858", node.path("multiplied").path("value").asText());
+    assertEquals( "foo", node.path("caseExpr").path("value").asText());
 
     node = jsonBindingsNodes.path(1);
-    assertEquals("Row 2 caseExpr value incorrect", "baz", node.path("caseExpr").path("value").asText());
+    assertEquals( "baz", node.path("caseExpr").path("value").asText());
 
     node = jsonBindingsNodes.path(2);
-    assertEquals("Row 3 caseExpr value incorrect", "rat", node.path("caseExpr").path("value").asText());
+    assertEquals( "rat", node.path("caseExpr").path("value").asText());
 
     node = jsonBindingsNodes.path(3);
-    assertEquals("Row 4 rowId value incorrect", "4", node.path("rowId").path("value").asText());
-    assertEquals("Row 4 colorDesc value incorrect", "red", node.path("colorDesc").path("value").asText());
+    assertEquals( "4", node.path("rowId").path("value").asText());
+    assertEquals( "red", node.path("colorDesc").path("value").asText());
 
-    assertEquals("Row 4 added value incorrect", "15", node.path("added").path("value").asText());
-    assertEquals("Row 4 subtracted value incorrect", "-3", node.path("subtracted").path("value").asText());
-    assertEquals("Row 4 divided value incorrect", "0.25", node.path("divided").path("value").asText());
-    assertEquals("Row 4 multiplied value incorrect", "2.400000095367432", node.path("multiplied").path("value").asText());
-    assertEquals("Row 4 caseExpr value incorrect", "bar", node.path("caseExpr").path("value").asText());
+    assertEquals( "15", node.path("added").path("value").asText());
+    assertEquals( "-3", node.path("subtracted").path("value").asText());
+    assertEquals( "0.25", node.path("divided").path("value").asText());
+    assertEquals( "2.400000095367432", node.path("multiplied").path("value").asText());
+    assertEquals( "bar", node.path("caseExpr").path("value").asText());
   }
 
   /*
@@ -609,15 +607,15 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodes = jacksonHandle.get().path("rows");
 
     // Should have 2 nodes returned.
-    assertEquals("Two nodes not returned from testJoinInnerDocOnJson method", 2, jsonBindingsNodes.size());
+    assertEquals( 2, jsonBindingsNodes.size());
     JsonNode node = jsonBindingsNodes.path(0);
-    assertEquals("Row 1 id value incorrect", "1", node.path("id").path("value").asText());
-    assertEquals("Row 1 val value incorrect", "2", node.path("val").path("value").asText());
-    assertEquals("Row 1 uri value incorrect", "/optic/lexicon/test/doc1.json", node.path("uri").path("value").asText());
+    assertEquals( "1", node.path("id").path("value").asText());
+    assertEquals( "2", node.path("val").path("value").asText());
+    assertEquals( "/optic/lexicon/test/doc1.json", node.path("uri").path("value").asText());
     node = jsonBindingsNodes.path(1);
-    assertEquals("Row 2 id value incorrect", "3", node.path("id").path("value").asText());
-    assertEquals("Row 2 val value incorrect", "6", node.path("val").path("value").asText());
-    assertEquals("Row 2 uri value incorrect", "/optic/lexicon/test/doc3.json", node.path("uri").path("value").asText());
+    assertEquals( "3", node.path("id").path("value").asText());
+    assertEquals( "6", node.path("val").path("value").asText());
+    assertEquals( "/optic/lexicon/test/doc3.json", node.path("uri").path("value").asText());
 
     // Verify TEST 17 - join inner doc with xpath accessing attribute on xml
     ModifyPlan output17 = p.fromLiterals(literals3)
@@ -636,14 +634,15 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
     rowMgr.resultDoc(output17, jacksonHandle17);
     JsonNode jsonBindingsNodes17 = jacksonHandle17.get().path("rows");
 
-    assertEquals("One node not returned from testJoinInnerDocOnJson method: " + jsonBindingsNodes17.toPrettyString(),
-        1, jsonBindingsNodes17.size());
+    assertEquals(
+        1, jsonBindingsNodes17.size(),
+		"One node not returned from testJoinInnerDocOnJson method: " + jsonBindingsNodes17.toPrettyString());
 
     JsonNode node17 = jsonBindingsNodes17.path(0);
-    assertEquals("Row 1 id value incorrect", "4", node17.path("id").path("value").asText());
-    assertEquals("Row 1 val value incorrect", "8", node17.path("val").path("value").asText());
-    assertEquals("Row 1 uri value incorrect", "/optic/lexicon/test/doc4.xml", node17.path("uri").path("value").asText());
-    assertEquals("Row 1 nodes value incorrect", "east", node17.path("nodes").path("value").asText());
+    assertEquals( "4", node17.path("id").path("value").asText());
+    assertEquals( "8", node17.path("val").path("value").asText());
+    assertEquals( "/optic/lexicon/test/doc4.xml", node17.path("uri").path("value").asText());
+    assertEquals( "east", node17.path("nodes").path("value").asText());
 
     // Verify TEST 18 - join inner doc with xpath traversing down and multiple
     // values on xml
@@ -662,13 +661,13 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodes18 = jacksonHandle18.get().path("rows");
 
     // Should have 1 node returned.
-    assertEquals("One node not returned from testJoinInnerDocOnJson method", 1, jsonBindingsNodes18.size());
+    assertEquals( 1, jsonBindingsNodes18.size());
     JsonNode node18 = jsonBindingsNodes18.path(0);
-    assertEquals("Row 1 id value incorrect", "4", node18.path("id").path("value").asText());
-    assertEquals("Row 1 val value incorrect", "8", node18.path("val").path("value").asText());
-    assertEquals("Row 1 uri value incorrect", "/optic/lexicon/test/doc4.xml", node18.path("uri").path("value").asText());
-    assertEquals("Row 1 nodes value incorrect", "39.90", node18.path("nodes").path("value").get(0).asText());
-    assertEquals("Row 1 nodes value incorrect", "116.40", node18.path("nodes").path("value").get(1).asText());
+    assertEquals( "4", node18.path("id").path("value").asText());
+    assertEquals( "8", node18.path("val").path("value").asText());
+    assertEquals( "/optic/lexicon/test/doc4.xml", node18.path("uri").path("value").asText());
+    assertEquals( "39.90", node18.path("nodes").path("value").get(0).asText());
+    assertEquals( "116.40", node18.path("nodes").path("value").get(1).asText());
 
     // Verify TEST 19 - join inner doc with traversing up xpath on json
     ModifyPlan output19 = p.fromLiterals(literals3)
@@ -686,24 +685,24 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodes19 = jacksonHandle19.get().path("rows");
 
     // Should have 3 nodes returned.
-    assertEquals("Three nodes not returned from testJoinInnerDocOnJson method", 3, jsonBindingsNodes19.size());
+    assertEquals( 3, jsonBindingsNodes19.size());
     JsonNode node19 = jsonBindingsNodes19.path(0);
-    assertEquals("Row 1 id value incorrect", "1", node19.path("id").path("value").asText());
-    assertEquals("Row 1 val value incorrect", "2", node19.path("val").path("value").asText());
-    assertEquals("Row 1 uri value incorrect", "/optic/lexicon/test/doc1.json", node19.path("uri").path("value").asText());
-    assertEquals("Row 1 nodes value incorrect", "london", node19.path("nodes").path("value").asText());
+    assertEquals( "1", node19.path("id").path("value").asText());
+    assertEquals( "2", node19.path("val").path("value").asText());
+    assertEquals( "/optic/lexicon/test/doc1.json", node19.path("uri").path("value").asText());
+    assertEquals( "london", node19.path("nodes").path("value").asText());
 
     node19 = jsonBindingsNodes19.path(1);
-    assertEquals("Row 2 id value incorrect", "3", node19.path("id").path("value").asText());
-    assertEquals("Row 2 val value incorrect", "6", node19.path("val").path("value").asText());
-    assertEquals("Row 2 uri value incorrect", "/optic/lexicon/test/doc3.json", node19.path("uri").path("value").asText());
-    assertEquals("Row 2 nodes value incorrect", "new jersey", node19.path("nodes").path("value").asText());
+    assertEquals( "3", node19.path("id").path("value").asText());
+    assertEquals( "6", node19.path("val").path("value").asText());
+    assertEquals( "/optic/lexicon/test/doc3.json", node19.path("uri").path("value").asText());
+    assertEquals( "new jersey", node19.path("nodes").path("value").asText());
 
     node19 = jsonBindingsNodes19.path(2);
-    assertEquals("Row 2 id value incorrect", "4", node19.path("id").path("value").asText());
-    assertEquals("Row 2 val value incorrect", "8", node19.path("val").path("value").asText());
-    assertEquals("Row 2 uri value incorrect", "/optic/lexicon/test/doc4.xml", node19.path("uri").path("value").asText());
-    assertEquals("Row 2 nodes value incorrect", "beijing", node19.path("nodes").path("value").asText());
+    assertEquals( "4", node19.path("id").path("value").asText());
+    assertEquals( "8", node19.path("val").path("value").asText());
+    assertEquals( "/optic/lexicon/test/doc4.xml", node19.path("uri").path("value").asText());
+    assertEquals( "beijing", node19.path("nodes").path("value").asText());
 
     // Verify TEST 15 - join inner doc with xpath accessing attribute on xml
     ModifyPlan output15 = p.fromLiterals(literals3)
@@ -720,12 +719,12 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodes15 = jacksonHandle15.get().path("rows");
 
     // Should have 1 node returned.
-    assertEquals("One node not returned from testJoinInnerDocOnJson method", 1, jsonBindingsNodes15.size());
+    assertEquals( 1, jsonBindingsNodes15.size());
     JsonNode node20 = jsonBindingsNodes15.path(0);
-    assertEquals("Row 1 id value incorrect", "4", node20.path("id").path("value").asText());
-    assertEquals("Row 1 val value incorrect", "8", node20.path("val").path("value").asText());
-    assertEquals("Row 1 uri value incorrect", "/optic/lexicon/test/doc4.xml", node20.path("uri").path("value").asText());
-    assertEquals("Row 1 nodes value incorrect", "<city>beijing</city>", node20.path("nodes").path("value").asText());
+    assertEquals( "4", node20.path("id").path("value").asText());
+    assertEquals( "8", node20.path("val").path("value").asText());
+    assertEquals( "/optic/lexicon/test/doc4.xml", node20.path("uri").path("value").asText());
+    assertEquals( "<city>beijing</city>", node20.path("nodes").path("value").asText());
 
     // Verify TEST 21 - join inner doc with traversing deep xpath on json and
     // xml
@@ -744,22 +743,22 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodes21 = jacksonHandle21.get().path("rows");
 
     // Should have 3 nodes returned.
-    assertEquals("Three nodes not returned from testJoinInnerDocOnJson method", 3, jsonBindingsNodes21.size());
+    assertEquals( 3, jsonBindingsNodes21.size());
     JsonNode node21 = jsonBindingsNodes21.path(0);
-    assertEquals("Row 1 id value incorrect", "1", node21.path("id").path("value").asText());
-    assertEquals("Row 1 val value incorrect", "2", node21.path("val").path("value").asText());
-    assertEquals("Row 1 uri value incorrect", "/optic/lexicon/test/doc1.json", node21.path("uri").path("value").asText());
-    assertEquals("Row 1 nodes value incorrect", "51.5", node21.path("nodes").path("value").asText());
+    assertEquals( "1", node21.path("id").path("value").asText());
+    assertEquals( "2", node21.path("val").path("value").asText());
+    assertEquals( "/optic/lexicon/test/doc1.json", node21.path("uri").path("value").asText());
+    assertEquals( "51.5", node21.path("nodes").path("value").asText());
     node21 = jsonBindingsNodes21.path(1);
-    assertEquals("Row 1 id value incorrect", "3", node21.path("id").path("value").asText());
-    assertEquals("Row 1 val value incorrect", "6", node21.path("val").path("value").asText());
-    assertEquals("Row 1 uri value incorrect", "/optic/lexicon/test/doc3.json", node21.path("uri").path("value").asText());
-    assertEquals("Row 1 nodes value incorrect", "40.72", node21.path("nodes").path("value").asText());
+    assertEquals( "3", node21.path("id").path("value").asText());
+    assertEquals( "6", node21.path("val").path("value").asText());
+    assertEquals( "/optic/lexicon/test/doc3.json", node21.path("uri").path("value").asText());
+    assertEquals( "40.72", node21.path("nodes").path("value").asText());
     node21 = jsonBindingsNodes21.path(2);
-    assertEquals("Row 1 id value incorrect", "4", node21.path("id").path("value").asText());
-    assertEquals("Row 1 val value incorrect", "8", node21.path("val").path("value").asText());
-    assertEquals("Row 1 uri value incorrect", "/optic/lexicon/test/doc4.xml", node21.path("uri").path("value").asText());
-    assertEquals("Row 1 nodes value incorrect", "39.9", node21.path("nodes").path("value").asText());
+    assertEquals( "4", node21.path("id").path("value").asText());
+    assertEquals( "8", node21.path("val").path("value").asText());
+    assertEquals( "/optic/lexicon/test/doc4.xml", node21.path("uri").path("value").asText());
+    assertEquals( "39.9", node21.path("nodes").path("value").asText());
   }
 
   /*
@@ -786,10 +785,10 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodes = jacksonHandle.get().path("rows");
 
     // Should have 3 nodes returned.
-    assertEquals("Three nodes not returned from testGroupbyWithoutAggregate method", 3, jsonBindingsNodes.size());
-    assertEquals("Row 1 colorId value incorrect", "1", jsonBindingsNodes.path(0).path("colorId").path("value").asText());
-    assertEquals("Row 2 colorId value incorrect", "2", jsonBindingsNodes.path(1).path("colorId").path("value").asText());
-    assertEquals("Row 3 colorId value incorrect", "5", jsonBindingsNodes.path(2).path("colorId").path("value").asText());
+    assertEquals( 3, jsonBindingsNodes.size());
+    assertEquals( "1", jsonBindingsNodes.path(0).path("colorId").path("value").asText());
+    assertEquals( "2", jsonBindingsNodes.path(1).path("colorId").path("value").asText());
+    assertEquals( "5", jsonBindingsNodes.path(2).path("colorId").path("value").asText());
   }
 
   /*
@@ -817,16 +816,16 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodes = jacksonHandle.get().path("rows");
 
     // Should have 9 nodes returned.
-    assertEquals("Nine nodes not returned from testUnionWithWhereDistinct method", 9, jsonBindingsNodes.size());
+    assertEquals( 9, jsonBindingsNodes.size());
 
-    assertEquals("Row 1 colorId value incorrect", "1", jsonBindingsNodes.path(0).path("colorId").path("value").asText());
-    assertEquals("Row 1 colorDesc value incorrect", "null", jsonBindingsNodes.path(0).path("colorDesc").path("value").asText());
-    assertEquals("Row 2 colorId value incorrect", "2", jsonBindingsNodes.path(1).path("colorId").path("value").asText());
-    assertEquals("Row 2 colorDesc value incorrect", "null", jsonBindingsNodes.path(1).path("colorDesc").path("value").asText());
-    assertEquals("Row 6 desc value incorrect", "null", jsonBindingsNodes.path(5).path("desc").path("value").asText());
-    assertEquals("Row 6 rowId value incorrect", "null", jsonBindingsNodes.path(5).path("rowId").path("value").asText());
-    assertEquals("Row 9 desc value incorrect", "null", jsonBindingsNodes.path(8).path("desc").path("value").asText());
-    assertEquals("Row 9 colorId value incorrect", "4", jsonBindingsNodes.path(8).path("colorId").path("value").asText());
+    assertEquals( "1", jsonBindingsNodes.path(0).path("colorId").path("value").asText());
+    assertEquals( "null", jsonBindingsNodes.path(0).path("colorDesc").path("value").asText());
+    assertEquals( "2", jsonBindingsNodes.path(1).path("colorId").path("value").asText());
+    assertEquals( "null", jsonBindingsNodes.path(1).path("colorDesc").path("value").asText());
+    assertEquals( "null", jsonBindingsNodes.path(5).path("desc").path("value").asText());
+    assertEquals( "null", jsonBindingsNodes.path(5).path("rowId").path("value").asText());
+    assertEquals( "null", jsonBindingsNodes.path(8).path("desc").path("value").asText());
+    assertEquals( "4", jsonBindingsNodes.path(8).path("colorId").path("value").asText());
   }
 
   /*
@@ -855,8 +854,8 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodes = jacksonHandle.get().path("rows");
 
     // Should have 1 node returned.
-    assertEquals("One node not returned from testIntersect method", 1, jsonBindingsNodes.size());
-    assertEquals("Row 1 txnDate value incorrect", "Jan-07-1999", jsonBindingsNodes.path(0).path("txnDate").path("value").asText());
+    assertEquals( 1, jsonBindingsNodes.size());
+    assertEquals( "Jan-07-1999", jsonBindingsNodes.path(0).path("txnDate").path("value").asText());
   }
 
   /*
@@ -885,10 +884,10 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodes = jacksonHandle.get().path("rows");
 
     // Should have 3 nodes returned.
-    assertEquals("Three nodes not returned from testExcept method", 3, jsonBindingsNodes.size());
-    assertEquals("Row 1 txnDate value incorrect", "Jan-05-1999", jsonBindingsNodes.path(0).path("txnDate").path("value").asText());
-    assertEquals("Row 2 txnDate value incorrect", "Jan-08-1999", jsonBindingsNodes.path(1).path("txnDate").path("value").asText());
-    assertEquals("Row 3 txnDate value incorrect", "Jan-08-1999", jsonBindingsNodes.path(2).path("txnDate").path("value").asText());
+    assertEquals( 3, jsonBindingsNodes.size());
+    assertEquals( "Jan-05-1999", jsonBindingsNodes.path(0).path("txnDate").path("value").asText());
+    assertEquals( "Jan-08-1999", jsonBindingsNodes.path(1).path("txnDate").path("value").asText());
+    assertEquals( "Jan-08-1999", jsonBindingsNodes.path(2).path("txnDate").path("value").asText());
   }
 
   /*
@@ -1025,10 +1024,10 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodes = jacksonHandle.get().path("rows");
 
     // Should have 4 nodes returned.
-    assertEquals("Four nodes not returned from testAggregateSeq method", 4, jsonBindingsNodes.size());
-    assertEquals("Row 1 myItem.rowId value incorrect", "1", jsonBindingsNodes.path(0).path("myItem.rowId").path("value").asText());
-    assertEquals("Row 1 colorIdArray length value incorrect", 4, jsonBindingsNodes.path(0).path("colorIdArray").path("value").size());
-    assertEquals("Row 2 colorIdArray array 1 value incorrect", "blue", jsonBindingsNodes.path(1).path("colorIdArray").path("value").path(0).asText());
+    assertEquals( 4, jsonBindingsNodes.size());
+    assertEquals( "1", jsonBindingsNodes.path(0).path("myItem.rowId").path("value").asText());
+    assertEquals( 4, jsonBindingsNodes.path(0).path("colorIdArray").path("value").size());
+    assertEquals( "blue", jsonBindingsNodes.path(1).path("colorIdArray").path("value").path(0).asText());
 
     // sequenceAggregate
 
@@ -1043,10 +1042,10 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
     jsonBindingsNodes = jacksonHandle.get().path("rows");
 
     // Should have 4 nodes returned.
-    assertEquals("Four nodes not returned from testAggregateSeq method", 4, jsonBindingsNodes.size());
-    assertEquals("Row 1 myItem.rowId value incorrect", "1", jsonBindingsNodes.path(0).path("myItem.rowId").path("value").asText());
-    assertEquals("Row 1 colorIdArray length value incorrect", 4, jsonBindingsNodes.path(0).path("colorIdArray").path("value").size());
-    assertEquals("Row 2 colorIdArray array 1 value incorrect", "blue", jsonBindingsNodes.path(1).path("colorIdArray").path("value").asText());
+    assertEquals( 4, jsonBindingsNodes.size());
+    assertEquals( "1", jsonBindingsNodes.path(0).path("myItem.rowId").path("value").asText());
+    assertEquals( 4, jsonBindingsNodes.path(0).path("colorIdArray").path("value").size());
+    assertEquals( "blue", jsonBindingsNodes.path(1).path("colorIdArray").path("value").asText());
 
     // TEST 37 - aggregate with distinct option
     // plans from literals
@@ -1067,12 +1066,12 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
     jsonBindingsNodes = jacksonHandle.get().path("rows");
 
     // Should have 4 nodes returned.
-    assertEquals("Four node not returned from testAggregateSeq method", 4, jsonBindingsNodes.size());
-    assertEquals("Row 1 rowId value incorrect", "1", jsonBindingsNodes.path(0).path("rowId").path("value").asText());
-    assertEquals("Row 1 descAgg value incorrect", 1, jsonBindingsNodes.path(0).path("descAgg").path("value").asInt());
+    assertEquals( 4, jsonBindingsNodes.size());
+    assertEquals( "1", jsonBindingsNodes.path(0).path("rowId").path("value").asText());
+    assertEquals( 1, jsonBindingsNodes.path(0).path("descAgg").path("value").asInt());
 
-    assertEquals("Row 1 rowId value incorrect", "4", jsonBindingsNodes.path(3).path("rowId").path("value").asText());
-    assertEquals("Row 1 descAgg value incorrect", 1, jsonBindingsNodes.path(3).path("descAgg").path("value").asInt());
+    assertEquals( "4", jsonBindingsNodes.path(3).path("rowId").path("value").asText());
+    assertEquals( 1, jsonBindingsNodes.path(3).path("descAgg").path("value").asInt());
 
     // aggregate with duplicate option
     PlanAggregateColSeq aggColSeqDup = p.aggregateSeq(p.count("descAgg", "desc", PlanValueOption.DUPLICATE));
@@ -1088,19 +1087,19 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodesDup = jacksonHandle.get().path("rows");
 
     // Should have 4 nodes returned. Duplicate values are included.
-    assertEquals("Four node not returned from testAggregateSeq method", 4, jsonBindingsNodesDup.size());
-    assertEquals("Row 1 rowId value incorrect", "1", jsonBindingsNodesDup.path(0).path("rowId").path("value").asText());
-    assertEquals("Row 1 descAgg value incorrect", 2, jsonBindingsNodesDup.path(0).path("descAgg").path("value").asInt());
+    assertEquals( 4, jsonBindingsNodesDup.size());
+    assertEquals( "1", jsonBindingsNodesDup.path(0).path("rowId").path("value").asText());
+    assertEquals( 2, jsonBindingsNodesDup.path(0).path("descAgg").path("value").asInt());
 
-    assertEquals("Row 1 rowId value incorrect", "4", jsonBindingsNodesDup.path(3).path("rowId").path("value").asText());
-    assertEquals("Row 1 descAgg value incorrect", 1, jsonBindingsNodesDup.path(3).path("descAgg").path("value").asInt());
+    assertEquals( "4", jsonBindingsNodesDup.path(3).path("rowId").path("value").asText());
+    assertEquals( 1, jsonBindingsNodesDup.path(3).path("descAgg").path("value").asInt());
   }
 
   /*
    * Test date time builtin functions
    */
-  @Ignore
-  public void testBuiltInFns() throws KeyManagementException, NoSuchAlgorithmException, IOException, SAXException, ParserConfigurationException
+  @Disabled
+  public void testBuiltInFns()
   {
     System.out.println("In testBuiltInFns method");
 
@@ -1141,7 +1140,7 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodes = jacksonHandle.get().path("rows");
 
     // Should have 2 nodes returned.
-    assertEquals("Two nodes not returned from testExcept method", 3, jsonBindingsNodes.size());
+    assertEquals( 3, jsonBindingsNodes.size());
   }
 
   /*
@@ -1174,8 +1173,8 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
       System.out.println("Exception message is " + str.toString());
     }
     // Should have SQL-NOCOLUMN exceptions.
-    assertTrue("Exceptions not found", str.toString().contains("SQL-NOCOLUMN"));
-    assertTrue("Exceptions not found", str.toString().contains("Column not found: rowIdRef"));
+    assertTrue( str.toString().contains("SQL-NOCOLUMN"));
+    assertTrue( str.toString().contains("Column not found: rowIdRef"));
 
     // invalid viewCol
     ModifyPlan outputExtCol = plan1.joinInner(plan2)
@@ -1189,8 +1188,8 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
       System.out.println("Exception message is " + str.toString());
     }
     // Should have SQL-NOCOLUMN exceptions.
-    assertTrue("Exceptions not found", str.toString().contains("SQL-NOCOLUMN"));
-    assertTrue("Exceptions not found", str.toString().contains("Column not found: invalid_view.colorId"));
+    assertTrue( str.toString().contains("SQL-NOCOLUMN"));
+    assertTrue( str.toString().contains("Column not found: invalid_view.colorId"));
   }
 
   /*
@@ -1224,8 +1223,8 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
       System.out.println("Exception message is " + str.toString());
     }
     // Should have OPTIC-INVALARGS exceptions.
-    assertTrue("Exceptions not found", str.toString().contains("OPTIC-INVALARGS"));
-    assertTrue("Exceptions not found", str.toString().contains("Invalid arguments: offset must be a non-negative number: -1"));
+    assertTrue( str.toString().contains("OPTIC-INVALARGS"));
+    assertTrue( str.toString().contains("Invalid arguments: offset must be a non-negative number: -1"));
   }
 
   /*
@@ -1258,8 +1257,8 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
       System.out.println("Exception message is " + str.toString());
     }
     // Should have OPTIC-INVALARGS exceptions.
-    assertTrue("Exceptions not found", str.toString().contains("SQL-NOCOLUMN"));
-    assertTrue("Exceptions not found", str.toString().contains("Column not found: table1_Invalid.colorId"));
+    assertTrue( str.toString().contains("SQL-NOCOLUMN"));
+    assertTrue( str.toString().contains("Column not found: table1_Invalid.colorId"));
   }
 
   /*
@@ -1346,18 +1345,18 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodes = jacksonHandle.get().path("rows");
 
     // Should have 4 node returned.
-    assertEquals("Four nodes not returned from testMapFunction method", 4, jsonBindingsNodes.size());
-    assertEquals("Row 1 rowId value incorrect", "1", jsonBindingsNodes.path(0).path("rowId").path("value").asText());
-    assertEquals("Row 1 myColorId value incorrect", "RED ROBIN", jsonBindingsNodes.path(0).path("myColorId").path("value").asText());
-    assertEquals("Row 1 description value incorrect", "ball", jsonBindingsNodes.path(0).path("description").path("value").asText());
+    assertEquals( 4, jsonBindingsNodes.size());
+    assertEquals( "1", jsonBindingsNodes.path(0).path("rowId").path("value").asText());
+    assertEquals( "RED ROBIN", jsonBindingsNodes.path(0).path("myColorId").path("value").asText());
+    assertEquals( "ball", jsonBindingsNodes.path(0).path("description").path("value").asText());
 
-    assertEquals("Row 2 rowId value incorrect", "2", jsonBindingsNodes.path(1).path("rowId").path("value").asText());
-    assertEquals("Row 2 myColorId value incorrect", "BLUE JAY", jsonBindingsNodes.path(1).path("myColorId").path("value").asText());
-    assertEquals("Row 2 description value incorrect", "square", jsonBindingsNodes.path(1).path("description").path("value").asText());
+    assertEquals( "2", jsonBindingsNodes.path(1).path("rowId").path("value").asText());
+    assertEquals( "BLUE JAY", jsonBindingsNodes.path(1).path("myColorId").path("value").asText());
+    assertEquals( "square", jsonBindingsNodes.path(1).path("description").path("value").asText());
 
-    assertEquals("Row 3 rowId value incorrect", "4", jsonBindingsNodes.path(3).path("rowId").path("value").asText());
-    assertEquals("Row 3 myColorId value incorrect", "RED ROBIN", jsonBindingsNodes.path(3).path("myColorId").path("value").asText());
-    assertEquals("Row 3 description value incorrect", "hoop", jsonBindingsNodes.path(3).path("description").path("value").asText());
+    assertEquals( "4", jsonBindingsNodes.path(3).path("rowId").path("value").asText());
+    assertEquals( "RED ROBIN", jsonBindingsNodes.path(3).path("myColorId").path("value").asText());
+    assertEquals( "hoop", jsonBindingsNodes.path(3).path("description").path("value").asText());
   }
 
   /*
@@ -1441,18 +1440,18 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodes = jacksonHandle.get().path("rows");
 
     // Should have 4 node returned.
-    assertEquals("Four nodes not returned from testMapFunction method", 4, jsonBindingsNodes.size());
-    assertEquals("Row 1 rowId value incorrect", "1", jsonBindingsNodes.path(0).path("myRowId").path("value").asText());
-    assertEquals("Row 1 myColorId value incorrect", "0", jsonBindingsNodes.path(0).path("i").path("value").asText());
-    assertEquals("Row 1 description value incorrect", "0", jsonBindingsNodes.path(0).path("fib").path("value").asText());
+    assertEquals( 4, jsonBindingsNodes.size());
+    assertEquals( "1", jsonBindingsNodes.path(0).path("myRowId").path("value").asText());
+    assertEquals( "0", jsonBindingsNodes.path(0).path("i").path("value").asText());
+    assertEquals( "0", jsonBindingsNodes.path(0).path("fib").path("value").asText());
 
-    assertEquals("Row 2 rowId value incorrect", "2", jsonBindingsNodes.path(1).path("myRowId").path("value").asText());
-    assertEquals("Row 2 myColorId value incorrect", "1", jsonBindingsNodes.path(1).path("i").path("value").asText());
-    assertEquals("Row 2 description value incorrect", "1", jsonBindingsNodes.path(1).path("fib").path("value").asText());
+    assertEquals( "2", jsonBindingsNodes.path(1).path("myRowId").path("value").asText());
+    assertEquals( "1", jsonBindingsNodes.path(1).path("i").path("value").asText());
+    assertEquals( "1", jsonBindingsNodes.path(1).path("fib").path("value").asText());
 
-    assertEquals("Row 3 rowId value incorrect", "4", jsonBindingsNodes.path(3).path("myRowId").path("value").asText());
-    assertEquals("Row 3 myColorId value incorrect", "3", jsonBindingsNodes.path(3).path("i").path("value").asText());
-    assertEquals("Row 3 description value incorrect", "2", jsonBindingsNodes.path(3).path("fib").path("value").asText());
+    assertEquals( "4", jsonBindingsNodes.path(3).path("myRowId").path("value").asText());
+    assertEquals( "3", jsonBindingsNodes.path(3).path("i").path("value").asText());
+    assertEquals( "2", jsonBindingsNodes.path(3).path("fib").path("value").asText());
   }
 
   /*
@@ -1575,7 +1574,7 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
 
     Collections.sort(existColorList);
 
-    assertTrue("Error while return from existsJoin", existColorList.equals(exptdExists));
+    assertTrue( existColorList.equals(exptdExists));
 
     // existJoin with literals - without on parameters
     ModifyPlan existsNoOptionsOutput = plan2.existsJoin(plan1).orderBy(p.desc(p.col("desc")));
@@ -1584,9 +1583,9 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
 
     rowMgr.resultDoc(existsNoOptionsOutput, jacksonHandle);
     jsonBindingsNodes = jacksonHandle.get().path("rows");
-    assertEquals("Element 1 desc value incorrect", "square", jsonBindingsNodes.path(0).path("table2.desc").path("value").asText());
-    assertEquals("Element 3 desc value incorrect", "circle", jsonBindingsNodes.path(2).path("table2.desc").path("value").asText());
-    assertEquals("Element 6 desc value incorrect", "ball", jsonBindingsNodes.path(5).path("table2.desc").path("value").asText());
+    assertEquals( "square", jsonBindingsNodes.path(0).path("table2.desc").path("value").asText());
+    assertEquals( "circle", jsonBindingsNodes.path(2).path("table2.desc").path("value").asText());
+    assertEquals( "ball", jsonBindingsNodes.path(5).path("table2.desc").path("value").asText());
 
     // not exists join
     ModifyPlan notExistsOutput = plan1.notExistsJoin(plan2, p.on(p.viewCol("table1", "colorDesc"), p.viewCol("table2", "colorDesc")));
@@ -1607,7 +1606,7 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
     notExistColorList.add(jsonBindingsNodes.path(1).path("table1.colorDesc").path("value").asText());
 
     Collections.sort(notExistColorList);
-    assertTrue("Error while return from notExistsJoin", notExistColorList.equals(exptdNotExists));
+    assertTrue( notExistColorList.equals(exptdNotExists));
   }
 
   /*
@@ -1718,9 +1717,9 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
 
     rowMgr.resultDoc(output1, jacksonHandle);
     JsonNode colorBucketNodes = jacksonHandle.get().path("rows");
-    assertEquals("Bucket group 1 count value incorrect", "7", colorBucketNodes.path(0).path("colorBucket").path("value").path(0).path("count").asText());
-    assertEquals("Bucket group 2 count value incorrect", "6", colorBucketNodes.path(0).path("colorBucket").path("value").path(1).path("count").asText());
-    assertEquals("Bucket group 3 count value incorrect", "4", colorBucketNodes.path(0).path("colorBucket").path("value").path(2).path("count").asText());
+    assertEquals( "7", colorBucketNodes.path(0).path("colorBucket").path("value").path(0).path("count").asText());
+    assertEquals( "6", colorBucketNodes.path(0).path("colorBucket").path("value").path(1).path("count").asText());
+    assertEquals( "4", colorBucketNodes.path(0).path("colorBucket").path("value").path(2).path("count").asText());
 
     // outside range
     ModifyPlan output2 = plan1.joinInner(plan2)
@@ -1731,7 +1730,7 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
 
     rowMgr.resultDoc(output2, jacksonHandle);
     JsonNode colorBucketNodesNoRange = jacksonHandle.get().path("rows");
-    assertEquals("Bucket group 1 count value incorrect", "17", colorBucketNodesNoRange.path(0).path("colorBucket").path("value").path(0).path("count").asText());
+    assertEquals( "17", colorBucketNodesNoRange.path(0).path("colorBucket").path("value").path(0).path("count").asText());
 
     // string range
     ModifyPlan output3 = plan1.joinInner(plan2)
@@ -1742,8 +1741,8 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
 
     rowMgr.resultDoc(output3, jacksonHandle);
     JsonNode descBucketNodesStringRange = jacksonHandle.get().path("rows");
-    assertEquals("Bucket group 1 count value incorrect", "9", descBucketNodesStringRange.path(0).path("descBucket").path("value").path(0).path("count").asText());
-    assertEquals("Bucket group 2 count value incorrect", "8", descBucketNodesStringRange.path(0).path("descBucket").path("value").path(1).path("count").asText());
+    assertEquals( "9", descBucketNodesStringRange.path(0).path("descBucket").path("value").path(0).path("count").asText());
+    assertEquals( "8", descBucketNodesStringRange.path(0).path("descBucket").path("value").path(1).path("count").asText());
 
     //bucket group negative test
     ModifyPlan output4 = plan1.joinInner(plan2)
@@ -1755,7 +1754,7 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
     try {
       rowMgr.resultDoc(output4, jacksonHandle);
     } catch (Exception ex) {
-      assertTrue("Incorrect error/exception message", ex.getMessage().contains("failed to apply resource at rows: Internal Server Error"));
+      assertTrue(ex.getMessage().contains("failed to apply resource at rows: Internal Server Error"));
     }
   }
 

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnMixedViews.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnMixedViews.java
@@ -22,14 +22,15 @@ import com.marklogic.client.expression.PlanBuilder.ModifyPlan;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.row.RowManager;
 import com.marklogic.client.type.*;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+
+
 
 /* The tests here are for sanity checks when we have plans from different sources
  * such as fromLexicons and fromtriples.
@@ -37,7 +38,7 @@ import static org.junit.Assert.assertTrue;
 
 public class TestOpticOnMixedViews extends AbstractFunctionalTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception
   {
     // Install the TDE templates
@@ -134,7 +135,7 @@ public class TestOpticOnMixedViews extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get();
 
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
-    assertTrue("Number of Elements after plan execution is incorrect. Should be 3", 3 == jsonBindingsNodes.size());
+    assertTrue( 3 == jsonBindingsNodes.size());
   }
 
   /*
@@ -206,7 +207,7 @@ public class TestOpticOnMixedViews extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get();
 
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
-    assertTrue("Number of Elements after plan execution is incorrect. Should be 5", 5 == jsonBindingsNodes.size());
+    assertTrue( 5 == jsonBindingsNodes.size());
   }
 
   /*
@@ -243,7 +244,7 @@ public class TestOpticOnMixedViews extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get();
 
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
-    assertTrue("Number of Elements after plan execution is incorrect. Should be 2", 2 == jsonBindingsNodes.size());
+    assertTrue( 2 == jsonBindingsNodes.size());
   }
 
   /*
@@ -286,8 +287,8 @@ public class TestOpticOnMixedViews extends AbstractFunctionalTest {
     row.put("colorId", 4);
     row.put("colorDesc", "yellow");
     literals2[3] = row;
-    
-    PlanTriplePatternSeq playerSeq = p.patternSeq( 
+
+    PlanTriplePatternSeq playerSeq = p.patternSeq(
     		p.pattern(playerIdCol, bb.iri("age"), playerAgeCol),
             p.pattern(playerIdCol, bb.iri("name"), playerNameCol),
             p.pattern(playerIdCol, bb.iri("team"), playerTeamCol)
@@ -315,11 +316,11 @@ public class TestOpticOnMixedViews extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get();
 
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
-    assertTrue("Number of Elements after plan execution is incorrect. Should be 2", 2 == jsonBindingsNodes.size());
-    assertEquals("Row 1 player_name value incorrect", "Matt Rose", jsonBindingsNodes.path(0).path("player_name").path("value").asText());
-    assertEquals("Row 1 colorDesc value incorrect", "red", jsonBindingsNodes.path(0).path("colorDesc").path("value").asText());
-    assertEquals("Row 2 player_name value incorrect", "Matt Rose", jsonBindingsNodes.path(1).path("player_name").path("value").asText());
-    assertEquals("Row 2 colorDesc value incorrect", "yellow", jsonBindingsNodes.path(1).path("colorDesc").path("value").asText());
+    assertTrue( 2 == jsonBindingsNodes.size());
+    assertEquals("Matt Rose", jsonBindingsNodes.path(0).path("player_name").path("value").asText());
+    assertEquals( "red", jsonBindingsNodes.path(0).path("colorDesc").path("value").asText());
+    assertEquals("Matt Rose", jsonBindingsNodes.path(1).path("player_name").path("value").asText());
+    assertEquals( "yellow", jsonBindingsNodes.path(1).path("colorDesc").path("value").asText());
   }
 
   /*
@@ -361,7 +362,7 @@ public class TestOpticOnMixedViews extends AbstractFunctionalTest {
     row.put("colorId", 4);
     row.put("colorDesc", "yellow");
     literals2[3] = row;
-    PlanTriplePatternSeq playerSeq = p.patternSeq( 
+    PlanTriplePatternSeq playerSeq = p.patternSeq(
     		p.pattern(playerIdCol, bb.iri("age"), playerAgeCol),
             p.pattern(playerIdCol, bb.iri("name"), playerNameCol),
             p.pattern(playerIdCol, bb.iri("team"), playerTeamCol)
@@ -392,8 +393,8 @@ public class TestOpticOnMixedViews extends AbstractFunctionalTest {
 
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
 
-    assertTrue("Number of Elements after plan execution is incorrect. Should be 2", 2 == jsonBindingsNodes.size());
-    assertEquals("Row 1 colorDesc value incorrect", "1", jsonBindingsNodes.path(0).path("myResults").path("value").path("myRows").path(0).asText());
-    assertEquals("Row 1 colorDesc value incorrect", "4", jsonBindingsNodes.path(1).path("myResults").path("value").path("myRows").path(0).asText());
+    assertTrue( 2 == jsonBindingsNodes.size());
+    assertEquals( "1", jsonBindingsNodes.path(0).path("myResults").path("value").path("myRows").path(0).asText());
+    assertEquals( "4", jsonBindingsNodes.path(1).path("myResults").path("value").path("myRows").path(0).asText());
   }
 }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnTriples.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnTriples.java
@@ -25,17 +25,16 @@ import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.row.RowManager;
 import com.marklogic.client.type.*;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Iterator;
 
-import static org.junit.Assert.*;
-
 public class TestOpticOnTriples extends AbstractFunctionalTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception
   {
     removeFieldIndices();
@@ -68,13 +67,13 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
     loadFileToDB(client, "city5.json", "/optic/lexicon/test/city5.json", "JSON", new String[] { "/optic/lexicon/test" });
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() {
     restoreFieldIndices();
   }
 
   @Test
-  public void testfromTriples() 
+  public void testfromTriples()
   {
     System.out.println("In testfromTriples method");
 
@@ -95,14 +94,14 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
     // Verify first node.
     Iterator<JsonNode> nameNodesItr = jsonBindingsNodes.elements();
     // Should have 8 nodes returned.
-    assertEquals("Eight nodes not returned from testfromTriples method ", 8, jsonBindingsNodes.size());
+    assertEquals( 8, jsonBindingsNodes.size());
     JsonNode jsonNameNode = null;
     if (nameNodesItr.hasNext()) {
       jsonNameNode = nameNodesItr.next();
       // Verify result 1's values.
-      assertEquals("Row 1 age value incorrect", "19", jsonNameNode.path("players.age").path("value").asText());
+      assertEquals( "19", jsonNameNode.path("players.age").path("value").asText());
       // Verify the last node's age value
-      assertEquals("Row 8 age value incorrect", "34", jsonBindingsNodes.get(7).path("players.age").path("value").asText());
+      assertEquals( "34", jsonBindingsNodes.get(7).path("players.age").path("value").asText());
     }
     else {
       fail("Could not traverse the Eight Triplesin testfromTriples method");
@@ -110,7 +109,7 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
   }
 
   @Test
-  public void testPrefixerfromTriples() 
+  public void testPrefixerfromTriples()
   {
     System.out.println("In testPrefixerfromTriples method");
 
@@ -118,10 +117,10 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
     RowManager rowMgr = client.newRowManager();
     PlanBuilder p = rowMgr.newPlanBuilder();
     PlanPrefixer rowGraph = p.prefixer("http://marklogic.com/baseball/players");
-    
+
     PlanTriplePatternSeq patSeq = p.patternSeq(
             p.pattern(p.col("id"), rowGraph.iri("age"), p.col("age")));
-    
+
     ExportablePlan plan1 = p.fromTriples(patSeq, "players", null, PlanTripleOption.DEDUPLICATED)
         .orderBy(p.col("age"));
 
@@ -135,14 +134,14 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
     // Verify first node.
     Iterator<JsonNode> nameNodesItr = jsonBindingsNodes.elements();
     // Should have 8 nodes returned.
-    assertEquals("Eight nodes not returned from testfromTriples method ", 8, jsonBindingsNodes.size());
+    assertEquals( 8, jsonBindingsNodes.size());
     JsonNode jsonNameNode = null;
     if (nameNodesItr.hasNext()) {
       jsonNameNode = nameNodesItr.next();
       // Verify result 1's values.
-      assertEquals("Row 1 age value incorrect", "19", jsonNameNode.path("players.age").path("value").asText());
+      assertEquals( "19", jsonNameNode.path("players.age").path("value").asText());
       // Verify the last node's age value
-      assertEquals("Row 8 age value incorrect", "34", jsonBindingsNodes.get(7).path("players.age").path("value").asText());
+      assertEquals( "34", jsonBindingsNodes.get(7).path("players.age").path("value").asText());
     }
     else {
       fail("Could not traverse the Eight Triplesin testfromTriples method");
@@ -151,11 +150,11 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
 
   /*
    * This test checks access with select aliased columns.
-   * 
+   *
    * Should return 8 results.
    */
   @Test
-  public void testAccessWithSelectAlias() 
+  public void testAccessWithSelectAlias()
   {
     System.out.println("In testAccessWithSelectAlias method");
 
@@ -189,23 +188,23 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get();
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
     // Should have 8 nodes returned.
-    assertEquals("Eight nodes not returned from testAccessWithSelectAlias method ", 8, jsonBindingsNodes.size());
+    assertEquals( 8, jsonBindingsNodes.size());
     JsonNode first = jsonBindingsNodes.path(0);
-    assertEquals("Row 1 PlayerName value incorrect", "Aoki Yamada", first.path("PlayerName").path("value").asText());
-    assertEquals("Row 1 PlayerPosition value incorrect", "First Base", first.path("PlayerPosition").path("value").asText());
+    assertEquals( "Aoki Yamada", first.path("PlayerName").path("value").asText());
+    assertEquals( "First Base", first.path("PlayerPosition").path("value").asText());
 
     JsonNode eight = jsonBindingsNodes.path(7);
-    assertEquals("Row 2 PlayerName value incorrect", "Pedro Barrozo", eight.path("PlayerName").path("value").asText());
-    assertEquals("Row 2 PlayerPosition value incorrect", "Midfielder", eight.path("PlayerPosition").path("value").asText());
+    assertEquals( "Pedro Barrozo", eight.path("PlayerName").path("value").asText());
+    assertEquals( "Midfielder", eight.path("PlayerPosition").path("value").asText());
   }
 
   /*
    * This test checks join inner with condition.
-   * 
+   *
    * Should return 2 results.
    */
   @Test
-  public void testJoinInnerWithCondition() 
+  public void testJoinInnerWithCondition()
   {
     System.out.println("In testJoinInnerWithCondition method");
     // Create a new Plan.
@@ -248,24 +247,24 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get();
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
     // Should have 2 nodes returned.
-    assertEquals("Two nodes not returned from testJoinInnerWithCondition method ", 2, jsonBindingsNodes.size());
+    assertEquals( 2, jsonBindingsNodes.size());
     JsonNode first = jsonBindingsNodes.path(0);
-    assertEquals("Row 1 PlayerName value incorrect", "Josh Ream", first.path("PlayerName").path("value").asText());
-    assertEquals("Row 1 PlayerAge value incorrect", "29", first.path("PlayerAge").path("value").asText());
-    assertEquals("Row 1 TeamName value incorrect", "San Francisco Giants", first.path("TeamName").path("value").asText());
+    assertEquals( "Josh Ream", first.path("PlayerName").path("value").asText());
+    assertEquals( "29", first.path("PlayerAge").path("value").asText());
+    assertEquals( "San Francisco Giants", first.path("TeamName").path("value").asText());
     JsonNode second = jsonBindingsNodes.path(1);
-    assertEquals("Row 2 PlayerName value incorrect", "John Doe", second.path("PlayerName").path("value").asText());
-    assertEquals("Row 2 PlayerAge value incorrect", "31", second.path("PlayerAge").path("value").asText());
-    assertEquals("Row 2 TeamName value incorrect", "San Francisco Giants", second.path("TeamName").path("value").asText());
+    assertEquals( "John Doe", second.path("PlayerName").path("value").asText());
+    assertEquals( "31", second.path("PlayerAge").path("value").asText());
+    assertEquals( "San Francisco Giants", second.path("TeamName").path("value").asText());
   }
 
   /*
    * This test checks union with where distinct.
-   * 
+   *
    * Should return 13 results.
    */
   @Test
-  public void testUnionWithWhereDistinct() 
+  public void testUnionWithWhereDistinct()
   {
     System.out.println("In testUnionWithWhereDistinct method");
 
@@ -300,7 +299,7 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get();
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
     // Should have 13 nodes returned.
-    assertEquals("Thirteen nodes not returned from testUnionWithWhereDistinct method ", 13, jsonBindingsNodes.size());
+    assertEquals( 13, jsonBindingsNodes.size());
   }
 
   /*
@@ -308,7 +307,7 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
    * max. Should return 4 results. Max - 34
    */
   @Test
-  public void testGroupBys() 
+  public void testGroupBys()
   {
     System.out.println("In testGroupBys method");
 
@@ -345,10 +344,10 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get();
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
     // Should have 4 nodes returned.
-    assertEquals("Four nodes not returned from testGroupBys method - Average ", 4, jsonBindingsNodes.size());
+    assertEquals( 4, jsonBindingsNodes.size());
     JsonNode fourth = jsonBindingsNodes.path(3);
-    assertEquals("Row 4 PlayerName value incorrect", "Giants", fourth.path("team_name").path("value").asText());
-    assertEquals("Row 4 PlayerAge value incorrect", "29", fourth.path("AverageAge").path("value").asText());
+    assertEquals( "Giants", fourth.path("team_name").path("value").asText());
+    assertEquals( "29", fourth.path("AverageAge").path("value").asText());
 
     // Group by max.
     ModifyPlan outputMax = player_plan.joinInner(team_plan)
@@ -362,9 +361,9 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
     jsonBindingsNodes = jsonResults.path("rows");
     // Should have 4 nodes returned.
     JsonNode first = jsonBindingsNodes.path(0);
-    assertEquals("Four nodes not returned from testGroupBys method - Max", 4, jsonBindingsNodes.size());
-    assertEquals("Row 1 PlayerName value incorrect", "Padres", first.path("team_name").path("value").asText());
-    assertEquals("Row 1 PlayerAge value incorrect", "34", first.path("MaxAge").path("value").asText());
+    assertEquals( 4, jsonBindingsNodes.size());
+    assertEquals( "Padres", first.path("team_name").path("value").asText());
+    assertEquals( "34", first.path("MaxAge").path("value").asText());
   }
 
   /*
@@ -373,7 +372,7 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
    * 4 results. Min - 25.45 3) Sum on all. Should return 1 result. Sum 350.4
    */
   @Test
-  public void testGroupByCountAndSum() 
+  public void testGroupByCountAndSum()
   {
     System.out.println("In testGroupByCountAndSum method");
 
@@ -392,7 +391,7 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
     PlanColumn teamNameCol = p.col("team_name");
     PlanColumn teamCityCol = p.col("team_city");
 
-    PlanTriplePatternSeq playerSeq = p.patternSeq( 
+    PlanTriplePatternSeq playerSeq = p.patternSeq(
     		p.pattern(playerIdCol, bb.iri("age"), playerAgeCol),
             p.pattern(playerIdCol, bb.iri("name"), playerNameCol),
             p.pattern(playerIdCol, bb.iri("team"), playerTeamCol),
@@ -414,13 +413,13 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get();
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
     // Should have 4 nodes returned.
-    assertEquals("Four nodes not returned from testGroupByCountAndSum method - Count", 4, jsonBindingsNodes.size());
+    assertEquals( 4, jsonBindingsNodes.size());
     JsonNode first = jsonBindingsNodes.path(0);
-    assertEquals("Row 1 PlayerName value incorrect", "Mariners", first.path("team_name").path("value").asText());
-    assertEquals("Row 1 PlayerAge value incorrect", "17", first.path("CountPlayer").path("value").asText());
+    assertEquals( "Mariners", first.path("team_name").path("value").asText());
+    assertEquals( "17", first.path("CountPlayer").path("value").asText());
     first = jsonBindingsNodes.path(3);
-    assertEquals("Row 4 PlayerName value incorrect", "Athletics", first.path("team_name").path("value").asText());
-    assertEquals("Row 4 PlayerAge value incorrect", "1", first.path("CountPlayer").path("value").asText());
+    assertEquals( "Athletics", first.path("team_name").path("value").asText());
+    assertEquals( "1", first.path("CountPlayer").path("value").asText());
 
     // group by min on decimals
     ModifyPlan outputMin = player_plan.joinInner(team_plan)
@@ -433,25 +432,25 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
     jsonResults = jacksonHandle.get();
     jsonBindingsNodes = jsonResults.path("rows");
     // Should have 4 nodes returned.
-    assertEquals("Four nodes not returned from testGroupByCountAndSum method - Min", 4, jsonBindingsNodes.size());
+    assertEquals( 4, jsonBindingsNodes.size());
     JsonNode third = jsonBindingsNodes.path(3);
-    assertEquals("Row 4 PlayerName value incorrect", "Giants", third.path("team_name").path("value").asText());
-    assertEquals("Row 4 PlayerAge value incorrect", "25.45", third.path("MinEff").path("value").asText());
+    assertEquals( "Giants", third.path("team_name").path("value").asText());
+    assertEquals( "25.45", third.path("MinEff").path("value").asText());
 
     // group by sum on all
-    PlanTriplePatternSeq playerSumSeq = p.patternSeq( 
+    PlanTriplePatternSeq playerSumSeq = p.patternSeq(
     p.pattern(playerIdCol, bb.iri("age"), playerAgeCol),
     p.pattern(playerIdCol, bb.iri("name"), playerNameCol),
     p.pattern(playerIdCol, bb.iri("team"), playerTeamCol),
     p.pattern(playerIdCol, bb.iri("eff"), playerEffCol));
-    
+
     PlanTriplePatternSeq team_planSumSeq = p.patternSeq(
     p.pattern(teamIdCol, tm.iri("name"), teamNameCol),
     p.pattern(teamIdCol, tm.iri("city"), teamCityCol));
-    
+
 	ModifyPlan player_planSum = p.fromTriples(playerSumSeq/* , "players", null, PlanTripleOption.DEDUPLICATED */);
     ModifyPlan team_planSum = p.fromTriples(team_planSumSeq);
-    
+
     ModifyPlan outputSum = player_planSum.joinInner(team_planSum)
         .groupBy(null, p.sum(p.col("SumAll"), playerEffCol));
     jacksonHandle = new JacksonHandle();
@@ -460,16 +459,17 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
     rowMgr.resultDoc(outputSum, jacksonHandle);
     jsonResults = jacksonHandle.get();
     jsonBindingsNodes = jsonResults.path("rows");
-    assertEquals("Node not returned from testGroupByCountAndSum method: " + jsonBindingsNodes.toPrettyString(), 1, jsonBindingsNodes.size());
+    assertEquals(1, jsonBindingsNodes.size(),
+		"Node not returned from testGroupByCountAndSum method: " + jsonBindingsNodes.toPrettyString());
     third = jsonBindingsNodes.path(0);
-    assertEquals("Row 1 Sum of All value incorrect", "843.75", third.path("SumAll").path("value").asText());
+    assertEquals( "843.75", third.path("SumAll").path("value").asText());
   }
 
   /*
    * This test checks join inner with graph iri and options.
    */
   @Test
-  public void testJoinInnerWithGraphIRI() 
+  public void testJoinInnerWithGraphIRI()
   {
     System.out.println("In testJoinInnerWithGraphIRI method");
     // 'TEST 13 - join inner with graph iri'
@@ -516,21 +516,21 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get().path("rows");
 
     // Should have 3 nodes returned.
-    assertEquals("Three nodes not returned from testJoinInnerWithGraphIRI method ", 3, jsonResults.size());
-    assertEquals("Row 1 PlayerName value incorrect", "Juan Leone", jsonResults.get(0).path("PlayerName").path("value").asText());
-    assertEquals("Row 1 PlayerAge value incorrect", "27", jsonResults.get(0).path("PlayerAge").path("value").asText());
-    assertEquals("Row 1 TeamName value incorrect", "San Francisco Giants", jsonResults.get(0).path("TeamName").path("value").asText());
-    assertEquals("Row 1 GraphName value incorrect", "/optic/player/triple/test", jsonResults.get(0).path("GraphName").path("value").asText());
+    assertEquals( 3, jsonResults.size());
+    assertEquals( "Juan Leone", jsonResults.get(0).path("PlayerName").path("value").asText());
+    assertEquals( "27", jsonResults.get(0).path("PlayerAge").path("value").asText());
+    assertEquals( "San Francisco Giants", jsonResults.get(0).path("TeamName").path("value").asText());
+    assertEquals( "/optic/player/triple/test", jsonResults.get(0).path("GraphName").path("value").asText());
 
-    assertEquals("Row 2 PlayerName value incorrect", "Josh Ream", jsonResults.get(1).path("PlayerName").path("value").asText());
-    assertEquals("Row 2 PlayerAge value incorrect", "29", jsonResults.get(1).path("PlayerAge").path("value").asText());
-    assertEquals("Row 2 TeamName value incorrect", "San Francisco Giants", jsonResults.get(1).path("TeamName").path("value").asText());
-    assertEquals("Row 2 GraphName value incorrect", "/optic/player/triple/test", jsonResults.get(1).path("GraphName").path("value").asText());
+    assertEquals( "Josh Ream", jsonResults.get(1).path("PlayerName").path("value").asText());
+    assertEquals( "29", jsonResults.get(1).path("PlayerAge").path("value").asText());
+    assertEquals( "San Francisco Giants", jsonResults.get(1).path("TeamName").path("value").asText());
+    assertEquals( "/optic/player/triple/test", jsonResults.get(1).path("GraphName").path("value").asText());
 
-    assertEquals("Row 3 PlayerName value incorrect", "John Doe", jsonResults.get(2).path("PlayerName").path("value").asText());
-    assertEquals("Row 3 PlayerAge value incorrect", "31", jsonResults.get(2).path("PlayerAge").path("value").asText());
-    assertEquals("Row 3 TeamName value incorrect", "San Francisco Giants", jsonResults.get(2).path("TeamName").path("value").asText());
-    assertEquals("Row 3 GraphName value incorrect", "/optic/player/triple/test", jsonResults.get(2).path("GraphName").path("value").asText());
+    assertEquals( "John Doe", jsonResults.get(2).path("PlayerName").path("value").asText());
+    assertEquals( "31", jsonResults.get(2).path("PlayerAge").path("value").asText());
+    assertEquals( "San Francisco Giants", jsonResults.get(2).path("TeamName").path("value").asText());
+    assertEquals( "/optic/player/triple/test", jsonResults.get(2).path("GraphName").path("value").asText());
   }
 
   /*
@@ -538,7 +538,7 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
    * and p.sem.rulesetStore()
    */
   @Test
-  public void testJoinInnerWithSemStore() 
+  public void testJoinInnerWithSemStore()
   {
     System.out.println("In testJoinInnerWithSemStore method");
 
@@ -592,18 +592,18 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get().path("rows");
 
     // Should have 3 nodes returned.
-    assertEquals("Three nodes not returned from testJoinInnerWithGraphIRI method ", 3, jsonResults.size());
-    assertEquals("Row 1 PlayerName value incorrect", "Juan Leone", jsonResults.get(0).path("PlayerName").path("value").asText());
-    assertEquals("Row 1 PlayerAge value incorrect", "27", jsonResults.get(0).path("PlayerAge").path("value").asText());
-    assertEquals("Row 1 TeamName value incorrect", "San Francisco Giants", jsonResults.get(0).path("TeamName").path("value").asText());
+    assertEquals( 3, jsonResults.size());
+    assertEquals( "Juan Leone", jsonResults.get(0).path("PlayerName").path("value").asText());
+    assertEquals( "27", jsonResults.get(0).path("PlayerAge").path("value").asText());
+    assertEquals( "San Francisco Giants", jsonResults.get(0).path("TeamName").path("value").asText());
 
-    assertEquals("Row 2 PlayerName value incorrect", "Josh Ream", jsonResults.get(1).path("PlayerName").path("value").asText());
-    assertEquals("Row 2 PlayerAge value incorrect", "29", jsonResults.get(1).path("PlayerAge").path("value").asText());
-    assertEquals("Row 2 TeamName value incorrect", "San Francisco Giants", jsonResults.get(1).path("TeamName").path("value").asText());
+    assertEquals( "Josh Ream", jsonResults.get(1).path("PlayerName").path("value").asText());
+    assertEquals( "29", jsonResults.get(1).path("PlayerAge").path("value").asText());
+    assertEquals( "San Francisco Giants", jsonResults.get(1).path("TeamName").path("value").asText());
 
-    assertEquals("Row 3 PlayerName value incorrect", "John Doe", jsonResults.get(2).path("PlayerName").path("value").asText());
-    assertEquals("Row 3 PlayerAge value incorrect", "31", jsonResults.get(2).path("PlayerAge").path("value").asText());
-    assertEquals("Row 3 TeamName value incorrect", "San Francisco Giants", jsonResults.get(2).path("TeamName").path("value").asText());
+    assertEquals( "John Doe", jsonResults.get(2).path("PlayerName").path("value").asText());
+    assertEquals( "31", jsonResults.get(2).path("PlayerAge").path("value").asText());
+    assertEquals( "San Francisco Giants", jsonResults.get(2).path("TeamName").path("value").asText());
 
     // Verify overloaded fromTriples() with graphIRI
     ModifyPlan player_plan1 = p.fromTriples(patPlayerSeq, (String) null, "/optic/player/triple/test", PlanTripleOption.DEDUPLICATED);
@@ -622,28 +622,28 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
     jsonResults = jacksonHandle.get().path("rows");
 
     // Should have 3 nodes returned.
-    assertEquals("Three nodes not returned from testJoinInnerWithGraphIRI method ", 3, jsonResults.size());
-    assertEquals("Row 1 PlayerName value incorrect", "Juan Leone", jsonResults.get(0).path("PlayerName").path("value").asText());
-    assertEquals("Row 1 PlayerAge value incorrect", "27", jsonResults.get(0).path("PlayerAge").path("value").asText());
-    assertEquals("Row 1 TeamName value incorrect", "San Francisco Giants", jsonResults.get(0).path("TeamName").path("value").asText());
-    assertEquals("Row 1 GraphName value incorrect", "/optic/player/triple/test", jsonResults.get(0).path("PlayerGraph").path("value").asText());
+    assertEquals( 3, jsonResults.size());
+    assertEquals( "Juan Leone", jsonResults.get(0).path("PlayerName").path("value").asText());
+    assertEquals( "27", jsonResults.get(0).path("PlayerAge").path("value").asText());
+    assertEquals( "San Francisco Giants", jsonResults.get(0).path("TeamName").path("value").asText());
+    assertEquals( "/optic/player/triple/test", jsonResults.get(0).path("PlayerGraph").path("value").asText());
 
-    assertEquals("Row 2 PlayerName value incorrect", "Josh Ream", jsonResults.get(1).path("PlayerName").path("value").asText());
-    assertEquals("Row 2 PlayerAge value incorrect", "29", jsonResults.get(1).path("PlayerAge").path("value").asText());
-    assertEquals("Row 2 TeamName value incorrect", "San Francisco Giants", jsonResults.get(1).path("TeamName").path("value").asText());
-    assertEquals("Row 2 GraphName value incorrect", "/optic/player/triple/test", jsonResults.get(1).path("PlayerGraph").path("value").asText());
+    assertEquals( "Josh Ream", jsonResults.get(1).path("PlayerName").path("value").asText());
+    assertEquals( "29", jsonResults.get(1).path("PlayerAge").path("value").asText());
+    assertEquals( "San Francisco Giants", jsonResults.get(1).path("TeamName").path("value").asText());
+    assertEquals( "/optic/player/triple/test", jsonResults.get(1).path("PlayerGraph").path("value").asText());
 
-    assertEquals("Row 3 PlayerName value incorrect", "John Doe", jsonResults.get(2).path("PlayerName").path("value").asText());
-    assertEquals("Row 3 PlayerAge value incorrect", "31", jsonResults.get(2).path("PlayerAge").path("value").asText());
-    assertEquals("Row 3 TeamName value incorrect", "San Francisco Giants", jsonResults.get(2).path("TeamName").path("value").asText());
-    assertEquals("Row 3 GraphName value incorrect", "/optic/player/triple/test", jsonResults.get(2).path("PlayerGraph").path("value").asText());
+    assertEquals( "John Doe", jsonResults.get(2).path("PlayerName").path("value").asText());
+    assertEquals( "31", jsonResults.get(2).path("PlayerAge").path("value").asText());
+    assertEquals( "San Francisco Giants", jsonResults.get(2).path("TeamName").path("value").asText());
+    assertEquals( "/optic/player/triple/test", jsonResults.get(2).path("PlayerGraph").path("value").asText());
   }
 
   /*
    * This test checks access with qualifier.
    */
   @Test
-  public void testAccessWithQualifier() 
+  public void testAccessWithQualifier()
   {
     System.out.println("In testAccessWithQualifier method");
 
@@ -669,16 +669,16 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
     JsonNode nodeVal = jsonBindingsNodes.path(0);
     // Should have 8 nodes returned.
-    assertEquals("Eight nodes not returned from testAccessWithQualifier method", 8, jsonBindingsNodes.size());
-    assertEquals("Row 1 myPlayer.id value incorrect", "http://marklogic.com/baseball/id#006", nodeVal.path("myPlayer.id").path("value").asText());
-    assertEquals("Row 1 myPlayer.age value incorrect", "34", nodeVal.path("myPlayer.age").path("value").asText());
-    assertEquals("Row 1 myPlayer.name value incorrect", "Aoki Yamada", nodeVal.path("myPlayer.name").path("value").asText());
-    assertEquals("Row 1 myPlayer.team value incorrect", "http://marklogic.com/mlb/team/id/003", nodeVal.path("myPlayer.team").path("value").asText());
+    assertEquals( 8, jsonBindingsNodes.size());
+    assertEquals( "http://marklogic.com/baseball/id#006", nodeVal.path("myPlayer.id").path("value").asText());
+    assertEquals( "34", nodeVal.path("myPlayer.age").path("value").asText());
+    assertEquals( "Aoki Yamada", nodeVal.path("myPlayer.name").path("value").asText());
+    assertEquals( "http://marklogic.com/mlb/team/id/003", nodeVal.path("myPlayer.team").path("value").asText());
     nodeVal = jsonBindingsNodes.path(7);
-    assertEquals("Row 8 myPlayer.id value incorrect", "http://marklogic.com/baseball/id#005", nodeVal.path("myPlayer.id").path("value").asText());
-    assertEquals("Row 8 myPlayer.age value incorrect", "19", nodeVal.path("myPlayer.age").path("value").asText());
-    assertEquals("Row 8 myPlayer.name value incorrect", "Pedro Barrozo", nodeVal.path("myPlayer.name").path("value").asText());
-    assertEquals("Row 8 myPlayer.team value incorrect", "http://marklogic.com/mlb/team/id/002", nodeVal.path("myPlayer.team").path("value").asText());
+    assertEquals( "http://marklogic.com/baseball/id#005", nodeVal.path("myPlayer.id").path("value").asText());
+    assertEquals( "19", nodeVal.path("myPlayer.age").path("value").asText());
+    assertEquals( "Pedro Barrozo", nodeVal.path("myPlayer.name").path("value").asText());
+    assertEquals( "http://marklogic.com/mlb/team/id/002", nodeVal.path("myPlayer.team").path("value").asText());
 
     // access with qualifier with where and order by
     ModifyPlan output1 = p.fromTriples(patSeq, "myPlayer")
@@ -694,13 +694,13 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
     nodeVal = jsonBindingsNodes.path(0);
 
     // Should have 3 nodes returned.
-    assertEquals("Three nodes not returned from testAccessWithQualifier method", 3, jsonBindingsNodes.size());
-    assertEquals("Row 1 myPlayer.name value incorrect", "Pedro Barrozo", nodeVal.path("myPlayer.name").path("value").asText());
-    assertEquals("Row 1 myPlayer.age value incorrect", "19", nodeVal.path("myPlayer.age").path("value").asText());
+    assertEquals( 3, jsonBindingsNodes.size());
+    assertEquals( "Pedro Barrozo", nodeVal.path("myPlayer.name").path("value").asText());
+    assertEquals( "19", nodeVal.path("myPlayer.age").path("value").asText());
 
     nodeVal = jsonBindingsNodes.path(2);
-    assertEquals("Row 3 myPlayer.name value incorrect", "Bob Brian", nodeVal.path("myPlayer.name").path("value").asText());
-    assertEquals("Row 3 myPlayer.age value incorrect", "23", nodeVal.path("myPlayer.age").path("value").asText());
+    assertEquals( "Bob Brian", nodeVal.path("myPlayer.name").path("value").asText());
+    assertEquals( "23", nodeVal.path("myPlayer.age").path("value").asText());
 
     // access with qualifier and no subject
     ModifyPlan outputNoSubject = p.fromTriples(p.pattern(null, bb.iri("age"), ageCol), "myPlayer", null, PlanTripleOption.DEDUPLICATED)
@@ -714,10 +714,10 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
     nodeVal = jsonBindingsNodes.path(0);
 
     // Should have 7 nodes returned.
-    assertEquals("Seven nodes not returned from testAccessWithQualifier method", 7, jsonBindingsNodes.size());
-    assertEquals("Row 1 myPlayer.age value incorrect", "34", nodeVal.path("myPlayer.age").path("value").asText());
+    assertEquals( 7, jsonBindingsNodes.size());
+    assertEquals( "34", nodeVal.path("myPlayer.age").path("value").asText());
     nodeVal = jsonBindingsNodes.path(6);
-    assertEquals("Row 8 myPlayer.age value incorrect", "19", nodeVal.path("myPlayer.age").path("value").asText());
+    assertEquals( "19", nodeVal.path("myPlayer.age").path("value").asText());
 
     // access with qualifier and no object
     ModifyPlan outputNoObject = p.fromTriples(p.pattern(idCol, bb.iri("age"), null), "myPlayer", null, PlanTripleOption.DEDUPLICATED)
@@ -728,12 +728,12 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
     rowMgr.resultDoc(outputNoObject, jacksonHandle);
     jsonResults = jacksonHandle.get();
     jsonBindingsNodes = jsonResults.path("rows");
-    assertEquals("Eight nodes not returned from testAccessWithQualifier method", 8, jsonBindingsNodes.size());
+    assertEquals( 8, jsonBindingsNodes.size());
 
     nodeVal = jsonBindingsNodes.path(0);
-    assertEquals("Row 1 myPlayer.id value incorrect", "http://marklogic.com/baseball/id#001", nodeVal.path("myPlayer.id").path("value").asText());
+    assertEquals( "http://marklogic.com/baseball/id#001", nodeVal.path("myPlayer.id").path("value").asText());
     nodeVal = jsonBindingsNodes.path(7);
-    assertEquals("Row 8 myPlayer.id value incorrect", "http://marklogic.com/baseball/id#008", nodeVal.path("myPlayer.id").path("value").asText());
+    assertEquals( "http://marklogic.com/baseball/id#008", nodeVal.path("myPlayer.id").path("value").asText());
 
     // access with qualifier and fragment id column
 
@@ -753,23 +753,23 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
     jsonResults = jacksonHandle.get();
     jsonBindingsNodes = jsonResults.path("rows");
     // Should return 3 nodes.
-    assertEquals("Three nodes not returned from testAccessWithQualifier method", 3, jsonBindingsNodes.size());
+    assertEquals( 3, jsonBindingsNodes.size());
 
-    assertEquals("Row 1 myPlayer.name value incorrect", "Pedro Barrozo", jsonBindingsNodes.get(0).path("myPlayer.name").path("value").asText());
-    assertEquals("Row 1 myPlayer.age value incorrect", "19", jsonBindingsNodes.get(0).path("myPlayer.age").path("value").asText());
+    assertEquals( "Pedro Barrozo", jsonBindingsNodes.get(0).path("myPlayer.name").path("value").asText());
+    assertEquals( "19", jsonBindingsNodes.get(0).path("myPlayer.age").path("value").asText());
 
-    assertEquals("Row 1 myPlayer.name value incorrect", "Pat Crenshaw", jsonBindingsNodes.get(1).path("myPlayer.name").path("value").asText());
-    assertEquals("Row 1 myPlayer.age value incorrect", "25", jsonBindingsNodes.get(1).path("myPlayer.age").path("value").asText());
+    assertEquals( "Pat Crenshaw", jsonBindingsNodes.get(1).path("myPlayer.name").path("value").asText());
+    assertEquals( "25", jsonBindingsNodes.get(1).path("myPlayer.age").path("value").asText());
 
-    assertEquals("Row 1 myPlayer.name value incorrect", "Bob Brian", jsonBindingsNodes.get(2).path("myPlayer.name").path("value").asText());
-    assertEquals("Row 1 myPlayer.age value incorrect", "23", jsonBindingsNodes.get(2).path("myPlayer.age").path("value").asText());
+    assertEquals( "Bob Brian", jsonBindingsNodes.get(2).path("myPlayer.name").path("value").asText());
+    assertEquals( "23", jsonBindingsNodes.get(2).path("myPlayer.age").path("value").asText());
   }
 
   /*
    * This test checks access with iri predicate.
    */
   @Test
-  public void testSemIRI() 
+  public void testSemIRI()
   {
     System.out.println("In testSemIRI method");
 
@@ -796,10 +796,10 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
     JsonNode nodeVal = jsonBindingsNodes.path(0);
     // Should have 8 nodes returned.
-    assertEquals("Eight nodes not returned from testSemIRI method", 8, jsonBindingsNodes.size());
-    assertEquals("Row 1 myPlayer.age  value incorrect", "31", nodeVal.path("myPlayer.age").path("value").asText());
+    assertEquals( 8, jsonBindingsNodes.size());
+    assertEquals( "31", nodeVal.path("myPlayer.age").path("value").asText());
     nodeVal = jsonBindingsNodes.path(7);
-    assertEquals("Row 8 myPlayer.age value incorrect", "27", nodeVal.path("myPlayer.age").path("value").asText());
+    assertEquals( "27", nodeVal.path("myPlayer.age").path("value").asText());
 
     // access with iri subject
     ModifyPlan output1 = p.fromTriples(p.pattern(p.sem.iri("http://marklogic.com/baseball/id#001"), bb.iri("age"), ageCol), "myPlayer");
@@ -811,15 +811,15 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
     jsonBindingsNodes = jsonResults.path("rows");
     nodeVal = jsonBindingsNodes.path(0);
     // Should have 1 nodes returned.
-    assertEquals("One node not returned from testSemIRI method", 1, jsonBindingsNodes.size());
-    assertEquals("Row 1 myPlayer.age value incorrect", "31", nodeVal.path("myPlayer.age").path("value").asText());
+    assertEquals( 1, jsonBindingsNodes.size());
+    assertEquals( "31", nodeVal.path("myPlayer.age").path("value").asText());
   }
 
   /*
    * This test checks join left outer with condition and multiple keymatch.
    */
   @Test
-  public void testJoinLeftWithMultipleKeyMatch() 
+  public void testJoinLeftWithMultipleKeyMatch()
   {
     System.out.println("In testJoinLeftWithMultipleKeyMatch method");
 
@@ -857,14 +857,14 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get();
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
     // Should have 1 nodes returned.
-    assertEquals("One node not returned from testJoinLeftWithMultipleKeyMatch method", 1, jsonBindingsNodes.size());
+    assertEquals( 1, jsonBindingsNodes.size());
   }
 
   /*
    * This test checks join inner outer with whereDistinct. Returns 8 results
    */
   @Test
-  public void testJoinWhereDistinct() 
+  public void testJoinWhereDistinct()
   {
     System.out.println("In testJoinWhereDistinct method");
 
@@ -908,14 +908,14 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get();
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
     // Should have 8 nodes returned.
-    assertEquals("Eight nodes not returned from testJoinWhereDistinct method", 8, jsonBindingsNodes.size());
+    assertEquals( 8, jsonBindingsNodes.size());
   }
 
   /*
    * This test checks value processing functions. Returns 8 results
    */
   @Test
-  public void testProcessingFunctions() 
+  public void testProcessingFunctions()
   {
     System.out.println("In testProcessingFunctions method");
 
@@ -971,23 +971,23 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
     JsonNode nodeVal = jsonBindingsNodes.path(0);
     // Should have 8 nodes returned.
-    assertEquals("Eight nodes not returned from testProcessingFunctions method", 8, jsonBindingsNodes.size());
+    assertEquals( 8, jsonBindingsNodes.size());
 
-    assertEquals("Row 1 name value incorrect", "pedro barrozo", nodeVal.path("name").path("value").asText());
-    assertEquals("Row 1 nameLength value incorrect", "13", nodeVal.path("nameLength").path("value").asText());
-    assertEquals("Row 1 firstname value incorrect", "Pedro", nodeVal.path("firstname").path("value").asText());
-    assertEquals("Row 1 year value incorrect", "1991", nodeVal.path("year").path("value").asText());
-    assertEquals("Row 1 month value incorrect", "12", nodeVal.path("month").path("value").asText());
-    assertEquals("Row 1 day value incorrect", "9", nodeVal.path("day").path("value").asText());
-    assertEquals("Row 1 log incorrect", "3.72930136861285", nodeVal.path("log").path("value").asText());
+    assertEquals( "pedro barrozo", nodeVal.path("name").path("value").asText());
+    assertEquals( "13", nodeVal.path("nameLength").path("value").asText());
+    assertEquals( "Pedro", nodeVal.path("firstname").path("value").asText());
+    assertEquals( "1991", nodeVal.path("year").path("value").asText());
+    assertEquals( "12", nodeVal.path("month").path("value").asText());
+    assertEquals( "9", nodeVal.path("day").path("value").asText());
+    assertEquals( "3.72930136861285", nodeVal.path("log").path("value").asText());
     nodeVal = jsonBindingsNodes.path(7);
-    assertEquals("Row 7 name value incorrect", "aoki yamada", nodeVal.path("name").path("value").asText());
-    assertEquals("Row 7 nameLength value incorrect", "11", nodeVal.path("nameLength").path("value").asText());
-    assertEquals("Row 7 firstname value incorrect", "Aoki", nodeVal.path("firstname").path("value").asText());
-    assertEquals("Row 7 year value incorrect", "1987", nodeVal.path("year").path("value").asText());
-    assertEquals("Row 7 month value incorrect", "3", nodeVal.path("month").path("value").asText());
-    assertEquals("Row 7 day value incorrect", "15", nodeVal.path("day").path("value").asText());
-    assertEquals("Row 7 log incorrect", "4.01096295328305", nodeVal.path("log").path("value").asText());
+    assertEquals( "aoki yamada", nodeVal.path("name").path("value").asText());
+    assertEquals( "11", nodeVal.path("nameLength").path("value").asText());
+    assertEquals( "Aoki", nodeVal.path("firstname").path("value").asText());
+    assertEquals( "1987", nodeVal.path("year").path("value").asText());
+    assertEquals( "3", nodeVal.path("month").path("value").asText());
+    assertEquals( "15", nodeVal.path("day").path("value").asText());
+    assertEquals( "4.01096295328305", nodeVal.path("log").path("value").asText());
   }
 
   /*
@@ -995,7 +995,7 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
    * contents.
    */
   @Test
-  public void testExportPlan() 
+  public void testExportPlan()
   {
     System.out.println("In testExportPlan method");
 
@@ -1031,20 +1031,20 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
     exportedPlan.export(strHandle);
     // Verify the handle contents - Some of the plan fields.
     String str = strHandle.get();
-    assertTrue("Function not available fromTriples in exported plan", str.contains("\"fn\":\"from-triples\""));
-    assertTrue("Left join fromTriples not in exported plan", str.contains("\"fn\":\"join-left-outer\""));
-    assertTrue("Player_id not available in exported plan", str.contains("\"args\":[\"player_id\"]"));
-    assertTrue("Players IRI not availables in exported plan", str.contains("\"args\":[\"http://marklogic.com/baseball/players/age\"]"));
-    assertTrue("Team IRI not available in exported plan", str.contains("\"args\":[\"http://marklogic.com/baseball/players/team\"]"));
-    assertTrue("Where clause values not available in exported plan", str.contains("\"ns\":\"xs\", \"fn\":\"int\", \"args\":[\"20\"]"));
-    assertTrue("Where clause values not available in exported plan", str.contains("\"fn\":\"is-defined\""));
+    assertTrue( str.contains("\"fn\":\"from-triples\""));
+    assertTrue( str.contains("\"fn\":\"join-left-outer\""));
+    assertTrue(str.contains("\"args\":[\"player_id\"]"));
+    assertTrue( str.contains("\"args\":[\"http://marklogic.com/baseball/players/age\"]"));
+    assertTrue( str.contains("\"args\":[\"http://marklogic.com/baseball/players/team\"]"));
+    assertTrue( str.contains("\"ns\":\"xs\", \"fn\":\"int\", \"args\":[\"20\"]"));
+    assertTrue( str.contains("\"fn\":\"is-defined\""));
   }
 
   /*
    * Test multiple left join on different prefixers
    */
   @Test
-  public void testMultipleLeftJoins() 
+  public void testMultipleLeftJoins()
   {
     System.out.println("In testMultipleLeftJoins method");
     RowManager rowMgr = client.newRowManager();
@@ -1092,33 +1092,33 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get();
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
     // Should have 8 nodes returned.
-    assertEquals("Eight nodes not returned from testProcessingFunctions method", 8, jsonBindingsNodes.size());
-    assertEquals("Row 1 myOriginal.org_name value incorrect", "Aoki Yamada", jsonBindingsNodes.path(0).path("myOriginal.org_name").path("value").asText());
-    assertEquals("Row 1 myTeam.team_name value incorrect", "Padres", jsonBindingsNodes.path(0).path("myTeam.team_name").path("value").asText());
-    assertEquals("Row 1 myPlayer.player_name value incorrect", "Phil Green", jsonBindingsNodes.path(0).path("myPlayer.player_name").path("value").asText());
+    assertEquals( 8, jsonBindingsNodes.size());
+    assertEquals("Aoki Yamada", jsonBindingsNodes.path(0).path("myOriginal.org_name").path("value").asText());
+    assertEquals("Padres", jsonBindingsNodes.path(0).path("myTeam.team_name").path("value").asText());
+    assertEquals("Phil Green", jsonBindingsNodes.path(0).path("myPlayer.player_name").path("value").asText());
 
-    assertEquals("Row 2 myOriginal.org_name value incorrect", "John Doe", jsonBindingsNodes.path(1).path("myOriginal.org_name").path("value").asText());
-    assertEquals("Row 2 myTeam.team_name value incorrect", "Giants", jsonBindingsNodes.path(1).path("myTeam.team_name").path("value").asText());
-    assertTrue("Row 2 myPlayer.player_name value incorrect", jsonBindingsNodes.path(1).path("myPlayer.player_name").asText().isEmpty());
+    assertEquals("John Doe", jsonBindingsNodes.path(1).path("myOriginal.org_name").path("value").asText());
+    assertEquals("Giants", jsonBindingsNodes.path(1).path("myTeam.team_name").path("value").asText());
+    assertTrue(jsonBindingsNodes.path(1).path("myPlayer.player_name").asText().isEmpty());
 
-    assertEquals("Row 6 myOriginal.org_name value incorrect", "Pat Crenshaw", jsonBindingsNodes.path(5).path("myOriginal.org_name").path("value").asText());
-    assertEquals("Row 6 myTeam.team_name value incorrect", "Mariners", jsonBindingsNodes.path(5).path("myTeam.team_name").path("value").asText());
-    assertEquals("Row 6 myTeam.team_city value incorrect", "Seattle", jsonBindingsNodes.path(5).path("myTeam.team_city").path("value").asText());
+    assertEquals("Pat Crenshaw", jsonBindingsNodes.path(5).path("myOriginal.org_name").path("value").asText());
+    assertEquals("Mariners", jsonBindingsNodes.path(5).path("myTeam.team_name").path("value").asText());
+    assertEquals("Seattle", jsonBindingsNodes.path(5).path("myTeam.team_city").path("value").asText());
 
-    assertEquals("Row 7 myOriginal.org_age value incorrect", "23", jsonBindingsNodes.path(6).path("myOriginal.org_age").path("value").asText());
+    assertEquals("23", jsonBindingsNodes.path(6).path("myOriginal.org_age").path("value").asText());
 
-    assertEquals("Row 8 myOriginal.org_name value incorrect", "Pedro Barrozo", jsonBindingsNodes.path(7).path("myOriginal.org_name").path("value").asText());
+    assertEquals("Pedro Barrozo", jsonBindingsNodes.path(7).path("myOriginal.org_name").path("value").asText());
   }
 
   // Negative Cases
 
   /*
    * This test checks additional parameter.
-   * 
+   *
    * Should return exceptions.
    */
   @Test
-  public void testInvalidViewCol() 
+  public void testInvalidViewCol()
   {
     System.out.println("In testInvalidViewCol method");
 
@@ -1148,18 +1148,18 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
       System.out.println("Exception message is " + str.toString());
     }
     // Should have SQL-NOCOLUMN exceptions.
-    assertTrue("Exceptions not found", str.toString().contains("SQL-NOCOLUMN"));
-    assertTrue("Exceptions not found", str.toString().contains("Column not found"));
-    assertTrue("Exceptions not found", str.toString().contains("myPlayer_Invalid.age"));
+    assertTrue( str.toString().contains("SQL-NOCOLUMN"));
+    assertTrue( str.toString().contains("Column not found"));
+    assertTrue( str.toString().contains("myPlayer_Invalid.age"));
   }
 
   /*
    * This test checks triples with invaid qualifier.
-   * 
+   *
    * Should return exception.
    */
   @Test
-  public void testInvalidQualifier() 
+  public void testInvalidQualifier()
   {
     System.out.println("In testInvalidQualifier method");
 
@@ -1191,17 +1191,17 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
       System.out.println("Exception message is " + str.toString());
     }
     // Should have SQL-NOCOLUMN exceptions.
-    assertTrue("Exceptions not found", str.toString().contains("SQL-NOCOLUMN"));
-    assertTrue("Exceptions not found", str.toString().contains("Column not found: myPlayer_Invalid.age"));
+    assertTrue( str.toString().contains("SQL-NOCOLUMN"));
+    assertTrue( str.toString().contains("Column not found: myPlayer_Invalid.age"));
   }
 
   /*
    * This test checks null value in avg function.
-   * 
+   *
    * Should return exception.
    */
   @Test
-  public void testNullAvgFunction() 
+  public void testNullAvgFunction()
   {
     System.out.println("In testNullAvgFunction method");
     StringBuilder str = new StringBuilder();
@@ -1240,14 +1240,14 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
       str.append(ex.getMessage());
       System.out.println("Exception message is : " + str.toString());
     }
-    assertTrue("Exceptions not found", str.toString().contains("column parameter for avg() cannot be null"));
+    assertTrue( str.toString().contains("column parameter for avg() cannot be null"));
   }
 
   /*
    * This test checks bindParam on triples' subject and object.
    */
   @Test
-  public void testFromTriplesWithbindParam() 
+  public void testFromTriplesWithbindParam()
   {
     System.out.println("In testFromTriplesWithbindParam method");
 
@@ -1273,9 +1273,9 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get();
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
     // Should have 1 nodes returned.
-    assertEquals("One node not returned from testFromTriplesWithbindParam method ", 1, jsonBindingsNodes.size());
-    assertEquals("Row 1 player name value incorrect", "Juan Leone", jsonBindingsNodes.path(0).path("player_name").path("value").asText());
-    assertEquals("Row 1 player team value incorrect", "http://marklogic.com/mlb/team/id/001", jsonBindingsNodes.path(0).path("player_team").path("value").asText());
+    assertEquals( 1, jsonBindingsNodes.size());
+    assertEquals( "Juan Leone", jsonBindingsNodes.path(0).path("player_name").path("value").asText());
+    assertEquals( "http://marklogic.com/mlb/team/id/001", jsonBindingsNodes.path(0).path("player_team").path("value").asText());
 
     // Verify bind value with different types, values.
     Plan player_plan2 = player_plan.bindParam(ageParam, p.xs.intVal(0));
@@ -1285,7 +1285,7 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
     rowMgr.resultDoc(player_plan2, jacksonHandle);
     jsonResults = jacksonHandle.get();
 
-    assertTrue("No data should have been returned", jsonResults == null);
+    assertTrue( jsonResults == null);
 
     // Should not throw an exception, but return null results
     Plan player_plan3 = player_plan.bindParam(ageParam, p.xs.intVal(-1));
@@ -1295,7 +1295,7 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
     rowMgr.resultDoc(player_plan3, jacksonHandle);
     jsonResults = jacksonHandle.get();
     // Should have null nodes returned.
-    assertTrue("No data should have been returned", jsonResults == null);
+    assertTrue( jsonResults == null);
 
     // Should not throw an exception, but return null results
     Plan player_plan4 = player_plan.bindParam(ageParam, p.xs.string("abcd"));
@@ -1305,14 +1305,14 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
     rowMgr.resultDoc(player_plan4, jacksonHandle);
     jsonResults = jacksonHandle.get();
     // Should have null nodes returned.
-    assertTrue("No data should have been returned", jsonResults == null);
+    assertTrue( jsonResults == null);
   }
 
   /*
    * This test checks union instead of join over pattern value permutations.
    */
   @Test
-  public void testPatternValuePermutations() 
+  public void testPatternValuePermutations()
   {
     System.out.println("In testPatternValuePermutations method");
 
@@ -1351,15 +1351,15 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
     JsonNode nodeVal = jsonBindingsNodes.path(0);
     // Should have 2 nodes returned.
-    assertEquals("Two nodes not returned from testPatternValuePermutations method", 2, jsonBindingsNodes.size());
-    assertEquals("Row 1 PlayerName value incorrect", "Bob Brian", nodeVal.path("PlayerName").path("value").asText());
-    assertEquals("Row 1 PlayerAge value incorrect", "23", nodeVal.path("PlayerAge").path("value").asText());
-    assertEquals("Row 1 PlayerPosition value incorrect", "Outfielder", nodeVal.path("PlayerPosition").path("value").asText());
+    assertEquals( 2, jsonBindingsNodes.size());
+    assertEquals( "Bob Brian", nodeVal.path("PlayerName").path("value").asText());
+    assertEquals( "23", nodeVal.path("PlayerAge").path("value").asText());
+    assertEquals( "Outfielder", nodeVal.path("PlayerPosition").path("value").asText());
 
     nodeVal = jsonBindingsNodes.path(1);
-    assertEquals("Row 2 PlayerName value incorrect", "Pedro Barrozo", nodeVal.path("PlayerName").path("value").asText());
-    assertEquals("Row 2 PlayerAge value incorrect", "19", nodeVal.path("PlayerAge").path("value").asText());
-    assertEquals("Row 2 PlayerPosition value incorrect", "Midfielder", nodeVal.path("PlayerPosition").path("value").asText());
+    assertEquals( "Pedro Barrozo", nodeVal.path("PlayerName").path("value").asText());
+    assertEquals( "19", nodeVal.path("PlayerAge").path("value").asText());
+    assertEquals( "Midfielder", nodeVal.path("PlayerPosition").path("value").asText());
 
     // Test for verifying that value permutations do not appear in the result
     // rows. They should not be part of results.
@@ -1373,11 +1373,11 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
     JsonNode jsonResults1 = jacksonHandle1.get();
     JsonNode jsonBindingsNodes1 = jsonResults1.path("rows");
     // Should have 2 nodes returned.
-    assertEquals("Two nodes not returned from testPatternValuePermutations method", 2, jsonBindingsNodes1.size());
-    assertTrue("Node not returned from testPatternValuePermutations method",
+    assertEquals( 2, jsonBindingsNodes1.size());
+    assertTrue(
         jsonBindingsNodes1.path(0).get("myPlayer.id").get("value").asText().contains("http://marklogic.com/baseball/id#005") ||
             jsonBindingsNodes1.path(0).get("myPlayer.id").get("value").asText().contains("http://marklogic.com/baseball/id#002"));
-    assertTrue("Node not returned from testPatternValuePermutations method",
+    assertTrue(
         jsonBindingsNodes1.path(1).get("myPlayer.id").get("value").asText().contains("http://marklogic.com/baseball/id#005") ||
             jsonBindingsNodes1.path(1).get("myPlayer.id").get("value").asText().contains("http://marklogic.com/baseball/id#002"));
     // Negative cases
@@ -1401,7 +1401,7 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
     JsonNode jsonResultsNeg = jacksonHandle.get();
 
     // Should have 0 nodes returned.
-    assertTrue("Zero nodes not returned from testPatternValuePermutations method", jsonResultsNeg == null);
+    assertTrue( jsonResultsNeg == null);
 
     PlanTriplePositionSeq objectSeqNeg1 = p.objectSeq(p.xs.intVal(23), p.xs.intVal(19), p.xs.intVal(-1));
 
@@ -1424,14 +1424,14 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodesNeg1 = jsonResultsNeg1.path("rows");
     JsonNode nodeValNeg1 = jsonBindingsNodesNeg1.path(0);
     // Should have 2 nodes returned.
-    assertEquals("Two nodes not returned from testPatternValuePermutations method", 2, jsonBindingsNodesNeg1.size());
-    assertEquals("Row 1 PlayerName value incorrect", "Bob Brian", nodeValNeg1.path("PlayerName").path("value").asText());
-    assertEquals("Row 1 PlayerAge value incorrect", "23", nodeValNeg1.path("PlayerAge").path("value").asText());
-    assertEquals("Row 1 PlayerPosition value incorrect", "Outfielder", nodeValNeg1.path("PlayerPosition").path("value").asText());
+    assertEquals( 2, jsonBindingsNodesNeg1.size());
+    assertEquals( "Bob Brian", nodeValNeg1.path("PlayerName").path("value").asText());
+    assertEquals( "23", nodeValNeg1.path("PlayerAge").path("value").asText());
+    assertEquals( "Outfielder", nodeValNeg1.path("PlayerPosition").path("value").asText());
 
     nodeValNeg1 = jsonBindingsNodesNeg1.path(1);
-    assertEquals("Row 2 PlayerName value incorrect", "Pedro Barrozo", nodeValNeg1.path("PlayerName").path("value").asText());
-    assertEquals("Row 2 PlayerAge value incorrect", "19", nodeValNeg1.path("PlayerAge").path("value").asText());
-    assertEquals("Row 2 PlayerPosition value incorrect", "Midfielder", nodeValNeg1.path("PlayerPosition").path("value").asText());
+    assertEquals( "Pedro Barrozo", nodeValNeg1.path("PlayerName").path("value").asText());
+    assertEquals( "19", nodeValNeg1.path("PlayerAge").path("value").asText());
+    assertEquals( "Midfielder", nodeValNeg1.path("PlayerPosition").path("value").asText());
   }
 }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnViews.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnViews.java
@@ -29,8 +29,9 @@ import com.marklogic.client.row.RowManager;
 import com.marklogic.client.row.RowRecord;
 import com.marklogic.client.row.RowSet;
 import com.marklogic.client.type.*;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 import org.w3c.dom.Document;
 
 import java.util.ArrayList;
@@ -38,11 +39,11 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 
-import static org.junit.Assert.*;
+
 
 public class TestOpticOnViews extends AbstractFunctionalTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
   // Install the TDE templates into schemadbName DB
   // loadFileToDB(client, filename, docURI, collection, document format)
@@ -96,42 +97,42 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
 
     // Should have 6 nodes returned.
-    assertEquals("Six nodes not returned from testnamedSchemaAndView method ", 6, jsonBindingsNodes.size());
+    assertEquals( 6, jsonBindingsNodes.size());
 
     // Verify result 1's values.
-    assertEquals("Element 1 opticFunctionalTest.detail.id type value incorrect", "xs:integer", jsonBindingsNodes.path(0).path("opticFunctionalTest.detail.id").path("type")
+    assertEquals( "xs:integer", jsonBindingsNodes.path(0).path("opticFunctionalTest.detail.id").path("type")
             .asText());
-    assertEquals("Element 1 opticFunctionalTest.detail.id value is incorrect", "1", jsonBindingsNodes.path(0).path("opticFunctionalTest.detail.id").path("value").asText());
+    assertEquals( "1", jsonBindingsNodes.path(0).path("opticFunctionalTest.detail.id").path("value").asText());
 
-    assertEquals("Element 1 opticFunctionalTest.detail.name type is incorrect", "xs:string", jsonBindingsNodes.path(0).path("opticFunctionalTest.detail.name").path("type")
+    assertEquals( "xs:string", jsonBindingsNodes.path(0).path("opticFunctionalTest.detail.name").path("type")
             .asText());
-    assertEquals("Element 1 opticFunctionalTest.detail.name value is incorrect", "Detail 1", jsonBindingsNodes.path(0).path("opticFunctionalTest.detail.name").path("value")
+    assertEquals( "Detail 1", jsonBindingsNodes.path(0).path("opticFunctionalTest.detail.name").path("value")
             .asText());
 
-    assertEquals("Element 1 opticFunctionalTest.detail.masterId type value incorrect", "xs:integer",
+    assertEquals( "xs:integer",
             jsonBindingsNodes.path(0).path("opticFunctionalTest.detail.masterId").path("type").asText());
-    assertEquals("Element 1 opticFunctionalTest.detail.masterId value is incorrect", "1", jsonBindingsNodes.path(0).path("opticFunctionalTest.detail.masterId").path("value")
+    assertEquals( "1", jsonBindingsNodes.path(0).path("opticFunctionalTest.detail.masterId").path("value")
             .asText());
 
-    assertEquals("Element 1 opticFunctionalTest.detail.amount type is incorrect", "xs:double", jsonBindingsNodes.path(0).path("opticFunctionalTest.detail.amount").path("type")
+    assertEquals( "xs:double", jsonBindingsNodes.path(0).path("opticFunctionalTest.detail.amount").path("type")
             .asText());
-    assertEquals("Element 1 opticFunctionalTest.detail.amount value is incorrect", "10.01", jsonBindingsNodes.path(0).path("opticFunctionalTest.detail.amount").path("value")
+    assertEquals( "10.01", jsonBindingsNodes.path(0).path("opticFunctionalTest.detail.amount").path("value")
             .asText());
 
-    assertEquals("Element 1 opticFunctionalTest.detail.color type is incorrect", "xs:string", jsonBindingsNodes.path(0).path("opticFunctionalTest.detail.color").path("type")
+    assertEquals( "xs:string", jsonBindingsNodes.path(0).path("opticFunctionalTest.detail.color").path("type")
             .asText());
-    assertEquals("Element 1 opticFunctionalTest.detail.color value is incorrect", "blue", jsonBindingsNodes.path(0).path("opticFunctionalTest.detail.color").path("value").asText());
+    assertEquals( "blue", jsonBindingsNodes.path(0).path("opticFunctionalTest.detail.color").path("value").asText());
     // Verify only the name value of other nodes in the array results.
 
-    assertEquals("Element 2 opticFunctionalTest.detail.name value is incorrect", "Detail 2", jsonBindingsNodes.path(1).path("opticFunctionalTest.detail.name").path("value")
+    assertEquals( "Detail 2", jsonBindingsNodes.path(1).path("opticFunctionalTest.detail.name").path("value")
             .asText());
-    assertEquals("Element 3 opticFunctionalTest.detail.name value is incorrect", "Detail 3", jsonBindingsNodes.path(2).path("opticFunctionalTest.detail.name").path("value")
+    assertEquals( "Detail 3", jsonBindingsNodes.path(2).path("opticFunctionalTest.detail.name").path("value")
             .asText());
-    assertEquals("Element 4 opticFunctionalTest.detail.name value is incorrect", "Detail 4", jsonBindingsNodes.path(3).path("opticFunctionalTest.detail.name").path("value")
+    assertEquals( "Detail 4", jsonBindingsNodes.path(3).path("opticFunctionalTest.detail.name").path("value")
             .asText());
-    assertEquals("Element 5 opticFunctionalTest.detail.name value is incorrect", "Detail 5", jsonBindingsNodes.path(4).path("opticFunctionalTest.detail.name").path("value")
+    assertEquals( "Detail 5", jsonBindingsNodes.path(4).path("opticFunctionalTest.detail.name").path("value")
             .asText());
-    assertEquals("Element 6 opticFunctionalTest.detail.name value is incorrect", "Detail 6", jsonBindingsNodes.path(5).path("opticFunctionalTest.detail.name").path("value")
+    assertEquals( "Detail 6", jsonBindingsNodes.path(5).path("opticFunctionalTest.detail.name").path("value")
             .asText());
   }
 
@@ -161,7 +162,7 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
 
     // Should have 6 nodes returned.
-    assertEquals("Six nodes not returned from testnamedSchemaViewWithQualifier method ", 6, jsonBindingsNodes.size());
+    assertEquals( 6, jsonBindingsNodes.size());
   }
 
   /*
@@ -197,16 +198,16 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
 
     // Should have 3 nodes returned.
-    assertEquals("Three nodes not returned from testgroupBy method ", 3, jsonBindingsNodes.size());
-    assertEquals("Element 1 testGroupBy MasterName value incorrect", "Master 2", jsonBindingsNodes.get(0).path("MasterName").path("value").asText());
-    assertEquals("Element 1 testGroupBy arrayDetail size incorrect", 0, jsonBindingsNodes.get(0).path("arrayDetail").path("value").size());
-    assertEquals("Element 2 testGroupBy MasterName value incorrect", "Master 1", jsonBindingsNodes.get(1).path("MasterName").path("value").asText());
-    assertEquals("Element 2 testGroupBy arrayDetail size incorrect", 0, jsonBindingsNodes.get(1).path("arrayDetail").path("value").size());
-    assertEquals("Element 3 testGroupBy arrayDetail size incorrect", 6, jsonBindingsNodes.get(2).path("arrayDetail").path("value").size());
+    assertEquals( 3, jsonBindingsNodes.size());
+    assertEquals( "Master 2", jsonBindingsNodes.get(0).path("MasterName").path("value").asText());
+    assertEquals( 0, jsonBindingsNodes.get(0).path("arrayDetail").path("value").size());
+    assertEquals( "Master 1", jsonBindingsNodes.get(1).path("MasterName").path("value").asText());
+    assertEquals( 0, jsonBindingsNodes.get(1).path("arrayDetail").path("value").size());
+    assertEquals( 6, jsonBindingsNodes.get(2).path("arrayDetail").path("value").size());
     // Verify arrayDetail array
-    assertEquals("Element 3 testGroupBy arrayDetail value at index 1 incorrect", "Detail 1", jsonBindingsNodes.get(2).path("arrayDetail").path("value").get(0).asText());
-    assertEquals("Element 3 testGroupBy arrayDetail value at index 2 incorrect", "Detail 2", jsonBindingsNodes.get(2).path("arrayDetail").path("value").get(1).asText());
-    assertEquals("Element 3 testGroupBy arrayDetail value at index 6 incorrect", "Detail 6", jsonBindingsNodes.get(2).path("arrayDetail").path("value").get(5).asText());
+    assertEquals( "Detail 1", jsonBindingsNodes.get(2).path("arrayDetail").path("value").get(0).asText());
+    assertEquals( "Detail 2", jsonBindingsNodes.get(2).path("arrayDetail").path("value").get(1).asText());
+    assertEquals( "Detail 6", jsonBindingsNodes.get(2).path("arrayDetail").path("value").get(5).asText());
   }
 
   /*
@@ -235,21 +236,21 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get();
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
     // Should have 6 nodes returned.
-    assertEquals("Six nodes not returned from testjoinInnerKeyMatch method ", 6, jsonBindingsNodes.size());
+    assertEquals( 6, jsonBindingsNodes.size());
     // Verify first node.
     JsonNode first = jsonBindingsNodes.path(0);
 
-    assertEquals("Element 1 opticFunctionalTest.detail.id value incorrect", "1", first.path("opticFunctionalTest.detail.id").path("value").asText());
-    assertEquals("Element 1 opticFunctionalTest.master.id value incorrect", "1", first.path("opticFunctionalTest.master.id").path("value").asText());
-    assertEquals("Element 1 opticFunctionalTest.detail.masterId value incorrect", "1", first.path("opticFunctionalTest.detail.masterId").path("value").asText());
-    assertEquals("Element 1 opticFunctionalTest.detail.name value incorrect", "Detail 1", first.path("opticFunctionalTest.detail.name").path("value").asText());
+    assertEquals( "1", first.path("opticFunctionalTest.detail.id").path("value").asText());
+    assertEquals( "1", first.path("opticFunctionalTest.master.id").path("value").asText());
+    assertEquals( "1", first.path("opticFunctionalTest.detail.masterId").path("value").asText());
+    assertEquals( "Detail 1", first.path("opticFunctionalTest.detail.name").path("value").asText());
 
     // Verify sixth node.
     JsonNode sixth = jsonBindingsNodes.path(5);
-    assertEquals("Element 6 opticFunctionalTest.detail.id value incorrect", "6", sixth.path("opticFunctionalTest.detail.id").path("value").asText());
-    assertEquals("Element 6 opticFunctionalTest.master.id value incorrect", "2", sixth.path("opticFunctionalTest.master.id").path("value").asText());
-    assertEquals("Element 6 opticFunctionalTest.detail.masterId value incorrect", "2", sixth.path("opticFunctionalTest.detail.masterId").path("value").asText());
-    assertEquals("Element 6 opticFunctionalTest.detail.name value incorrect", "Detail 6", sixth.path("opticFunctionalTest.detail.name").path("value").asText());
+    assertEquals( "6", sixth.path("opticFunctionalTest.detail.id").path("value").asText());
+    assertEquals( "2", sixth.path("opticFunctionalTest.master.id").path("value").asText());
+    assertEquals( "2", sixth.path("opticFunctionalTest.detail.masterId").path("value").asText());
+    assertEquals( "Detail 6", sixth.path("opticFunctionalTest.detail.name").path("value").asText());
   }
 
   /*
@@ -287,18 +288,18 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get();
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
     // Should have 6 nodes returned.
-    assertEquals("Three nodes not returned from testjoinInnerOffsetAndLimit method ", 6, jsonBindingsNodes.size());
+    assertEquals( 6, jsonBindingsNodes.size());
     // Verify first node.
     JsonNode first = jsonBindingsNodes.path(0);
 
-    assertEquals("Element 1 MasterName value incorrect", "Master 2", first.path("MasterName").path("value").asText());
-    assertEquals("Element 1 DetailName value incorrect", "Detail 6", first.path("DetailName").path("value").asText());
-    assertEquals("Element 1 opticFunctionalTest.detail.amount value incorrect", "60.06", first.path("opticFunctionalTest.detail.amount").path("value").asText());
+    assertEquals( "Master 2", first.path("MasterName").path("value").asText());
+    assertEquals( "Detail 6", first.path("DetailName").path("value").asText());
+    assertEquals( "60.06", first.path("opticFunctionalTest.detail.amount").path("value").asText());
     // Verify sixth node.
     JsonNode sixth = jsonBindingsNodes.path(5);
-    assertEquals("Element 6 MasterName value incorrect", "Master 1", sixth.path("MasterName").path("value").asText());
-    assertEquals("Element 6 DetailName value incorrect", "Detail 1", sixth.path("DetailName").path("value").asText());
-    assertEquals("Element 6 opticFunctionalTest.detail.color value incorrect", "blue", sixth.path("opticFunctionalTest.detail.color").path("value").asText());
+    assertEquals( "Master 1", sixth.path("MasterName").path("value").asText());
+    assertEquals( "Detail 1", sixth.path("DetailName").path("value").asText());
+    assertEquals( "blue", sixth.path("opticFunctionalTest.detail.color").path("value").asText());
   }
 
   /*
@@ -330,16 +331,16 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get();
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
     // Should have 2 nodes returned.
-    assertEquals("Two nodes not returned from testjoinInnerGroupBy method ", 2, jsonBindingsNodes.size());
+    assertEquals( 2, jsonBindingsNodes.size());
     // Verify first node.
     JsonNode first = jsonBindingsNodes.path(0);
 
-    assertEquals("Element 1 opticFunctionalTest.master.name value incorrect", "Master 2", first.path("opticFunctionalTest.master.name").path("value").asText());
-    assertEquals("Element 1 DetailSum value incorrect", "120.12", first.path("DetailSum").path("value").asText());
+    assertEquals( "Master 2", first.path("opticFunctionalTest.master.name").path("value").asText());
+    assertEquals( "120.12", first.path("DetailSum").path("value").asText());
     // Verify second node.
     JsonNode second = jsonBindingsNodes.path(1);
-    assertEquals("Element 2 opticFunctionalTest.master.name value incorrect", "Master 1", second.path("opticFunctionalTest.master.name").path("value").asText());
-    assertEquals("Element 2 DetailSum value incorrect", "90.09", second.path("DetailSum").path("value").asText());
+    assertEquals( "Master 1", second.path("opticFunctionalTest.master.name").path("value").asText());
+    assertEquals( "90.09", second.path("DetailSum").path("value").asText());
   }
 
   /*
@@ -370,22 +371,22 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get();
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
     // Should have 12 nodes returned.
-    assertEquals("Twelve nodes not returned from testjoinLeftOuterWithSelect method ", 12, jsonBindingsNodes.size());
+    assertEquals( 12, jsonBindingsNodes.size());
     // Verify first node.
     JsonNode first = jsonBindingsNodes.path(0);
 
-    assertEquals("Element 1 MasterName value incorrect", "Master 2", first.path("MasterName").path("value").asText());
-    assertEquals("Element 1 DetailName value incorrect", "Detail 6", first.path("DetailName").path("value").asText());
+    assertEquals( "Master 2", first.path("MasterName").path("value").asText());
+    assertEquals( "Detail 6", first.path("DetailName").path("value").asText());
 
     // Verify second node.
     JsonNode second = jsonBindingsNodes.path(1);
-    assertEquals("Element 2 MasterName value incorrect", "Master 1", second.path("MasterName").path("value").asText());
-    assertEquals("Element 2 DetailName value incorrect", "Detail 6", second.path("DetailName").path("value").asText());
+    assertEquals( "Master 1", second.path("MasterName").path("value").asText());
+    assertEquals( "Detail 6", second.path("DetailName").path("value").asText());
 
     // Verify twelveth node.
     JsonNode twelve = jsonBindingsNodes.path(11);
-    assertEquals("Element 12 MasterName value incorrect", "Master 1", twelve.path("MasterName").path("value").asText());
-    assertEquals("Element 12 DetailName value incorrect", "Detail 1", twelve.path("DetailName").path("value").asText());
+    assertEquals( "Master 1", twelve.path("MasterName").path("value").asText());
+    assertEquals( "Detail 1", twelve.path("DetailName").path("value").asText());
   }
 
   /*
@@ -417,19 +418,19 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get();
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
     // Should have 12 nodes returned.
-    assertEquals("Twelve nodes not returned from testjoinCrossProduct method ", 12, jsonBindingsNodes.size());
+    assertEquals( 12, jsonBindingsNodes.size());
     // Verify first node.
     JsonNode first = jsonBindingsNodes.path(0);
-    assertEquals("Element 1 MasterName value incorrect", "Master 1", first.path("MasterName").path("value").asText());
-    assertEquals("Element 1 DetailName value incorrect", "Detail 6", first.path("DetailName").path("value").asText());
+    assertEquals( "Master 1", first.path("MasterName").path("value").asText());
+    assertEquals( "Detail 6", first.path("DetailName").path("value").asText());
     // Verify second node.
     JsonNode second = jsonBindingsNodes.path(1);
-    assertEquals("Element 2 MasterName value incorrect", "Master 1", second.path("MasterName").path("value").asText());
-    assertEquals("Element 2 DetailName value incorrect", "Detail 5", second.path("DetailName").path("value").asText());
+    assertEquals( "Master 1", second.path("MasterName").path("value").asText());
+    assertEquals( "Detail 5", second.path("DetailName").path("value").asText());
     // Verify second node.
     JsonNode twelve = jsonBindingsNodes.path(11);
-    assertEquals("Element 12 MasterName value incorrect", "Master 2", twelve.path("MasterName").path("value").asText());
-    assertEquals("Element 12 DetailName value incorrect", "Detail 1", twelve.path("DetailName").path("value").asText());
+    assertEquals( "Master 2", twelve.path("MasterName").path("value").asText());
+    assertEquals( "Detail 1", twelve.path("DetailName").path("value").asText());
   }
 
   /*
@@ -463,25 +464,25 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get();
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
     // Should have 3 nodes returned.
-    assertEquals("Three nodes not returned from testjoinInnerAccessorPlanAndOn method ", 3, jsonBindingsNodes.size());
+    assertEquals( 3, jsonBindingsNodes.size());
     // Verify first node.
     JsonNode first = jsonBindingsNodes.path(0);
-    assertEquals("Element 1 myMaster.id value incorrect", "1", first.path("myMaster.id").path("value").asText());
-    assertEquals("Element 1 myMaster.name value incorrect", "Master 1", first.path("myMaster.name").path("value").asText());
-    assertEquals("Element 1 myDetail.id value incorrect", "5", first.path("myDetail.id").path("value").asText());
-    assertEquals("Element 1 myDetail.name value incorrect", "Detail 5", first.path("myDetail.name").path("value").asText());
+    assertEquals( "1", first.path("myMaster.id").path("value").asText());
+    assertEquals( "Master 1", first.path("myMaster.name").path("value").asText());
+    assertEquals( "5", first.path("myDetail.id").path("value").asText());
+    assertEquals( "Detail 5", first.path("myDetail.name").path("value").asText());
     // Verify second node.
     JsonNode second = jsonBindingsNodes.path(1);
-    assertEquals("Element 2 myMaster.id value incorrect", "2", second.path("myMaster.id").path("value").asText());
-    assertEquals("Element 2 myMaster.name value incorrect", "Master 2", second.path("myMaster.name").path("value").asText());
-    assertEquals("Element 2 myDetail.id value incorrect", "4", second.path("myDetail.id").path("value").asText());
-    assertEquals("Element 2 myDetail.name value incorrect", "Detail 4", second.path("myDetail.name").path("value").asText());
+    assertEquals( "2", second.path("myMaster.id").path("value").asText());
+    assertEquals( "Master 2", second.path("myMaster.name").path("value").asText());
+    assertEquals( "4", second.path("myDetail.id").path("value").asText());
+    assertEquals( "Detail 4", second.path("myDetail.name").path("value").asText());
     // Verify third node.
     JsonNode third = jsonBindingsNodes.path(2);
-    assertEquals("Element 3 myMaster.id value incorrect", "1", third.path("myMaster.id").path("value").asText());
-    assertEquals("Element 3 myMaster.name value incorrect", "Master 1", third.path("myMaster.name").path("value").asText());
-    assertEquals("Element 3 myDetail.id value incorrect", "3", third.path("myDetail.id").path("value").asText());
-    assertEquals("Element 3 myDetail.name value incorrect", "Detail 3", third.path("myDetail.name").path("value").asText());
+    assertEquals( "1", third.path("myMaster.id").path("value").asText());
+    assertEquals( "Master 1", third.path("myMaster.name").path("value").asText());
+    assertEquals( "3", third.path("myDetail.id").path("value").asText());
+    assertEquals( "Detail 3", third.path("myDetail.name").path("value").asText());
 
     // Verify RowSet and RowRecord.
     RowSet<RowRecord> rowSet = rowMgr.resultRows(plan3);
@@ -499,13 +500,13 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     RowRecord record = null;
     if (rowItr.hasNext()) {
       record = rowItr.next();
-      assertEquals("Element 1 RowSet Iterator value incorrect", 1, record.getInt("myMaster.id"));
-      assertEquals("Element 1 RowSet Iterator value incorrect", 5, record.getInt("myDetail.id"));
-      assertEquals("Element 1 RowSet Iterator value incorrect", "Detail 5", record.getString("myDetail.name"));
-      assertEquals("Element 1 RowSet Iterator value incorrect", "Master 1", record.getString("myMaster.name"));
+      assertEquals( 1, record.getInt("myMaster.id"));
+      assertEquals( 5, record.getInt("myDetail.id"));
+      assertEquals( "Detail 5", record.getString("myDetail.name"));
+      assertEquals( "Master 1", record.getString("myMaster.name"));
 
       XsStringVal str = record.getValueAs("myMaster.name", XsStringVal.class);
-      assertEquals("Element 1 RowSet Iterator value incorrect", "Master 1", str.getString());
+      assertEquals( "Master 1", str.getString());
     } else {
       fail("Could not traverse Iterator<RowRecord> in testjoinInnerOffsetAndLimit method");
     }
@@ -539,19 +540,19 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
 
     // Should have 3 node3 returned.
-    assertEquals("Three nodes not returned from testExportPlan method ", 3, jsonBindingsNodes.size());
+    assertEquals( 3, jsonBindingsNodes.size());
     // Verify first node.
     JsonNode first = jsonBindingsNodes.path(0);
-    assertEquals("Element 1 opticFunctionalTest3.detail3.id value incorrect", "7", first.path("opticFunctionalTest3.detail3.id").path("value").asText());
-    assertEquals("Element 1 opticFunctionalTest3.master3.date value incorrect", "2016-03-01", first.path("opticFunctionalTest3.master3.date").path("value").asText());
+    assertEquals( "7", first.path("opticFunctionalTest3.detail3.id").path("value").asText());
+    assertEquals( "2016-03-01", first.path("opticFunctionalTest3.master3.date").path("value").asText());
 
     JsonNode second = jsonBindingsNodes.path(1);
-    assertEquals("Element 2 opticFunctionalTest3.detail3.name value incorrect", "Detail 8", second.path("opticFunctionalTest3.detail3.name").path("value").asText());
-    assertEquals("Element 2 opticFunctionalTest3.detail3.amount value incorrect", "89.36", second.path("opticFunctionalTest3.detail3.amount").path("value").asText());
+    assertEquals( "Detail 8", second.path("opticFunctionalTest3.detail3.name").path("value").asText());
+    assertEquals( "89.36", second.path("opticFunctionalTest3.detail3.amount").path("value").asText());
 
     JsonNode third = jsonBindingsNodes.path(2);
-    assertEquals("Element 3 opticFunctionalTest3.detail3.name value incorrect", "Detail 11", third.path("opticFunctionalTest3.detail3.name").path("value").asText());
-    assertEquals("Element 3 opticFunctionalTest3.detail3.color value incorrect", "green", third.path("opticFunctionalTest3.detail3.color").path("value").asText());
+    assertEquals( "Detail 11", third.path("opticFunctionalTest3.detail3.name").path("value").asText());
+    assertEquals( "green", third.path("opticFunctionalTest3.detail3.color").path("value").asText());
   }
 
   /*
@@ -587,27 +588,27 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get();
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
     // Should have 1 node returned.
-    assertEquals("One node not returned from testExportPlan method ", 1, jsonBindingsNodes.size());
+    assertEquals( 1, jsonBindingsNodes.size());
     // Verify first node.
     JsonNode first = jsonBindingsNodes.path(0);
-    assertEquals("Element 1 opticFunctionalTest.master.id value incorrect", "1", first.path("opticFunctionalTest.master.id").path("value").asText());
-    assertEquals("Element 1 opticFunctionalTest.master.name value incorrect", "Master 1", first.path("opticFunctionalTest.master.name").path("value").asText());
-    assertEquals("Element 1 opticFunctionalTest.detail.id value incorrect", "1", first.path("opticFunctionalTest.detail.id").path("value").asText());
-    assertEquals("Element 1 opticFunctionalTest.detail.name value incorrect", "Detail 1", first.path("opticFunctionalTest.detail.name").path("value").asText());
-    assertEquals("Element 1 opticFunctionalTest.detail.masterId value incorrect", "1", first.path("opticFunctionalTest.detail.masterId").path("value").asText());
-    assertEquals("Element 1 opticFunctionalTest.master.date value incorrect", "2015-12-01", first.path("opticFunctionalTest.master.date").path("value").asText());
-    assertEquals("Element 1 opticFunctionalTest.detail.amount value incorrect", "10.01", first.path("opticFunctionalTest.detail.amount").path("value").asText());
-    assertEquals("Element 1 opticFunctionalTest.detail.color value incorrect", "blue", first.path("opticFunctionalTest.detail.color").path("value").asText());
+    assertEquals( "1", first.path("opticFunctionalTest.master.id").path("value").asText());
+    assertEquals( "Master 1", first.path("opticFunctionalTest.master.name").path("value").asText());
+    assertEquals( "1", first.path("opticFunctionalTest.detail.id").path("value").asText());
+    assertEquals( "Detail 1", first.path("opticFunctionalTest.detail.name").path("value").asText());
+    assertEquals( "1", first.path("opticFunctionalTest.detail.masterId").path("value").asText());
+    assertEquals( "2015-12-01", first.path("opticFunctionalTest.master.date").path("value").asText());
+    assertEquals( "10.01", first.path("opticFunctionalTest.detail.amount").path("value").asText());
+    assertEquals( "blue", first.path("opticFunctionalTest.detail.color").path("value").asText());
 
     // Export the Plan to a handle.
     exportedPlan.export(exportHandle);
     JsonNode exportNode = exportHandle.get();
     // verify parts of the Exported Plan String.
-    assertEquals("Plan export incorrect", "from-view", exportNode.path("$optic").path("args").get(0).path("fn").asText());
-    assertEquals("Plan export incorrect", "join-inner", exportNode.path("$optic").path("args").get(1).path("fn").asText());
-    assertEquals("Plan export incorrect", "from-view", exportNode.path("$optic").path("args").get(1).path("args").get(0).path("args").get(0).path("fn").asText());
-    assertEquals("Plan export incorrect", "order-by", exportNode.path("$optic").path("args").get(2).path("fn").asText());
-    assertEquals("Plan export incorrect", "offset-limit", exportNode.path("$optic").path("args").get(3).path("fn").asText());
+    assertEquals( "from-view", exportNode.path("$optic").path("args").get(0).path("fn").asText());
+    assertEquals( "join-inner", exportNode.path("$optic").path("args").get(1).path("fn").asText());
+    assertEquals( "from-view", exportNode.path("$optic").path("args").get(1).path("args").get(0).path("args").get(0).path("fn").asText());
+    assertEquals( "order-by", exportNode.path("$optic").path("args").get(2).path("fn").asText());
+    assertEquals( "offset-limit", exportNode.path("$optic").path("args").get(3).path("fn").asText());
 
     // ExportAs the Plan to a handle.
     String strJackHandleAs = exportedPlan.exportAs(String.class);
@@ -616,27 +617,27 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     // verify parts of the Exported Plan String.
     ObjectMapper mapper = new ObjectMapper();
     JsonNode exportedAs = mapper.readTree(strJackHandleAs);
-    assertEquals("Plan exportAs incorrect", "from-view", exportedAs.path("$optic").path("args").get(0).path("fn").asText());
-    assertEquals("Plan exportAs incorrect", "join-inner", exportedAs.path("$optic").path("args").get(1).path("fn").asText());
-    assertEquals("Plan exportAs incorrect", "from-view", exportedAs.path("$optic").path("args").get(1).path("args").get(0).path("args").get(0).path("fn").asText());
-    assertEquals("Plan exportAs incorrect", "order-by", exportedAs.path("$optic").path("args").get(2).path("fn").asText());
-    assertEquals("Plan exportAs incorrect", "offset-limit", exportedAs.path("$optic").path("args").get(3).path("fn").asText());
+    assertEquals( "from-view", exportedAs.path("$optic").path("args").get(0).path("fn").asText());
+    assertEquals( "join-inner", exportedAs.path("$optic").path("args").get(1).path("fn").asText());
+    assertEquals( "from-view", exportedAs.path("$optic").path("args").get(1).path("args").get(0).path("args").get(0).path("fn").asText());
+    assertEquals( "order-by", exportedAs.path("$optic").path("args").get(2).path("fn").asText());
+    assertEquals( "offset-limit", exportedAs.path("$optic").path("args").get(3).path("fn").asText());
 
     // Verify with exportAs to JsonNode
-    assertEquals("Plan exportAs incorrect", "from-view", JsonNodeAs.path("$optic").path("args").get(0).path("fn").asText());
-    assertEquals("Plan exportAs incorrect", "join-inner", JsonNodeAs.path("$optic").path("args").get(1).path("fn").asText());
-    assertEquals("Plan exportAs incorrect", "from-view", JsonNodeAs.path("$optic").path("args").get(1).path("args").get(0).path("args").get(0).path("fn").asText());
-    assertEquals("Plan exportAs incorrect", "order-by", JsonNodeAs.path("$optic").path("args").get(2).path("fn").asText());
-    assertEquals("Plan exportAs incorrect", "offset-limit", JsonNodeAs.path("$optic").path("args").get(3).path("fn").asText());
+    assertEquals( "from-view", JsonNodeAs.path("$optic").path("args").get(0).path("fn").asText());
+    assertEquals( "join-inner", JsonNodeAs.path("$optic").path("args").get(1).path("fn").asText());
+    assertEquals( "from-view", JsonNodeAs.path("$optic").path("args").get(1).path("args").get(0).path("args").get(0).path("fn").asText());
+    assertEquals( "order-by", JsonNodeAs.path("$optic").path("args").get(2).path("fn").asText());
+    assertEquals( "offset-limit", JsonNodeAs.path("$optic").path("args").get(3).path("fn").asText());
 
     // Export a plan with error / incorrect column
     exportHandle = new JacksonHandle();
     exportedPlan.export(exportHandle);
     JsonNode exportNodedAA = exportHandle.get();
 
-    assertEquals("Plan exportAs incorrect", "from-view", exportNodedAA.path("$optic").path("args").get(0).path("fn").asText());
-    assertEquals("Plan exportAs incorrect", "join-inner", exportedAs.path("$optic").path("args").get(1).path("fn").asText());
-    assertEquals("Plan exportAs incorrect", "order-by", exportedAs.path("$optic").path("args").get(2).path("fn").asText());
+    assertEquals( "from-view", exportNodedAA.path("$optic").path("args").get(0).path("fn").asText());
+    assertEquals( "join-inner", exportedAs.path("$optic").path("args").get(1).path("fn").asText());
+    assertEquals( "order-by", exportedAs.path("$optic").path("args").get(2).path("fn").asText());
   }
 
   /*
@@ -670,24 +671,24 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get();
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
     // Should have 3 node returned.
-    assertEquals("Three nodes not returned from testoffsetVales method ", 3, jsonBindingsNodes.size());
+    assertEquals( 3, jsonBindingsNodes.size());
     // Verify first node.
     JsonNode first = jsonBindingsNodes.path(0);
-    assertEquals("Element 1 myMaster.id value incorrect", "1", first.path("myMaster.id").path("value").asText());
-    assertEquals("Element 1 myMaster.name value incorrect", "Master 1", first.path("myMaster.name").path("value").asText());
-    assertEquals("Element 1 myDetail.id value incorrect", "5", first.path("myDetail.id").path("value").asText());
-    assertEquals("Element 1 myDetail.name value incorrect", "Detail 5", first.path("myDetail.name").path("value").asText());
+    assertEquals( "1", first.path("myMaster.id").path("value").asText());
+    assertEquals( "Master 1", first.path("myMaster.name").path("value").asText());
+    assertEquals( "5", first.path("myDetail.id").path("value").asText());
+    assertEquals( "Detail 5", first.path("myDetail.name").path("value").asText());
     JsonNode second = jsonBindingsNodes.path(1);
-    assertEquals("Element 2 myMaster.id value incorrect", "2", second.path("myMaster.id").path("value").asText());
-    assertEquals("Element 2 myMaster.name value incorrect", "Master 2", second.path("myMaster.name").path("value").asText());
-    assertEquals("Element 2 myDetail.id value incorrect", "4", second.path("myDetail.id").path("value").asText());
-    assertEquals("Element 2 myDetail.name value incorrect", "Detail 4", second.path("myDetail.name").path("value").asText());
+    assertEquals( "2", second.path("myMaster.id").path("value").asText());
+    assertEquals( "Master 2", second.path("myMaster.name").path("value").asText());
+    assertEquals( "4", second.path("myDetail.id").path("value").asText());
+    assertEquals( "Detail 4", second.path("myDetail.name").path("value").asText());
 
     JsonNode third = jsonBindingsNodes.path(2);
-    assertEquals("Element 3 myMaster.id value incorrect", "1", third.path("myMaster.id").path("value").asText());
-    assertEquals("Element 3 myMaster.name value incorrect", "Master 1", third.path("myMaster.name").path("value").asText());
-    assertEquals("Element 3 myDetail.id value incorrect", "3", third.path("myDetail.id").path("value").asText());
-    assertEquals("Element 3 myDetail.name value incorrect", "Detail 3", third.path("myDetail.name").path("value").asText());
+    assertEquals( "1", third.path("myMaster.id").path("value").asText());
+    assertEquals( "Master 1", third.path("myMaster.name").path("value").asText());
+    assertEquals( "3", third.path("myDetail.id").path("value").asText());
+    assertEquals( "Detail 3", third.path("myDetail.name").path("value").asText());
 
     // offset with out of bound value
     ModifyPlan plan4 = plan1.joinInner(plan2)
@@ -704,7 +705,7 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     JsonNode jsonResults10 = jacksonHandle10.get();
 
     // Should be null.
-    assertNull("No nodes should have returned from testoffsetVales method ", jsonResults10);
+    assertNull( jsonResults10);
 
     // offset with 0 bound value
     ModifyPlan plan5 = plan1.joinInner(plan2)
@@ -719,7 +720,7 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     JsonNode jsonResultsZOffset = jacksonHandleZOffset.get();
     JsonNode jsonBindingsNodesZOffset = jsonResultsZOffset.path("rows");
     // Should have 6 node returned.
-    assertEquals("Six nodes not returned from testoffsetVales method ", 6, jsonBindingsNodesZOffset.size());
+    assertEquals( 6, jsonBindingsNodesZOffset.size());
 
     // offset with negative bound value
     StringBuilder str = new StringBuilder();
@@ -737,7 +738,7 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     } catch (Exception ex) {
       str.append(ex.getMessage());
     }
-    assertTrue("Exception message incorrect", str.toString().contains("Invalid arguments: offset must be a non-negative number: -2"));
+    assertTrue( str.toString().contains("Invalid arguments: offset must be a non-negative number: -2"));
   }
 
   /*
@@ -773,24 +774,24 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get();
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
     // Should have 3 node returned.
-    assertEquals("Three nodes not returned from testlimitValues method ", 3, jsonBindingsNodes.size());
+    assertEquals( 3, jsonBindingsNodes.size());
     // Verify first node.
     JsonNode first = jsonBindingsNodes.path(0);
-    assertEquals("Element 1 myMaster.id value incorrect", "1", first.path("myMaster.id").path("value").asText());
-    assertEquals("Element 1 myMaster.name value incorrect", "Master 1", first.path("myMaster.name").path("value").asText());
-    assertEquals("Element 1 myDetail.id value incorrect", "5", first.path("myDetail.id").path("value").asText());
-    assertEquals("Element 1 myDetail.name value incorrect", "Detail 5", first.path("myDetail.name").path("value").asText());
+    assertEquals( "1", first.path("myMaster.id").path("value").asText());
+    assertEquals( "Master 1", first.path("myMaster.name").path("value").asText());
+    assertEquals( "5", first.path("myDetail.id").path("value").asText());
+    assertEquals( "Detail 5", first.path("myDetail.name").path("value").asText());
     JsonNode second = jsonBindingsNodes.path(1);
-    assertEquals("Element 2 myMaster.id value incorrect", "2", second.path("myMaster.id").path("value").asText());
-    assertEquals("Element 2 myMaster.name value incorrect", "Master 2", second.path("myMaster.name").path("value").asText());
-    assertEquals("Element 2 myDetail.id value incorrect", "4", second.path("myDetail.id").path("value").asText());
-    assertEquals("Element 2 myDetail.name value incorrect", "Detail 4", second.path("myDetail.name").path("value").asText());
+    assertEquals( "2", second.path("myMaster.id").path("value").asText());
+    assertEquals( "Master 2", second.path("myMaster.name").path("value").asText());
+    assertEquals( "4", second.path("myDetail.id").path("value").asText());
+    assertEquals( "Detail 4", second.path("myDetail.name").path("value").asText());
 
     JsonNode third = jsonBindingsNodes.path(2);
-    assertEquals("Element 3 myMaster.id value incorrect", "1", third.path("myMaster.id").path("value").asText());
-    assertEquals("Element 3 myMaster.name value incorrect", "Master 1", third.path("myMaster.name").path("value").asText());
-    assertEquals("Element 3 myDetail.id value incorrect", "3", third.path("myDetail.id").path("value").asText());
-    assertEquals("Element 3 myDetail.name value incorrect", "Detail 3", third.path("myDetail.name").path("value").asText());
+    assertEquals( "1", third.path("myMaster.id").path("value").asText());
+    assertEquals( "Master 1", third.path("myMaster.name").path("value").asText());
+    assertEquals( "3", third.path("myDetail.id").path("value").asText());
+    assertEquals( "Detail 3", third.path("myDetail.name").path("value").asText());
 
     // Limit with large value
     ModifyPlan plan4 = plan1.joinInner(plan2)
@@ -808,7 +809,7 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     JsonNode jsonResultsLarge = jacksonHandleLarge.get();
     JsonNode jsonBindingsNodesLarge = jsonResultsLarge.path("rows");
     // Should have 6 node returned.
-    assertEquals("Six nodes not returned from testlimitValues method ", 6, jsonBindingsNodesLarge.size());
+    assertEquals( 6, jsonBindingsNodesLarge.size());
 
     // Limit with 0 value
     StringBuilder strZ = new StringBuilder();
@@ -831,7 +832,7 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     } catch (Exception ex) {
       strZ.append(ex.getMessage());
     }
-    assertTrue("Exception message incorrect", strZ.toString().contains("Invalid arguments: limit must be a positive number: 0"));
+    assertTrue( strZ.toString().contains("Invalid arguments: limit must be a positive number: 0"));
 
     // Limit with negative value
     StringBuilder strNeg = new StringBuilder();
@@ -852,7 +853,7 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     } catch (Exception ex) {
       strNeg.append(ex.getMessage());
     }
-    assertTrue("Exception message incorrect", strNeg.toString().contains("Invalid arguments: limit must be a positive number: -2"));
+    assertTrue( strNeg.toString().contains("Invalid arguments: limit must be a positive number: -2"));
   }
 
   /*
@@ -889,9 +890,9 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
 
     // Should have 2 nodes returned.
-    assertEquals("Twelve nodes not returned from testjoinInnerWhereDisctinct method ", 2, jsonBindingsNodes.size());
-    assertEquals("Detail.color first node value incorrect", "green", jsonBindingsNodes.get(0).path("opticFunctionalTest.detail.color").path("value").asText());
-    assertEquals("Detail.color second node value incorrect", "blue", jsonBindingsNodes.get(1).path("opticFunctionalTest.detail.color").path("value").asText());
+    assertEquals( 2, jsonBindingsNodes.size());
+    assertEquals( "green", jsonBindingsNodes.get(0).path("opticFunctionalTest.detail.color").path("value").asText());
+    assertEquals( "blue", jsonBindingsNodes.get(1).path("opticFunctionalTest.detail.color").path("value").asText());
   }
 
   /*
@@ -928,11 +929,11 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     RowRecord record = null;
     if (rowItr.hasNext()) {
       record = rowItr.next();
-      assertEquals("Date from RowSet Iterator first node value incorrect", "2015-12-02", record.getString("opticFunctionalTest.master.date"));
+      assertEquals( "2015-12-02", record.getString("opticFunctionalTest.master.date"));
 
-      assertEquals("Master Name RowSet Iterator first node value incorrect", "Master 2", record.getString("MasterName"));
-      assertEquals("Detail Name RowSet Iterator first node value incorrect", "Detail 6", record.getString("DetailName"));
-      assertEquals("Color Name RowSet Iterator first node value incorrect", "green", record.getString("color"));
+      assertEquals( "Master 2", record.getString("MasterName"));
+      assertEquals( "Detail 6", record.getString("DetailName"));
+      assertEquals( "green", record.getString("color"));
       assertEquals(60.06, record.getDouble("opticFunctionalTest.detail.amount"), 0.00);
     } else {
       fail("Could not traverse Iterator<RowRecord> in testJoinLeftOuter method");
@@ -947,20 +948,20 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
 
     // Should have 12 nodes returned.
-    assertEquals("Twelve nodes not returned from testJoinLeftOuter method ", 12, jsonBindingsNodes.size());
+    assertEquals( 12, jsonBindingsNodes.size());
     // Verify first node
-    assertEquals("Element 1 MasterName value incorrect", "Master 2", jsonBindingsNodes.get(0).path("MasterName").path("value").asText());
-    assertEquals("Element 1 Master Date value incorrect", "2015-12-02", jsonBindingsNodes.get(0).path("opticFunctionalTest.master.date").path("value").asText());
-    assertEquals("Element 1 DetailName value incorrect", "Detail 6", jsonBindingsNodes.get(0).path("DetailName").path("value").asText());
+    assertEquals( "Master 2", jsonBindingsNodes.get(0).path("MasterName").path("value").asText());
+    assertEquals( "2015-12-02", jsonBindingsNodes.get(0).path("opticFunctionalTest.master.date").path("value").asText());
+    assertEquals( "Detail 6", jsonBindingsNodes.get(0).path("DetailName").path("value").asText());
     assertEquals(60.06, jsonBindingsNodes.get(0).path("opticFunctionalTest.detail.amount").path("value").asDouble(), 0.00d);
-    assertEquals("Element 1 Detail Color value incorrect", "green", jsonBindingsNodes.get(0).path("opticFunctionalTest.detail.color").path("value").asText());
+    assertEquals( "green", jsonBindingsNodes.get(0).path("opticFunctionalTest.detail.color").path("value").asText());
 
     // Verify twelveth node
-    assertEquals("Element 12 MasterName value incorrect", "Master 1", jsonBindingsNodes.get(11).path("MasterName").path("value").asText());
-    assertEquals("Element 12 Master Date value incorrect", "2015-12-01", jsonBindingsNodes.get(11).path("opticFunctionalTest.master.date").path("value").asText());
-    assertEquals("Element 12 DetailName value incorrect", "Detail 1", jsonBindingsNodes.get(11).path("DetailName").path("value").asText());
+    assertEquals( "Master 1", jsonBindingsNodes.get(11).path("MasterName").path("value").asText());
+    assertEquals( "2015-12-01", jsonBindingsNodes.get(11).path("opticFunctionalTest.master.date").path("value").asText());
+    assertEquals( "Detail 1", jsonBindingsNodes.get(11).path("DetailName").path("value").asText());
     assertEquals(10.01, jsonBindingsNodes.get(11).path("opticFunctionalTest.detail.amount").path("value").asDouble(), 0.00d);
-    assertEquals("Element 12 Detail Color value incorrect", "blue", jsonBindingsNodes.get(11).path("opticFunctionalTest.detail.color").path("value").asText());
+    assertEquals( "blue", jsonBindingsNodes.get(11).path("opticFunctionalTest.detail.color").path("value").asText());
   }
 
   @Test
@@ -991,11 +992,11 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     RowRecord record = null;
     if (rowItr.hasNext()) {
       record = rowItr.next();
-      assertEquals("Date from RowSet Iterator first node value incorrect", "2015-12-02", record.getString("opticFunctionalTest.master.date"));
+      assertEquals( "2015-12-02", record.getString("opticFunctionalTest.master.date"));
 
-      assertEquals("Master Name RowSet Iterator first node value incorrect", "Master 2", record.getString("MasterName"));
-      assertEquals("Detail Name RowSet Iterator first node value incorrect", "Detail 6", record.getString("DetailName"));
-      assertEquals("Color Name RowSet Iterator first node value incorrect", "green", record.getString("color"));
+      assertEquals( "Master 2", record.getString("MasterName"));
+      assertEquals( "Detail 6", record.getString("DetailName"));
+      assertEquals( "green", record.getString("color"));
       assertEquals(60.06, record.getDouble("opticFunctionalTest.detail.amount"), 0.00);
     } else {
       fail("Could not traverse Iterator<RowRecord> in testJoinFullOuter method");
@@ -1010,20 +1011,20 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
 
     // Should have 12 nodes returned.
-    assertEquals("Twelve nodes not returned from testJoinFullOuter method ", 12, jsonBindingsNodes.size());
+    assertEquals( 12, jsonBindingsNodes.size());
     // Verify first node
-    assertEquals("Element 1 MasterName value incorrect", "Master 2", jsonBindingsNodes.get(0).path("MasterName").path("value").asText());
-    assertEquals("Element 1 Master Date value incorrect", "2015-12-02", jsonBindingsNodes.get(0).path("opticFunctionalTest.master.date").path("value").asText());
-    assertEquals("Element 1 DetailName value incorrect", "Detail 6", jsonBindingsNodes.get(0).path("DetailName").path("value").asText());
+    assertEquals( "Master 2", jsonBindingsNodes.get(0).path("MasterName").path("value").asText());
+    assertEquals( "2015-12-02", jsonBindingsNodes.get(0).path("opticFunctionalTest.master.date").path("value").asText());
+    assertEquals( "Detail 6", jsonBindingsNodes.get(0).path("DetailName").path("value").asText());
     assertEquals(60.06, jsonBindingsNodes.get(0).path("opticFunctionalTest.detail.amount").path("value").asDouble(), 0.00d);
-    assertEquals("Element 1 Detail Color value incorrect", "green", jsonBindingsNodes.get(0).path("opticFunctionalTest.detail.color").path("value").asText());
+    assertEquals( "green", jsonBindingsNodes.get(0).path("opticFunctionalTest.detail.color").path("value").asText());
 
     // Verify twelveth node
-    assertEquals("Element 12 MasterName value incorrect", "Master 1", jsonBindingsNodes.get(11).path("MasterName").path("value").asText());
-    assertEquals("Element 12 Master Date value incorrect", "2015-12-01", jsonBindingsNodes.get(11).path("opticFunctionalTest.master.date").path("value").asText());
-    assertEquals("Element 12 DetailName value incorrect", "Detail 1", jsonBindingsNodes.get(11).path("DetailName").path("value").asText());
+    assertEquals( "Master 1", jsonBindingsNodes.get(11).path("MasterName").path("value").asText());
+    assertEquals( "2015-12-01", jsonBindingsNodes.get(11).path("opticFunctionalTest.master.date").path("value").asText());
+    assertEquals( "Detail 1", jsonBindingsNodes.get(11).path("DetailName").path("value").asText());
     assertEquals(10.01, jsonBindingsNodes.get(11).path("opticFunctionalTest.detail.amount").path("value").asDouble(), 0.00d);
-    assertEquals("Element 12 Detail Color value incorrect", "blue", jsonBindingsNodes.get(11).path("opticFunctionalTest.detail.color").path("value").asText());
+    assertEquals( "blue", jsonBindingsNodes.get(11).path("opticFunctionalTest.detail.color").path("value").asText());
   }
 
   /*
@@ -1063,14 +1064,14 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
 
     // Should have 8 nodes returned.
-    assertEquals("Eight nodes not returned from testUnion method ", 8, jsonBindingsNodes.size());
-    assertEquals("Element 1 union id value incorrect", "5", jsonBindingsNodes.get(0).path("unionId").path("value").asText());
-    assertEquals("Element 1 union id value incorrect", "6", jsonBindingsNodes.get(1).path("unionId").path("value").asText());
-    assertEquals("Element 1 union id value incorrect", "7", jsonBindingsNodes.get(2).path("unionId").path("value").asText());
-    assertEquals("Element 1 union id value incorrect", "8", jsonBindingsNodes.get(3).path("unionId").path("value").asText());
-    assertEquals("Element 1 union id value incorrect", "9", jsonBindingsNodes.get(4).path("unionId").path("value").asText());
+    assertEquals( 8, jsonBindingsNodes.size());
+    assertEquals( "5", jsonBindingsNodes.get(0).path("unionId").path("value").asText());
+    assertEquals( "6", jsonBindingsNodes.get(1).path("unionId").path("value").asText());
+    assertEquals( "7", jsonBindingsNodes.get(2).path("unionId").path("value").asText());
+    assertEquals( "8", jsonBindingsNodes.get(3).path("unionId").path("value").asText());
+    assertEquals( "9", jsonBindingsNodes.get(4).path("unionId").path("value").asText());
 
-    assertEquals("Element 1 union id value incorrect", "12", jsonBindingsNodes.get(7).path("unionId").path("value").asText());
+    assertEquals( "12", jsonBindingsNodes.get(7).path("unionId").path("value").asText());
   }
 
   /*
@@ -1104,11 +1105,11 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
 
     // Should have 4 nodes returned.
-    assertEquals("Four nodes not returned from testIntersectDiffSchemas method ", 4, jsonBindingsNodes.size());
-    assertEquals("Element 1 union id value incorrect", "1", jsonBindingsNodes.get(0).path("unionId").path("value").asText());
-    assertEquals("Element 1 union id value incorrect", "2", jsonBindingsNodes.get(1).path("unionId").path("value").asText());
-    assertEquals("Element 1 union id value incorrect", "3", jsonBindingsNodes.get(2).path("unionId").path("value").asText());
-    assertEquals("Element 1 union id value incorrect", "4", jsonBindingsNodes.get(3).path("unionId").path("value").asText());
+    assertEquals( 4, jsonBindingsNodes.size());
+    assertEquals( "1", jsonBindingsNodes.get(0).path("unionId").path("value").asText());
+    assertEquals( "2", jsonBindingsNodes.get(1).path("unionId").path("value").asText());
+    assertEquals( "3", jsonBindingsNodes.get(2).path("unionId").path("value").asText());
+    assertEquals( "4", jsonBindingsNodes.get(3).path("unionId").path("value").asText());
   }
 
   /*
@@ -1146,7 +1147,7 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
 
     // Should have 6 nodes returned.
-    assertEquals("Six nodes not returned from testArithmeticOperations method ", 6, jsonBindingsNodes.size());
+    assertEquals( 6, jsonBindingsNodes.size());
     // Verify first node
     assertEquals(11.01, jsonBindingsNodes.get(0).path("added").path("value").asDouble(), 0.00d);
     assertEquals(9.01, jsonBindingsNodes.get(0).path("substracted").path("value").asDouble(), 0.00d);
@@ -1191,7 +1192,7 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
 
     // Should have 3 nodes returned.
-    assertEquals("Three nodes not returned from testBuiltinFuncs method ", 3, jsonBindingsNodes.size());
+    assertEquals( 3, jsonBindingsNodes.size());
     // Verify nodes
     assertEquals(40.04, jsonBindingsNodes.get(0).path("myAmount").path("value").asDouble(), 0.00d);
     assertEquals(50.05, jsonBindingsNodes.get(1).path("myAmount").path("value").asDouble(), 0.00d);
@@ -1231,7 +1232,7 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get();
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
     // Should have 3 nodes returned.
-    assertEquals("Three nodes not returned from testjoinInnerWithDataTypes method ", 3, jsonBindingsNodes.size());
+    assertEquals( 3, jsonBindingsNodes.size());
 
     // Pass a String
     ModifyPlan plan4 = plan1.joinInner(plan2, p.on(masterIdCol1, masterIdCol2), p.ge(detailIdCol, p.xs.string("3")))
@@ -1246,7 +1247,7 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     rowMgr.resultDoc(plan4, jacksonHandleStr);
     JsonNode jsonResultsStr = jacksonHandleStr.get();
     // Should have 3 nodes returned.
-    assertEquals("Three nodes not returned from testjoinInnerWithDataTypes method ", 3, jsonResultsStr.path("rows").size());
+    assertEquals( 3, jsonResultsStr.path("rows").size());
 
     // Pass as a date
     try {
@@ -1263,7 +1264,7 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     } catch (Exception ex) {
       str.append(ex.toString());
     }
-    assertTrue("Exception Message incorrect", str.toString().contains("java.lang.IllegalArgumentException: 3"));
+    assertTrue( str.toString().contains("java.lang.IllegalArgumentException: 3"));
 
     // Pass as a decimal
 
@@ -1280,7 +1281,7 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     JsonNode jsonResultsDecimal = jacksonHandleDecimal.get();
     JsonNode jsonBindingsNodesDecimal = jsonResultsDecimal.path("rows");
     // Should have 3 nodes returned.
-    assertEquals("Three nodes not returned from testjoinInnerWithDataTypes method ", 3, jsonBindingsNodesDecimal.size());
+    assertEquals( 3, jsonBindingsNodesDecimal.size());
   }
 
   /*
@@ -1305,11 +1306,11 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
       exceptionSch = ex.getMessage();
       System.out.println("Exception message is " + exceptionSch.toString());
     }
-    assertTrue("Exception not thrown or invalid message",
+    assertTrue(
             exceptionSch.contains("SQL-TABLENOTFOUND:") &&
                     exceptionSch.contains("Unknown table: Table 'opticFunctionalTestInvalid.detail' not found"));
     /* Original assert
-    assertTrue("Exception not thrown or invalid message",
+    assertTrue(
             exceptionSch.contains("SQL-TABLENOTFOUND: plan.view(\"opticFunctionalTestInvalid\", \"detail\", null, \"MarkLogicQAQualifier\")") &&
                     exceptionSch.contains("Unknown table: Table 'opticFunctionalTestInvalid.detail' not found"));
     */
@@ -1327,11 +1328,11 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
       System.out.println("Exception message is " + exceptionVw.toString());
     }
     /* Original assert
-    assertTrue("Exception not thrown or invalid message",
+    assertTrue(
             exceptionVw.contains("SQL-TABLENOTFOUND: plan.view(\"opticFunctionalTest\", \"detailInvalid\", null, \"MarkLogicQAQualifier\")") &&
                     exceptionVw.contains("Unknown table: Table 'opticFunctionalTest.detailInvalid' not found"));
      */
-    assertTrue("Exception not thrown or invalid message",
+    assertTrue(
             exceptionVw.contains("SQL-TABLENOTFOUND") &&
                     exceptionVw.contains("Unknown table: Table 'opticFunctionalTest.detailInvalid' not found"));
 
@@ -1348,7 +1349,7 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
       exceptionNoView = ex.getMessage();
       System.out.println("Exception message is " + exceptionNoView.toString());
     }
-    assertTrue("Exception not thrown or invalid message", exceptionNoView.contains("OPTIC-INVALARGS") &&
+    assertTrue( exceptionNoView.contains("OPTIC-INVALARGS") &&
             exceptionNoView.contains("Invalid arguments: cannot specify fromView() without view name"));
 
     // Verify for empty Schma name
@@ -1364,7 +1365,7 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
       exceptionNoySch = ex.getMessage();
       System.out.println("Exception message is " + exceptionNoySch.toString());
     }
-    assertTrue("Exception not thrown or invalid message", exceptionNoySch.contains("OPTIC-INVALARGS") &&
+    assertTrue( exceptionNoySch.contains("OPTIC-INVALARGS") &&
             exceptionNoySch.contains("Invalid arguments: cannot specify fromView() with invalid schema name"));
   }
 
@@ -1399,8 +1400,8 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
       System.out.println("Exception message is " + str.toString());
     }
     // Should have SQL-AMBCOLUMN exceptions.
-    assertTrue("Exceptions not found", str.toString().contains("SQL-AMBCOLUMN"));
-    assertTrue("Exceptions not found", str.toString().contains("Ambiguous column reference: found opticFunctionalTest.master.id and opticFunctionalTest.detail.id"));
+    assertTrue( str.toString().contains("SQL-AMBCOLUMN"));
+    assertTrue( str.toString().contains("Ambiguous column reference: found opticFunctionalTest.master.id and opticFunctionalTest.detail.id"));
   }
 
   /*
@@ -1435,8 +1436,8 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
       System.out.println("Exception message is " + strSchema.toString());
     }
     // Should have SQL-NOCOLUMN exceptions.
-    assertTrue("Exceptions not found", strSchema.toString().contains("SQL-NOCOLUMN"));
-    assertTrue("Exceptions not found", strSchema.toString().contains("Column not found: opticFunctionalTest_invalid.detail.id"));
+    assertTrue( strSchema.toString().contains("SQL-NOCOLUMN"));
+    assertTrue( strSchema.toString().contains("Column not found: opticFunctionalTest_invalid.detail.id"));
 
     // Invalid View name on schemaCol
     StringBuilder strView = new StringBuilder();
@@ -1459,8 +1460,8 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
       System.out.println("Exception message is " + strView.toString());
     }
     // Should have SQL-NOCOLUMN exceptions.
-    assertTrue("Exceptions not found", strView.toString().contains("SQL-NOCOLUMN"));
-    assertTrue("Exceptions not found", strView.toString().contains("Column not found: opticFunctionalTest.detail_invalid.id"));
+    assertTrue( strView.toString().contains("SQL-NOCOLUMN"));
+    assertTrue( strView.toString().contains("Column not found: opticFunctionalTest.detail_invalid.id"));
 
     // Invalid Column name on schemaCol
     StringBuilder strCol = new StringBuilder();
@@ -1483,8 +1484,8 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
       System.out.println("Exception message is " + strCol.toString());
     }
     // Should have SQL-NOCOLUMN exceptions.
-    assertTrue("Exceptions not found", strCol.toString().contains("SQL-NOCOLUMN"));
-    assertTrue("Exceptions not found", strCol.toString().contains("Column not found: opticFunctionalTest.detail.id_invalid"));
+    assertTrue( strCol.toString().contains("SQL-NOCOLUMN"));
+    assertTrue( strCol.toString().contains("Column not found: opticFunctionalTest.detail.id_invalid"));
 
     // Invalid column in where
     StringBuilder strWhereCol = new StringBuilder();
@@ -1507,8 +1508,8 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
       System.out.println("Exception message is " + strWhereCol.toString());
     }
     // Should have SQL-NOCOLUMN exceptions.
-    assertTrue("Exceptions not found", strWhereCol.toString().contains("SQL-NOCOLUMN"));
-    assertTrue("Exceptions not found", strWhereCol.toString().contains("Column not found: opticFunctionalTest.master.id_invalid"));
+    assertTrue( strWhereCol.toString().contains("SQL-NOCOLUMN"));
+    assertTrue( strWhereCol.toString().contains("Column not found: opticFunctionalTest.master.id_invalid"));
 
     // Invalid column in viewCol
     StringBuilder strViewCol = new StringBuilder();
@@ -1529,8 +1530,8 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
       System.out.println("Exception message is " + strViewCol.toString());
     }
     // Should have SQL-NOCOLUMN exceptions.
-    assertTrue("Exceptions not found", strViewCol.toString().contains("SQL-NOCOLUMN"));
-    assertTrue("Exceptions not found", strViewCol.toString().contains("Column not found: detail_invalid.id"));
+    assertTrue( strViewCol.toString().contains("SQL-NOCOLUMN"));
+    assertTrue( strViewCol.toString().contains("Column not found: detail_invalid.id"));
   }
 
   /*
@@ -1570,7 +1571,7 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
       System.out.println("Exception message is " + strIntersect.toString());
     }
     JsonNode jsonBindingsNodes = jacksonHandle.get();
-    assertTrue("Handle should be null from testDifferentColumns method ", jsonBindingsNodes == null);
+    assertTrue( jsonBindingsNodes == null);
     // except with different number of columns
     StringBuilder strExcept = new StringBuilder();
     try {
@@ -1593,7 +1594,7 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
       System.out.println("Exception message is " + strExcept.toString());
     }
     jsonBindingsNodes = jacksonHandle.get();
-    assertEquals("Two nodes not returned from testDifferentColumns method ", 2, jsonBindingsNodes.size());
+    assertEquals( 2, jsonBindingsNodes.size());
   }
 
   /*
@@ -1636,16 +1637,16 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
             .orderBy(p.desc(p.col("DetailName")));
     JsonNode explainNode = rowMgr.explain(output, new JacksonHandle()).get();
     // Making sure explain() does not blow up for a valid plan.
-    assertEquals("Explain of plan incorrect", explainNode.path("node").asText(), "plan");
+    assertEquals( explainNode.path("node").asText(), "plan");
     if (isML11OrHigher) {
-      assertEquals("Explain of plan incorrect", explainNode.path("expr").path("columns").get(0).path("name").asText(), "MasterName");
+      assertEquals( explainNode.path("expr").path("columns").get(0).path("name").asText(), "MasterName");
     } else {
-      assertEquals("Explain of plan incorrect", explainNode.path("expr").path("columns").get(0).path("column").asText(), "DetailName");
+      assertEquals( explainNode.path("expr").path("columns").get(0).path("column").asText(), "DetailName");
     }
     // Invalid string - Use txt instead of json or xml
     String explainNodetxt = rowMgr.explain(output, new StringHandle()).get();
     System.out.println(explainNodetxt);
-    assertTrue("Explain of plan incorrect", explainNodetxt.contains("\"node\":\"plan\""));
+    assertTrue( explainNodetxt.contains("\"node\":\"plan\""));
     // Invalid Plan
     ModifyPlan plan3 = p.fromView("opticFunctionalTest", "master")
             .orderBy(p.schemaCol("opticFunctionalTest", "master", "id"));
@@ -1664,7 +1665,7 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
               .orderBy(p.asc(p.schemaCol("opticFunctionalTest", "detail", "id")));
 
       explainNodeInv = rowMgr.explain(outputInv, new JacksonHandle()).get();
-      assertEquals("Explain of Invalid plan incorrect", explainNodeInv.path("node").asText(), "plan");
+      assertEquals( explainNodeInv.path("node").asText(), "plan");
     } catch (Exception ex) {
       System.out.println(ex.getMessage());
       fail("Explain of Invalid plan has Exceptions");
@@ -1714,15 +1715,15 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     JsonNode node = jsonBindingsNodes.get(0);
 
     // Should have 6 nodes returned.
-    assertEquals("Six nodes not returned from testFragmentId method ", 6, jsonBindingsNodes.size());
+    assertEquals( 6, jsonBindingsNodes.size());
     // Verify nodes
-    assertEquals("Element 1 MasterName value incorrect", "Master 2", node.path("MasterName").path("value").asText());
-    assertEquals("Element 1 DetailName value incorrect", "Detail 6", node.path("DetailName").path("value").asText());
-    assertEquals("Element 1 opticFunctionalTest.detail.amount value incorrect", "60.06", node.path("opticFunctionalTest.detail.amount").path("value").asText());
+    assertEquals( "Master 2", node.path("MasterName").path("value").asText());
+    assertEquals( "Detail 6", node.path("DetailName").path("value").asText());
+    assertEquals( "60.06", node.path("opticFunctionalTest.detail.amount").path("value").asText());
     node = jsonBindingsNodes.get(5);
-    assertEquals("Element 6 MasterName value incorrect", "Master 1", node.path("MasterName").path("value").asText());
-    assertEquals("Element 6 DetailName value incorrect", "Detail 1", node.path("DetailName").path("value").asText());
-    assertEquals("Element 6 opticFunctionalTest.detail.amount value incorrect", "10.01", node.path("opticFunctionalTest.detail.amount").path("value").asText());
+    assertEquals( "Master 1", node.path("MasterName").path("value").asText());
+    assertEquals( "Detail 1", node.path("DetailName").path("value").asText());
+    assertEquals( "10.01", node.path("opticFunctionalTest.detail.amount").path("value").asText());
   }
 
   /*
@@ -1750,21 +1751,21 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get();
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
     // Should have 6 nodes returned.
-    assertEquals("Six nodes not returned from testjoinInnerWithBind method ", 6, jsonBindingsNodes.size());
+    assertEquals( 6, jsonBindingsNodes.size());
     // Verify first node.
     JsonNode first = jsonBindingsNodes.path(0);
 
-    assertEquals("Row 1 opticFunctionalTest.detail.id value incorrect", "1", first.path("opticFunctionalTest.detail.id").path("value").asText());
-    assertEquals("Row 1 opticFunctionalTest.master.id value incorrect", "1", first.path("opticFunctionalTest.master.id").path("value").asText());
-    assertEquals("Row 1 opticFunctionalTest.detail.masterId value incorrect", "1", first.path("opticFunctionalTest.detail.masterId").path("value").asText());
-    assertEquals("Row 1 opticFunctionalTest.detail.name value incorrect", "Detail 1", first.path("opticFunctionalTest.detail.name").path("value").asText());
+    assertEquals( "1", first.path("opticFunctionalTest.detail.id").path("value").asText());
+    assertEquals( "1", first.path("opticFunctionalTest.master.id").path("value").asText());
+    assertEquals( "1", first.path("opticFunctionalTest.detail.masterId").path("value").asText());
+    assertEquals( "Detail 1", first.path("opticFunctionalTest.detail.name").path("value").asText());
 
     // Verify sixth node.
     JsonNode sixth = jsonBindingsNodes.path(5);
-    assertEquals("Row 6 opticFunctionalTest.detail.id value incorrect", "6", sixth.path("opticFunctionalTest.detail.id").path("value").asText());
-    assertEquals("Row 6 opticFunctionalTest.master.id value incorrect", "1", sixth.path("opticFunctionalTest.master.id").path("value").asText());
-    assertEquals("Row 6 opticFunctionalTest.detail.masterId value incorrect", "2", sixth.path("opticFunctionalTest.detail.masterId").path("value").asText());
-    assertEquals("Row 6 opticFunctionalTest.detail.name value incorrect", "Detail 6", sixth.path("opticFunctionalTest.detail.name").path("value").asText());
+    assertEquals( "6", sixth.path("opticFunctionalTest.detail.id").path("value").asText());
+    assertEquals( "1", sixth.path("opticFunctionalTest.master.id").path("value").asText());
+    assertEquals( "2", sixth.path("opticFunctionalTest.detail.masterId").path("value").asText());
+    assertEquals( "Detail 6", sixth.path("opticFunctionalTest.detail.name").path("value").asText());
 
     // Verify with negative value.
     jacksonHandle = new JacksonHandle();
@@ -1772,7 +1773,7 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     rowMgr.resultDoc(plan3.bindParam(idParam, -1), jacksonHandle);
     jsonResults = jacksonHandle.get();
     // Should have null returned.
-    assertTrue("No nodes should returned. But found some.", jsonResults == null);
+    assertTrue( jsonResults == null);
 
     // Verify with double value.
     PlanParamExpr amtParam = p.param("AMT");
@@ -1785,13 +1786,13 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     rowMgr.resultDoc(planAmt.bindParam(amtParam, 10.1), jacksonHandle);
     jsonResults = jacksonHandle.get().path("rows");
     // Should have 5 rows returned.
-    assertEquals("Five rows not returned from testjoinInnerWithBind method ", 5, jsonResults.size());
+    assertEquals( 5, jsonResults.size());
 
-    assertEquals("Row 1 opticFunctionalTest.detail.amount value incorrect", "20.02", jsonResults.path(0).path("opticFunctionalTest.detail.amount").path("value").asText());
-    assertEquals("Row 2 opticFunctionalTest.detail.amount value incorrect", "30.03", jsonResults.path(1).path("opticFunctionalTest.detail.amount").path("value").asText());
-    assertEquals("Row 3 opticFunctionalTest.detail.amount value incorrect", "40.04", jsonResults.path(2).path("opticFunctionalTest.detail.amount").path("value").asText());
-    assertEquals("Row 4 opticFunctionalTest.detail.amount value incorrect", "50.05", jsonResults.path(3).path("opticFunctionalTest.detail.amount").path("value").asText());
-    assertEquals("Row 5 opticFunctionalTest.detail.amount value incorrect", "60.06", jsonResults.path(4).path("opticFunctionalTest.detail.amount").path("value").asText());
+    assertEquals( "20.02", jsonResults.path(0).path("opticFunctionalTest.detail.amount").path("value").asText());
+    assertEquals( "30.03", jsonResults.path(1).path("opticFunctionalTest.detail.amount").path("value").asText());
+    assertEquals( "40.04", jsonResults.path(2).path("opticFunctionalTest.detail.amount").path("value").asText());
+    assertEquals( "50.05", jsonResults.path(3).path("opticFunctionalTest.detail.amount").path("value").asText());
+    assertEquals( "60.06", jsonResults.path(4).path("opticFunctionalTest.detail.amount").path("value").asText());
 
     // verify for Strings.
     PlanParamExpr detNameParam = p.param("DETAILNAME");
@@ -1803,8 +1804,8 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     jacksonHandle.setMimetype("application/json");
     rowMgr.resultDoc(planStringBind.bindParam(detNameParam, p.xs.string("Detail 6")), jacksonHandle);
     jsonResults = jacksonHandle.get().path("rows");
-    assertEquals("One row not returned from testjoinInnerWithBind method ", 1, jsonResults.size());
-    assertEquals("Row 1 opticFunctionalTest.detail.amount value incorrect", "60.06", jsonResults.path(0).path("opticFunctionalTest.detail.amount").path("value").asText());
+    assertEquals( 1, jsonResults.size());
+    assertEquals( "60.06", jsonResults.path(0).path("opticFunctionalTest.detail.amount").path("value").asText());
 
     // Verify with different types in multiple places.
     ModifyPlan planMultiBind = p.fromView("opticFunctionalTest", "detail")
@@ -1819,8 +1820,8 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     rowMgr.resultDoc(planMultiBind.bindParam(detNameParam, p.xs.string("Detail 6")).bindParam("ID", 6), jacksonHandle);
     jsonResults = jacksonHandle.get().path("rows");
     // Should have 1 node returned.
-    assertEquals("One row not returned from testjoinInnerWithBind method ", 1, jsonResults.size());
-    assertEquals("Row 1 opticFunctionalTest.detail.amount value incorrect", "60.06", jsonResults.path(0).path("opticFunctionalTest.detail.amount").path("value").asText());
+    assertEquals( 1, jsonResults.size());
+    assertEquals( "60.06", jsonResults.path(0).path("opticFunctionalTest.detail.amount").path("value").asText());
   }
 
   /*
@@ -1848,21 +1849,21 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get();
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
     // Should have 6 nodes returned.
-    assertEquals("Six nodes not returned from testjoinInnerWithBind method ", 6, jsonBindingsNodes.size());
+    assertEquals( 6, jsonBindingsNodes.size());
     // Verify first node.
     JsonNode first = jsonBindingsNodes.path(0);
 
-    assertEquals("Row 1 opticFunctionalTest.detail.id value incorrect", "1", first.path("opticFunctionalTest.detail.id").path("value").asText());
-    assertEquals("Row 1 opticFunctionalTest.master.id value incorrect", "1", first.path("opticFunctionalTest.master.id").path("value").asText());
-    assertEquals("Row 1 opticFunctionalTest.detail.masterId value incorrect", "1", first.path("opticFunctionalTest.detail.masterId").path("value").asText());
-    assertEquals("Row 1 opticFunctionalTest.detail.name value incorrect", "Detail 1", first.path("opticFunctionalTest.detail.name").path("value").asText());
+    assertEquals( "1", first.path("opticFunctionalTest.detail.id").path("value").asText());
+    assertEquals( "1", first.path("opticFunctionalTest.master.id").path("value").asText());
+    assertEquals( "1", first.path("opticFunctionalTest.detail.masterId").path("value").asText());
+    assertEquals( "Detail 1", first.path("opticFunctionalTest.detail.name").path("value").asText());
 
     // Verify sixth node.
     JsonNode sixth = jsonBindingsNodes.path(5);
-    assertEquals("Row 6 opticFunctionalTest.detail.id value incorrect", "6", sixth.path("opticFunctionalTest.detail.id").path("value").asText());
-    assertEquals("Row 6 opticFunctionalTest.master.id value incorrect", "1", sixth.path("opticFunctionalTest.master.id").path("value").asText());
-    assertEquals("Row 6 opticFunctionalTest.detail.masterId value incorrect", "2", sixth.path("opticFunctionalTest.detail.masterId").path("value").asText());
-    assertEquals("Row 6 opticFunctionalTest.detail.name value incorrect", "Detail 6", sixth.path("opticFunctionalTest.detail.name").path("value").asText());
+    assertEquals( "6", sixth.path("opticFunctionalTest.detail.id").path("value").asText());
+    assertEquals( "1", sixth.path("opticFunctionalTest.master.id").path("value").asText());
+    assertEquals( "2", sixth.path("opticFunctionalTest.detail.masterId").path("value").asText());
+    assertEquals( "Detail 6", sixth.path("opticFunctionalTest.detail.name").path("value").asText());
 
     // Verify with negative value.
     jacksonHandle = new JacksonHandle();
@@ -1870,7 +1871,7 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     rowMgr.resultDoc(plan3.bindParam("ID", -1), jacksonHandle);
     jsonResults = jacksonHandle.get();
     // Should have null returned.
-    assertTrue("No nodes should returned. But found some.", jsonResults == null);
+    assertTrue( jsonResults == null);
 
     // Verify with double value.
     PlanParamExpr amtParam = p.param("AMT");
@@ -1883,13 +1884,13 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     rowMgr.resultDoc(planAmt.bindParam("AMT", 10.1), jacksonHandle);
     jsonResults = jacksonHandle.get().path("rows");
     // Should have 5 rows returned.
-    assertEquals("Five rows not returned from testjoinInnerWithBind method ", 5, jsonResults.size());
+    assertEquals( 5, jsonResults.size());
 
-    assertEquals("Row 1 opticFunctionalTest.detail.amount value incorrect", "20.02", jsonResults.path(0).path("opticFunctionalTest.detail.amount").path("value").asText());
-    assertEquals("Row 2 opticFunctionalTest.detail.amount value incorrect", "30.03", jsonResults.path(1).path("opticFunctionalTest.detail.amount").path("value").asText());
-    assertEquals("Row 3 opticFunctionalTest.detail.amount value incorrect", "40.04", jsonResults.path(2).path("opticFunctionalTest.detail.amount").path("value").asText());
-    assertEquals("Row 4 opticFunctionalTest.detail.amount value incorrect", "50.05", jsonResults.path(3).path("opticFunctionalTest.detail.amount").path("value").asText());
-    assertEquals("Row 5 opticFunctionalTest.detail.amount value incorrect", "60.06", jsonResults.path(4).path("opticFunctionalTest.detail.amount").path("value").asText());
+    assertEquals( "20.02", jsonResults.path(0).path("opticFunctionalTest.detail.amount").path("value").asText());
+    assertEquals( "30.03", jsonResults.path(1).path("opticFunctionalTest.detail.amount").path("value").asText());
+    assertEquals( "40.04", jsonResults.path(2).path("opticFunctionalTest.detail.amount").path("value").asText());
+    assertEquals( "50.05", jsonResults.path(3).path("opticFunctionalTest.detail.amount").path("value").asText());
+    assertEquals( "60.06", jsonResults.path(4).path("opticFunctionalTest.detail.amount").path("value").asText());
 
     // verify for Strings.
     PlanParamExpr detNameParam = p.param("DETAILNAME");
@@ -1901,8 +1902,8 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     jacksonHandle.setMimetype("application/json");
     rowMgr.resultDoc(planStringBind.bindParam(detNameParam, p.xs.string("Detail 6")), jacksonHandle);
     jsonResults = jacksonHandle.get().path("rows");
-    assertEquals("One row not returned from testjoinInnerWithBind method ", 1, jsonResults.size());
-    assertEquals("Row 1 opticFunctionalTest.detail.amount value incorrect", "60.06", jsonResults.path(0).path("opticFunctionalTest.detail.amount").path("value").asText());
+    assertEquals( 1, jsonResults.size());
+    assertEquals( "60.06", jsonResults.path(0).path("opticFunctionalTest.detail.amount").path("value").asText());
 
     // Verify with different types in multiple places.
     ModifyPlan planMultiBind = p.fromView("opticFunctionalTest", "detail")
@@ -1917,8 +1918,8 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     rowMgr.resultDoc(planMultiBind.bindParam(detNameParam, p.xs.string("Detail 6")).bindParam("ID", 6), jacksonHandle);
     jsonResults = jacksonHandle.get().path("rows");
     // Should have 1 node returned.
-    assertEquals("One row not returned from testjoinInnerWithBind method ", 1, jsonResults.size());
-    assertEquals("Row 1 opticFunctionalTest.detail.amount value incorrect", "60.06", jsonResults.path(0).path("opticFunctionalTest.detail.amount").path("value").asText());
+    assertEquals( 1, jsonResults.size());
+    assertEquals( "60.06", jsonResults.path(0).path("opticFunctionalTest.detail.amount").path("value").asText());
   }
 
 
@@ -1964,7 +1965,7 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     expected.add("myDetail.name");
     Collections.sort(expected);
 
-    assertTrue("Column names not equal from JsonNode.class", expected.equals(actual));
+    assertTrue( expected.equals(actual));
 
     Iterator<JsonNode> jsonRowItr = jsonResults.iterator();
     JsonNode first = null;
@@ -1974,10 +1975,10 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     } else {
       fail("No JsonNodes available when JsonNode.class used");
     }
-    assertEquals("Element 1 myMaster.id value incorrect", "1", first.path("myMaster.id").path("value").asText());
-    assertEquals("Element 1 myMaster.name value incorrect", "Master 1", first.path("myMaster.name").path("value").asText());
-    assertEquals("Element 1 myDetail.id value incorrect", "5", first.path("myDetail.id").path("value").asText());
-    assertEquals("Element 1 myDetail.name value incorrect", "Detail 5", first.path("myDetail.name").path("value").asText());
+    assertEquals( "1", first.path("myMaster.id").path("value").asText());
+    assertEquals( "Master 1", first.path("myMaster.name").path("value").asText());
+    assertEquals( "5", first.path("myDetail.id").path("value").asText());
+    assertEquals( "Detail 5", first.path("myDetail.name").path("value").asText());
 
     jsonResults.close();
 
@@ -1990,7 +1991,7 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     for (String cols : colNamesXML)
       actualXmlCol.add(cols);
     Collections.sort(actualXmlCol);
-    assertTrue("Column names not equal from Document.class", expected.equals(actualXmlCol));
+    assertTrue( expected.equals(actualXmlCol));
 
     Iterator<Document> xmlRowItr = xmlResults.iterator();
     DOMHandle firstXML = new DOMHandle();
@@ -1999,10 +2000,10 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
       firstXMLDoc = xmlRowItr.next();
       String rowContents = firstXML.with(firstXMLDoc).toString();
       System.out.println("Row iterated using Document.class" + rowContents);
-      assertTrue("Row contents incorrect", rowContents.contains("<t:cell name=\"myMaster.id\" type=\"xs:integer\">1</t:cell>"));
-      assertTrue("Row contents incorrect", rowContents.contains("<t:cell name=\"myMaster.name\" type=\"xs:string\">Master 1</t:cell>"));
-      assertTrue("Row contents incorrect", rowContents.contains("<t:cell name=\"myDetail.id\" type=\"xs:integer\">5</t:cell>"));
-      assertTrue("Row contents incorrect", rowContents.contains("<t:cell name=\"myDetail.name\" type=\"xs:string\">Detail 5</t:cell>"));
+      assertTrue( rowContents.contains("<t:cell name=\"myMaster.id\" type=\"xs:integer\">1</t:cell>"));
+      assertTrue( rowContents.contains("<t:cell name=\"myMaster.name\" type=\"xs:string\">Master 1</t:cell>"));
+      assertTrue( rowContents.contains("<t:cell name=\"myDetail.id\" type=\"xs:integer\">5</t:cell>"));
+      assertTrue( rowContents.contains("<t:cell name=\"myDetail.name\" type=\"xs:string\">Detail 5</t:cell>"));
     } else {
       fail("No JsonNodes available when Document.class used");
     }
@@ -2033,15 +2034,15 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get();
     jsonResults = jacksonHandle.get().path("rows");
     // Should have 6 nodes returned.
-    assertEquals("Six rows not returned from testFromSqljoinInnerWithkeymatch method ", 6, jsonResults.size());
-    assertEquals("Row 1 opticFunctionalTest.detail.id value incorrect", 1, jsonResults.path(0).path("opticFunctionalTest.detail.id").path("value").asInt());
-    assertEquals("Row 1 opticFunctionalTest.master.id value incorrect", 1, jsonResults.path(0).path("opticFunctionalTest.master.id").path("value").asInt());
-    assertEquals("Row 1 opticFunctionalTest.detail.masterId value incorrect", 1, jsonResults.path(0).path("opticFunctionalTest.detail.masterId").path("value").asInt());
-    assertEquals("Row 1 opticFunctionalTest.detail.name value incorrect", "Detail 1", jsonResults.path(0).path("opticFunctionalTest.detail.name").path("value").asText());
-    assertEquals("Row 6 opticFunctionalTest.detail.id value incorrect", 6, jsonResults.path(5).path("opticFunctionalTest.detail.id").path("value").asInt());
-    assertEquals("Row 6 opticFunctionalTest.master.id value incorrect", 2, jsonResults.path(5).path("opticFunctionalTest.master.id").path("value").asInt());
-    assertEquals("Row 6 opticFunctionalTest.detail.masterId value incorrect", 2, jsonResults.path(5).path("opticFunctionalTest.detail.masterId").path("value").asInt());
-    assertEquals("Row 6 opticFunctionalTest.detail.name value incorrect", "Detail 6", jsonResults.path(5).path("opticFunctionalTest.detail.name").path("value").asText());
+    assertEquals( 6, jsonResults.size());
+    assertEquals( 1, jsonResults.path(0).path("opticFunctionalTest.detail.id").path("value").asInt());
+    assertEquals( 1, jsonResults.path(0).path("opticFunctionalTest.master.id").path("value").asInt());
+    assertEquals( 1, jsonResults.path(0).path("opticFunctionalTest.detail.masterId").path("value").asInt());
+    assertEquals( "Detail 1", jsonResults.path(0).path("opticFunctionalTest.detail.name").path("value").asText());
+    assertEquals( 6, jsonResults.path(5).path("opticFunctionalTest.detail.id").path("value").asInt());
+    assertEquals( 2, jsonResults.path(5).path("opticFunctionalTest.master.id").path("value").asInt());
+    assertEquals( 2, jsonResults.path(5).path("opticFunctionalTest.detail.masterId").path("value").asInt());
+    assertEquals( "Detail 6", jsonResults.path(5).path("opticFunctionalTest.detail.name").path("value").asText());
   }
 
   //fromsql TEST 2 - join inner with keymatch and select
@@ -2062,13 +2063,13 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get();
     jsonResults = jacksonHandle.get().path("rows");
     // Should have 6 nodes returned.
-    assertEquals("Six rows not returned from testFromSqljoinInnerWithkeymatchSelect method ", 6, jsonResults.size());
-    assertEquals("Row 1 MasterName value incorrect", "Master 2", jsonResults.path(0).path("MasterName").path("value").asText());
-    assertEquals("Row 1 DetailName value incorrect", "Detail 6", jsonResults.path(0).path("DetailName").path("value").asText());
-    assertEquals("Row 1 opticFunctionalTest.detail.amount value incorrect", "60.06", jsonResults.path(0).path("opticFunctionalTest.detail.amount").path("value").asText());
-    assertEquals("Row 6 MasterName value incorrect", "Master 1", jsonResults.path(5).path("MasterName").path("value").asText());
-    assertEquals("Row 6 DetailName value incorrect", "Detail 1", jsonResults.path(5).path("DetailName").path("value").asText());
-    assertEquals("Row 6 opticFunctionalTest.detail.color value incorrect", "blue", jsonResults.path(5).path("opticFunctionalTest.detail.color").path("value").asText());
+    assertEquals( 6, jsonResults.size());
+    assertEquals( "Master 2", jsonResults.path(0).path("MasterName").path("value").asText());
+    assertEquals( "Detail 6", jsonResults.path(0).path("DetailName").path("value").asText());
+    assertEquals( "60.06", jsonResults.path(0).path("opticFunctionalTest.detail.amount").path("value").asText());
+    assertEquals( "Master 1", jsonResults.path(5).path("MasterName").path("value").asText());
+    assertEquals( "Detail 1", jsonResults.path(5).path("DetailName").path("value").asText());
+    assertEquals( "blue", jsonResults.path(5).path("opticFunctionalTest.detail.color").path("value").asText());
   }
 
   //fromsql TEST 4 - sql group by
@@ -2090,11 +2091,11 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get();
     jsonResults = jacksonHandle.get().path("rows");
     // Should have 2 nodes returned.
-    assertEquals("Two rows not returned from testFromSqlGroupBy method ", 2, jsonResults.size());
-    assertEquals("Row 1 opticFunctionalTest.master.name value incorrect", "Master 2", jsonResults.path(0).path("opticFunctionalTest.master.name").path("value").asText());
-    assertEquals("Row 1 DetailSum value incorrect", "120.12", jsonResults.path(0).path("DetailSum").path("value").asText());
-    assertEquals("Row 2 opticFunctionalTest.master.name value incorrect", "Master 1", jsonResults.path(1).path("opticFunctionalTest.master.name").path("value").asText());
-    assertEquals("Row 2 DetailSum value incorrect", "90.09", jsonResults.path(1).path("DetailSum").path("value").asText());
+    assertEquals( 2, jsonResults.size());
+    assertEquals( "Master 2", jsonResults.path(0).path("opticFunctionalTest.master.name").path("value").asText());
+    assertEquals( "120.12", jsonResults.path(0).path("DetailSum").path("value").asText());
+    assertEquals( "Master 1", jsonResults.path(1).path("opticFunctionalTest.master.name").path("value").asText());
+    assertEquals( "90.09", jsonResults.path(1).path("DetailSum").path("value").asText());
   }
 
   //fromsql TEST 8 - select with empty string qualifier and as
@@ -2121,13 +2122,13 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get();
     jsonResults = jacksonHandle.get().path("rows");
     // Should have 6 nodes returned.
-    assertEquals("Six rows not returned from testFromSqlSelectEmptyAs method ", 6, jsonResults.size());
-    assertEquals("Row 1 opticFunctionalTest.detail.id value incorrect", "1", jsonResults.path(0).path("opticFunctionalTest.detail.id").path("value").asText());
-    assertEquals("Row 1 opticFunctionalTest.detail.color value incorrect", "blue", jsonResults.path(0).path("opticFunctionalTest.detail.color").path("value").asText());
-    assertEquals("Row 1 masterName value incorrect", "Master 1", jsonResults.path(0).path("masterName").path("value").asText());
-    assertEquals("Row 5 opticFunctionalTest.detail.id value incorrect", "6", jsonResults.path(5).path("opticFunctionalTest.detail.id").path("value").asText());
-    assertEquals("Row 5 opticFunctionalTest.detail.color value incorrect", "green", jsonResults.path(5).path("opticFunctionalTest.detail.color").path("value").asText());
-    assertEquals("Row 5 masterName value incorrect", "Master 2", jsonResults.path(5).path("masterName").path("value").asText());
+    assertEquals( 6, jsonResults.size());
+    assertEquals( "1", jsonResults.path(0).path("opticFunctionalTest.detail.id").path("value").asText());
+    assertEquals( "blue", jsonResults.path(0).path("opticFunctionalTest.detail.color").path("value").asText());
+    assertEquals( "Master 1", jsonResults.path(0).path("masterName").path("value").asText());
+    assertEquals( "6", jsonResults.path(5).path("opticFunctionalTest.detail.id").path("value").asText());
+    assertEquals( "green", jsonResults.path(5).path("opticFunctionalTest.detail.color").path("value").asText());
+    assertEquals( "Master 2", jsonResults.path(5).path("masterName").path("value").asText());
   }
 
   //fromsql TEST 12 - arithmetic operations
@@ -2152,15 +2153,15 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get();
     jsonResults = jacksonHandle.get().path("rows");
     // Should have 6 nodes returned.
-    assertEquals("Six rows not returned from testFromSqlArithmetic method ", 6, jsonResults.size());
-    assertEquals("Row 1 added value incorrect", "11.01", jsonResults.path(0).path("added").path("value").asText());
-    assertEquals("Row 1 substracted value incorrect", "9.01", jsonResults.path(0).path("substracted").path("value").asText());
-    assertEquals("Row 1 modulo value incorrect", "0.00999999999999979", jsonResults.path(0).path("modulo").path("value").asText());
-    assertEquals("Row 1 divided value incorrect", "1", jsonResults.path(0).path("divided").path("value").asText());
-    assertEquals("Row 6 added value incorrect", "62.06", jsonResults.path(5).path("added").path("value").asText());
-    assertEquals("Row 6 substracted value incorrect", "58.06", jsonResults.path(5).path("substracted").path("value").asText());
-    assertEquals("Row 6 modulo value incorrect", "0.0600000000000023", jsonResults.path(5).path("modulo").path("value").asText());
-    assertEquals("Row 6 divided value incorrect", "0.166666666666667", jsonResults.path(5).path("divided").path("value").asText());
+    assertEquals( 6, jsonResults.size());
+    assertEquals( "11.01", jsonResults.path(0).path("added").path("value").asText());
+    assertEquals( "9.01", jsonResults.path(0).path("substracted").path("value").asText());
+    assertEquals( "0.00999999999999979", jsonResults.path(0).path("modulo").path("value").asText());
+    assertEquals( "1", jsonResults.path(0).path("divided").path("value").asText());
+    assertEquals( "62.06", jsonResults.path(5).path("added").path("value").asText());
+    assertEquals( "58.06", jsonResults.path(5).path("substracted").path("value").asText());
+    assertEquals( "0.0600000000000023", jsonResults.path(5).path("modulo").path("value").asText());
+    assertEquals( "0.166666666666667", jsonResults.path(5).path("divided").path("value").asText());
   }
 
   //fromsql TEST 19 - sql between with sql condition
@@ -2189,9 +2190,9 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get();
     jsonResults = jacksonHandle.get().path("rows");
     // Should have 2 nodes returned.
-    assertEquals("Two rows not returned from testFromSqlBetweenAndSqlCondition method ", 2, jsonResults.size());
-    assertEquals("Row 1 NewDetail.amount value incorrect", "20.02", jsonResults.path(0).path("NewDetail.amount").path("value").asText());
-    assertEquals("Row 2 NewDetail.amount value incorrect", "30.03", jsonResults.path(1).path("NewDetail.amount").path("value").asText());
+    assertEquals( 2, jsonResults.size());
+    assertEquals( "20.02", jsonResults.path(0).path("NewDetail.amount").path("value").asText());
+    assertEquals( "30.03", jsonResults.path(1).path("NewDetail.amount").path("value").asText());
   }
 
 
@@ -2218,9 +2219,9 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get();
     jsonResults = jacksonHandle.get().path("rows");
     // Should have 2 nodes returned.
-    assertEquals("Two rows not returned from testFromSqlUnionSelectOrderbyLimitOffset method ", 2, jsonResults.size());
-    assertEquals("Row 1 myName value incorrect", "Detail 5", jsonResults.path(0).path("myName").path("value").asText());
-    assertEquals("Row 2 myName value incorrect", "Detail 4", jsonResults.path(1).path("myName").path("value").asText());
+    assertEquals( 2, jsonResults.size());
+    assertEquals( "Detail 5", jsonResults.path(0).path("myName").path("value").asText());
+    assertEquals( "Detail 4", jsonResults.path(1).path("myName").path("value").asText());
   }
 
 
@@ -2245,10 +2246,10 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     rowMgr.resultDoc(plan1, jacksonHandle);
     JsonNode jsonResults = jacksonHandle.get().path("rows");
     // Should have 3 nodes returned.
-    assertEquals("Three rows not returned from testFromSqlUnionOffsetLimit method ", 3, jsonResults.size());
-    assertEquals("Row 1 myPlan value incorrect", "Detail 5", jsonResults.path(0).path("myPlan.name").path("value").asText());
-    assertEquals("Row 2 myPlan value incorrect", "Detail 4", jsonResults.path(1).path("myPlan.name").path("value").asText());
-    assertEquals("Row 3 myPlan value incorrect", "Detail 3", jsonResults.path(2).path("myPlan.name").path("value").asText());
+    assertEquals( 3, jsonResults.size());
+    assertEquals( "Detail 5", jsonResults.path(0).path("myPlan.name").path("value").asText());
+    assertEquals( "Detail 4", jsonResults.path(1).path("myPlan.name").path("value").asText());
+    assertEquals( "Detail 3", jsonResults.path(2).path("myPlan.name").path("value").asText());
   }
 
   // Tests for Query DSL
@@ -2286,14 +2287,14 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     System.out.println("Results are : " + jsonResults);
 
     // Should have 6 nodes returned.
-    assertEquals("Six rows not returned from testQueryDSLjoinInnerWithkeymatch method ", 6, jsonResults.size());
-    assertEquals("Row 1 detail id value incorrect", "1", jsonResults.path(0).path("opticFunctionalTest.detail.id").path("value").asText());
-    assertEquals("Row 1 master id value incorrect", "1", jsonResults.path(0).path("opticFunctionalTest.master.id").path("value").asText());
-    assertEquals("Row 1 detail masterId value incorrect", "1", jsonResults.path(0).path("opticFunctionalTest.detail.masterId").path("value").asText());
-    assertEquals("Row 1 detail name value incorrect", "Detail 1", jsonResults.path(0).path("opticFunctionalTest.detail.name").path("value").asText());
-    assertEquals("Row 6 detail amount value incorrect", "60.06", jsonResults.path(5).path("opticFunctionalTest.detail.amount").path("value").asText());
-    assertEquals("Row 6 detail color value incorrect", "green", jsonResults.path(5).path("opticFunctionalTest.detail.color").path("value").asText());
-    assertEquals("Row 6 master name value incorrect", "Master 2", jsonResults.path(5).path("opticFunctionalTest.master.name").path("value").asText());
+    assertEquals( 6, jsonResults.size());
+    assertEquals( "1", jsonResults.path(0).path("opticFunctionalTest.detail.id").path("value").asText());
+    assertEquals( "1", jsonResults.path(0).path("opticFunctionalTest.master.id").path("value").asText());
+    assertEquals( "1", jsonResults.path(0).path("opticFunctionalTest.detail.masterId").path("value").asText());
+    assertEquals( "Detail 1", jsonResults.path(0).path("opticFunctionalTest.detail.name").path("value").asText());
+    assertEquals( "60.06", jsonResults.path(5).path("opticFunctionalTest.detail.amount").path("value").asText());
+    assertEquals( "green", jsonResults.path(5).path("opticFunctionalTest.detail.color").path("value").asText());
+    assertEquals( "Master 2", jsonResults.path(5).path("opticFunctionalTest.master.name").path("value").asText());
   }
 
   /*
@@ -2348,36 +2349,36 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     System.out.println("Results are : " + jsonResults);
 
     // Should have 6 nodes returned.
-    assertEquals("Six rows not returned from testQueryDSLArithmeticOperators method ", 6, jsonResults.size());
+    assertEquals( 6, jsonResults.size());
     // Verify values for row 1
-    assertEquals("Row 1 addLong value incorrect", "2", jsonResults.path(0).path("addLong").path("value").asText());
-    assertEquals("Row 1 subtractLong value incorrect", "0", jsonResults.path(0).path("subtractLong").path("value").asText());
-    assertEquals("Row 1 nameJSLen value incorrect", "8", jsonResults.path(0).path("nameJSLen").path("value").asText());
-    assertEquals("Row 1 nameJSConcat value incorrect", "DEHEAD 1", jsonResults.path(0).path("nameJSConcat").path("value").asText());
-    assertEquals("Row 1 add value incorrect", "11.01", jsonResults.path(0).path("add").path("value").asText());
-    assertEquals("Row 1 multiple value incorrect", "20.02", jsonResults.path(0).path("multiple").path("value").asText());
-    assertEquals("Row 1 subtract value incorrect", "9.01", jsonResults.path(0).path("subtract").path("value").asText());
-    assertEquals("Row 1 divide value incorrect", "3.33666666666667", jsonResults.path(0).path("divide").path("value").asText());
-    assertEquals("Row 1 equality value incorrect", "true", jsonResults.path(0).path("equality").path("value").asText());
-    assertEquals("Row 1 inequality value incorrect", "false", jsonResults.path(0).path("inequality").path("value").asText());
+    assertEquals( "2", jsonResults.path(0).path("addLong").path("value").asText());
+    assertEquals( "0", jsonResults.path(0).path("subtractLong").path("value").asText());
+    assertEquals( "8", jsonResults.path(0).path("nameJSLen").path("value").asText());
+    assertEquals( "DEHEAD 1", jsonResults.path(0).path("nameJSConcat").path("value").asText());
+    assertEquals( "11.01", jsonResults.path(0).path("add").path("value").asText());
+    assertEquals( "20.02", jsonResults.path(0).path("multiple").path("value").asText());
+    assertEquals( "9.01", jsonResults.path(0).path("subtract").path("value").asText());
+    assertEquals( "3.33666666666667", jsonResults.path(0).path("divide").path("value").asText());
+    assertEquals( "true", jsonResults.path(0).path("equality").path("value").asText());
+    assertEquals( "false", jsonResults.path(0).path("inequality").path("value").asText());
 
-    assertEquals("Row 1 numeralLiteral value incorrect", "4", jsonResults.path(0).path("numeralLiteral").path("value").asText());
-    assertEquals("Row 1 stringLiteral value incorrect", "Oracle", jsonResults.path(0).path("stringLiteral").path("value").asText());
+    assertEquals( "4", jsonResults.path(0).path("numeralLiteral").path("value").asText());
+    assertEquals( "Oracle", jsonResults.path(0).path("stringLiteral").path("value").asText());
 
     // Verify data types for row 6
-    assertEquals("Row 6 addLong type incorrect", "xs:integer", jsonResults.path(5).path("addLong").path("type").asText());
-    assertEquals("Row 6 subtractLong type incorrect", "xs:integer", jsonResults.path(5).path("subtractLong").path("type").asText());
-    assertEquals("Row 6 nameJSLen type incorrect", "xs:integer", jsonResults.path(5).path("nameJSLen").path("type").asText());
-    assertEquals("Row 6 nameJSConcat type incorrect", "xs:string", jsonResults.path(5).path("nameJSConcat").path("type").asText());
-    assertEquals("Row 6 add type incorrect", "xs:double", jsonResults.path(5).path("add").path("type").asText());
-    assertEquals("Row 6 multiple type incorrect", "xs:double", jsonResults.path(5).path("multiple").path("type").asText());
-    assertEquals("Row 6 subtract type incorrect", "xs:double", jsonResults.path(5).path("subtract").path("type").asText());
-    assertEquals("Row 6 divide type incorrect", "xs:double", jsonResults.path(5).path("divide").path("type").asText());
-    assertEquals("Row 6 equality type incorrect", "xs:boolean", jsonResults.path(5).path("equality").path("type").asText());
-    assertEquals("Row 6 inequality type incorrect", "xs:boolean", jsonResults.path(5).path("inequality").path("type").asText());
+    assertEquals( "xs:integer", jsonResults.path(5).path("addLong").path("type").asText());
+    assertEquals( "xs:integer", jsonResults.path(5).path("subtractLong").path("type").asText());
+    assertEquals( "xs:integer", jsonResults.path(5).path("nameJSLen").path("type").asText());
+    assertEquals( "xs:string", jsonResults.path(5).path("nameJSConcat").path("type").asText());
+    assertEquals( "xs:double", jsonResults.path(5).path("add").path("type").asText());
+    assertEquals( "xs:double", jsonResults.path(5).path("multiple").path("type").asText());
+    assertEquals( "xs:double", jsonResults.path(5).path("subtract").path("type").asText());
+    assertEquals( "xs:double", jsonResults.path(5).path("divide").path("type").asText());
+    assertEquals( "xs:boolean", jsonResults.path(5).path("equality").path("type").asText());
+    assertEquals( "xs:boolean", jsonResults.path(5).path("inequality").path("type").asText());
 
-    assertEquals("Row 6 numeralLiteral type incorrect", "xs:integer", jsonResults.path(0).path("numeralLiteral").path("type").asText());
-    assertEquals("Row 6 stringLiteral type incorrect", "xs:string", jsonResults.path(0).path("stringLiteral").path("type").asText());
+    assertEquals( "xs:integer", jsonResults.path(0).path("numeralLiteral").path("type").asText());
+    assertEquals( "xs:string", jsonResults.path(0).path("stringLiteral").path("type").asText());
   }
 
   /*
@@ -2413,13 +2414,13 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     JsonNode jsonResults = jacksonHandle.get().get("rows");
     System.out.println("Results are : " + jsonResults);
     // Should have 2 nodes returned.
-    assertEquals("Six rows not returned from testQueryDSLFromViewDateType method ", 2, jsonResults.size());
-    assertEquals("Row 1 Master id value incorrect", "Master 1", jsonResults.path(0).path("MasterName").path("value").asText());
-    assertEquals("Row 1 Master date value incorrect", "2015-12-01", jsonResults.path(0).path("opticFunctionalTest.master.date").path("value").asText());
-    assertEquals("Row 1 Detail color value incorrect", "blue", jsonResults.path(0).path("opticFunctionalTest.detail.color").path("value").asText());
-    assertEquals("Row 2 Master id value incorrect", "Master 1", jsonResults.path(1).path("MasterName").path("value").asText());
-    assertEquals("Row 2 Master date value incorrect", "2015-12-01", jsonResults.path(1).path("opticFunctionalTest.master.date").path("value").asText());
-    assertEquals("Row 2 Detail color value incorrect", "blue", jsonResults.path(1).path("opticFunctionalTest.detail.color").path("value").asText());
+    assertEquals( 2, jsonResults.size());
+    assertEquals( "Master 1", jsonResults.path(0).path("MasterName").path("value").asText());
+    assertEquals( "2015-12-01", jsonResults.path(0).path("opticFunctionalTest.master.date").path("value").asText());
+    assertEquals( "blue", jsonResults.path(0).path("opticFunctionalTest.detail.color").path("value").asText());
+    assertEquals( "Master 1", jsonResults.path(1).path("MasterName").path("value").asText());
+    assertEquals( "2015-12-01", jsonResults.path(1).path("opticFunctionalTest.master.date").path("value").asText());
+    assertEquals( "blue", jsonResults.path(1).path("opticFunctionalTest.detail.color").path("value").asText());
 
     strbldrWhereValidDate.append(".where(op.and(op.gt(op.schemaCol('opticFunctionalTest', 'master', 'date'), xs.date('2015-12-01'))," +
             " op.eq(op.schemaCol('opticFunctionalTest', 'detail', 'color'), 'blue')))");
@@ -2446,13 +2447,13 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     System.out.println("Results from Valid date in View are : " + jsonResults);
 
     // Should have 3 nodes returned.
-    assertEquals("Six rows not returned from testQueryDSLFromViewDateType method ", 3, jsonResults.size());
-    assertEquals("Row 1 amount value incorrect", "10.01", jsonResults.path(0).path("opticFunctionalTest.detail.amount").path("value").asText());
-    assertEquals("Row 1 Master date value incorrect", "2015-12-02", jsonResults.path(0).path("opticFunctionalTest.master.date").path("value").asText());
-    assertEquals("Row 1 Detail color value incorrect", "blue", jsonResults.path(0).path("opticFunctionalTest.detail.color").path("value").asText());
-    assertEquals("Row 2 amount value incorrect", "20.02", jsonResults.path(1).path("opticFunctionalTest.detail.amount").path("value").asText());
-    assertEquals("Row 3 amount value incorrect", "30.03", jsonResults.path(2).path("opticFunctionalTest.detail.amount").path("value").asText());
-    assertEquals("Row 3 Detail name value incorrect", "Detail 3", jsonResults.path(2).path("opticFunctionalTest.detail.name").path("value").asText());
+    assertEquals( 3, jsonResults.size());
+    assertEquals( "10.01", jsonResults.path(0).path("opticFunctionalTest.detail.amount").path("value").asText());
+    assertEquals( "2015-12-02", jsonResults.path(0).path("opticFunctionalTest.master.date").path("value").asText());
+    assertEquals( "blue", jsonResults.path(0).path("opticFunctionalTest.detail.color").path("value").asText());
+    assertEquals( "20.02", jsonResults.path(1).path("opticFunctionalTest.detail.amount").path("value").asText());
+    assertEquals( "30.03", jsonResults.path(2).path("opticFunctionalTest.detail.amount").path("value").asText());
+    assertEquals( "Detail 3", jsonResults.path(2).path("opticFunctionalTest.detail.name").path("value").asText());
 
     // Invalid date - XDMP-CAST Exception
     strbldr = new StringBuilder();
@@ -2513,11 +2514,11 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     System.out.println("Results are : " + jsonResults);
 
     // Should have 2 nodes returned.
-    assertEquals("Two rows not returned from testQueryDSLFromSQL method ", 2, jsonResults.size());
-    assertEquals("Row 1 opticFunctionalTest.master.name value incorrect", "Master 2", jsonResults.path(0).path("opticFunctionalTest.master.name").path("value").asText());
-    assertEquals("Row 1 DetailSum value incorrect", "120.12", jsonResults.path(0).path("DetailSum").path("value").asText());
-    assertEquals("Row 2 opticFunctionalTest.master.name value incorrect", "Master 1", jsonResults.path(1).path("opticFunctionalTest.master.name").path("value").asText());
-    assertEquals("Row 2 DetailSum value incorrect", "90.09", jsonResults.path(1).path("DetailSum").path("value").asText());
+    assertEquals( 2, jsonResults.size());
+    assertEquals( "Master 2", jsonResults.path(0).path("opticFunctionalTest.master.name").path("value").asText());
+    assertEquals( "120.12", jsonResults.path(0).path("DetailSum").path("value").asText());
+    assertEquals( "Master 1", jsonResults.path(1).path("opticFunctionalTest.master.name").path("value").asText());
+    assertEquals( "90.09", jsonResults.path(1).path("DetailSum").path("value").asText());
   }
 
   /*
@@ -2556,13 +2557,13 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     System.out.println("Results are : " + jsonResults);
 
     // Should have 3 nodes returned.
-    assertEquals("Six rows not returned from testQueryDSLFromViewDateType method ", 3, jsonResults.size());
-    assertEquals("Row 1 amount value incorrect", "10.01", jsonResults.path(0).path("opticFunctionalTest.detail.amount").path("value").asText());
-    assertEquals("Row 1 Master date value incorrect", "2015-12-02", jsonResults.path(0).path("opticFunctionalTest.master.date").path("value").asText());
-    assertEquals("Row 1 Detail color value incorrect", "blue", jsonResults.path(0).path("opticFunctionalTest.detail.color").path("value").asText());
-    assertEquals("Row 2 amount value incorrect", "20.02", jsonResults.path(1).path("opticFunctionalTest.detail.amount").path("value").asText());
-    assertEquals("Row 3 amount value incorrect", "30.03", jsonResults.path(2).path("opticFunctionalTest.detail.amount").path("value").asText());
-    assertEquals("Row 3 Detail name value incorrect", "Detail 3", jsonResults.path(2).path("opticFunctionalTest.detail.name").path("value").asText());
+    assertEquals( 3, jsonResults.size());
+    assertEquals( "10.01", jsonResults.path(0).path("opticFunctionalTest.detail.amount").path("value").asText());
+    assertEquals( "2015-12-02", jsonResults.path(0).path("opticFunctionalTest.master.date").path("value").asText());
+    assertEquals( "blue", jsonResults.path(0).path("opticFunctionalTest.detail.color").path("value").asText());
+    assertEquals( "20.02", jsonResults.path(1).path("opticFunctionalTest.detail.amount").path("value").asText());
+    assertEquals( "30.03", jsonResults.path(2).path("opticFunctionalTest.detail.amount").path("value").asText());
+    assertEquals( "Detail 3", jsonResults.path(2).path("opticFunctionalTest.detail.name").path("value").asText());
 
     // Invalid value in bind
     PlanBuilder.Plan planDSL1 = rowMgr.newRawQueryDSLPlan(strHdl)
@@ -2698,19 +2699,19 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
     System.out.println("Results are : " + jsonBindingsNodes);
     // Should have 10 array nodes returned.
-    assertEquals("Ten nodes not returned from testgroupByUnion method ", 10, jsonBindingsNodes.size());
-    assertEquals("Row 1 testgroupByUnion color value incorrect", "blue", jsonBindingsNodes.get(0).path("color").path("value").asText());
-    assertEquals("Row 1 testgroupByUnion ColorCount size incorrect", 3, jsonBindingsNodes.get(0).path("ColorCount").path("value").asInt());
-    assertEquals("Row 1 testgroupByUnion AverageAmout value incorrect", "20.02", jsonBindingsNodes.get(0).path("AverageAmout").path("value").asText());
+    assertEquals( 10, jsonBindingsNodes.size());
+    assertEquals( "blue", jsonBindingsNodes.get(0).path("color").path("value").asText());
+    assertEquals( 3, jsonBindingsNodes.get(0).path("ColorCount").path("value").asInt());
+    assertEquals( "20.02", jsonBindingsNodes.get(0).path("AverageAmout").path("value").asText());
 
-    assertEquals("Row 2 testgroupByUnion color value incorrect", "green", jsonBindingsNodes.get(1).path("color").path("value").asText());
-    assertEquals("Row 2 testgroupByUnion ColorCount size incorrect", 3, jsonBindingsNodes.get(1).path("ColorCount").path("value").asInt());
-    assertEquals("Row 2 testgroupByUnion AverageAmout value incorrect", "50.05", jsonBindingsNodes.get(1).path("AverageAmout").path("value").asText());
+    assertEquals( "green", jsonBindingsNodes.get(1).path("color").path("value").asText());
+    assertEquals( 3, jsonBindingsNodes.get(1).path("ColorCount").path("value").asInt());
+    assertEquals( "50.05", jsonBindingsNodes.get(1).path("AverageAmout").path("value").asText());
     // Assert for null in both grouping columns. We will have one row with nulls
 
-    assertEquals("Row 10 testgroupByUnion color value incorrect", "null", jsonBindingsNodes.get(9).path("color").path("type").asText());
-    assertEquals("Row 10 testgroupByUnion ColorCount size incorrect", 0, jsonBindingsNodes.get(9).path("ColorCount").path("value").asInt());
-    assertEquals("Row 10 testgroupByUnion AverageAmout value incorrect", "null", jsonBindingsNodes.get(9).path("AverageAmout").path("type").asText());
+    assertEquals( "null", jsonBindingsNodes.get(9).path("color").path("type").asText());
+    assertEquals( 0, jsonBindingsNodes.get(9).path("ColorCount").path("value").asInt());
+    assertEquals( "null", jsonBindingsNodes.get(9).path("AverageAmout").path("type").asText());
     // Use date in aggregate
     ModifyPlan plan4 = plan1.union(plan2)
             .select(p.as("MasterDate", p.schemaCol("opticFunctionalTest", "master", "date")),
@@ -2730,14 +2731,14 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodesDate = jsonResultsDate.path("rows");
     System.out.println("Results from date grouping are : " + jsonBindingsNodesDate);
 
-    assertEquals("Six nodes not returned from testgroupByUnion method ", 6, jsonBindingsNodesDate.size());
-    assertEquals("Row 1 testgroupByUnion MasterDate value incorrect", "2015-12-02", jsonBindingsNodesDate.get(0).path("MasterDate").path("value").asText());
-    assertEquals("Row 1 testgroupByUnion DateCount size incorrect", 1, jsonBindingsNodesDate.get(0).path("DateCount").path("value").asInt());
-    assertEquals("Row 1 testgroupByUnion color value incorrect", "null", jsonBindingsNodesDate.get(0).path("color").path("type").asText());
+    assertEquals( 6, jsonBindingsNodesDate.size());
+    assertEquals( "2015-12-02", jsonBindingsNodesDate.get(0).path("MasterDate").path("value").asText());
+    assertEquals( 1, jsonBindingsNodesDate.get(0).path("DateCount").path("value").asInt());
+    assertEquals( "null", jsonBindingsNodesDate.get(0).path("color").path("type").asText());
 
-    assertEquals("Row 2 testgroupByUnion MasterDate value incorrect", "2015-12-01", jsonBindingsNodesDate.get(1).path("MasterDate").path("value").asText());
-    assertEquals("Row 2 testgroupByUnion DateCount size incorrect", 1, jsonBindingsNodesDate.get(1).path("DateCount").path("value").asInt());
-    assertEquals("Row 2 testgroupByUnion color value incorrect", "null", jsonBindingsNodesDate.get(1).path("color").path("type").asText());
+    assertEquals( "2015-12-01", jsonBindingsNodesDate.get(1).path("MasterDate").path("value").asText());
+    assertEquals( 1, jsonBindingsNodesDate.get(1).path("DateCount").path("value").asInt());
+    assertEquals( "null", jsonBindingsNodesDate.get(1).path("color").path("type").asText());
 
     // Note that this plan5 is ued to verify if non-alphabetic col key name have any issues. Refer to BT56490
     ModifyPlan plan5 = plan1.union(plan2)
@@ -2759,11 +2760,11 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodesColOrd = jsonResultsColOrd.path("rows");
     System.out.println("Results from Column in non alphbetic column name order are : " + jsonBindingsNodesColOrd);
 
-    assertEquals("Nine nodes not returned from testgroupByUnion of plan5 ", 9, jsonBindingsNodesColOrd.size());
-    assertEquals("Row 1 plan5 of testgroupByUnion MasterDate value incorrect", "2015-12-02", jsonBindingsNodesColOrd.get(0).path("MasterDate").path("value").asText());
-    assertEquals("Row 1 plan5 of testgroupByUnion DateCount size incorrect", 1, jsonBindingsNodesColOrd.get(0).path("DateCount").path("value").asInt());
-    assertEquals("Row 7 plan5 of testgroupByUnion color type incorrect", "null", jsonBindingsNodesColOrd.get(7).path("color").path("type").asText());
-    assertEquals("Row 7 plan5 of testgroupByUnion color value incorrect", "blue", jsonBindingsNodesColOrd.get(6).path("color").path("value").asText());
+    assertEquals( 9, jsonBindingsNodesColOrd.size());
+    assertEquals( "2015-12-02", jsonBindingsNodesColOrd.get(0).path("MasterDate").path("value").asText());
+    assertEquals( 1, jsonBindingsNodesColOrd.get(0).path("DateCount").path("value").asInt());
+    assertEquals( "null", jsonBindingsNodesColOrd.get(7).path("color").path("type").asText());
+    assertEquals( "blue", jsonBindingsNodesColOrd.get(6).path("color").path("value").asText());
 
   }
 
@@ -2799,10 +2800,10 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodes = jsonResults.path("rows");
     System.out.println("Results are : " + jsonBindingsNodes);
     // Should be returning as one array containing sub arrays for each namedgroup
-    assertEquals("1 node not returned from testgroupByArrays method ", 1, jsonBindingsNodes.size());
+    assertEquals( 1, jsonBindingsNodes.size());
 
     JsonNode jsonDetColorNodes = jsonBindingsNodes.get(0).get("DetColor").get("value");
-    assertEquals("2 nodes not returned from color nodes array ", 2, jsonDetColorNodes.size());
+    assertEquals( 2, jsonDetColorNodes.size());
 
     // Order of the aggregated rows is not consistent
     JsonNode firstRow = jsonDetColorNodes.get(0);
@@ -2811,16 +2812,16 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     JsonNode blueRow =  firstRowIsBlue ? firstRow : secondRow;
     JsonNode greenRow = firstRowIsBlue ? secondRow : firstRow;
 
-    assertEquals("Row 1 color node value incorrect", "blue", blueRow.path("color").asText());
-    assertEquals("Row 1 sum node value incorrect", "60.06", blueRow.path("sum").asText());
-    assertEquals("Row 1 color count node value incorrect", "3", blueRow.path("CountofColors").asText());
+    assertEquals( "blue", blueRow.path("color").asText());
+    assertEquals( "60.06", blueRow.path("sum").asText());
+    assertEquals( "3", blueRow.path("CountofColors").asText());
 
-    assertEquals("Row 2 color node value incorrect", "green", greenRow.path("color").asText());
-    assertEquals("Row 2 sum node value incorrect", "150.15", greenRow.path("sum").asText());
-    assertEquals("Row 2 color count node value incorrect", "3", greenRow.path("CountofColors").asText());
+    assertEquals( "green", greenRow.path("color").asText());
+    assertEquals( "150.15", greenRow.path("sum").asText());
+    assertEquals( "3", greenRow.path("CountofColors").asText());
 
     JsonNode jsonAmtNodes = jsonBindingsNodes.get(0).get("Amt").get("value");
-    assertEquals("6 nodes not returned from color nodes array ", 6, jsonAmtNodes.size());
+    assertEquals( 6, jsonAmtNodes.size());
 
     // Verify without aggregate param
     ModifyPlan plan4 =
@@ -2872,14 +2873,14 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
 
     JsonNode jsonBindingsNodes1 = jsonResults.get(0);
     System.out.println("First Results are : " + jsonBindingsNodes1);
-    assertEquals("Facet Nodes count value incorrect ", 3, jsonBindingsNodes1.get("count").asInt());
-    assertEquals("Facet Nodes color value incorrect ", "blue", jsonBindingsNodes1.get("color").asText());
+    assertEquals( 3, jsonBindingsNodes1.get("count").asInt());
+    assertEquals( "blue", jsonBindingsNodes1.get("color").asText());
 
     // Verify next facet value
     JsonNode jsonBindingsNodes2 = jsonResults.get(1);
     System.out.println("Second Results are : " + jsonBindingsNodes2);
-    assertEquals("Facet Nodes count value incorrect ", 3, jsonBindingsNodes2.get("count").asInt());
-    assertEquals("Facet Nodes color value incorrect ", "green", jsonBindingsNodes2.get("color").asText());
+    assertEquals( 3, jsonBindingsNodes2.get("count").asInt());
+    assertEquals( "green", jsonBindingsNodes2.get("color").asText());
 
     // Verify two parameter facetBy method
     PlanSystemColumn fIdCol1 = p.fragmentIdCol("fragIdCol1");
@@ -2913,8 +2914,8 @@ public class TestOpticOnViews extends AbstractFunctionalTest {
     //System.out.println("Results are " + jsonResultsFrag);
 
     JsonNode jsonColumnsResults = jsonResultsFrag.get("columns");
-    assertEquals("Facet Nodes group name value incorrect ", "group0", jsonColumnsResults.get(0).get("name").asText());
-    assertEquals("Facet Nodes group name value incorrect ", "group1", jsonColumnsResults.get(1).get("name").asText());
+    assertEquals( "group0", jsonColumnsResults.get(0).get("name").asText());
+    assertEquals( "group1", jsonColumnsResults.get(1).get("name").asText());
   }
 
   // Testing columnInfo - similar to testgroupBy

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOptimisticLocking.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOptimisticLocking.java
@@ -34,8 +34,9 @@ import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.query.StructuredQueryBuilder;
 import com.marklogic.client.query.StructuredQueryDefinition;
 import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.junit.AfterClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 import org.xml.sax.SAXException;
 
 import javax.xml.parsers.ParserConfigurationException;
@@ -46,12 +47,12 @@ import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 
-import static org.junit.Assert.*;
+
 
 public class TestOptimisticLocking extends AbstractFunctionalTest {
 
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() throws Exception
   {
     DatabaseClient client = getDatabaseClient("rest-admin", "x", getConnType());
@@ -124,7 +125,7 @@ public class TestOptimisticLocking extends AbstractFunctionalTest {
     }
 
     boolean isExceptionThrown = exception.contains(expectedException);
-    assertTrue("Exception is not thrown", isExceptionThrown);
+    assertTrue( isExceptionThrown);
     System.out.println(exception);
 
     // write document with unknown version
@@ -134,7 +135,7 @@ public class TestOptimisticLocking extends AbstractFunctionalTest {
     StringHandle readHandle = new StringHandle();
     docMgr.read(desc, readHandle);
     String content = readHandle.get();
-    assertTrue("Wrong content", content.contains("<name>noodle</name>"));
+    assertTrue( content.contains("<name>noodle</name>"));
 
     // get the good version
     long goodVersion = desc.getVersion();
@@ -161,7 +162,7 @@ public class TestOptimisticLocking extends AbstractFunctionalTest {
     }
     System.out.println(updateException);
     boolean isUpdateExceptionThrown = updateException.contains(expectedUpdateException);
-    assertTrue("Exception is not thrown", isUpdateExceptionThrown);
+    assertTrue( isUpdateExceptionThrown);
 
     // update with unknown version
     desc.setVersion(DocumentDescriptor.UNKNOWN_VERSION);
@@ -177,7 +178,7 @@ public class TestOptimisticLocking extends AbstractFunctionalTest {
 
     boolean isUpdateUnknownExceptionThrown = updateUnknownException.contains(expectedUpdateUnknownException);
     System.out.println(updateUnknownException);
-    assertTrue("Exception is not thrown", isUpdateUnknownExceptionThrown);
+    assertTrue( isUpdateUnknownExceptionThrown);
 
     desc = docMgr.exists(docId);
     goodVersion = desc.getVersion();
@@ -191,7 +192,7 @@ public class TestOptimisticLocking extends AbstractFunctionalTest {
     StringHandle updateReadHandle = new StringHandle();
     docMgr.read(desc, updateReadHandle);
     String updateContent = updateReadHandle.get();
-    assertTrue("Wrong content", updateContent.contains("<name>fried noodle</name>"));
+    assertTrue( updateContent.contains("<name>fried noodle</name>"));
 
     // DELETE
     // delete using bad version
@@ -208,7 +209,7 @@ public class TestOptimisticLocking extends AbstractFunctionalTest {
 
     boolean isDeleteExceptionThrown = deleteException.contains(expectedDeleteException);
     System.out.println("Delete exception" + deleteException);
-    assertTrue("Exception is not thrown", isDeleteExceptionThrown);
+    assertTrue( isDeleteExceptionThrown);
 
     // delete using unknown version
     desc.setVersion(DocumentDescriptor.UNKNOWN_VERSION);
@@ -224,7 +225,7 @@ public class TestOptimisticLocking extends AbstractFunctionalTest {
 
     boolean isDeleteUnknownExceptionThrown = deleteUnknownException.contains(expectedDeleteUnknownException);
     System.out.println("Delete exception" + deleteUnknownException);
-    assertTrue("Exception is not thrown", isDeleteUnknownExceptionThrown);
+    assertTrue( isDeleteUnknownExceptionThrown);
 
     // delete using good version
     desc = docMgr.exists(docId);
@@ -245,7 +246,7 @@ public class TestOptimisticLocking extends AbstractFunctionalTest {
     }
 
     boolean isVerifyDeleteExceptionThrown = verifyDeleteException.contains(expectedVerifyDeleteException);
-    assertTrue("Exception is not thrown", isVerifyDeleteExceptionThrown);
+    assertTrue( isVerifyDeleteExceptionThrown);
     System.out.println("Delete exception" + verifyDeleteException);
   }
 
@@ -303,7 +304,7 @@ public class TestOptimisticLocking extends AbstractFunctionalTest {
     }
 
     boolean isExceptionThrown = exception.contains(expectedException);
-    assertTrue("Exception is not thrown", isExceptionThrown);
+    assertTrue( isExceptionThrown);
 
     // write document with unknown version
     desc.setVersion(DocumentDescriptor.UNKNOWN_VERSION);
@@ -312,7 +313,7 @@ public class TestOptimisticLocking extends AbstractFunctionalTest {
     StringHandle readHandle = new StringHandle();
     docMgr.read(desc, readHandle);
     String content = readHandle.get();
-    assertTrue("Wrong content", content.contains("John"));
+    assertTrue( content.contains("John"));
 
     // get the unknown version
     long unknownVersion = desc.getVersion();
@@ -339,7 +340,7 @@ public class TestOptimisticLocking extends AbstractFunctionalTest {
     }
 
     boolean isUpdateExceptionThrown = updateException.contains(expectedUpdateException);
-    assertTrue("Exception is not thrown", isUpdateExceptionThrown);
+    assertTrue( isUpdateExceptionThrown);
 
     // update with unknown version
     desc.setVersion(DocumentDescriptor.UNKNOWN_VERSION);
@@ -349,7 +350,7 @@ public class TestOptimisticLocking extends AbstractFunctionalTest {
     StringHandle updateReadHandle = new StringHandle();
     docMgr.read(desc, updateReadHandle);
     String updateContent = updateReadHandle.get();
-    assertTrue("Wrong content", updateContent.contains("Aries"));
+    assertTrue( updateContent.contains("Aries"));
 
     unknownVersion = desc.getVersion();
 
@@ -360,7 +361,7 @@ public class TestOptimisticLocking extends AbstractFunctionalTest {
     StringHandle readMatchHandle = new StringHandle();
     docMgr.read(desc, readMatchHandle);
     String readMatchContent = readMatchHandle.get();
-    assertNull("Document does not return null", readMatchContent);
+    assertNull( readMatchContent);
 
     // DELETE
     // delete using bad version
@@ -376,7 +377,7 @@ public class TestOptimisticLocking extends AbstractFunctionalTest {
     }
 
     boolean isDeleteExceptionThrown = deleteException.contains(expectedDeleteException);
-    assertTrue("Exception is not thrown", isDeleteExceptionThrown);
+    assertTrue( isDeleteExceptionThrown);
 
     // delete using unknown version
     desc.setVersion(DocumentDescriptor.UNKNOWN_VERSION);
@@ -397,7 +398,7 @@ public class TestOptimisticLocking extends AbstractFunctionalTest {
     }
 
     boolean isVerifyDeleteExceptionThrown = verifyDeleteException.contains(expectedVerifyDeleteException);
-    assertTrue("Exception is not thrown", isVerifyDeleteExceptionThrown);
+    assertTrue( isVerifyDeleteExceptionThrown);
   }
 
   @Test
@@ -454,7 +455,7 @@ public class TestOptimisticLocking extends AbstractFunctionalTest {
     }
 
     boolean isExceptionThrown = exception.contains(expectedException);
-    assertTrue("Exception is not thrown", isExceptionThrown);
+    assertTrue( isExceptionThrown);
 
     // write document with unknown version
     desc.setVersion(DocumentDescriptor.UNKNOWN_VERSION);
@@ -463,7 +464,7 @@ public class TestOptimisticLocking extends AbstractFunctionalTest {
     StringHandle readHandle = new StringHandle();
     docMgr.read(desc, readHandle);
     String content = readHandle.get();
-    assertTrue("Wrong content", content.contains("John"));
+    assertTrue( content.contains("John"));
 
     // get the good version
     long goodVersion = desc.getVersion();
@@ -490,7 +491,7 @@ public class TestOptimisticLocking extends AbstractFunctionalTest {
     }
 
     boolean isUpdateExceptionThrown = updateException.contains(expectedUpdateException);
-    assertTrue("Exception is not thrown", isUpdateExceptionThrown);
+    assertTrue( isUpdateExceptionThrown);
 
     // update with good version
     desc.setVersion(goodVersion);
@@ -500,7 +501,7 @@ public class TestOptimisticLocking extends AbstractFunctionalTest {
     StringHandle updateReadHandle = new StringHandle();
     docMgr.read(desc, updateReadHandle);
     String updateContent = updateReadHandle.get();
-    assertTrue("Wrong content", updateContent.contains("Aries"));
+    assertTrue( updateContent.contains("Aries"));
 
     goodVersion = desc.getVersion();
 
@@ -511,7 +512,7 @@ public class TestOptimisticLocking extends AbstractFunctionalTest {
     StringHandle readMatchHandle = new StringHandle();
     docMgr.read(desc, readMatchHandle);
     String readMatchContent = readMatchHandle.get();
-    assertNull("Document does not return null", readMatchContent);
+    assertNull( readMatchContent);
 
     // DELETE
     // delete using bad version
@@ -527,7 +528,7 @@ public class TestOptimisticLocking extends AbstractFunctionalTest {
     }
 
     boolean isDeleteExceptionThrown = deleteException.contains(expectedDeleteException);
-    assertTrue("Exception is not thrown", isDeleteExceptionThrown);
+    assertTrue( isDeleteExceptionThrown);
 
     // delete using good version
     desc.setVersion(goodVersion);
@@ -548,7 +549,7 @@ public class TestOptimisticLocking extends AbstractFunctionalTest {
     }
 
     boolean isVerifyDeleteExceptionThrown = verifyDeleteException.contains(expectedVerifyDeleteException);
-    assertTrue("Exception is not thrown", isVerifyDeleteExceptionThrown);
+    assertTrue( isVerifyDeleteExceptionThrown);
   }
 
   @Test
@@ -601,7 +602,7 @@ public class TestOptimisticLocking extends AbstractFunctionalTest {
     StringHandle readHandle = new StringHandle();
     docMgr.read(desc, readHandle);
     String content = readHandle.get();
-    assertTrue("Wrong content", content.contains("John"));
+    assertTrue( content.contains("John"));
 
     // UPDATE
     File updateFile = new File("src/test/java/com/marklogic/client/functionaltest/data/" + updateFilename);
@@ -618,7 +619,7 @@ public class TestOptimisticLocking extends AbstractFunctionalTest {
     StringHandle updateReadHandle = new StringHandle();
     docMgr.read(desc, updateReadHandle);
     String updateContent = updateReadHandle.get();
-    assertTrue("Wrong content", updateContent.contains("Aries"));
+    assertTrue( updateContent.contains("Aries"));
 
     // DELETE
     // delete using bad version
@@ -637,9 +638,9 @@ public class TestOptimisticLocking extends AbstractFunctionalTest {
     }
 
     boolean isVerifyDeleteExceptionThrown = verifyDeleteException.contains(expectedVerifyDeleteException);
-    assertTrue("Exception is not thrown", isVerifyDeleteExceptionThrown);
+    assertTrue( isVerifyDeleteExceptionThrown);
   }
-  
+
   @Test
   public void testAfterAndBeforeQuery() throws KeyManagementException, NoSuchAlgorithmException, IOException
   {
@@ -649,7 +650,7 @@ public class TestOptimisticLocking extends AbstractFunctionalTest {
 	  String[] filenames2 = { "constraint3.xml" };
 	  String[] filenames3 = { "constraint4.xml" };
 	  String[] filenames4 = { "constraint5.xml" };
-	
+
 	  String URLprefix = "/structured-query-andnot/";
 
 	  // connect the client
@@ -701,7 +702,7 @@ public class TestOptimisticLocking extends AbstractFunctionalTest {
 
 	  DocumentDescriptor desc4 = docMgr.exists(URLprefix + "constraint4.xml");
 	  long constraint4 = desc4.getVersion();
-	  
+
 	  DocumentDescriptor desc5 = docMgr.exists(URLprefix + "constraint5.xml");
 	  long constraint5 = desc5.getVersion();
 
@@ -717,15 +718,15 @@ public class TestOptimisticLocking extends AbstractFunctionalTest {
 	  }
 	  catch (Exception ex) {
 		  String aftQueryExMsg = ex.getMessage();
-		  assertTrue("Exception message incorrect - afterQuery with zero timestamp", 
+		  assertTrue(
 				  aftQueryExMsg.contains("timestamp cannot be zero") );
-	  }    
+	  }
 	  try {
 		  qd = qb.beforeQuery(0L);
 	  }
 	  catch (Exception ex) {
 		  String aftQueryExMsg = ex.getMessage();
-		  assertTrue("Exception message incorrect - beforeQuery with zero timestamp", 
+		  assertTrue(
 				  aftQueryExMsg.contains("timestamp cannot be zero") );
 	  }
 	  // Search with actual constarint1 time-stamp value
@@ -736,57 +737,57 @@ public class TestOptimisticLocking extends AbstractFunctionalTest {
 		  ex.printStackTrace();
 		  fail("afterQuery with constraint1 timestamp failed");
 	  }
-	  // create handle    
+	  // create handle
 	  JacksonHandle resultsHandle = new JacksonHandle();
 	  queryMgr.search(qd, resultsHandle);
 	  JsonNode jsRes = resultsHandle.get();
 	  System.out.println("Total from results is : " + jsRes.get("total").asText());
-	  assertEquals("After Query returned incorrect value with contraint1 timestamp", "3", jsRes.get("total").asText());
+	  assertEquals( "3", jsRes.get("total").asText());
 	  jsRes = null;
 	  resultsHandle = null;
 
 	  Instant inst = Instant.ofEpochMilli(constraint1);
 	  Instant inst2 = inst.minus(1L, ChronoUnit.DAYS);
-	 
+
 	  QueryManager queryMgr2 = client.newQueryManager();
 	  StructuredQueryBuilder qb2 = queryMgr2.newStructuredQueryBuilder();
 	  // Search with constarint1 time-stamp value minus 1 day.
-	  try {		  
+	  try {
 		  qd2 = qb2.beforeQuery(inst2.getEpochSecond() * 1000);
 	  }
 	  catch (Exception ex) {
 		  ex.printStackTrace();
 		  fail("resultsHandleBef2 with constraint1 timestamp failed");
-	  } 
+	  }
 	  JacksonHandle resultsHandleBef2 = new JacksonHandle();
 	  queryMgr2.search(qd2, resultsHandleBef2);
 	  JsonNode jsRes2 = resultsHandleBef2.get();
 	  System.out.println("Total from results is on the day before: " + jsRes2.get("total").asText());
 	  // Zero documents should be available for yesterday
-	  assertEquals("Before Query returned incorrect value with contraint1 timestamp minus 1 day", "0", jsRes2.get("total").asText());
-	  
+	  assertEquals( "0", jsRes2.get("total").asText());
+
 	  inst = Instant.ofEpochMilli(constraint3);
 	  Instant inst3 = inst.plus(1L, ChronoUnit.MINUTES);
-	  
+
 	  System.out.println("inst3 " + inst3.toString());
-	 
+
 	  QueryManager queryMgr3 = client.newQueryManager();
 	  StructuredQueryBuilder qb3 = queryMgr3.newStructuredQueryBuilder();
 	  // Search with constarint3 time-stamp value plus 1 minute.
-	  try {  
+	  try {
 		  qd3 = qb3.afterQuery(inst3.getEpochSecond() * 1000);
 	  }
 	  catch (Exception ex) {
 		  ex.printStackTrace();
 		  fail("afterQuery with constraint3 timestamp failed");
-	  } 
+	  }
 	  JacksonHandle resultsHandleBef3 = new JacksonHandle();
 	  queryMgr3.search(qd3, resultsHandleBef3);
 	  JsonNode jsRes3 = resultsHandleBef3.get();
 	  System.out.println("Total from results is : " + jsRes3.get("total").asText());
 	  // Two documents should be available for the time
-	  assertEquals("After Query returned incorrect value with contraint3 timestamp", "2", jsRes3.get("total").asText());
-	  
+	  assertEquals( "2", jsRes3.get("total").asText());
+
 	  QueryManager queryMgr4 = client.newQueryManager();
 	  StructuredQueryBuilder qb4 = queryMgr4.newStructuredQueryBuilder();
 	  // Search with constarint3 time-stamp value plus 1 minute.
@@ -796,14 +797,14 @@ public class TestOptimisticLocking extends AbstractFunctionalTest {
 	  catch (Exception ex) {
 		  ex.printStackTrace();
 		  fail("beforeQuery with constraint3 timestamp failed");
-	  } 
+	  }
 	  JacksonHandle resultsHandleBef4 = new JacksonHandle();
 	  queryMgr3.search(qd4, resultsHandleBef4);
 	  JsonNode jsRes4 = resultsHandleBef4.get();
 	  System.out.println("Total from results is : " + jsRes4.get("total").asText());
 	  // Three documents should be available for the time
-	  assertEquals("Before Query returned incorrect value with contraint3 timestamp", "3", jsRes4.get("total").asText());
-	  
+	  assertEquals( "3", jsRes4.get("total").asText());
+
 	  // Test for meta data changes. First make sure after constraint5 timestamp + 1 there are no docs. Should be zero.
 	  inst = Instant.ofEpochMilli(constraint5);
 	  Instant inst5 = inst.plus(1L, ChronoUnit.MINUTES);
@@ -813,13 +814,13 @@ public class TestOptimisticLocking extends AbstractFunctionalTest {
 	  catch (Exception ex) {
 		  ex.printStackTrace();
 		  fail("afterQuery with constraint5 timestamp failed");
-	  } 
+	  }
 	  resultsHandleBef4 = new JacksonHandle();
 	  queryMgr3.search(qd4, resultsHandleBef4);
 	  jsRes4 = resultsHandleBef4.get();
 	  System.out.println("Total from results is : " + jsRes4.get("total").asText());
 	  // Zero documents should be available for the time
-	  assertEquals("Afetr Query returned incorrect value with contraint5 timestamp", "0", jsRes4.get("total").asText());
+	  assertEquals( "0", jsRes4.get("total").asText());
 	  //Now update meta data for contraint5.xml file and see if update is reflected.
 	  DocumentMetadataPatchBuilder patchBldr = docMgr.newPatchBuilder(Format.JSON);
 	  // Adding the initial meta-data, since there are none.
@@ -833,12 +834,12 @@ public class TestOptimisticLocking extends AbstractFunctionalTest {
 	  catch (Exception ex) {
 		  ex.printStackTrace();
 		  fail("afterQuery with constraint5 timestamp failed");
-	  } 
+	  }
       resultsHandleBef4 = new JacksonHandle();
       queryMgr3.search(qd4, resultsHandleBef4);
       jsRes4 = resultsHandleBef4.get();
       System.out.println("Total from results after meta-data update is : " + jsRes4.get("total").asText());
-      assertEquals("After Query returned incorrect value with contraint5 timestamp", "1", jsRes4.get("total").asText());  
+      assertEquals( "1", jsRes4.get("total").asText());
 }
 
 }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOBasicSearch.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOBasicSearch.java
@@ -20,13 +20,14 @@ import com.marklogic.client.functionaltest.Artifact;
 import com.marklogic.client.functionaltest.Company;
 import com.marklogic.client.pojo.PojoPage;
 import com.marklogic.client.pojo.PojoRepository;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-import static org.junit.Assert.*;
+
 
 public class TestPOJOBasicSearch extends AbstractFunctionalTest {
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     client = getDatabaseClient("rest-admin", "x", getConnType());
   }
@@ -48,9 +49,9 @@ public class TestPOJOBasicSearch extends AbstractFunctionalTest {
 
   public void validateArtifact(Artifact art)
   {
-    assertNotNull("Artifact object should never be Null", art);
-    assertNotNull("Id should never be Null", art.id);
-    assertTrue("Inventry is always greater than 1000", art.getInventory() > 1000);
+    assertNotNull( art);
+    assertNotNull( art.id);
+    assertTrue( art.getInventory() > 1000);
   }
 
   // This test is to search objects under different collections, read documents
@@ -68,9 +69,9 @@ public class TestPOJOBasicSearch extends AbstractFunctionalTest {
         products.write(this.getArtifact(i), "odd", "numbers");
       }
     }
-    assertEquals("Total number of object recods", 111, products.count("numbers"));
-    assertEquals("Collection even count", 55, products.count("even"));
-    assertEquals("Collection odd count", 56, products.count("odd"));
+    assertEquals( 111, products.count("numbers"));
+    assertEquals( 55, products.count("even"));
+    assertEquals( 56, products.count("odd"));
 
     products.setPageLength(5);
     long pageNo = 1, count = 0;
@@ -80,33 +81,33 @@ public class TestPOJOBasicSearch extends AbstractFunctionalTest {
       while (p.iterator().hasNext()) {
         Artifact a = p.iterator().next();
         validateArtifact(a);
-        assertTrue("Artifact Id is even", a.getId() % 2 == 0);
+        assertTrue( a.getId() % 2 == 0);
         count++;
       }
-      assertEquals("Page size", count, p.size());
+      assertEquals( count, p.size());
       pageNo = pageNo + p.getPageSize();
     } while (!p.isLastPage() && pageNo < p.getTotalSize());
-    assertEquals("total no of pages", 11, p.getTotalPages());
+    assertEquals( 11, p.getTotalPages());
     pageNo = 1;
     do {
       count = 0;
       p = products.search(1, "odd");
       while (p.iterator().hasNext()) {
         Artifact a = p.iterator().next();
-        assertTrue("Artifact Id is even", a.getId() % 2 != 0);
+        assertTrue( a.getId() % 2 != 0);
         validateArtifact(a);
         products.delete(a.getId());
         count++;
       }
-      // assertEquals("Page size",count,p.size());
+      // assertEquals(count,p.size());
       pageNo = pageNo + p.getPageSize();
 
     } while (!p.isLastPage());
 
-    assertEquals("Total no of documents left", 55, products.count());
+    assertEquals( 55, products.count());
     products.deleteAll();
     // see any document exists
-    assertFalse("all the documents are deleted", products.exists((long) 12));
+    assertFalse( products.exists((long) 12));
   }
 
   @Test
@@ -122,56 +123,56 @@ public class TestPOJOBasicSearch extends AbstractFunctionalTest {
         products.write(this.getArtifact(i), "odd", "numbers");
       }
     }
-    assertEquals("Total number of object recods", 111, products.count("numbers"));
-    assertEquals("Collection even count", 56, products.count("even"));
-    assertEquals("Collection odd count", 55, products.count("odd"));
+    assertEquals( 111, products.count("numbers"));
+    assertEquals( 56, products.count("even"));
+    assertEquals( 55, products.count("odd"));
 
     System.out.println("Default Page length setting on docMgr :" + products.getPageLength());
-    assertEquals("Default setting for page length", 50, products.getPageLength());
+    assertEquals( 50, products.getPageLength());
     products.setPageLength(1);
-    assertEquals("explicit setting for page length", 1, products.getPageLength());
+    assertEquals( 1, products.getPageLength());
     PojoPage<Artifact> p = products.search(1, "even", "odd");
     // test for page methods
-    assertEquals("Number of records", 1, p.size());
+    assertEquals( 1, p.size());
     System.out.println("Page size" + p.size());
-    assertEquals("Starting record in first page ", 1, p.getStart());
+    assertEquals( 1, p.getStart());
     System.out.println("Starting record in first page " + p.getStart());
 
-    assertEquals("Total number of estimated results:", 111, p.getTotalSize());
+    assertEquals( 111, p.getTotalSize());
     System.out.println("Total number of estimated results:" + p.getTotalSize());
-    assertEquals("Total number of estimated pages :", 111, p.getTotalPages());
+    assertEquals( 111, p.getTotalPages());
     System.out.println("Total number of estimated pages :" + p.getTotalPages());
-    assertTrue("Is this First page :", p.isFirstPage());// this is bug
-    assertFalse("Is this Last page :", p.isLastPage());
-    assertTrue("Is this First page has content:", p.hasContent());
+    assertTrue( p.isFirstPage());// this is bug
+    assertFalse( p.isLastPage());
+    assertTrue( p.hasContent());
     // Need the Issue #75 to be fixed
-    assertFalse("Is first page has previous page ?", p.hasPreviousPage());
+    assertFalse( p.hasPreviousPage());
     long pageNo = 1, count = 0;
     do {
       count = 0;
       p = products.search(pageNo, "numbers");
 
       if (pageNo > 1) {
-        assertFalse("Is this first Page", p.isFirstPage());
-        assertTrue("Is page has previous page ?", p.hasPreviousPage());
+        assertFalse( p.isFirstPage());
+        assertTrue( p.hasPreviousPage());
       }
 
       while (p.iterator().hasNext()) {
         this.validateArtifact(p.iterator().next());
         count++;
       }
-      assertEquals("document count", p.size(), count);
+      assertEquals( p.size(), count);
 
       pageNo = pageNo + p.getPageSize();
     } while (!(p.isLastPage()) && pageNo < p.getTotalSize());
-    // assertTrue("page count is 111 ",pageNo == p.getTotalPages());
-    assertTrue("Page has previous page ?", p.hasPreviousPage());
-    assertEquals("page size", 1, p.getPageSize());
-    assertEquals("document count", 111, p.getTotalSize());
+    // assertTrue(pageNo == p.getTotalPages());
+    assertTrue( p.hasPreviousPage());
+    assertEquals( 1, p.getPageSize());
+    assertEquals( 111, p.getTotalSize());
 
     products.deleteAll();
     p = products.readAll(1);
-    assertFalse("Page has any records ?", p.hasContent());
+    assertFalse( p.hasContent());
 
   }
 }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOMissingIdGetSetMethod.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOMissingIdGetSetMethod.java
@@ -27,21 +27,19 @@ import com.marklogic.client.io.Format;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.pojo.PojoRepository;
 import com.marklogic.client.pojo.annotation.Id;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Calendar;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 /*
  * This class has test methods that check POJO's ability to read and report errors
  * (negative test cases) when the POJO class has missing @Id on its data field
  * and getter /setter methods.
- * 
+ *
  *   NOTE: If this class is renamed, then variable docId (URI) of the POJO documents needs to changed accordingly.
  *   NOTE: Also change the type value present within the json string to proper class name.
  */
@@ -159,7 +157,7 @@ public class TestPOJOMissingIdGetSetMethod extends AbstractFunctionalTest {
     }
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     client = getDatabaseClient("rest-admin", "x", getConnType());
   }
@@ -186,12 +184,12 @@ public class TestPOJOMissingIdGetSetMethod extends AbstractFunctionalTest {
    * SmallArtifactMissingGetter.
    */
   public void validateMissingArtifactGetter(SmallArtifactMissingGetter artifact) {
-    assertNotNull("Artifact object should never be Null", artifact);
-    assertNotNull("Id should never be Null", artifact.id);
-    assertEquals("Id of the object is ", -99, artifact.getId());
-    assertEquals("Name of the object is ", "SmallArtifact",
+    assertNotNull(artifact);
+    assertNotNull(artifact.id);
+    assertEquals( -99, artifact.getId());
+    assertEquals( "SmallArtifact",
         artifact.getName());
-    assertEquals("Inventory of the object is ", 1000,
+    assertEquals( 1000,
         artifact.getInventory());
   }
 
@@ -200,12 +198,12 @@ public class TestPOJOMissingIdGetSetMethod extends AbstractFunctionalTest {
    * SmallArtifactMissingSetter.
    */
   public void validateMissingArtifactSetter(SmallArtifactMissingSetter artifact, String name) {
-    assertNotNull("Artifact object should never be Null", artifact);
-    assertNotNull("Id should never be Null", artifact.id);
-    assertEquals("Id of the object is ", -99, artifact.getId());
-    assertEquals("Name of the object is ", name,
+    assertNotNull( artifact);
+    assertNotNull( artifact.id);
+    assertEquals( -99, artifact.getId());
+    assertEquals( name,
         artifact.getName());
-    assertEquals("Inventory of the object is ", 1000,
+    assertEquals( 1000,
         artifact.getInventory());
   }
 
@@ -214,12 +212,12 @@ public class TestPOJOMissingIdGetSetMethod extends AbstractFunctionalTest {
    * SmallArtifactMissGetSet.
    */
   public void validateMissingArtifactGetSet(SmallArtifactMissGetSet artifact) {
-    assertNotNull("Artifact object should never be Null", artifact);
-    assertNotNull("Id should never be Null", artifact.id);
-    assertEquals("Id of the object is ", -99, artifact.getId());
-    assertEquals("Name of the object is ", "SmallArtifact",
+    assertNotNull( artifact);
+    assertNotNull( artifact.id);
+    assertEquals( -99, artifact.getId());
+    assertEquals( "SmallArtifact",
         artifact.getName());
-    assertEquals("Inventory of the object is ", 1000,
+    assertEquals( 1000,
         artifact.getInventory());
   }
 
@@ -363,9 +361,8 @@ public class TestPOJOMissingIdGetSetMethod extends AbstractFunctionalTest {
    * with valid POJO specific URI. Uses SmallArtifactMissGetSet class which has
    * no @Id on any of its class members.
    */
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testPOJOReadMissingGetterSetter() throws KeyManagementException, NoSuchAlgorithmException, Exception {
+	@Test
+  public void testPOJOReadMissingGetterSetter() throws Exception {
 
     String docId[] = { "com.marklogic.client.functionaltest.TestPOJOMissingIdGetSetMethod$SmallArtifactMissingSetter/SmallArtifactMissGetSet.json" };
     String json1 = new String(
@@ -393,12 +390,8 @@ public class TestPOJOMissingIdGetSetMethod extends AbstractFunctionalTest {
 
     docMgr.write(writeset);
 
-    PojoRepository<SmallArtifactMissGetSet, String> pojoReposSmallArtifact = client
-        .newPojoRepository(SmallArtifactMissGetSet.class, String.class);
-    String artifactName = new String("SmallArtifact");
-
-    SmallArtifactMissGetSet artifact1 = pojoReposSmallArtifact.read(artifactName);
-    validateMissingArtifactGetSet(artifact1);
+    assertThrows(IllegalArgumentException.class, () -> client
+        .newPojoRepository(SmallArtifactMissGetSet.class, String.class));
   }
 
 }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOQueryBuilderContainerQuery.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOQueryBuilderContainerQuery.java
@@ -24,17 +24,18 @@ import com.marklogic.client.pojo.PojoQueryBuilder;
 import com.marklogic.client.pojo.PojoQueryBuilder.Operator;
 import com.marklogic.client.pojo.PojoQueryDefinition;
 import com.marklogic.client.pojo.PojoRepository;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 
-import static org.junit.Assert.*;
+
 
 public class TestPOJOQueryBuilderContainerQuery extends AbstractFunctionalTest {
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     client = getDatabaseClient("rest-admin", "x", getConnType());
 
@@ -87,9 +88,9 @@ public class TestPOJOQueryBuilderContainerQuery extends AbstractFunctionalTest {
 
   public void validateArtifact(Artifact art)
   {
-    assertNotNull("Artifact object should never be Null", art);
-    assertNotNull("Id should never be Null", art.id);
-    assertTrue("Inventry is always greater than 1000", art.getInventory() > 1000);
+    assertNotNull( art);
+    assertNotNull( art.id);
+    assertTrue( art.getInventory() > 1000);
   }
 
   public void loadSimplePojos(PojoRepository products)
@@ -116,7 +117,7 @@ public class TestPOJOQueryBuilderContainerQuery extends AbstractFunctionalTest {
     JacksonHandle jh = new JacksonHandle();
     products.setPageLength(5);
     p = products.search(qd, 1, jh);
-    assertEquals("total no of pages", 3, p.getTotalPages());
+    assertEquals( 3, p.getTotalPages());
     System.out.println(jh.get().toString());
 
     long pageNo = 1, count = 0;
@@ -126,18 +127,18 @@ public class TestPOJOQueryBuilderContainerQuery extends AbstractFunctionalTest {
       while (p.hasNext()) {
         Artifact a = p.next();
         validateArtifact(a);
-        assertTrue("Verifying document id is part of the search ids", a.getId() % 5 == 0);
-        assertTrue("Verifying Manufacurer has term counter", a.getManufacturer().getName().contains("counter"));
+        assertTrue( a.getId() % 5 == 0);
+        assertTrue( a.getManufacturer().getName().contains("counter"));
         count++;
         System.out.println(a.getManufacturer().getName());
       }
-      assertEquals("Page size", count, p.size());
+      assertEquals( count, p.size());
       pageNo = pageNo + p.getPageSize();
     } while (!p.isLastPage() && pageNo <= p.getTotalSize());
-    assertEquals("page number after the loop", 3, p.getPageNumber());
-    assertEquals("total no of pages", 3, p.getTotalPages());
-    assertEquals("page length from search handle", 5, jh.get().path("page-length").asInt());
-    assertEquals("Total results from search handle", 11, jh.get().path("total").asInt());
+    assertEquals( 3, p.getPageNumber());
+    assertEquals( 3, p.getTotalPages());
+    assertEquals( 5, jh.get().path("page-length").asInt());
+    assertEquals( 11, jh.get().path("total").asInt());
 
   }
 
@@ -156,8 +157,8 @@ public class TestPOJOQueryBuilderContainerQuery extends AbstractFunctionalTest {
     JacksonHandle jh = new JacksonHandle();
     products.setPageLength(11);
     p = products.search(qd, 1, jh);
-    assertEquals("page number after the loop", 1, p.getPageNumber());
-    // assertEquals("total no of pages",1,p.getTotalPages());
+    assertEquals( 1, p.getPageNumber());
+    // assertEquals(1,p.getTotalPages());
     long pageNo = 1, count = 0, total = 0;
     do {
       count = 0;
@@ -165,19 +166,19 @@ public class TestPOJOQueryBuilderContainerQuery extends AbstractFunctionalTest {
       while (p.hasNext()) {
         Artifact a = p.next();
         validateArtifact(a);
-        assertTrue("Verifying document id is part of the search ids", a.getId() % 5 == 0);
-        assertTrue("Verifying name is part of the search", a.getManufacturer().getName().contains("special"));
+        assertTrue( a.getId() % 5 == 0);
+        assertTrue( a.getManufacturer().getName().contains("special"));
         count++;
         total++;
         System.out.println(a.getName());
       }
-      assertEquals("Page size", count, p.size());
+      assertEquals( count, p.size());
       pageNo = pageNo + p.getPageSize();
     } while (!p.isLastPage() && pageNo <= p.getTotalSize());
-    // assertEquals("page number after the loop",2,p.getPageNumber());
-    // assertEquals("total no of pages",0,p.getTotalPages());
-    assertEquals("page length from search handle", 11, jh.get().path("page-length").asInt());
-    assertEquals("Total results from search handle", 11, total);
+    // assertEquals(2,p.getPageNumber());
+    // assertEquals(0,p.getTotalPages());
+    assertEquals( 11, jh.get().path("page-length").asInt());
+    assertEquals( 11, total);
   }
 
   // Below scenario is verifying range query from PojoBuilder
@@ -192,7 +193,7 @@ public class TestPOJOQueryBuilderContainerQuery extends AbstractFunctionalTest {
     JacksonHandle jh = new JacksonHandle();
     products.setPageLength(56);
     p = products.search(qd, 1, jh);
-    assertEquals("total no of pages", 1, p.getTotalPages());
+    assertEquals( 1, p.getTotalPages());
 
     long pageNo = 1, count = 0;
     do {
@@ -201,16 +202,16 @@ public class TestPOJOQueryBuilderContainerQuery extends AbstractFunctionalTest {
       while (p.hasNext()) {
         Artifact a = p.next();
         validateArtifact(a);
-        assertTrue("Verifying document id is part of the search ids", a.getId() >= 55);
+        assertTrue( a.getId() >= 55);
         count++;
       }
-      assertEquals("Page size", count, p.size());
+      assertEquals( count, p.size());
       pageNo = pageNo + p.getPageSize();
     } while (!p.isLastPage() && pageNo <= p.getTotalSize());
-    assertEquals("page number after the loop", 1, p.getPageNumber());
-    assertEquals("total no of pages", 1, p.getTotalPages());
-    assertEquals("page length from search handle", 56, jh.get().path("page-length").asInt());
-    assertEquals("Total results from search handle", 56, jh.get().path("total").asInt());
+    assertEquals( 1, p.getPageNumber());
+    assertEquals( 1, p.getTotalPages());
+    assertEquals( 56, jh.get().path("page-length").asInt());
+    assertEquals( 56, jh.get().path("total").asInt());
   }
 
   // Below scenario is to test range query with options
@@ -227,7 +228,7 @@ public class TestPOJOQueryBuilderContainerQuery extends AbstractFunctionalTest {
     products.setPageLength(55);
     p = products.search(qd, 1, jh);
     System.out.println(jh.get().toString());
-    assertEquals("total no of pages", 1, p.getTotalPages());
+    assertEquals( 1, p.getTotalPages());
 
     long pageNo = 1, count = 0;
     do {
@@ -236,16 +237,16 @@ public class TestPOJOQueryBuilderContainerQuery extends AbstractFunctionalTest {
       while (p.hasNext()) {
         Artifact a = p.next();
         validateArtifact(a);
-        assertTrue("Verifying document id is part of the search ids", a.getId() <= 54);
+        assertTrue( a.getId() <= 54);
         count++;
       }
-      assertEquals("Page size", count, p.size());
+      assertEquals( count, p.size());
       pageNo = pageNo + p.getPageSize();
     } while (!p.isLastPage() && pageNo <= p.getTotalSize());
-    assertEquals("page number after the loop", 1, p.getPageNumber());
-    assertEquals("total no of pages", 1, p.getTotalPages());
-    assertEquals("page length from search handle", 55, jh.get().path("page-length").asInt());
-    assertEquals("Total results from search handle", 54, jh.get().path("total").asInt());
+    assertEquals( 1, p.getPageNumber());
+    assertEquals( 1, p.getTotalPages());
+    assertEquals( 55, jh.get().path("page-length").asInt());
+    assertEquals( 54, jh.get().path("total").asInt());
   }
 
   // Below scenario is verifying and query with all pojo builder methods
@@ -275,14 +276,14 @@ public class TestPOJOQueryBuilderContainerQuery extends AbstractFunctionalTest {
       while (p.hasNext()) {
         Artifact a = p.next();
         validateArtifact(a);
-        assertTrue("Verifying document id is part of the search ids", a.getId() < 1101);
-        assertFalse("Verifying document has word counter", a.getManufacturer().getName().contains("special"));
-        assertTrue("Verifying document has Name Acme", a.getManufacturer().getName().contains("Acme"));
+        assertTrue( a.getId() < 1101);
+        assertFalse( a.getManufacturer().getName().contains("special"));
+        assertTrue( a.getManufacturer().getName().contains("Acme"));
         count++;
         total++;
 
       }
-      assertEquals("Page size", count, p.size());
+      assertEquals( count, p.size());
 
       if (p.size() <= 0) {
         System.out.println(p.getTotalSize() + " " + p.isLastPage() + "page size" + p.size());
@@ -291,10 +292,10 @@ public class TestPOJOQueryBuilderContainerQuery extends AbstractFunctionalTest {
       pageNo = pageNo + p.getPageSize();
     } while (p.size() > 0 && p.hasNextPage());
     System.out.println(pageNo);
-    assertEquals("page has results", 25, jh.get().path("results").size());
-    assertEquals("Page no after the loop", 51, pageNo);
-    assertEquals("page length from search handle", 25, jh.get().path("page-length").asInt());
-    assertEquals("Total results from search handle", 40, total);
+    assertEquals( 25, jh.get().path("results").size());
+    assertEquals( 51, pageNo);
+    assertEquals( 25, jh.get().path("page-length").asInt());
+    assertEquals( 40, total);
   }
 
 }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOQueryBuilderGeoQueries.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOQueryBuilderGeoQueries.java
@@ -23,14 +23,14 @@ import com.marklogic.client.pojo.PojoPage;
 import com.marklogic.client.pojo.PojoQueryBuilder;
 import com.marklogic.client.pojo.PojoQueryDefinition;
 import com.marklogic.client.pojo.PojoRepository;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestPOJOQueryBuilderGeoQueries extends AbstractFunctionalTest {
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     client = getDatabaseClient("rest-admin", "x", getConnType());
   }
@@ -86,9 +86,9 @@ public class TestPOJOQueryBuilderGeoQueries extends AbstractFunctionalTest {
 
   public void validateArtifact(GeoSpecialArtifact art)
   {
-    assertNotNull("Artifact object should never be Null", art);
-    assertNotNull("Id should never be Null", art.id);
-    assertTrue("Inventry is always greater than 1000", art.getInventory() > 1000);
+    assertNotNull( art);
+    assertNotNull( art.id);
+    assertTrue( art.getInventory() > 1000);
   }
 
   public void loadSimplePojos(PojoRepository products)
@@ -121,7 +121,7 @@ public class TestPOJOQueryBuilderGeoQueries extends AbstractFunctionalTest {
     products.setPageLength(5);
     p = products.search(qd, 1, jh);
     System.out.println(jh.get().toString());
-    assertEquals("total no of pages", 3, p.getTotalPages());
+    assertEquals( 3, p.getTotalPages());
     System.out.println(jh.get().toString());
 
     long pageNo = 1, count = 0;
@@ -131,17 +131,17 @@ public class TestPOJOQueryBuilderGeoQueries extends AbstractFunctionalTest {
       while (p.hasNext()) {
         GeoSpecialArtifact a = p.next();
         validateArtifact(a);
-        assertTrue("Verifying document id is part of the search ids", a.getId() % 5 == 0);
-        assertEquals("Verifying Manufacurer is from state ", "Reno", a.getManufacturer().getState());
+        assertTrue( a.getId() % 5 == 0);
+        assertEquals( "Reno", a.getManufacturer().getState());
         count++;
       }
-      assertEquals("Page size", count, p.size());
+      assertEquals( count, p.size());
       pageNo = pageNo + p.getPageSize();
     } while (!p.isLastPage() && pageNo <= p.getTotalSize());
-    assertEquals("page number after the loop", 3, p.getPageNumber());
-    assertEquals("total no of pages", 3, p.getTotalPages());
-    assertEquals("page length from search handle", 5, jh.get().path("page-length").asInt());
-    assertEquals("Total results from search handle", 11, jh.get().path("total").asInt());
+    assertEquals( 3, p.getPageNumber());
+    assertEquals( 3, p.getTotalPages());
+    assertEquals( 5, jh.get().path("page-length").asInt());
+    assertEquals( 11, jh.get().path("total").asInt());
 
   }
 
@@ -168,14 +168,14 @@ public class TestPOJOQueryBuilderGeoQueries extends AbstractFunctionalTest {
       while (p.hasNext()) {
         GeoSpecialArtifact a = p.next();
         validateArtifact(a);
-        assertTrue("Verifying document id is part of the search ids", a.getId() % 5 == 0);
-        assertEquals("Verifying Manufacurer is from state ", "Las Vegas", a.getManufacturer().getState());
+        assertTrue( a.getId() % 5 == 0);
+        assertEquals( "Las Vegas", a.getManufacturer().getState());
         count++;
       }
-      assertEquals("Page size", count, p.size());
+      assertEquals( count, p.size());
       pageNo = pageNo + p.getPageSize();
     } while (!p.isLastPage() && pageNo <= p.getTotalSize());
-    assertEquals("Total results from search handle", 5, jh.get().path("results").size());
+    assertEquals( 5, jh.get().path("results").size());
 
   }
 
@@ -195,7 +195,7 @@ public class TestPOJOQueryBuilderGeoQueries extends AbstractFunctionalTest {
     products.setPageLength(15);
     p = products.search(qd, 1, jh);
     System.out.println(jh.get().toString());
-    assertEquals("total no of pages", 3, p.getTotalPages());
+    assertEquals( 3, p.getTotalPages());
     System.out.println(jh.get().toString());
 
     long pageNo = 1, count = 0;
@@ -205,17 +205,17 @@ public class TestPOJOQueryBuilderGeoQueries extends AbstractFunctionalTest {
       while (p.hasNext()) {
         GeoSpecialArtifact a = p.next();
         validateArtifact(a);
-        assertTrue("Verifying document id is part of the search ids", a.getId() % 2 == 0);
-        assertEquals("Verifying Manufacurer is from state ", "Los Angles", a.getManufacturer().getState());
+        assertTrue( a.getId() % 2 == 0);
+        assertEquals( "Los Angles", a.getManufacturer().getState());
         count++;
       }
-      assertEquals("Page size", count, p.size());
+      assertEquals( count, p.size());
       pageNo = pageNo + p.getPageSize();
     } while (!p.isLastPage() && pageNo <= p.getTotalSize());
-    assertEquals("page number after the loop", 3, p.getPageNumber());
-    assertEquals("total no of pages", 3, p.getTotalPages());
-    assertEquals("page length from search handle", 15, jh.get().path("page-length").asInt());
-    assertEquals("Total results from search handle", 44, jh.get().path("total").asInt());
+    assertEquals( 3, p.getPageNumber());
+    assertEquals( 3, p.getTotalPages());
+    assertEquals( 15, jh.get().path("page-length").asInt());
+    assertEquals( 44, jh.get().path("total").asInt());
 
   }
 }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOQueryBuilderValueQuery.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOQueryBuilderValueQuery.java
@@ -26,29 +26,30 @@ import com.marklogic.client.pojo.PojoQueryDefinition;
 import com.marklogic.client.pojo.PojoRepository;
 import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.query.StructuredQueryDefinition;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 
-import static org.junit.Assert.*;
+
 
 public class TestPOJOQueryBuilderValueQuery extends AbstractFunctionalTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     setDatabaseProperties(DB_NAME, "trailing-wildcard-searches", false);
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     setDatabaseProperties(DB_NAME, "trailing-wildcard-searches", true);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     client = getDatabaseClient("rest-admin", "x", getConnType());
 
@@ -100,9 +101,9 @@ public class TestPOJOQueryBuilderValueQuery extends AbstractFunctionalTest {
   }
 
   public void validateArtifact(Artifact art) {
-    assertNotNull("Artifact object should never be Null", art);
-    assertNotNull("Id should never be Null", art.id);
-    assertTrue("Inventry is always greater than 1000", art.getInventory() > 1000);
+    assertNotNull( art);
+    assertNotNull( art.id);
+    assertTrue( art.getInventory() > 1000);
   }
 
   public void loadSimplePojos(PojoRepository products) {
@@ -132,7 +133,7 @@ public class TestPOJOQueryBuilderValueQuery extends AbstractFunctionalTest {
     JacksonHandle jh = new JacksonHandle();
     products.setPageLength(5);
     p = products.search(qd, 1, jh);
-    assertEquals("total no of pages", 5, p.getTotalPages());
+    assertEquals( 5, p.getTotalPages());
     System.out.println(jh.get().toString());
     long pageNo = 1, count = 0;
     do {
@@ -141,16 +142,16 @@ public class TestPOJOQueryBuilderValueQuery extends AbstractFunctionalTest {
       while (p.hasNext()) {
         Artifact a = p.next();
         validateArtifact(a);
-        assertTrue("Verifying document id is part of the search ids", a.getId() % 5 == 0);
+        assertTrue( a.getId() % 5 == 0);
         count++;
       }
-      assertEquals("Page size", count, p.size());
+      assertEquals( count, p.size());
       pageNo = pageNo + p.getPageSize();
     } while (!p.isLastPage() && pageNo < p.getTotalSize());
-    assertEquals("page number after the loop", 5, p.getPageNumber());
-    assertEquals("total no of pages", 5, p.getTotalPages());
-    assertEquals("page length from search handle", 5, jh.get().path("page-length").asInt());
-    assertEquals("Total results from search handle", 22, jh.get().path("total").asInt());
+    assertEquals( 5, p.getPageNumber());
+    assertEquals( 5, p.getTotalPages());
+    assertEquals( 5, jh.get().path("page-length").asInt());
+    assertEquals( 22, jh.get().path("total").asInt());
   }
 
   // Below scenario is to test value query with wild cards in strings
@@ -175,16 +176,16 @@ public class TestPOJOQueryBuilderValueQuery extends AbstractFunctionalTest {
       while (p.hasNext()) {
         Artifact a = p.next();
         validateArtifact(a);
-        assertTrue("Verifying document id is part of the search ids", a.getId() % 5 == 0);
-        assertTrue("Verifying document name has Acme/Wigets special",
+        assertTrue( a.getId() % 5 == 0);
+        assertTrue(
             a.getManufacturer().getName().contains("Acme special") || a.getManufacturer().getName().contains("Widgets special"));
         count++;
         System.out.println(a.getId());
       }
-      assertEquals("Page size", count, p.size());
+      assertEquals( count, p.size());
       pageNo = pageNo + p.getPageSize();
     } while (!p.isLastPage() && pageNo <= p.getTotalSize());
-    assertEquals("page length from search handle", 5, jh.get().path("results").size());
+    assertEquals( 5, jh.get().path("results").size());
   }
 
   // Below scenario is verifying value query from PojoBuilder that matches to no
@@ -205,7 +206,7 @@ public class TestPOJOQueryBuilderValueQuery extends AbstractFunctionalTest {
     p = products.search(qd, 1, jh);
     setupServerRequestLogging(client, false);
     System.out.println(jh.get().toString());
-    assertEquals("total no of pages", 0, p.getTotalPages());
+    assertEquals( 0, p.getTotalPages());
 
     long pageNo = 1, count = 0;
     do {
@@ -214,16 +215,16 @@ public class TestPOJOQueryBuilderValueQuery extends AbstractFunctionalTest {
       while (p.hasNext()) {
         Artifact a = p.next();
         validateArtifact(a);
-        assertTrue("Verifying document id is part of the search ids", a.getId() % 5 == 0);
+        assertTrue( a.getId() % 5 == 0);
         count++;
         System.out.println(a.getId());
       }
-      assertEquals("Page size", count, p.size());
+      assertEquals( count, p.size());
       pageNo = pageNo + p.getPageSize();
     } while (!p.isLastPage() && pageNo <= p.getTotalSize());
-    assertEquals("page number after the loop", 1, p.getPageNumber());
-    assertEquals("total no of pages", 0, p.getTotalPages());
-    assertEquals("page length from search handle", 5, jh.get().path("page-length").asInt());
+    assertEquals( 1, p.getPageNumber());
+    assertEquals( 0, p.getTotalPages());
+    assertEquals( 5, jh.get().path("page-length").asInt());
   }
 
   // Below scenario is to test word query without options
@@ -239,7 +240,7 @@ public class TestPOJOQueryBuilderValueQuery extends AbstractFunctionalTest {
     products.setPageLength(5);
     p = products.search(qd, 1, jh);
     System.out.println(jh.get().toString());
-    assertEquals("total no of pages", 5, p.getTotalPages());
+    assertEquals( 5, p.getTotalPages());
 
     long pageNo = 1, count = 0;
     do {
@@ -248,18 +249,18 @@ public class TestPOJOQueryBuilderValueQuery extends AbstractFunctionalTest {
       while (p.hasNext()) {
         Artifact a = p.next();
         validateArtifact(a);
-        assertTrue("Verifying document id is part of the search ids", a.getId() % 5 == 0);
-        assertTrue("Verifying document has word counter", a.getManufacturer().getName().contains("counter") || a.getManufacturer().getName().contains("special"));
+        assertTrue( a.getId() % 5 == 0);
+        assertTrue( a.getManufacturer().getName().contains("counter") || a.getManufacturer().getName().contains("special"));
         count++;
         System.out.println(a.getId());
       }
-      assertEquals("Page size", count, p.size());
+      assertEquals( count, p.size());
       pageNo = pageNo + p.getPageSize();
     } while (!p.isLastPage() && pageNo <= p.getTotalSize());
-    assertEquals("page number after the loop", 5, p.getPageNumber());
-    assertEquals("total no of pages", 5, p.getTotalPages());
-    assertEquals("page length from search handle", 5, jh.get().path("page-length").asInt());
-    assertEquals("Total results from search handle", 22, jh.get().path("total").asInt());
+    assertEquals( 5, p.getPageNumber());
+    assertEquals( 5, p.getTotalPages());
+    assertEquals( 5, jh.get().path("page-length").asInt());
+    assertEquals( 22, jh.get().path("total").asInt());
   }
 
   // Below scenario is verifying word query from PojoBuilder with options
@@ -287,16 +288,16 @@ public class TestPOJOQueryBuilderValueQuery extends AbstractFunctionalTest {
       while (p.hasNext()) {
         Artifact a = p.next();
         validateArtifact(a);
-        assertTrue("Verifying document id is part of the search ids", a.getId() % 5 == 0);
-        assertTrue("Verifying document has word counter", a.getManufacturer().getName().contains("counter"));
+        assertTrue( a.getId() % 5 == 0);
+        assertTrue( a.getManufacturer().getName().contains("counter"));
         count++;
       }
       System.out.println(jh.get().toString());
-      assertEquals("Page size", count, p.size());
+      assertEquals( count, p.size());
       pageNo = pageNo + p.getPageSize();
     } while (!p.isLastPage() && pageNo <= p.getTotalSize());
     System.out.println(p.getPageNumber());
-    assertEquals("page length from search handle", 5, jh.get().path("page-length").asInt());
+    assertEquals( 5, jh.get().path("page-length").asInt());
   }
 
   /*
@@ -315,61 +316,61 @@ public class TestPOJOQueryBuilderValueQuery extends AbstractFunctionalTest {
     PojoQueryDefinition qd1 = qb.value("name", searchOptions, 100.0, searchNames);
     long cnt1 = products.count(qd1);
     System.out.println("Count returned from PojoRepository is " + cnt1);
-    assertEquals("Number of results returned incorrect in response", 110, cnt1);
+    assertEquals( 110, cnt1);
     JacksonHandle jh = new JacksonHandle();
     products.setPageLength(5);
     p = products.search(qd1, 1, jh);
 
     JsonNode nodePos = jh.get();
     // Return 1 node - constraint2.xml
-    assertEquals("Number of results returned incorrect in response", "110", nodePos.path("total").asText());
+    assertEquals( "110", nodePos.path("total").asText());
 
     PojoQueryDefinition qd2 = qb.value("name", searchOptions, 100.0, searchNames).withCriteria("Cogs 101");
     long cnt2 = products.count(qd2);
     System.out.println("Count returned from PojoRepository is " + cnt2);
-    assertEquals("Number of results returned incorrect in response", 1, cnt2);
+    assertEquals( 1, cnt2);
 
     String[] searchNames3 = { "Cogs 101", "Cogs 110", "Cogs 3" };
     PojoQueryDefinition qd3 = qb.value("name", searchOptions, 100.0, searchNames3);
     long cnt3 = products.count(qd3);
     System.out.println("Count returned from PojoRepository is " + cnt3);
-    assertEquals("Number of results returned incorrect in response", 2, cnt3);
+    assertEquals( 2, cnt3);
 
     String[] searchNames4 = { "Cogs 3" };
     PojoQueryDefinition qd4 = qb.value("name", searchOptions, 100.0, searchNames4);
     long cnt4 = products.count(qd4);
     System.out.println("Count returned from PojoRepository is " + cnt4);
-    assertEquals("Number of results returned incorrect in response", 1, cnt4);
+    assertEquals( 1, cnt4);
 
     String[] searchNames5 = { "12345" };
     PojoQueryDefinition qd5 = qb.value("name", searchOptions, 100.0, searchNames5);
     long cnt5 = products.count(qd5);
     System.out.println("Count returned from PojoRepository is " + cnt5);
-    assertEquals("Number of results returned incorrect in response", 0, cnt5);
+    assertEquals( 0, cnt5);
 
     String[] searchNames6 = { "*" };
     PojoQueryDefinition qd6 = qb.value("name", searchOptions, 100.0, searchNames6);
     long cnt6 = products.count(qd6);
     System.out.println("Count returned from PojoRepository is " + cnt6);
-    assertEquals("Number of results returned incorrect in response", 110, cnt6);
+    assertEquals( 110, cnt6);
 
     String[] searchNames7 = { " " };
     PojoQueryDefinition qd7 = qb.value("name", searchOptions, 100.0, searchNames7);
     long cnt7 = products.count(qd7);
     System.out.println("Count returned from PojoRepository is " + cnt7);
-    assertEquals("Number of results returned incorrect in response", 0, cnt7);
+    assertEquals( 0, cnt7);
 
     String[] searchNames8 = { "" };
     PojoQueryDefinition qd8 = qb.value("name", searchOptions, 100.0, searchNames8);
     long cnt8 = products.count(qd8);
     System.out.println("Count returned from PojoRepository is " + cnt8);
-    assertEquals("Number of results returned incorrect in response", 0, cnt8);
+    assertEquals( 0, cnt8);
 
     String[] searchNames9 = { " ", "Cogs 3" };
     PojoQueryDefinition qd9 = qb.value("name", searchOptions, 100.0, searchNames9);
     long cnt9 = products.count(qd9);
     System.out.println("Count returned from PojoRepository is " + cnt9);
-    assertEquals("Number of results returned incorrect in response", 1, cnt9);
+    assertEquals( 1, cnt9);
   }
 
   /*
@@ -394,8 +395,8 @@ public class TestPOJOQueryBuilderValueQuery extends AbstractFunctionalTest {
     JsonNode nodePos = jh.get();
     System.out.println(nodePos);
     // Return 1 node - constraint2.xml
-    assertEquals("Number of results returned incorrect in response", "1", nodePos.path("total").asText());
-    assertEquals("Result returned incorrect in response", "com.marklogic.client.functionaltest.Artifact/101.json", nodePos.path("results").get(0).path("uri").asText());
+    assertEquals( "1", nodePos.path("total").asText());
+    assertEquals( "com.marklogic.client.functionaltest.Artifact/101.json", nodePos.path("results").get(0).path("uri").asText());
   }
 
   @Test
@@ -418,7 +419,7 @@ public class TestPOJOQueryBuilderValueQuery extends AbstractFunctionalTest {
 
     JsonNode nodePos = jh.get();
     // Return 1 node - constraint2.xml
-    assertEquals("Number of results returned incorrect in response", "1", nodePos.path("total").asText());
-    assertEquals("Result returned incorrect in response", "com.marklogic.client.functionaltest.Artifact/101.json", nodePos.path("results").get(0).path("uri").asText());
+    assertEquals( "1", nodePos.path("total").asText());
+    assertEquals( "com.marklogic.client.functionaltest.Artifact/101.json", nodePos.path("results").get(0).path("uri").asText());
   }
 }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOReadWrite1.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOReadWrite1.java
@@ -27,13 +27,12 @@ import com.marklogic.client.pojo.PojoQueryBuilder.Operator;
 import com.marklogic.client.pojo.PojoQueryDefinition;
 import com.marklogic.client.pojo.PojoRepository;
 import com.marklogic.client.pojo.annotation.Id;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Calendar;
 import java.util.TimeZone;
-
-import static org.junit.Assert.*;
 
 public class TestPOJOReadWrite1 extends AbstractFunctionalTest {
   Calendar calOne = null;
@@ -121,7 +120,7 @@ public class TestPOJOReadWrite1 extends AbstractFunctionalTest {
     }
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     client = getDatabaseClient("rest-admin", "x", getConnType());
   }
@@ -142,9 +141,9 @@ public class TestPOJOReadWrite1 extends AbstractFunctionalTest {
   }
 
   public void validateArtifact(Artifact art) {
-    assertNotNull("Artifact object should never be Null", art);
-    assertNotNull("Id should never be Null", art.id);
-    assertTrue("Inventry is always greater than 1000", art.getInventory() > 1000);
+    assertNotNull( art);
+    assertNotNull( art.id);
+    assertTrue( art.getInventory() > 1000);
   }
 
   // This test is to persist a simple design model objects in ML, read from ML,
@@ -157,19 +156,19 @@ public class TestPOJOReadWrite1 extends AbstractFunctionalTest {
     for (int i = 1; i < 112; i++) {
       products.write(this.getArtifact(i));
     }
-    assertEquals("Total number of object recods", 111, products.count());
+    assertEquals( 111, products.count());
     for (long i = 1; i < 112; i++) {
-      assertTrue("Product id " + i + " does not exist", products.exists(i));
+      assertTrue(products.exists(i));
       this.validateArtifact(products.read(i));
     }
     products.deleteAll();
     for (long i = 1; i < 112; i++) {
-      assertFalse("Product id exists ?", products.exists(i));
+      assertFalse(products.exists(i));
     }
   }
 
   // Issue 192 describes the use case
-  @Test(expected = ResourceNotFoundException.class)
+	@Test
   public void testPOJOReadInvalidId() {
     PojoRepository<Artifact, Long> products = client.newPojoRepository(Artifact.class, Long.class);
     products.deleteAll();
@@ -177,14 +176,9 @@ public class TestPOJOReadWrite1 extends AbstractFunctionalTest {
     for (int i = 1; i < 112; i++) {
       products.write(this.getArtifact(i));
     }
-    assertEquals("Total number of object recods", 111, products.count());
-    for (long i = 1143; i < 1193; i++) {
-      this.validateArtifact(products.read(i));
-    }
+    assertEquals( 111, products.count());
+	assertThrows(ResourceNotFoundException.class, () -> this.validateArtifact(products.read(1143l)));
     products.deleteAll();
-    for (long i = 1; i < 112; i++) {
-      assertFalse("Product id exists ?", products.exists(i));
-    }
   }
 
   // This test is to persist objects into different collections, read documents
@@ -202,20 +196,20 @@ public class TestPOJOReadWrite1 extends AbstractFunctionalTest {
         products.write(this.getArtifact(i), "odd", "numbers");
       }
     }
-    assertEquals("Total number of object recods", 110, products.count("numbers"));
-    assertEquals("Collection even count", 55, products.count("even"));
-    assertEquals("Collection odd count", 55, products.count("odd"));
+    assertEquals( 110, products.count("numbers"));
+    assertEquals( 55, products.count("even"));
+    assertEquals( 55, products.count("odd"));
     for (long i = 112; i < 222; i++) {
       // validate all the records inserted are readable
-      assertTrue("Product id " + i + " does not exist", products.exists(i));
+      assertTrue(products.exists(i));
       this.validateArtifact(products.read(i));
     }
     products.delete((long) 112);
-    assertFalse("Product id 112 exists ?", products.exists((long) 112));
+    assertFalse( products.exists((long) 112));
     products.deleteAll();
     // see any document exists
     for (long i = 112; i < 222; i++) {
-      assertFalse("Product id " + i + " exists ?", products.exists(i));
+      assertFalse(products.exists(i));
     }
     // see if it complains when there are no records
     products.delete((long) 112);
@@ -244,12 +238,12 @@ public class TestPOJOReadWrite1 extends AbstractFunctionalTest {
     }
     ids[j] = (long) 1234234;
     j++;
-    assertEquals("Total number of object recods", 111, products.count("numbers"));
-    assertEquals("Collection even count", 56, products.count("even"));
-    assertEquals("Collection odd count", 55, products.count("odd"));
+    assertEquals( 111, products.count("numbers"));
+    assertEquals( 56, products.count("even"));
+    assertEquals( 55, products.count("odd"));
 
     System.out.println("Default Page length setting on docMgr :" + products.getPageLength());
-    assertEquals("Default setting for page length", 50, products.getPageLength());
+    assertEquals( 50, products.getPageLength());
 
     PojoPage<Artifact> p = products.read(ids);
     // test for page methods
@@ -260,11 +254,11 @@ public class TestPOJOReadWrite1 extends AbstractFunctionalTest {
       this.validateArtifact(p.next());
       count++;
     }
-    assertEquals("document count", 111, count);
+    assertEquals( 111, count);
     products.deleteAll();
     // see any document exists
     for (long i = 112; i < 222; i++) {
-      assertFalse("Product id " + i + " exists ?", products.exists(i));
+      assertFalse(products.exists(i));
     }
     // see if it complains when there are no records
   }
@@ -282,63 +276,63 @@ public class TestPOJOReadWrite1 extends AbstractFunctionalTest {
         products.write(this.getArtifact(i), "odd", "numbers");
       }
     }
-    assertEquals("Total number of object recods", 111, products.count("numbers"));
-    assertEquals("Collection even count", 56, products.count("even"));
-    assertEquals("Collection odd count", 55, products.count("odd"));
+    assertEquals( 111, products.count("numbers"));
+    assertEquals( 56, products.count("even"));
+    assertEquals( 55, products.count("odd"));
 
     System.out.println("Default Page length setting on docMgr :" + products.getPageLength());
-    assertEquals("Default setting for page length", 50, products.getPageLength());
+    assertEquals( 50, products.getPageLength());
     products.setPageLength(1);
-    assertEquals("explicit setting for page length", 1, products.getPageLength());
+    assertEquals( 1, products.getPageLength());
     PojoPage<Artifact> p = products.readAll(1);
     // test for page methods
-    assertEquals("Number of records", 1, p.size());
+    assertEquals( 1, p.size());
     System.out.println("Page size" + p.size());
-    assertEquals("Starting record in first page ", 1, p.getStart());
+    assertEquals( 1, p.getStart());
     System.out.println("Starting record in first page " + p.getStart());
 
-    assertEquals("Total number of estimated results:", 111, p.getTotalSize());
+    assertEquals(111, p.getTotalSize());
     System.out.println("Total number of estimated results:" + p.getTotalSize());
-    assertEquals("Total number of estimated pages :", 111, p.getTotalPages());
+    assertEquals(111, p.getTotalPages());
     System.out.println("Total number of estimated pages :" + p.getTotalPages());
-    assertTrue("Is this First page :", p.isFirstPage());
-    assertFalse("Is this Last page :", p.isLastPage());
-    assertTrue("Is this First page has content:", p.hasContent());
+    assertTrue(p.isFirstPage());
+    assertFalse(p.isLastPage());
+    assertTrue(p.hasContent());
     // Need the Issue #75 to be fixed
-    assertFalse("Is first page has previous page ?", p.hasPreviousPage());
+    assertFalse( p.hasPreviousPage());
     long pageNo = 1, count = 0;
     do {
       count = 0;
       p = products.readAll(pageNo);
 
       if (pageNo > 1) {
-        assertFalse("Is this first Page", p.isFirstPage());
-        assertTrue("Is page has previous page ?", p.hasPreviousPage());
+        assertFalse( p.isFirstPage());
+        assertTrue( p.hasPreviousPage());
       }
 
       while (p.iterator().hasNext()) {
         this.validateArtifact(p.iterator().next());
         count++;
       }
-      assertEquals("document count", p.size(), count);
+      assertEquals( p.size(), count);
 
       pageNo = pageNo + p.getPageSize();
     } while (!(p.isLastPage()) && pageNo < p.getTotalSize());
-    assertTrue("page count is 111 ", pageNo == p.getTotalPages());
-    assertTrue("Page has previous page ?", p.hasPreviousPage());
-    assertEquals("page size", 1, p.getPageSize());
-    assertEquals("document count", 111, p.getTotalSize());
+    assertTrue( pageNo == p.getTotalPages());
+    assertTrue( p.hasPreviousPage());
+    assertEquals( 1, p.getPageSize());
+    assertEquals( 111, p.getTotalSize());
 
     products.deleteAll();
     p = products.readAll(1);
-    assertFalse("Page has any records ?", p.hasContent());
+    assertFalse( p.hasContent());
   }
 
   @Test
   public void testPOJOgetDocumentUri() {
     PojoRepository<StringPOJO, String> strPojoRepo = client.newPojoRepository(StringPOJO.class, String.class);
     StringPOJO sobj = new StringPOJO();
-    
+
     sobj.setName("StringUri");
     strPojoRepo.write(sobj);
     System.out.println(strPojoRepo.getDocumentUri(sobj));
@@ -394,7 +388,7 @@ public class TestPOJOReadWrite1 extends AbstractFunctionalTest {
     JacksonHandle jh = new JacksonHandle();
     rangeQryRepos.setPageLength(56);
     p = rangeQryRepos.search(qdEQ, 1, jh);
-    assertEquals("total no of pages", 1, p.getTotalPages());
+    assertEquals( 1, p.getTotalPages());
 
     long pageNo = 1, count = 0;
     do {
@@ -403,29 +397,29 @@ public class TestPOJOReadWrite1 extends AbstractFunctionalTest {
       while (p.hasNext()) {
         ArtifactIndexedOnCalendar a = p.next();
 
-        assertTrue("Artifact Expiry date incorrect", a.getExpiryDate().getTime().equals(calOne.getTime()));
-        assertTrue("Artifact id incorrect", a.getId() == 57);
-        assertTrue("Artifact inventory incorrect", a.getInventory() == 1057);
-        assertTrue("Artifact name incorrect", a.getName().equalsIgnoreCase("Cogs special 57"));
-        assertTrue("Artifact manufacturer latitude incorrect", a.getManufacturer().getLatitude() == 98.998);
-        assertTrue("Artifact manufacturer longitude incorrect", a.getManufacturer().getLongitude() == -30.966);
-        assertTrue("Artifact manufacturer name incorrect", a.getManufacturer().getName().equalsIgnoreCase("Acme special, Inc."));
-        assertTrue("Artifact website incorrect", a.getManufacturer().getWebsite().equalsIgnoreCase("http://www.acme special.com"));
+        assertTrue( a.getExpiryDate().getTime().equals(calOne.getTime()));
+        assertTrue( a.getId() == 57);
+        assertTrue( a.getInventory() == 1057);
+        assertTrue( a.getName().equalsIgnoreCase("Cogs special 57"));
+        assertTrue( a.getManufacturer().getLatitude() == 98.998);
+        assertTrue( a.getManufacturer().getLongitude() == -30.966);
+        assertTrue( a.getManufacturer().getName().equalsIgnoreCase("Acme special, Inc."));
+        assertTrue( a.getManufacturer().getWebsite().equalsIgnoreCase("http://www.acme special.com"));
 
         count++;
       }
-      assertEquals("Page size", count, p.size());
+      assertEquals( count, p.size());
       pageNo = pageNo + p.getPageSize();
     } while (!p.isLastPage() && pageNo <= p.getTotalSize());
-    assertEquals("page number after the loop", 1, p.getPageNumber());
-    assertEquals("total no of pages", 1, p.getTotalPages());
+    assertEquals( 1, p.getPageNumber());
+    assertEquals( 1, p.getTotalPages());
 
     // Range query on Greater than equal.
     PojoQueryDefinition qdGE = qb.range("expiryDate", Operator.GE, calTwo);
     JacksonHandle jhGE = new JacksonHandle();
 
     p = rangeQryRepos.search(qdGE, 1, jhGE);
-    assertEquals("total no of pages", 1, p.getTotalPages());
+    assertEquals( 1, p.getTotalPages());
 
     pageNo = 1;
     count = 0;
@@ -437,13 +431,13 @@ public class TestPOJOReadWrite1 extends AbstractFunctionalTest {
         ArtifactIndexedOnCalendar a = p.next();
 
         if (a.getId() == 97) {
-          assertTrue("Expiry date incorrect", a.getExpiryDate().getTime().equals(calTwo.getTime()));
-          assertTrue("Artifact inventory incorrect", a.getInventory() == 1097);
-          assertTrue("Artifact name incorrect", a.getName().equalsIgnoreCase("Cogs special 97"));
-          assertTrue("Artifact manufacturer latitude incorrect", a.getManufacturer().getLatitude() == 138.998);
-          assertTrue("Artifact manufacturer longitude incorrect", a.getManufacturer().getLongitude() == 9.03400000000001);
-          assertTrue("Artifact manufacturer name incorrect", a.getManufacturer().getName().equalsIgnoreCase("Acme special, Inc."));
-          assertTrue("Artifact website incorrect incorrect", a.getManufacturer().getWebsite().equalsIgnoreCase("http://www.acme special.com"));
+          assertTrue( a.getExpiryDate().getTime().equals(calTwo.getTime()));
+          assertTrue( a.getInventory() == 1097);
+          assertTrue( a.getName().equalsIgnoreCase("Cogs special 97"));
+          assertTrue( a.getManufacturer().getLatitude() == 138.998);
+          assertTrue( a.getManufacturer().getLongitude() == 9.03400000000001);
+          assertTrue( a.getManufacturer().getName().equalsIgnoreCase("Acme special, Inc."));
+          assertTrue( a.getManufacturer().getWebsite().equalsIgnoreCase("http://www.acme special.com"));
 
           bFound = true;
         }
@@ -453,19 +447,19 @@ public class TestPOJOReadWrite1 extends AbstractFunctionalTest {
       if (!bFound) {
         fail("Range Query on Calendar type failed when greater than or equal used.");
       }
-      assertEquals("Number of rows returned count should be 14", 14, count);
-      assertEquals("Page size", count, p.size());
+      assertEquals( 14, count);
+      assertEquals( count, p.size());
       pageNo = pageNo + p.getPageSize();
     } while (!p.isLastPage() && pageNo <= p.getTotalSize());
-    assertEquals("page number after the loop", 1, p.getPageNumber());
-    assertEquals("total no of pages", 1, p.getTotalPages());
+    assertEquals( 1, p.getPageNumber());
+    assertEquals( 1, p.getTotalPages());
 
     // Range query on Greater than. count should be 1 less than previous count.
     PojoQueryDefinition qdGT = qb.range("expiryDate", Operator.GT, calTwo);
     JacksonHandle jhGT = new JacksonHandle();
 
     p = rangeQryRepos.search(qdGT, 1, jhGT);
-    assertEquals("total no of pages", 1, p.getTotalPages());
+    assertEquals( 1, p.getTotalPages());
 
     pageNo = 1;
     count = 0;
@@ -482,12 +476,12 @@ public class TestPOJOReadWrite1 extends AbstractFunctionalTest {
         count++;
       }
 
-      assertEquals("Number of rows returned count should be 13", 13, count);
-      assertEquals("Page size", count, p.size());
+      assertEquals( 13, count);
+      assertEquals( count, p.size());
       pageNo = pageNo + p.getPageSize();
     } while (!p.isLastPage() && pageNo <= p.getTotalSize());
-    assertEquals("page number after the loop", 1, p.getPageNumber());
-    assertEquals("total no of pages", 1, p.getTotalPages());
+    assertEquals( 1, p.getPageNumber());
+    assertEquals( 1, p.getTotalPages());
   }
 
   public void loadSimplePojos(PojoRepository rangeQueryRepos) {

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOReadWriteWithTransactions.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOReadWriteWithTransactions.java
@@ -24,32 +24,32 @@ import com.marklogic.client.pojo.PojoPage;
 import com.marklogic.client.pojo.PojoRepository;
 import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.query.StringQueryDefinition;
-import org.junit.*;
-import org.junit.runners.MethodSorters;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.*;
 
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Iterator;
 
-import static org.junit.Assert.*;
 
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+
+@TestMethodOrder(MethodOrderer.MethodName.class)
 public class TestPOJOReadWriteWithTransactions extends AbstractFunctionalTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpBeforeClass() throws Exception {
     createUserRolesWithPrevilages("pojoRole", "xdmp:eval", "xdmp:eval-in", "xdbc:eval", "xdbc:eval-in", "any-uri", "xdbc:invoke", "xdbc:invoke-in", "xdmp:invoke", "xdmp:invoke-in");
     createRESTUser("pojoUser", "pojoUser", "tde-admin", "tde-view", "pojoRole", "rest-admin", "rest-writer",
             "rest-reader", "rest-extension-user", "manage-user", "query-view-admin");
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownAfterClass() throws Exception {
     deleteUserRole("pojoRole");
     deleteRESTUser("pojoUser");
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     client = getDatabaseClient("pojoUser", "pojoUser", getConnType());
   }
@@ -71,9 +71,9 @@ public class TestPOJOReadWriteWithTransactions extends AbstractFunctionalTest {
 
   public void validateArtifact(Artifact art)
   {
-    assertNotNull("Artifact object should never be Null", art);
-    assertNotNull("Id should never be Null", art.id);
-    assertTrue("Inventry is always greater than 1000", art.getInventory() > 1000);
+    assertNotNull( art);
+    assertNotNull( art.id);
+    assertTrue( art.getInventory() > 1000);
   }
 
   // This test is to persist a simple design model objects in ML, read from ML,
@@ -88,9 +88,9 @@ public class TestPOJOReadWriteWithTransactions extends AbstractFunctionalTest {
       for (int i = 1; i < 112; i++) {
         products.write(this.getArtifact(i), t);
       }
-      assertEquals("Total number of object recods", 111, products.count(t));
+      assertEquals( 111, products.count(t));
       for (long i = 1; i < 112; i++) {
-        assertTrue("Product id " + i + " does not exist", products.exists(i, t));
+        assertTrue(products.exists(i, t));
         this.validateArtifact(products.read(i, t));
       }
 
@@ -101,7 +101,7 @@ public class TestPOJOReadWriteWithTransactions extends AbstractFunctionalTest {
     }
 
     for (long i = 1; i < 112; i++) {
-      assertFalse("Product id exists ?", products.exists(i));
+      assertFalse( products.exists(i));
     }
   }
 
@@ -126,23 +126,23 @@ public class TestPOJOReadWriteWithTransactions extends AbstractFunctionalTest {
     } finally {
       t.commit();
     }
-    assertEquals("Total number of object recods", 110, products.count("numbers"));
-    assertEquals("Collection even count", 55, products.count("even"));
-    assertEquals("Collection odd count", 55, products.count("odd"));
+    assertEquals( 110, products.count("numbers"));
+    assertEquals( 55, products.count("even"));
+    assertEquals( 55, products.count("odd"));
     for (long i = 112; i < 222; i++) {
       // validate all the records inserted are readable
-      assertTrue("Product id " + i + " does not exist", products.exists(i));
+      assertTrue(products.exists(i));
       this.validateArtifact(products.read(i));
     }
     Transaction t2 = client.openTransaction();
     try {
       Long[] ids = { (long) 112, (long) 113 };
       products.delete(ids, t2);
-      assertFalse("Product id 112 exists ?", products.exists((long) 112, t2));
-      // assertTrue("Product id 112 exists ?",products.exists((long)112));
+      assertFalse( products.exists((long) 112, t2));
+      // assertTrue(products.exists((long)112));
       products.deleteAll(t2);
       for (long i = 112; i < 222; i++) {
-        assertFalse("Product id " + i + " exists ?", products.exists(i, t2));
+        assertFalse(products.exists(i, t2));
         // assertTrue("Product id "+i+" exists ?",products.exists(i));
       }
     } catch (Exception e) {
@@ -152,7 +152,7 @@ public class TestPOJOReadWriteWithTransactions extends AbstractFunctionalTest {
     }
     // see any document exists
     for (long i = 112; i < 222; i++) {
-      assertFalse("Product id " + i + " exists ?", products.exists(i));
+      assertFalse(products.exists(i));
     }
     // see if it complains when there are no records
     products.delete((long) 112);
@@ -178,57 +178,57 @@ public class TestPOJOReadWriteWithTransactions extends AbstractFunctionalTest {
         products.write(this.getArtifact(i), "odd", "numbers");
       }
     }
-    assertEquals("Total number of object recods", 111, products.count("numbers"));
-    assertEquals("Collection even count", 56, products.count("even"));
-    assertEquals("Collection odd count", 55, products.count("odd"));
+    assertEquals( 111, products.count("numbers"));
+    assertEquals( 56, products.count("even"));
+    assertEquals( 55, products.count("odd"));
 
     System.out.println("Default Page length setting on docMgr :" + products.getPageLength());
-    assertEquals("Default setting for page length", 50, products.getPageLength());
+    assertEquals( 50, products.getPageLength());
     products.setPageLength(100);
-    assertEquals("explicit setting for page length", 100, products.getPageLength());
+    assertEquals( 100, products.getPageLength());
     PojoPage<Artifact> p = products.search(1, "numbers");
     // test for page methods
-    assertEquals("Number of records", 100, p.size());
+    assertEquals( 100, p.size());
     // System.out.println("Page size"+p.size());
-    assertEquals("Starting record in first page ", 1, p.getStart());
+    assertEquals( 1, p.getStart());
     // System.out.println("Starting record in first page "+p.getStart());
 
-    assertEquals("Total number of estimated results:", 111, p.getTotalSize());
+    assertEquals( 111, p.getTotalSize());
     // System.out.println("Total number of estimated results:"+p.getTotalSize());
-    assertEquals("Total number of estimated pages :", 2, p.getTotalPages());
+    assertEquals( 2, p.getTotalPages());
     // System.out.println("Total number of estimated pages :"+p.getTotalPages());
     System.out.println("is this firstPage or LastPage:" + p.isFirstPage() + "  " + p.isLastPage() + "has  previous page" + p.hasPreviousPage());
-    assertTrue("Is this First page :", p.isFirstPage());// this is bug
-    assertFalse("Is this Last page :", p.isLastPage());
-    assertTrue("Is this First page has content:", p.hasContent());
+    assertTrue( p.isFirstPage());// this is bug
+    assertFalse( p.isLastPage());
+    assertTrue( p.hasContent());
     // Need the Issue #75 to be fixed
-    assertFalse("Is first page has previous page ?", p.hasPreviousPage());
+    assertFalse( p.hasPreviousPage());
     long pageNo = 1, count = 0;
     do {
       count = 0;
       p = products.search(pageNo, "numbers");
       if (pageNo > 1) {
-        assertFalse("Is this first Page", p.isFirstPage());
-        assertTrue("Is page has previous page ?", p.hasPreviousPage());
+        assertFalse( p.isFirstPage());
+        assertTrue( p.hasPreviousPage());
       }
       Iterator<Artifact> itr = p.iterator();
       while (itr.hasNext()) {
         this.validateArtifact(p.iterator().next());
         count++;
       }
-      // assertEquals("document count", p.size(),count);
+      // assertEquals( p.size(),count);
       System.out.println("Is this Last page :" + p.hasContent() + p.isLastPage() + p.getPageNumber());
       pageNo = pageNo + p.getPageSize();
     } while (pageNo < p.getTotalSize());
-    assertTrue("Page has previous page ?", p.hasPreviousPage());
-    assertEquals("page size", 11, p.size());
-    assertEquals("document count", 111, p.getTotalSize());
-    assertTrue("Page has any records ?", p.hasContent());
+    assertTrue( p.hasPreviousPage());
+    assertEquals( 11, p.size());
+    assertEquals( 111, p.getTotalSize());
+    assertTrue( p.hasContent());
 
     products.deleteAll();
     // see any document exists
     for (long i = 112; i < 222; i++) {
-      assertFalse("Product id " + i + " exists ?", products.exists(i));
+      assertFalse(products.exists(i));
     }
     // see if it complains when there are no records
   }
@@ -252,54 +252,54 @@ public class TestPOJOReadWriteWithTransactions extends AbstractFunctionalTest {
       }
 
       // System.out.println("Default Page length setting on docMgr :"+products.getPageLength());
-      assertEquals("Default setting for page length", 50, products.getPageLength());
+      assertEquals( 50, products.getPageLength());
       products.setPageLength(25);
-      assertEquals("explicit setting for page length", 25, products.getPageLength());
+      assertEquals( 25, products.getPageLength());
       p = products.readAll(1, t);
       // test for page methods
-      assertEquals("Number of records", 25, p.size());
+      assertEquals( 25, p.size());
       System.out.println("Page size" + p.size());
-      assertEquals("Starting record in first page ", 1, p.getStart());
+      assertEquals( 1, p.getStart());
       System.out.println("Starting record in first page " + p.getStart());
 
-      assertEquals("Total number of estimated results:", 111, p.getTotalSize());
+      assertEquals( 111, p.getTotalSize());
       System.out.println("Total number of estimated results:" + p.getTotalSize());
-      assertEquals("Total number of estimated pages :", 5, p.getTotalPages());
+      assertEquals( 5, p.getTotalPages());
       System.out.println("Total number of estimated pages :" + p.getTotalPages());
-      assertTrue("Is this First page :", p.isFirstPage());
-      assertFalse("Is this Last page :", p.isLastPage());
-      assertTrue("Is this First page has content:", p.hasContent());
+      assertTrue( p.isFirstPage());
+      assertFalse( p.isLastPage());
+      assertTrue( p.hasContent());
       // Need the Issue #75 to be fixed
-      assertFalse("Is first page has previous page ?", p.hasPreviousPage());
+      assertFalse( p.hasPreviousPage());
       long pageNo = 1, count = 0;
       do {
         count = 0;
         p = products.readAll(pageNo, t);
 
         if (pageNo > 1) {
-          assertFalse("Is this first Page", p.isFirstPage());
-          assertTrue("Is page has previous page ?", p.hasPreviousPage());
+          assertFalse( p.isFirstPage());
+          assertTrue( p.hasPreviousPage());
         }
 
         while (p.iterator().hasNext()) {
           this.validateArtifact(p.iterator().next());
           count++;
         }
-        assertEquals("document count", p.size(), count);
+        assertEquals( p.size(), count);
 
         pageNo = pageNo + p.getPageSize();
       } while (!(p.isLastPage()) && pageNo < p.getTotalSize());
 
-      assertTrue("Page has previous page ?", p.hasPreviousPage());
-      assertEquals("page size", 11, p.size());
-      assertEquals("document count", 111, p.getTotalSize());
+      assertTrue( p.hasPreviousPage());
+      assertEquals( 11, p.size());
+      assertEquals( 111, p.getTotalSize());
     } catch (Exception e) {
       throw e;
     } finally {
       t.rollback();
     }
     p = products.readAll(1);
-    assertFalse("Page has any records ?", p.hasContent());
+    assertFalse( p.hasContent());
 
   }
 
@@ -319,9 +319,9 @@ public class TestPOJOReadWriteWithTransactions extends AbstractFunctionalTest {
           products.write(this.getArtifact(i), "odd", "numbers");
         }
       }
-      assertEquals("Total number of object recods", 56, products.count("numbers"));
-      assertEquals("Collection even count", 0, products.count("even"));
-      assertEquals("Collection odd count", 56, products.count("odd"));
+      assertEquals( 56, products.count("numbers"));
+      assertEquals( 0, products.count("even"));
+      assertEquals( 56, products.count("odd"));
 
       products.setPageLength(10);
       long pageNo = 1, count = 0;
@@ -331,26 +331,26 @@ public class TestPOJOReadWriteWithTransactions extends AbstractFunctionalTest {
         while (p.iterator().hasNext()) {
           Artifact a = p.iterator().next();
           validateArtifact(a);
-          assertTrue("Artifact Id is even", a.getId() % 2 == 0);
+          assertTrue( a.getId() % 2 == 0);
           count++;
         }
-        assertEquals("Page size", count, p.size());
+        assertEquals( count, p.size());
         pageNo = pageNo + p.getPageSize();
       } while (!p.isLastPage() && pageNo < p.getTotalSize());
-      assertEquals("total no of pages", 0, p.getTotalPages());
+      assertEquals( 0, p.getTotalPages());
       do {
         count = 0;
         p = products.search(pageNo, t, "even");
         while (p.iterator().hasNext()) {
           Artifact a = p.iterator().next();
           validateArtifact(a);
-          assertTrue("Artifact Id is even", a.getId() % 2 == 0);
+          assertTrue( a.getId() % 2 == 0);
           count++;
         }
-        assertEquals("Page size", count, p.size());
+        assertEquals( count, p.size());
         pageNo = pageNo + p.getPageSize();
       } while (!p.isLastPage() && pageNo < p.getTotalSize());
-      assertEquals("total no of pages", 6, p.getTotalPages());
+      assertEquals( 6, p.getTotalPages());
 
       pageNo = 1;
       do {
@@ -358,24 +358,24 @@ public class TestPOJOReadWriteWithTransactions extends AbstractFunctionalTest {
         p = products.search(1, t, "odd");
         while (p.iterator().hasNext()) {
           Artifact a = p.iterator().next();
-          assertTrue("Artifact Id is even", a.getId() % 2 != 0);
+          assertTrue( a.getId() % 2 != 0);
           validateArtifact(a);
           products.delete(a.getId());
           count++;
         }
-        // assertEquals("Page size",count,p.size());
+        // assertEquals(count,p.size());
         pageNo = pageNo + p.getPageSize();
 
       } while (!p.isLastPage());
 
-      assertEquals("Total no of documents left", 0, products.count());
+      assertEquals( 0, products.count());
     } catch (Exception e) {
       throw e;
     } finally {
       t.rollback();
     }
     // see any document exists
-    assertFalse("all the documents are deleted", products.exists((long) 12));
+    assertFalse( products.exists((long) 12));
   }
 
   @Test
@@ -394,9 +394,9 @@ public class TestPOJOReadWriteWithTransactions extends AbstractFunctionalTest {
           products.write(this.getArtifact(i), "odd", "numbers");
         }
       }
-      assertEquals("Total number of object recods", 56, products.count("numbers"));
-      assertEquals("Collection even count", 0, products.count("even"));
-      assertEquals("Collection odd count", 56, products.count("odd"));
+      assertEquals( 56, products.count("numbers"));
+      assertEquals( 0, products.count("even"));
+      assertEquals( 56, products.count("odd"));
 
       products.setPageLength(10);
       QueryManager queryMgr = client.newQueryManager();
@@ -411,10 +411,10 @@ public class TestPOJOReadWriteWithTransactions extends AbstractFunctionalTest {
           validateArtifact(a);
           count++;
         }
-        assertEquals("Page size", count, p.size());
+        assertEquals( count, p.size());
         pageNo = pageNo + p.getPageSize();
       } while (!p.isLastPage() && pageNo < p.getTotalSize());
-      assertEquals("total no of pages", 6, p.getTotalPages());
+      assertEquals( 6, p.getTotalPages());
       do {
         count = 0;
         p = products.search(qd, pageNo, t);
@@ -423,10 +423,10 @@ public class TestPOJOReadWriteWithTransactions extends AbstractFunctionalTest {
           validateArtifact(a);
           count++;
         }
-        assertEquals("Page size", count, p.size());
+        assertEquals( count, p.size());
         pageNo = pageNo + p.getPageSize();
       } while (!p.isLastPage() && pageNo < p.getTotalSize());
-      assertEquals("total no of pages", 12, p.getTotalPages());
+      assertEquals( 12, p.getTotalPages());
       SearchHandle results = new SearchHandle();
       pageNo = 1;
       do {
@@ -438,19 +438,19 @@ public class TestPOJOReadWriteWithTransactions extends AbstractFunctionalTest {
           // products.delete(a.getId());
           count++;
         }
-        assertEquals("Page size", count, p.size());
+        assertEquals( count, p.size());
         pageNo = pageNo + p.getPageSize();
 
       } while (!p.isLastPage());
       System.out.println(results.getTotalResults());
-      assertEquals("Total no of documents ", 56, products.count());
+      assertEquals( 56, products.count());
     } catch (Exception e) {
       throw e;
     } finally {
       t.rollback();
     }
     // see any document exists
-    assertFalse("all the documents are deleted", products.exists((long) 12));
+    assertFalse( products.exists((long) 12));
   }
 
 }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOSpecialCharRead.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOSpecialCharRead.java
@@ -23,13 +23,11 @@ import com.marklogic.client.pojo.PojoPage;
 import com.marklogic.client.pojo.PojoRepository;
 import com.marklogic.client.pojo.annotation.Id;
 import com.marklogic.client.query.StringQueryDefinition;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Arrays;
 import java.util.Iterator;
-
-import static org.junit.Assert.*;
 
 /*
  * Purpose : To test the following special cases for PojoRepository class methods
@@ -195,7 +193,7 @@ public class TestPOJOSpecialCharRead extends AbstractFunctionalTest {
     }
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     client = getDatabaseClient("rest-admin", "x", getConnType());
   }
@@ -326,13 +324,13 @@ public class TestPOJOSpecialCharRead extends AbstractFunctionalTest {
    * This method is used when there is a need to validate one read and search.
    */
   public void validateArtifact(Artifact artifact, long longId) {
-    assertNotNull("Artifact object should never be Null", artifact);
-    assertNotNull("Id should never be Null", artifact.id);
-    assertEquals("Id of the object is ", longId, artifact.getId());
-    assertEquals("Name of the object is ", "Cogs", artifact.getName());
-    assertEquals("Inventory of the object is ", 1000, artifact.getInventory());
-    assertEquals("Company name of the object is ", "Acme Inc.", artifact.getManufacturer().getName());
-    assertEquals("Web site of the object is ", "http://www.acme.com", artifact.getManufacturer().getWebsite());
+    assertNotNull( artifact);
+    assertNotNull( artifact.id);
+    assertEquals( longId, artifact.getId());
+    assertEquals( "Cogs", artifact.getName());
+    assertEquals( 1000, artifact.getInventory());
+    assertEquals( "Acme Inc.", artifact.getManufacturer().getName());
+    assertEquals( "http://www.acme.com", artifact.getManufacturer().getWebsite());
     assertEquals(-87.966, artifact.getManufacturer().getLongitude(), 0.00);
     assertEquals(41.998, artifact.getManufacturer().getLatitude(), 0.00);
   }
@@ -342,13 +340,13 @@ public class TestPOJOSpecialCharRead extends AbstractFunctionalTest {
    * with default Id field value. Verify that artifact.getId() returns 0L.
    */
   public void validateArtifactWithDefault(Artifact artifact) {
-    assertNotNull("Artifact object should never be Null", artifact);
-    assertNotNull("Id should never be Null", artifact.id);
-    assertEquals("Id of the object is ", 0, artifact.getId());
-    assertEquals("Name of the object is ", "Cogs", artifact.getName());
-    assertEquals("Inventory of the object is ", 1000, artifact.getInventory());
-    assertEquals("Company name of the object is ", "Acme Inc.", artifact.getManufacturer().getName());
-    assertEquals("Web site of the object is ", "http://www.acme.com", artifact.getManufacturer().getWebsite());
+    assertNotNull( artifact);
+    assertNotNull( artifact.id);
+    assertEquals( 0, artifact.getId());
+    assertEquals( "Cogs", artifact.getName());
+    assertEquals( 1000, artifact.getInventory());
+    assertEquals( "Acme Inc.", artifact.getManufacturer().getName());
+    assertEquals( "http://www.acme.com", artifact.getManufacturer().getWebsite());
     assertEquals(-87.966, artifact.getManufacturer().getLongitude(), 0.00);
     assertEquals(41.998, artifact.getManufacturer().getLatitude(), 0.00);
   }
@@ -359,11 +357,11 @@ public class TestPOJOSpecialCharRead extends AbstractFunctionalTest {
    * that has some parts not yet created/defined etc..
    */
   public void validateArtifactWithNull(Artifact artifact, long longId) {
-    assertNotNull("Artifact object should never be Null", artifact);
-    assertNotNull("Id should never be Null", artifact.id);
-    assertEquals("Id of the object is ", longId, artifact.getId());
-    assertEquals("Name of the object is ", "Cogs", artifact.getName());
-    assertEquals("Inventory of the object is ", 1000, artifact.getInventory());
+    assertNotNull( artifact);
+    assertNotNull( artifact.id);
+    assertEquals( longId, artifact.getId());
+    assertEquals( "Cogs", artifact.getName());
+    assertEquals( 1000, artifact.getInventory());
     assertNull(artifact.getManufacturer());
   }
 
@@ -372,13 +370,13 @@ public class TestPOJOSpecialCharRead extends AbstractFunctionalTest {
    * with special characters in SpecialArtifact Name field.
    */
   public void validateSpecialArtifactWithSpecialCharacter(SpecialArtifact artifact, String artifactName, long longId) {
-    assertNotNull("Artifact object should never be Null", artifact);
-    assertNotNull("Id should never be Null", artifact.id);
-    assertEquals("Id of the object is ", longId, artifact.getId());
-    assertEquals("Name of the object is ", artifactName, artifact.getName());
-    assertEquals("Inventory of the object is ", 1000, artifact.getInventory());
-    assertEquals("Company name of the object is ", artifactName, artifact.getManufacturer().getName());
-    assertEquals("Web site of the object is ", "http://www.acme.com", artifact.getManufacturer().getWebsite());
+    assertNotNull( artifact);
+    assertNotNull( artifact.id);
+    assertEquals( longId, artifact.getId());
+    assertEquals( artifactName, artifact.getName());
+    assertEquals( 1000, artifact.getInventory());
+    assertEquals( artifactName, artifact.getManufacturer().getName());
+    assertEquals( "http://www.acme.com", artifact.getManufacturer().getWebsite());
     assertEquals(-87.966, artifact.getManufacturer().getLongitude(), 0.00);
     assertEquals(41.998, artifact.getManufacturer().getLatitude(), 0.00);
   }
@@ -388,13 +386,13 @@ public class TestPOJOSpecialCharRead extends AbstractFunctionalTest {
    * with special characters in SpArtifactWithGetSetId Name field.
    */
   public void validateSpArtifactWithSpecialCharacter(SpArtifactWithGetSetId artifact, String artifactName, long longId) {
-    assertNotNull("Artifact object should never be Null", artifact);
-    assertNotNull("Id should never be Null", artifact.id);
-    assertEquals("Id of the object is ", longId, artifact.getId());
-    assertEquals("Name of the object is ", artifactName, artifact.getName());
-    assertEquals("Inventory of the object is ", 1000, artifact.getInventory());
-    assertEquals("Company name of the object is ", artifactName, artifact.getManufacturer().getName());
-    assertEquals("Web site of the object is ", "http://www.acme.com", artifact.getManufacturer().getWebsite());
+    assertNotNull( artifact);
+    assertNotNull( artifact.id);
+    assertEquals( longId, artifact.getId());
+    assertEquals( artifactName, artifact.getName());
+    assertEquals( 1000, artifact.getInventory());
+    assertEquals( artifactName, artifact.getManufacturer().getName());
+    assertEquals( "http://www.acme.com", artifact.getManufacturer().getWebsite());
     assertEquals(-87.966, artifact.getManufacturer().getLongitude(), 0.00);
     assertEquals(41.998, artifact.getManufacturer().getLatitude(), 0.00);
   }
@@ -404,13 +402,13 @@ public class TestPOJOSpecialCharRead extends AbstractFunctionalTest {
    * searches.
    */
   public void validateArtifactTwo(Artifact artifact, long longId) {
-    assertNotNull("Artifact object should never be Null", artifact);
-    assertNotNull("Id should never be Null", artifact.id);
-    assertEquals("Id of the object is ", longId, artifact.getId());
-    assertEquals("Name of the object is ", "Cogs", artifact.getName());
-    assertEquals("Inventory of the object is ", 1000, artifact.getInventory());
-    assertEquals("Company name of the object is ", "Acme Inc.", artifact.getManufacturer().getName());
-    assertEquals("Web site of the object is ", "http://www.acme.com", artifact.getManufacturer().getWebsite());
+    assertNotNull( artifact);
+    assertNotNull( artifact.id);
+    assertEquals( longId, artifact.getId());
+    assertEquals( "Cogs", artifact.getName());
+    assertEquals( 1000, artifact.getInventory());
+    assertEquals( "Acme Inc.", artifact.getManufacturer().getName());
+    assertEquals( "http://www.acme.com", artifact.getManufacturer().getWebsite());
     assertEquals(-87.966, artifact.getManufacturer().getLongitude(), 0.00);
     assertEquals(41.998, artifact.getManufacturer().getLatitude(), 0.00);
   }
@@ -420,10 +418,10 @@ public class TestPOJOSpecialCharRead extends AbstractFunctionalTest {
    * @Id on id field.
    */
   public void validateByteArray(ByteArrayId artifact, byte[] arrayOrig, byte bTest) {
-    assertNotNull("Artifact object should never be Null", artifact);
-    assertNotNull("Id should never be Null", artifact.id);
+    assertNotNull( artifact);
+    assertNotNull( artifact.id);
     assertTrue(Arrays.equals(artifact.getByteName(), arrayOrig));
-    assertEquals("Id of the object is ", bTest, artifact.getId());
+    assertEquals( bTest, artifact.getId());
   }
 
   /*
@@ -431,10 +429,10 @@ public class TestPOJOSpecialCharRead extends AbstractFunctionalTest {
    * @Id on a byte[] array class member.
    */
   public void validateAnnotatedByteArray(AnnotateByteArray artifact, byte[] arrayOrig, byte bTest) {
-    assertNotNull("Artifact object should never be Null", artifact);
-    assertNotNull("Id should never be Null", artifact.id);
+    assertNotNull( artifact);
+    assertNotNull( artifact.id);
     assertTrue(Arrays.equals(artifact.getByteName(), arrayOrig));
-    assertEquals("Id of the object is ", bTest, artifact.getId());
+    assertEquals( bTest, artifact.getId());
   }
 
   /*
@@ -475,8 +473,7 @@ public class TestPOJOSpecialCharRead extends AbstractFunctionalTest {
    * instance @Id field value with Negative numbers. Expect
    * ResourceNotFoundException when there are no URI found. As per Git # 188.
    */
-
-  @Test(expected = ResourceNotFoundException.class)
+	@Test
   public void testPOJORepoDeleteWithNegativeId() {
     PojoRepository<Artifact, Long> pojoReposProducts = client.newPojoRepository(Artifact.class, Long.class);
 
@@ -486,11 +483,7 @@ public class TestPOJOSpecialCharRead extends AbstractFunctionalTest {
 
     // Delete the object
     pojoReposProducts.delete(longId);
-
-    // Validate the artifact read back. ResourceNotFoundException will be
-    // thrown.
-    @SuppressWarnings("unused")
-    Artifact artifact = pojoReposProducts.read(longId);
+    assertThrows(ResourceNotFoundException.class, () -> pojoReposProducts.read(longId));
   }
 
   /*
@@ -516,13 +509,13 @@ public class TestPOJOSpecialCharRead extends AbstractFunctionalTest {
     // Validate the artifacts read back.
     pojoArtifactPage = pojoReposProducts.read(pojoReposProductsIdLongArray);
 
-    assertEquals("The count of items in this page ", 2, pojoArtifactPage.size());
+    assertEquals( 2, pojoArtifactPage.size());
 
     pojoReposProducts.delete(longId1, longId2);
 
     pojoArtifactPage = pojoReposProducts.read(pojoReposProductsIdLongArray);
 
-    assertEquals("The count of items in this page ", 0, pojoArtifactPage.size());
+    assertEquals( 0, pojoArtifactPage.size());
 
     System.out.println("The count of items in this page " + pojoArtifactPage.size());
 
@@ -554,22 +547,22 @@ public class TestPOJOSpecialCharRead extends AbstractFunctionalTest {
     pojoArtifactPage = pojoReposProducts.read(pojoReposProductsIdLongArray);
 
     System.out.println("The count of items in this page " + pojoArtifactPage.size());
-    assertEquals("The count of items in this page ", 2, pojoArtifactPage.size());
+    assertEquals( 2, pojoArtifactPage.size());
 
     System.out.println("The number of pages covering all possible items " + pojoArtifactPage.getTotalPages());
-    assertEquals("The number of pages covering all possible items ", 1, pojoArtifactPage.getTotalPages());
+    assertEquals( 1, pojoArtifactPage.getTotalPages());
 
     System.out.println("The page number within the count of all possible pages " + pojoArtifactPage.getPageNumber());
-    assertEquals("The page number within the count of all possible pages ", 1, pojoArtifactPage.getPageNumber());
+    assertEquals( 1, pojoArtifactPage.getPageNumber());
 
     System.out.println("The page size which is the maximum number of items allowed in one page " + pojoArtifactPage.getPageSize());
-    assertEquals("The page size which is the maximum number of items allowed in one page ", 2, pojoArtifactPage.getPageSize());
+    assertEquals( 2, pojoArtifactPage.getPageSize());
 
     System.out.println("The start position of this page within all possible items " + pojoArtifactPage.getStart());
-    assertEquals("The start position of this page within all possible items ", 1, pojoArtifactPage.getStart());
+    assertEquals( 1, pojoArtifactPage.getStart());
 
     System.out.println("The total count (potentially an estimate) of all possible items in the set " + pojoArtifactPage.getTotalSize());
-    assertEquals("The total count (potentially an estimate) of all possible items in the set ", 2, pojoArtifactPage.getTotalSize());
+    assertEquals(2, pojoArtifactPage.getTotalSize());
 
     Iterator<Artifact> itr = pojoArtifactPage.iterator();
     Artifact artifact = null;
@@ -827,11 +820,11 @@ public class TestPOJOSpecialCharRead extends AbstractFunctionalTest {
       while (page.hasNext()) {
         String artifactName = new String("Byte Array test " + count);
         byte[] testByteArray = artifactName.getBytes();
-        assertNotNull("Should return an object", page.next());
+        assertNotNull( page.next());
         count++;
       }
       page.close();
     }
-    assertEquals("total number of iterations", 101, i);
+    assertEquals( 101, i);
   }
 }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOWithDocsStoredByOthers.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOWithDocsStoredByOthers.java
@@ -18,6 +18,7 @@ package com.marklogic.client.fastfunctest;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marklogic.client.MarkLogicIOException;
 import com.marklogic.client.ResourceNotFoundException;
 import com.marklogic.client.document.DocumentManager.Metadata;
 import com.marklogic.client.document.DocumentWriteSet;
@@ -28,15 +29,13 @@ import com.marklogic.client.io.Format;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.pojo.PojoRepository;
 import com.marklogic.client.pojo.annotation.Id;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Calendar;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 public class TestPOJOWithDocsStoredByOthers extends AbstractFunctionalTest {
 
@@ -187,7 +186,7 @@ public class TestPOJOWithDocsStoredByOthers extends AbstractFunctionalTest {
     }
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     client = getDatabaseClient("rest-admin", "x", getConnType());
   }
@@ -213,12 +212,12 @@ public class TestPOJOWithDocsStoredByOthers extends AbstractFunctionalTest {
    * This method is used when there is a need to validate SmallArtifact.
    */
   public void validateSmallArtifact(SmallArtifactIdInSuper artifact) {
-    assertNotNull("Artifact object should never be Null", artifact);
-    assertNotNull("Id should never be Null", artifact.id);
-    assertEquals("Id of the object is ", -99, artifact.getId());
-    assertEquals("Name of the object is ", "SmallArtifact",
+    assertNotNull( artifact);
+    assertNotNull( artifact.id);
+    assertEquals( -99, artifact.getId());
+    assertEquals( "SmallArtifact",
         artifact.getName());
-    assertEquals("Inventory of the object is ", 1000,
+    assertEquals( 1000,
         artifact.getInventory());
   }
 
@@ -227,14 +226,14 @@ public class TestPOJOWithDocsStoredByOthers extends AbstractFunctionalTest {
    * test annotation only in super class.
    */
   public void validateSmallArtifactSuper(SmallArtifactNoId artifact) {
-    assertNotNull("Artifact object should never be Null", artifact);
-    assertNotNull("Id should never be Null", artifact.getId());
-    assertEquals("Id of the object is ", 0, artifact.getId());
-    assertEquals("Name of the object is ", "SmallArtifactInSuperOnly",
+    assertNotNull( artifact);
+    assertNotNull( artifact.getId());
+    assertEquals( 0, artifact.getId());
+    assertEquals( "SmallArtifactInSuperOnly",
         artifact.getName());
-    assertEquals("Inventory of the object is ", 1000,
+    assertEquals( 1000,
         artifact.getInventory());
-    assertEquals("Country of origin of the object is ", "USA",
+    assertEquals( "USA",
         artifact.getOriginCountry());
   }
 
@@ -244,14 +243,14 @@ public class TestPOJOWithDocsStoredByOthers extends AbstractFunctionalTest {
    * class.
    */
   public void validateSmallArtifactSuperAndSub(SmallArtifactIdInSuperAndSub artifact) {
-    assertNotNull("Artifact object should never be Null", artifact);
-    assertNotNull("Id should never be Null", artifact.getId());
-    assertEquals("Id of the object is ", -100, artifact.getId());
-    assertEquals("Name of the object is ", "SmallArtifactInSuperAndSub",
+    assertNotNull( artifact);
+    assertNotNull( artifact.getId());
+    assertEquals( -100, artifact.getId());
+    assertEquals( "SmallArtifactInSuperAndSub",
         artifact.getName());
-    assertEquals("Inventory of the object is ", 1000,
+    assertEquals( 1000,
         artifact.getInventory());
-    assertEquals("Country of origin of the object is ", "USA",
+    assertEquals( "USA",
         artifact.getOriginCountry());
   }
 
@@ -260,14 +259,14 @@ public class TestPOJOWithDocsStoredByOthers extends AbstractFunctionalTest {
    * test annotation in super class and in sub class.
    */
   public void validateSmallArtifactDiffAccessSpec(SmallArtifactPublic artifact) {
-    assertNotNull("Artifact object should never be Null", artifact);
-    assertNotNull("Id should never be Null", artifact.getId());
-    assertEquals("Id of the object is ", -100, artifact.getId());
-    assertEquals("Name of the object is ", "SmallArtifactDiffAccess",
+    assertNotNull( artifact);
+    assertNotNull( artifact.getId());
+    assertEquals( -100, artifact.getId());
+    assertEquals( "SmallArtifactDiffAccess",
         artifact.getName());
-    assertEquals("Inventory of the object is ", 1000,
+    assertEquals( 1000,
         artifact.getInventory());
-    assertEquals("Country of origin of the object is ", "USA",
+    assertEquals( "USA",
         artifact.getOriginCountry());
   }
 
@@ -276,12 +275,12 @@ public class TestPOJOWithDocsStoredByOthers extends AbstractFunctionalTest {
    * to test annotation in super class and in sub class.
    */
   public void validateSubObjReferencedbySuperClassvariable(SmallArtifactIdInSuper artifact) {
-    assertNotNull("Artifact object should never be Null", artifact);
-    assertNotNull("Id should never be Null", artifact.getId());
-    assertEquals("Id of the object is ", -100, artifact.getId());
-    assertEquals("Name of the object is ", "SmallArtifactNoId",
+    assertNotNull( artifact);
+    assertNotNull( artifact.getId());
+    assertEquals( -100, artifact.getId());
+    assertEquals( "SmallArtifactNoId",
         artifact.getName());
-    assertEquals("Inventory of the object is ", 1000,
+    assertEquals( 1000,
         artifact.getInventory());
   }
 
@@ -291,12 +290,12 @@ public class TestPOJOWithDocsStoredByOthers extends AbstractFunctionalTest {
    * class.
    */
   public void validateSubObjReferencedbySuperClassvariableOne(SmallArtifactIdInSuperAndSub artifact) {
-    assertNotNull("Artifact object should never be Null", artifact);
-    assertNotNull("Id should never be Null", artifact.getId());
-    assertEquals("Id of the object is ", -100, artifact.getId());
-    assertEquals("Name of the object is ", "SmallArtifactIdInSuperAndSub",
+    assertNotNull( artifact);
+    assertNotNull( artifact.getId());
+    assertEquals( -100, artifact.getId());
+    assertEquals( "SmallArtifactIdInSuperAndSub",
         artifact.getName());
-    assertEquals("Inventory of the object is ", 1000,
+    assertEquals( 1000,
         artifact.getInventory());
   }
 
@@ -305,14 +304,14 @@ public class TestPOJOWithDocsStoredByOthers extends AbstractFunctionalTest {
    * URI and has invalid POJO collection Uses SmallArtifact class which has @Id
    * on the name methods. Test result expectations are: read should return a
    * null since the POJO internal content and document's are different.
-   * 
+   *
    * Current results (10/13/2014) are: java.lang.IllegalArgumentException:
    * Invalid type id 'junk' (for id type 'Id.class'): no such class found Issue
    * 136 might solve this also.
    */
 
-  @Test(expected = com.marklogic.client.MarkLogicIOException.class)
-  public void testPOJOReadDocStoredWithInvalidContent() throws KeyManagementException, NoSuchAlgorithmException, Exception {
+	@Test
+  public void testPOJOReadDocStoredWithInvalidContent() throws Exception {
 
     String docId[] = { "com.marklogic.client.fastfunctest.TestPOJOWithDocsStoredByOthers$SmallArtifactIdInSuper/SmallArtifactIdInSuper.json" };
     String json1 = new String(
@@ -341,8 +340,7 @@ public class TestPOJOWithDocsStoredByOthers extends AbstractFunctionalTest {
         .newPojoRepository(SmallArtifactIdInSuper.class, String.class);
     String artifactName = new String("SmallArtifactIdInSuper");
 
-    SmallArtifactIdInSuper artifact1 = pojoReposSmallArtifact.read(artifactName);
-    validateSmallArtifact(artifact1);
+    assertThrows(MarkLogicIOException.class, () -> pojoReposSmallArtifact.read(artifactName));
   }
 
   /*
@@ -385,12 +383,12 @@ public class TestPOJOWithDocsStoredByOthers extends AbstractFunctionalTest {
 
     // Validate the SmallArtifactIdInSuper read back.
     SmallArtifactIdInSuper artifact = pojoReposSmallArtifact.read(artifactName);
-    assertNotNull("Artifact object should never be Null", artifact);
-    assertNotNull("Id should never be Null", artifact.id);
-    assertEquals("Id of the object is ", -99, artifact.getId());
-    assertEquals("Name of the object is ", "SmallArtifactIdInSuper",
+    assertNotNull( artifact);
+    assertNotNull( artifact.id);
+    assertEquals( -99, artifact.getId());
+    assertEquals( "SmallArtifactIdInSuper",
         artifact.getName());
-    assertEquals("Inventory of the object is ", 0, artifact.getInventory());
+    assertEquals( 0, artifact.getInventory());
   }
 
   /*
@@ -400,8 +398,7 @@ public class TestPOJOWithDocsStoredByOthers extends AbstractFunctionalTest {
    * expectations are: read should return ResourceNotFoundException exception.
    * Field inventory has a String
    */
-
-  @Test(expected = ResourceNotFoundException.class)
+	@Test
   public void testPOJOReadDocStoredWithInvalidDataType() throws Exception {
 
     String docId[] = { "com.marklogic.client.fastfunctest.TestPOJOWithDocsStoredByOthers$SmallArtifact/SmallArtifact.json" };
@@ -432,17 +429,15 @@ public class TestPOJOWithDocsStoredByOthers extends AbstractFunctionalTest {
 
     PojoRepository<SmallArtifactIdInSuper, String> pojoReposSmallArtifact = client
         .newPojoRepository(SmallArtifactIdInSuper.class, String.class);
-    String artifactName = new String("SmallArtifact");
-
-    @SuppressWarnings("unused")
-    SmallArtifactIdInSuper artifact1 = pojoReposSmallArtifact.read(artifactName);
+    String artifactName = "SmallArtifact";
+    assertThrows(ResourceNotFoundException.class, () -> pojoReposSmallArtifact.read(artifactName));
   }
 
   /*
    * Purpose : This test is to validate Test creating an @id in super class only
    * SmallArtifactSuper class which has @Id only on the name class member of the
    * super class SmallArtifact.
-   * 
+   *
    * Current results (10/13/2014) are: java.lang.IllegalArgumentException: Your
    * class com.marklogic.client.fastfunctest.
    * TestPOJOWithDocsStoredByOthers$SmallArtifactSuper does not have a method or
@@ -472,7 +467,7 @@ public class TestPOJOWithDocsStoredByOthers extends AbstractFunctionalTest {
    * Purpose : This test is to validate Test creating an @id in super class and
    * sub class. Both SmallArtifactSuperAndSub and SmallArtifact class have a
    * similar @Id on the name class member.
-   * 
+   *
    * Current results (10/13/2014) are: Read works fine.
    */
   @Test
@@ -499,7 +494,7 @@ public class TestPOJOWithDocsStoredByOthers extends AbstractFunctionalTest {
    * Purpose : This test is to validate creating an @id in super class and sub
    * class that has different access specifiers. Both SmallArtifactSuperAndSub
    * and SmallArtifact class have a similar @Id on the name class member.
-   * 
+   *
    * Current results (10/13/2014) are: Read works fine.
    */
   @Test
@@ -527,7 +522,7 @@ public class TestPOJOWithDocsStoredByOthers extends AbstractFunctionalTest {
    * referenced by a Super class variable type. Both SmallArtifactIdInSuper and
    * SmallArtifactNoId classes are used. POJO repository cannot read back the
    * sub class.
-   * 
+   *
    * PojoRepository is on the super class.
    */
 
@@ -556,7 +551,7 @@ public class TestPOJOWithDocsStoredByOthers extends AbstractFunctionalTest {
    * referenced by a Super class variable type. Both SmallArtifactIdInSuper and
    * SmallArtifactNoId classes are used. This is a variation of
    * testPOJOSubObjReferencedBySuperClassVariable()
-   * 
+   *
    * PojoRepository is on the sub class.
    */
 

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOWithStringQD.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOWithStringQD.java
@@ -30,17 +30,16 @@ import com.marklogic.client.pojo.PojoRepository;
 import com.marklogic.client.query.MatchDocumentSummary;
 import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.query.StringQueryDefinition;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 
-import static org.junit.Assert.*;
-
 public class TestPOJOWithStringQD extends AbstractFunctionalTest {
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     client = getDatabaseClient("rest-admin", "x", getConnType());
   }
@@ -92,9 +91,9 @@ public class TestPOJOWithStringQD extends AbstractFunctionalTest {
 
   public void validateArtifact(Artifact art)
   {
-    assertNotNull("Artifact object should never be Null", art);
-    assertNotNull("Id should never be Null", art.id);
-    assertTrue("Inventry is always greater than 1000", art.getInventory() > 1000);
+    assertNotNull( art);
+    assertNotNull( art.id);
+    assertNotNull( art.getInventory() > 1000);
   }
 
   public void loadSimplePojos(PojoRepository products)
@@ -120,7 +119,7 @@ public class TestPOJOWithStringQD extends AbstractFunctionalTest {
 
     products.setPageLength(11);
     p = products.search(qd, 1);
-    assertEquals("total no of pages", 5, p.getTotalPages());
+    assertEquals( 5, p.getTotalPages());
     System.out.println(p.getTotalPages());
     long pageNo = 1, count = 0;
     do {
@@ -131,17 +130,17 @@ public class TestPOJOWithStringQD extends AbstractFunctionalTest {
       while (p.iterator().hasNext()) {
         Artifact a = p.iterator().next();
         validateArtifact(a);
-        assertTrue("Artifact Id is odd", a.getId() % 2 != 0);
-        assertTrue("Company name contains widgets", a.getManufacturer().getName().contains("Widgets"));
+        assertNotNull( a.getId() % 2 != 0);
+        assertNotNull( a.getManufacturer().getName().contains("Widgets"));
         count++;
         // System.out.println(a.getId()+" "+a.getManufacturer().getName()
         // +"  "+count);
       }
-      assertEquals("Page size", count, p.size());
+      assertEquals( count, p.size());
       pageNo = pageNo + p.getPageSize();
     } while (!p.isLastPage() && pageNo < p.getTotalSize());
-    assertEquals("page number after the loop", 5, p.getPageNumber());
-    assertEquals("total no of pages", 5, p.getTotalPages());
+    assertEquals( 5, p.getPageNumber());
+    assertEquals( 5, p.getTotalPages());
   }
 
   @Test
@@ -155,7 +154,7 @@ public class TestPOJOWithStringQD extends AbstractFunctionalTest {
     SearchHandle results = new SearchHandle();
     products.setPageLength(11);
     p = products.search(qd, 1, results);
-    assertEquals("total no of pages", 5, p.getTotalPages());
+    assertEquals( 5, p.getTotalPages());
     System.out.println(p.getTotalPages());
     long pageNo = 1, count = 0;
     do {
@@ -165,29 +164,29 @@ public class TestPOJOWithStringQD extends AbstractFunctionalTest {
       while (p.iterator().hasNext()) {
         Artifact a = p.iterator().next();
         validateArtifact(a);
-        assertTrue("Artifact Id is even", a.getId() % 2 == 0);
-        assertTrue("Company name contains Acme", a.getManufacturer().getName().contains("Acme"));
+        assertNotNull( a.getId() % 2 == 0);
+        assertNotNull( a.getManufacturer().getName().contains("Acme"));
         count++;
         // System.out.println(a.getId()+" "+a.getManufacturer().getName()
         // +"  "+count);
       }
-      assertEquals("Page size", count, p.size());
+      assertEquals( count, p.size());
       pageNo = pageNo + p.getPageSize();
       MatchDocumentSummary[] mds = results.getMatchResults();
-      assertEquals("Size of the results summary", 11, mds.length);
+      assertEquals( 11, mds.length);
       for (MatchDocumentSummary md : mds) {
-        assertTrue("every uri should contain the class name", md.getUri().contains("Artifact"));
+        assertNotNull( md.getUri().contains("Artifact"));
       }
       String[] facetNames = results.getFacetNames();
       for (String fname : facetNames) {
         System.out.println(fname);
       }
-      assertEquals("Total resulr from search handle ", 55, results.getTotalResults());
-      // assertTrue("Search Handle metric results ",results.getMetrics().getTotalTime()>0);
+      assertEquals( 55, results.getTotalResults());
+      // assertNotNull(results.getMetrics().getTotalTime()>0);
     } while (!p.isLastPage() && pageNo < p.getTotalSize());
-    assertEquals("Page start check", 45, p.getStart());
-    assertEquals("page number after the loop", 5, p.getPageNumber());
-    assertEquals("total no of pages", 5, p.getTotalPages());
+    assertEquals( 45, p.getStart());
+    assertEquals( 5, p.getPageNumber());
+    assertEquals( 5, p.getTotalPages());
   }
 
   @Test
@@ -201,7 +200,7 @@ public class TestPOJOWithStringQD extends AbstractFunctionalTest {
     JacksonHandle results = new JacksonHandle();
     p = products.search(qd, 1, results);
     products.setPageLength(11);
-    assertEquals("total no of pages", 3, p.getTotalPages());
+    assertEquals( 3, p.getTotalPages());
     // System.out.println(p.getTotalPages()+results.get().toString());
     long pageNo = 1, count = 0;
     do {
@@ -215,19 +214,19 @@ public class TestPOJOWithStringQD extends AbstractFunctionalTest {
         // System.out.println(a.getId()+" "+a.getManufacturer().getName()
         // +"  "+count);
       }
-      assertEquals("Page size", count, p.size());
+      assertEquals( count, p.size());
       pageNo = pageNo + p.getPageSize();
 
-      assertEquals("Page start from search handls vs page methods", results.get().get("start").asLong(), p.getStart());
-      assertEquals("Format in the search handle", "json", results.get().withArray("results").get(1).path("format").asText());
-      assertTrue("Uri in search handle contains Artifact", results.get().withArray("results").get(1).path("uri").asText().contains("Artifact"));
+      assertEquals( results.get().get("start").asLong(), p.getStart());
+      assertEquals( "json", results.get().withArray("results").get(1).path("format").asText());
+      assertNotNull( results.get().withArray("results").get(1).path("uri").asText().contains("Artifact"));
       // System.out.println(results.get().toString());
     } while (!p.isLastPage() && pageNo < p.getTotalSize());
-    // assertTrue("search handle has metrics",results.get().has("metrics"));
-    assertEquals("Search text is", "cogs", results.get().path("qtext").asText());
-    assertEquals("Total from search handle", 110, results.get().get("total").asInt());
-    assertEquals("page number after the loop", 10, p.getPageNumber());
-    assertEquals("total no of pages", 10, p.getTotalPages());
+    // assertNotNull(results.get().has("metrics"));
+    assertEquals( "cogs", results.get().path("qtext").asText());
+    assertEquals( 110, results.get().get("total").asInt());
+    assertEquals( 10, p.getPageNumber());
+    assertEquals( 10, p.getTotalPages());
   }
 
   // Searching for Id as Number in JSON using string should not return any
@@ -252,19 +251,19 @@ public class TestPOJOWithStringQD extends AbstractFunctionalTest {
         Artifact a = p.iterator().next();
         validateArtifact(a);
       }
-      assertEquals("Page total results", 0, p.getTotalSize());
+      assertEquals( 0, p.getTotalSize());
       pageNo = pageNo + p.getPageSize();
       // System.out.println(results.get().toString());
     } while (!p.isLastPage() && pageNo < p.getTotalSize());
-    assertFalse("String handle is not empty", results.get().isEmpty());
-    assertTrue("String handle contains results", results.get().contains("results"));
-    assertFalse("String handle contains format", results.get().contains("\"format\":\"json\""));
+    assertFalse(results.get().isEmpty());
+    assertNotNull( results.get().contains("results"));
+    assertFalse(results.get().contains("\"format\":\"json\""));
 
     ObjectMapper mapper = new ObjectMapper();
     JsonNode actNode = mapper.readTree(results.get()).get("total");
     // System.out.println(expNode.equals(actNode)+"\n"+
     // expNode.toString()+"\n"+actNode.toString());
 
-    assertEquals("Total search results resulted are ", actNode.asInt(), 0);
+    assertEquals( actNode.asInt(), 0);
   }
 }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOWithStrucQD.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOWithStrucQD.java
@@ -32,18 +32,17 @@ import com.marklogic.client.pojo.PojoQueryDefinition;
 import com.marklogic.client.pojo.PojoRepository;
 import com.marklogic.client.query.*;
 import com.marklogic.client.query.StructuredQueryBuilder.Operator;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 
-import static org.junit.Assert.*;
-
 public class TestPOJOWithStrucQD extends AbstractFunctionalTest {
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     client = getDatabaseClient("rest-admin", "x", getConnType());
   }
@@ -95,9 +94,9 @@ public class TestPOJOWithStrucQD extends AbstractFunctionalTest {
 
   public void validateArtifact(Artifact art)
   {
-    assertNotNull("Artifact object should never be Null", art);
-    assertNotNull("Id should never be Null", art.id);
-    assertTrue("Inventry is always greater than 1000", art.getInventory() > 1000);
+    assertNotNull( art);
+    assertNotNull( art.id);
+    assertTrue( art.getInventory() > 1000);
   }
 
   public void loadSimplePojos(PojoRepository products)
@@ -156,7 +155,7 @@ public class TestPOJOWithStrucQD extends AbstractFunctionalTest {
     StructuredQueryDefinition qd = qb.and(q1, qb.collection("odd"));
     products.setPageLength(11);
     p = products.search(qd, 1);
-    assertEquals("total no of pages", 4, p.getTotalPages());
+    assertEquals( 4, p.getTotalPages());
     // System.out.println(p.getTotalPages());
     long pageNo = 1, count = 0;
     do {
@@ -167,18 +166,18 @@ public class TestPOJOWithStrucQD extends AbstractFunctionalTest {
       while (p.iterator().hasNext()) {
         Artifact a = p.iterator().next();
         validateArtifact(a);
-        assertFalse("Verifying document with special is not there", a.getId() % 5 == 0);
-        assertTrue("Artifact Id is odd", a.getId() % 2 != 0);
-        assertTrue("Company name contains widgets", a.getManufacturer().getName().contains("Widgets"));
+        assertFalse( a.getId() % 5 == 0);
+        assertTrue( a.getId() % 2 != 0);
+        assertTrue( a.getManufacturer().getName().contains("Widgets"));
         count++;
         // System.out.println(a.getId()+" "+a.getManufacturer().getName()
         // +"  "+count);
       }
-      assertEquals("Page size", count, p.size());
+      assertEquals( count, p.size());
       pageNo = pageNo + p.getPageSize();
     } while (!p.isLastPage() && pageNo < p.getTotalSize());
-    assertEquals("page number after the loop", 4, p.getPageNumber());
-    assertEquals("total no of pages", 4, p.getTotalPages());
+    assertEquals( 4, p.getPageNumber());
+    assertEquals( 4, p.getTotalPages());
   }
 
   @Test
@@ -193,7 +192,7 @@ public class TestPOJOWithStrucQD extends AbstractFunctionalTest {
     SearchHandle results = new SearchHandle();
     products.setPageLength(10);
     p = products.search(qd, 1, results);
-    assertEquals("total no of pages", 5, p.getTotalPages());
+    assertEquals( 5, p.getTotalPages());
     System.out.println(p.getTotalPages());
     long pageNo = 1, count = 0;
     do {
@@ -203,31 +202,31 @@ public class TestPOJOWithStrucQD extends AbstractFunctionalTest {
       while (p.iterator().hasNext()) {
         Artifact a = p.iterator().next();
         validateArtifact(a);
-        assertTrue("Enventory lies between 1010 to 1110", a.getInventory() > 1010 && a.getInventory() <= 1110);
-        assertTrue("Artifact Id is even", a.getId() % 2 == 0);
-        assertTrue("Company name contains Acme", a.getManufacturer().getName().contains("Acme"));
+        assertTrue( a.getInventory() > 1010 && a.getInventory() <= 1110);
+        assertTrue( a.getId() % 2 == 0);
+        assertTrue( a.getManufacturer().getName().contains("Acme"));
         count++;
         // System.out.println(a.getId()+" "+a.getManufacturer().getName()
         // +"  "+count);
       }
-      assertEquals("Page size", count, p.size());
+      assertEquals( count, p.size());
       pageNo = pageNo + p.getPageSize();
       MatchDocumentSummary[] mds = results.getMatchResults();
-      assertEquals("Size of the results summary", 10, mds.length);
+      assertEquals( 10, mds.length);
       for (MatchDocumentSummary md : mds) {
-        assertTrue("every uri should contain the class name", md.getUri().contains("Artifact"));
+        assertTrue( md.getUri().contains("Artifact"));
       }
       String[] facetNames = results.getFacetNames();
       for (String fname : facetNames) {
         System.out.println(fname);
       }
-      assertEquals("search handle has facets ", 0, results.getFacetNames().length);
-      assertEquals("Total resulr from search handle ", 50, results.getTotalResults());
-      assertNull("Search Handle metric results ", results.getMetrics());
+      assertEquals( 0, results.getFacetNames().length);
+      assertEquals( 50, results.getTotalResults());
+      assertNull(results.getMetrics());
     } while (!p.isLastPage() && pageNo < p.getTotalSize());
-    assertEquals("Page start check", 41, p.getStart());
-    assertEquals("page number after the loop", 5, p.getPageNumber());
-    assertEquals("total no of pages", 5, p.getTotalPages());
+    assertEquals( 41, p.getStart());
+    assertEquals( 5, p.getPageNumber());
+    assertEquals( 5, p.getTotalPages());
   }
 
   @Test
@@ -235,14 +234,14 @@ public class TestPOJOWithStrucQD extends AbstractFunctionalTest {
     PojoRepository<Artifact, Long> products = client.newPojoRepository(Artifact.class, Long.class);
     PojoPage<Artifact> p;
     this.loadSimplePojos(products);
-    ;
+
     StructuredQueryBuilder qb = new StructuredQueryBuilder();
     StructuredQueryDefinition q1 = qb.containerQuery(qb.jsonProperty("name"), qb.term("special"));
     PojoQueryDefinition qd = qb.and(q1, qb.word(qb.jsonProperty("name"), "acme"));
     JacksonHandle results = new JacksonHandle();
     p = products.search(qd, 1, results);
     products.setPageLength(11);
-    assertEquals("total no of pages", 1, p.getTotalPages());
+    assertEquals( 1, p.getTotalPages());
     System.out.println(p.getTotalPages() + results.get().toString());
     long pageNo = 1, count = 0;
     do {
@@ -253,22 +252,22 @@ public class TestPOJOWithStrucQD extends AbstractFunctionalTest {
         Artifact a = p.iterator().next();
         validateArtifact(a);
         count++;
-        assertTrue("Manufacture name starts with acme", a.getManufacturer().getName().contains("Acme"));
-        assertTrue("Artifact name contains", a.getName().contains("special"));
+        assertTrue( a.getManufacturer().getName().contains("Acme"));
+        assertTrue( a.getName().contains("special"));
 
       }
-      assertEquals("Page size", count, p.size());
+      assertEquals( count, p.size());
       pageNo = pageNo + p.getPageSize();
 
-      assertEquals("Page start from search handls vs page methods", results.get().get("start").asLong(), p.getStart());
-      assertEquals("Format in the search handle", "json", results.get().withArray("results").get(1).path("format").asText());
-      assertTrue("Uri in search handle contains Artifact", results.get().withArray("results").get(1).path("uri").asText().contains("Artifact"));
+      assertEquals( results.get().get("start").asLong(), p.getStart());
+      assertEquals( "json", results.get().withArray("results").get(1).path("format").asText());
+      assertTrue( results.get().withArray("results").get(1).path("uri").asText().contains("Artifact"));
       // System.out.println(results.get().toString());
     } while (!p.isLastPage() && pageNo < p.getTotalSize());
-    assertFalse("search handle has metrics", results.get().has("metrics"));
-    assertEquals("Total from search handle", 11, results.get().get("total").asInt());
-    assertEquals("page number after the loop", 1, p.getPageNumber());
-    assertEquals("total no of pages", 1, p.getTotalPages());
+    assertFalse( results.get().has("metrics"));
+    assertEquals( 11, results.get().get("total").asInt());
+    assertEquals( 1, p.getPageNumber());
+    assertEquals( 1, p.getTotalPages());
   }
 
   // Searching for Id as Number in JSON using value query
@@ -297,13 +296,13 @@ public class TestPOJOWithStrucQD extends AbstractFunctionalTest {
         validateArtifact(a);
         count++;
       }
-      assertEquals("Page total results", count, p.getTotalSize());
+      assertEquals( count, p.getTotalSize());
       pageNo = pageNo + p.getPageSize();
       // System.out.println(results.get().toString());
     } while (!p.isLastPage() && pageNo < p.getTotalSize());
-    assertFalse("String handle is not empty", results.get().isEmpty());
-    assertTrue("String handle contains results", results.get().contains("results"));
-    assertTrue("String handle contains format", results.get().contains("\"format\":\"json\""));
+    assertFalse( results.get().isEmpty());
+    assertTrue( results.get().contains("results"));
+    assertTrue( results.get().contains("\"format\":\"json\""));
     // String expected= jh.get().toString();
     // System.out.println(results.get().contains("\"format\":\"json\"")+
     // expected);
@@ -316,7 +315,7 @@ public class TestPOJOWithStrucQD extends AbstractFunctionalTest {
     // System.out.println(expNode.equals(actNode)+"\n"+
     // expNode.toString()+"\n"+actNode.toString());
 
-    assertEquals("Total search results resulted are ", 6, actNode.asInt());
+    assertEquals( 6, actNode.asInt());
   }
 
   /*
@@ -360,17 +359,17 @@ public class TestPOJOWithStrucQD extends AbstractFunctionalTest {
         //validateArtifact(a);
         count++;
       }
-      assertEquals("Page total results", count, p.getTotalSize());
+      assertEquals( count, p.getTotalSize());
       pageNo = pageNo + p.getPageSize();
 
     } while (!p.isLastPage() && pageNo < p.getTotalSize());
-    assertFalse("String handle is not empty", results.get().isEmpty());
-    assertTrue("String handle contains results", results.get().contains("results"));
-    assertTrue("String handle contains format", results.get().contains("\"format\":\"json\""));
+    assertFalse( results.get().isEmpty());
+    assertTrue( results.get().contains("results"));
+    assertTrue( results.get().contains("\"format\":\"json\""));
 
     ObjectMapper mapper = new ObjectMapper();
     JsonNode actNode = mapper.readTree(results.get()).get("total");
-    assertEquals("Total search results resulted are ", 6, actNode.asInt());
+    assertEquals( 6, actNode.asInt());
   }
 
   @Test
@@ -391,13 +390,13 @@ public class TestPOJOWithStrucQD extends AbstractFunctionalTest {
             "</search:term-query> </search:and-query>" +
             "</search:query>";
     StringHandle rh = new StringHandle(rawXMLQuery);
-    
+
     StringQueryDefinition qd = queryMgr.newStringDefinition();
     qd.setCriteria("special AND Acme");
     JacksonHandle results = new JacksonHandle();
     p = products.search(qd, 1, results);
     products.setPageLength(11);
-    assertEquals("total no of pages", 1, p.getTotalPages());
+    assertEquals( 1, p.getTotalPages());
     System.out.println(p.getTotalPages() + results.get().toString());
     long pageNo = 1, count = 0;
     do {
@@ -408,22 +407,22 @@ public class TestPOJOWithStrucQD extends AbstractFunctionalTest {
         Artifact a = p.iterator().next();
         validateArtifact(a);
         count++;
-        assertTrue("Manufacture name starts with acme", a.getManufacturer().getName().contains("Acme"));
-        assertTrue("Artifact name contains", a.getName().contains("special"));
+        assertTrue( a.getManufacturer().getName().contains("Acme"));
+        assertTrue( a.getName().contains("special"));
 
       }
-      assertEquals("Page size", count, p.size());
+      assertEquals( count, p.size());
       pageNo = pageNo + p.getPageSize();
 
-      assertEquals("Page start from search handls vs page methods", results.get().get("start").asLong(), p.getStart());
-      assertEquals("Format in the search handle", "json", results.get().withArray("results").get(1).path("format").asText());
-      assertTrue("Uri in search handle contains Artifact", results.get().withArray("results").get(1).path("uri").asText().contains("Artifact"));
+      assertEquals( results.get().get("start").asLong(), p.getStart());
+      assertEquals( "json", results.get().withArray("results").get(1).path("format").asText());
+      assertTrue( results.get().withArray("results").get(1).path("uri").asText().contains("Artifact"));
       // System.out.println(results.get().toString());
     } while (!p.isLastPage() && pageNo < p.getTotalSize());
-    assertFalse("search handle has metrics", results.get().has("metrics"));
-    assertEquals("Total from search handle", 11, results.get().get("total").asInt());
-    assertEquals("page number after the loop", 1, p.getPageNumber());
-    assertEquals("total no of pages", 1, p.getTotalPages());
+    assertFalse( results.get().has("metrics"));
+    assertEquals( 11, results.get().get("total").asInt());
+    assertEquals( 1, p.getPageNumber());
+    assertEquals( 1, p.getTotalPages());
   }
 
   @Test
@@ -468,7 +467,7 @@ public class TestPOJOWithStrucQD extends AbstractFunctionalTest {
     JacksonHandle results = new JacksonHandle();
     p = products.search(qd, 1, results);
     products.setPageLength(11);
-    assertEquals("total no of pages", 1, p.getTotalPages());
+    assertEquals( 1, p.getTotalPages());
     System.out.println(p.getTotalPages() + results.get().toString());
     long pageNo = 1, count = 0;
     do {
@@ -479,22 +478,22 @@ public class TestPOJOWithStrucQD extends AbstractFunctionalTest {
         Artifact a = p.iterator().next();
         validateArtifact(a);
         count++;
-        assertTrue("Manufacture name starts with acme", a.getManufacturer().getName().contains("Widgets"));
-        assertTrue("Artifact name contains", a.getName().contains("special"));
+        assertTrue( a.getManufacturer().getName().contains("Widgets"));
+        assertTrue( a.getName().contains("special"));
 
       }
-      assertEquals("Page size", count, p.size());
+      assertEquals( count, p.size());
       pageNo = pageNo + p.getPageSize();
 
-      assertEquals("Page start from search handls vs page methods", results.get().get("start").asLong(), p.getStart());
-      assertEquals("Format in the search handle", "json", results.get().withArray("results").get(1).path("format").asText());
-      assertTrue("Uri in search handle contains Artifact", results.get().withArray("results").get(1).path("uri").asText().contains("Artifact"));
+      assertEquals( results.get().get("start").asLong(), p.getStart());
+      assertEquals( "json", results.get().withArray("results").get(1).path("format").asText());
+      assertTrue( results.get().withArray("results").get(1).path("uri").asText().contains("Artifact"));
       System.out.println(results.get().toString());
     } while (!p.isLastPage() && pageNo < p.getTotalSize());
-    assertFalse("search handle has metrics", results.get().has("metrics"));
-    assertEquals("Total from search handle", 11, results.get().get("total").asInt());
-    assertEquals("page number after the loop", 1, p.getPageNumber());
-    assertEquals("total no of pages", 1, p.getTotalPages());
+    assertFalse( results.get().has("metrics"));
+    assertEquals( 11, results.get().get("total").asInt());
+    assertEquals( 1, p.getPageNumber());
+    assertEquals( 1, p.getTotalPages());
   }
 
 }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOwithQBEQueryDef.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOwithQBEQueryDef.java
@@ -30,18 +30,17 @@ import com.marklogic.client.pojo.PojoQueryDefinition;
 import com.marklogic.client.pojo.PojoRepository;
 import com.marklogic.client.query.MatchDocumentSummary;
 import com.marklogic.client.query.QueryManager;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 
-import static org.junit.Assert.*;
-
 public class TestPOJOwithQBEQueryDef extends AbstractFunctionalTest {
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     client = getDatabaseClient("rest-admin", "x", getConnType());
   }
@@ -93,9 +92,9 @@ public class TestPOJOwithQBEQueryDef extends AbstractFunctionalTest {
 
   public void validateArtifact(Artifact art)
   {
-    assertNotNull("Artifact object should never be Null", art);
-    assertNotNull("Id should never be Null", art.id);
-    assertTrue("Inventry is always greater than 1000", art.getInventory() > 1000);
+    assertNotNull( art);
+    assertNotNull( art.id);
+    assertTrue( art.getInventory() > 1000);
   }
 
   public void loadSimplePojos(PojoRepository products)
@@ -110,7 +109,7 @@ public class TestPOJOwithQBEQueryDef extends AbstractFunctionalTest {
     }
   }
 
-  @Test(expected = ClassCastException.class)
+	@Test
   public void testPOJOqbeSearchWithoutSearchHandle() {
     PojoRepository<Artifact, Long> products = client.newPojoRepository(Artifact.class, Long.class);
     PojoPage<Artifact> p;
@@ -122,36 +121,14 @@ public class TestPOJOwithQBEQueryDef extends AbstractFunctionalTest {
             + ",\"$not\":[{\"name\":{\"$word\":\"special\",\"$exact\": false}}]"
             + "}}";
 
-    PojoQueryDefinition qd = (PojoQueryDefinition) queryMgr.newRawQueryByExampleDefinition(new StringHandle(queryAsString).withFormat(Format.JSON));
-    qd.setCollections("odd");
-    products.setPageLength(11);
-    p = products.search(qd, 1);
-    assertEquals("total no of pages", 4, p.getTotalPages());
-    // System.out.println(p.getTotalPages());
-    long pageNo = 1, count = 0;
-    do {
-      count = 0;
-
-      p = products.search(qd, pageNo);
-
-      while (p.iterator().hasNext()) {
-        Artifact a = p.iterator().next();
-        validateArtifact(a);
-        assertFalse("Verifying document with special is not there", a.getId() % 5 == 0);
-        assertTrue("Artifact Id is odd", a.getId() % 2 != 0);
-        assertTrue("Company name contains widgets", a.getManufacturer().getName().contains("Widgets"));
-        count++;
-        // System.out.println(a.getId()+" "+a.getManufacturer().getName()
-        // +"  "+count);
-      }
-      assertEquals("Page size", count, p.size());
-      pageNo = pageNo + p.getPageSize();
-    } while (!p.isLastPage() && pageNo < p.getTotalSize());
-    assertEquals("page number after the loop", 4, p.getPageNumber());
-    assertEquals("total no of pages", 4, p.getTotalPages());
+		assertThrows(ClassCastException.class, () -> {
+				PojoQueryDefinition queryDef = (PojoQueryDefinition)
+					queryMgr.newRawQueryByExampleDefinition(new StringHandle(queryAsString).withFormat(Format.JSON));
+			}
+		);
   }
 
-  @Test(expected = ClassCastException.class)
+	@Test
   public void testPOJOqbeSearchWithSearchHandle() {
     PojoRepository<Artifact, Long> products = client.newPojoRepository(Artifact.class, Long.class);
     PojoPage<Artifact> p;
@@ -163,49 +140,12 @@ public class TestPOJOwithQBEQueryDef extends AbstractFunctionalTest {
             + "\"$and\":[{\"inventory\":{\"$gt\":1010}},{\"inventory\":{\"$le\":1110}}]"
             + ",\"$filtered\": true}}";
     System.out.println(queryAsString);
-    PojoQueryDefinition qd = (PojoQueryDefinition) queryMgr.newRawQueryByExampleDefinition(new StringHandle(queryAsString).withFormat(Format.JSON));
-    qd.setCollections("even");
-    SearchHandle results = new SearchHandle();
-    products.setPageLength(10);
-    p = products.search(qd, 1, results);
-    assertEquals("total no of pages", 5, p.getTotalPages());
-    System.out.println(p.getTotalPages());
-    // System.out.println(results.getMetrics().getQueryResolutionTime());
-    long pageNo = 1, count = 0;
-    do {
-      count = 0;
-      p = products.search(qd, pageNo, results);
-
-      while (p.iterator().hasNext()) {
-        Artifact a = p.iterator().next();
-        validateArtifact(a);
-        assertTrue("Enventory lies between 1010 to 1110", a.getInventory() > 1010 && a.getInventory() <= 1110);
-        assertTrue("Artifact Id is even", a.getId() % 2 == 0);
-        assertTrue("Company name contains Acme", a.getManufacturer().getName().contains("Acme"));
-        count++;
-        // System.out.println(a.getId()+" "+a.getManufacturer().getName()
-        // +"  "+count);
-      }
-      assertEquals("Page size", count, p.size());
-      pageNo = pageNo + p.getPageSize();
-      MatchDocumentSummary[] mds = results.getMatchResults();
-      assertEquals("Size of the results summary", 10, mds.length);
-      for (MatchDocumentSummary md : mds) {
-        assertTrue("every uri should contain the class name", md.getUri().contains("Artifact"));
-      }
-      String[] facetNames = results.getFacetNames();
-      for (String fname : facetNames) {
-        System.out.println(fname);
-      }
-      // assertEquals("Total results from search handle ",50,results.getTotalResults());
-      // assertTrue("Search Handle metric results ",results.getMetrics().getTotalTime()>0);
-    } while (!p.isLastPage() && pageNo < p.getTotalSize());
-    assertEquals("Page start check", 41, p.getStart());
-    assertEquals("page number after the loop", 5, p.getPageNumber());
-    assertEquals("total no of pages", 5, p.getTotalPages());
+	assertThrows(ClassCastException.class, () -> {
+		PojoQueryDefinition qd = (PojoQueryDefinition) queryMgr.newRawQueryByExampleDefinition(new StringHandle(queryAsString).withFormat(Format.JSON));
+	});
   }
 
-  @Test(expected = ClassCastException.class)
+	@Test
   public void testPOJOCombinedSearchWithJacksonHandle() {
     PojoRepository<Artifact, Long> products = client.newPojoRepository(Artifact.class, Long.class);
     PojoPage<Artifact> p;
@@ -217,42 +157,14 @@ public class TestPOJOwithQBEQueryDef extends AbstractFunctionalTest {
         + "\"options\":{\"constraint\":{\"name\":\"pojo-name-field\", \"word\":{\"json-property\":\"name\"}}}"
         + "}}";
 
-    PojoQueryDefinition qd = (PojoQueryDefinition) queryMgr.newRawCombinedQueryDefinition(new StringHandle(queryAsString).withFormat(Format.JSON));
-    JacksonHandle results = new JacksonHandle();
-    p = products.search(qd, 1, results);
-    products.setPageLength(11);
-    assertEquals("total no of pages", 1, p.getTotalPages());
-    // System.out.println(p.getTotalPages()+results.get().toString());
-    long pageNo = 1, count = 0;
-    do {
-      count = 0;
-      p = products.search(qd, pageNo, results);
-
-      while (p.iterator().hasNext()) {
-        Artifact a = p.iterator().next();
-        validateArtifact(a);
-        count++;
-        assertTrue("Manufacture name starts with acme", a.getManufacturer().getName().contains("Acme"));
-        assertTrue("Artifact name contains", a.getName().contains("special"));
-
-      }
-      assertEquals("Page size", count, p.size());
-      pageNo = pageNo + p.getPageSize();
-
-      assertEquals("Page start from search handls vs page methods", results.get().get("start").asLong(), p.getStart());
-      assertEquals("Format in the search handle", "json", results.get().withArray("results").get(1).path("format").asText());
-      assertTrue("Uri in search handle contains Artifact", results.get().withArray("results").get(1).path("uri").asText().contains("Artifact"));
-      // System.out.println(results.get().toString());
-    } while (!p.isLastPage() && pageNo < p.getTotalSize());
-    assertFalse("search handle has metrics", results.get().has("metrics"));
-    assertEquals("Total from search handle", 11, results.get().get("total").asInt());
-    assertEquals("page number after the loop", 1, p.getPageNumber());
-    assertEquals("total no of pages", 1, p.getTotalPages());
+	assertThrows(ClassCastException.class, () -> {
+		PojoQueryDefinition qd = (PojoQueryDefinition) queryMgr.newRawCombinedQueryDefinition(new StringHandle(queryAsString).withFormat(Format.JSON));
+	});
   }
 
   // Searching for Id as Number in JSON using range query
-  @Test(expected = ClassCastException.class)
-  public void testPOJOcombinedSearchforNumberWithStringHandle() throws KeyManagementException, NoSuchAlgorithmException, JsonProcessingException, IOException {
+	@Test
+  public void testPOJOcombinedSearchforNumberWithStringHandle() {
     PojoRepository<Artifact, Long> products = client.newPojoRepository(Artifact.class, Long.class);
     PojoPage<Artifact> p;
     this.loadSimplePojos(products);
@@ -262,32 +174,9 @@ public class TestPOJOwithQBEQueryDef extends AbstractFunctionalTest {
         + "\"range-constraint-query\":{\"constraint-name\":\"id\", \"value\":[5,10,15,20,25,30]}},"
         + "\"options\":{\"return-metrics\":false, \"constraint\":{\"name\":\"id\", \"range\":{\"type\": \"xs:long\",\"json-property\":\"id\"}}}"
         + "}}";
-    PojoQueryDefinition qd = (PojoQueryDefinition) queryMgr.newRawCombinedQueryDefinition(new StringHandle(queryAsString).withFormat(Format.JSON));
-
-    StringHandle results = new StringHandle();
-    JacksonHandle jh = new JacksonHandle();
-    p = products.search(qd, 1, jh);
-
-    long pageNo = 1, count = 0;
-    do {
-      count = 0;
-      p = products.search(qd, pageNo, results.withFormat(Format.JSON));
-
-      while (p.iterator().hasNext()) {
-        Artifact a = p.iterator().next();
-        validateArtifact(a);
-        count++;
-      }
-      assertEquals("Page total results", count, p.getTotalSize());
-      pageNo = pageNo + p.getPageSize();
-      System.out.println(results.get().toString());
-    } while (!p.isLastPage() && pageNo < p.getTotalSize());
-    assertFalse("String handle is not empty", results.get().isEmpty());
-    assertTrue("String handle contains results", results.get().contains("results"));
-    assertTrue("String handle contains format", results.get().contains("\"format\":\"json\""));
-    ObjectMapper mapper = new ObjectMapper();
-    JsonNode actNode = mapper.readTree(results.get()).get("total");
-    assertEquals("Total search results resulted are ", 6, actNode.asInt());
+	assertThrows(ClassCastException.class, () -> {
+		PojoQueryDefinition qd = (PojoQueryDefinition) queryMgr.newRawCombinedQueryDefinition(new StringHandle(queryAsString).withFormat(Format.JSON));
+	});
   }
 
 }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPartialUpdate.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPartialUpdate.java
@@ -33,23 +33,24 @@ import com.marklogic.client.io.DocumentMetadataHandle.DocumentCollections;
 import com.marklogic.client.io.marker.DocumentPatchHandle;
 import com.marklogic.client.query.*;
 import org.json.JSONException;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.io.File;
 import java.io.IOException;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+
+
 
 public class TestPartialUpdate extends AbstractFunctionalTest {
   private static String dbName = "java-functest";
   private static int uberPort;
   private static String appServerHostname = null;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
     System.out.println("In setup");
 	// Don't know why this was called "uberPort" or why it defaulted to 8000 before
@@ -87,7 +88,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
 
     System.out.println(content);
 
-    assertTrue("fragment is not inserted", content.contains("<modified>2013-03-21</modified></root>"));
+    assertTrue( content.contains("<modified>2013-03-21</modified></root>"));
 
     // Check boolean replaces with XML documents.
     String xmlDocId = "/replaceBoolXml";
@@ -106,7 +107,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
     // Read it back to make sure the write worked.
     String contentXml = docMgr.read(xmlDocId, new StringHandle()).get();
 
-    assertTrue("XML Replace fragment is not inserted", contentXml.contains(xmlStr2));
+    assertTrue( contentXml.contains(xmlStr2));
 
     DocumentPatchBuilder patchBldrBool = docMgr.newPatchBuilder();
     patchBldrBool.pathLanguage(PathLanguage.XPATH);
@@ -123,7 +124,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
     System.out.println(content1);
     String xmlStr2Mod = new String("<resources><screen name=\"screen_small\">false</screen><screen name=\"adjust_view_bounds\">true</screen></resources>");
 
-    assertTrue("XML fragment is not replaced", content1.contains(xmlStr2Mod));
+    assertTrue( content1.contains(xmlStr2Mod));
     // release client
     client.release();
   }
@@ -134,8 +135,8 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
    * Message : Local message: write failed: Unauthorized. Server Message:
    * Unauthorized
    */
-  @Test(expected = FailedRequestException.class)
-  public void testJSONParserException() throws IOException
+	@Test
+  public void testJSONParserException()
   {
     System.out.println("Running testPartialUpdateJSON");
 
@@ -146,7 +147,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
 
     // write docs
     for (String filename : filenames) {
-      writeDocumentUsingInputStreamHandle(client, filename, "/partial-update/", "JSON");
+      assertThrows(FailedRequestException.class, () -> writeDocumentUsingInputStreamHandle(client, filename, "/partial-update/", "JSON"));
     }
     // release client
     client.release();
@@ -198,9 +199,9 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
 
     System.out.println(content);
 
-    assertTrue("fragment is not inserted", content.contains("{\"insertedKey\":9}"));
-    assertTrue("Original fragment is not inserted or incorrect", content.contains("{\"original\":true}"));
-    assertTrue("Modified fragment is not inserted or incorrect", content.contains("{\"modified\":false}"));
+    assertTrue( content.contains("{\"insertedKey\":9}"));
+    assertTrue( content.contains("{\"original\":true}"));
+    assertTrue( content.contains("{\"modified\":false}"));
 
     // Test for replaceValue with booleans.
     DocumentPatchBuilder patchBldrBool = docMgr.newPatchBuilder();
@@ -218,8 +219,8 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
 
     System.out.println(content1);
     // Make sure the inserted content is present.
-    assertTrue("Original fragment is not replaced", content1.contains("{\"original\":false}"));
-    assertTrue("Modified fragment is not replaced", content1.contains("{\"modified\":true}"));
+    assertTrue( content1.contains("{\"original\":false}"));
+    assertTrue( content1.contains("{\"modified\":true}"));
 
     // release client
     client.release();
@@ -266,7 +267,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
 
     System.out.println("After Updating" + contentAfter);
 
-    assertTrue("fragment is not inserted", contentAfter.contains("<modified>2012-11-5</modified></root>"));
+    assertTrue( contentAfter.contains("<modified>2012-11-5</modified></root>"));
 
     // //
     // Updating Doc Element
@@ -281,7 +282,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
     System.out.println("After Updating" + contentAfter);
 
     // Check
-    assertTrue("Element Value has not Changed", contentAfter.contains("<popularity>10</popularity>"));
+    assertTrue( contentAfter.contains("<popularity>10</popularity>"));
 
     // //
     // Updating Doc Attribute
@@ -299,7 +300,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
 
     System.out.println("After Updating" + contentAfter);
     // Check
-    assertTrue("Value of amt has not Changed", contentAfter.contains("<price amt=\"0.5\" xmlns=\"http://cloudbank.com\"/>"));
+    assertTrue( contentAfter.contains("<price amt=\"0.5\" xmlns=\"http://cloudbank.com\"/>"));
 
     // //
     // Updating Doc Namespace
@@ -315,7 +316,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
 
     System.out.println("After Updating" + contentAfter);
     // Check
-    assertTrue("Element Value has not Changed", contentAfter.contains("<date xmlns=\"http://purl.org/dc/elements/1.1/\">2006-02-02</date>"));
+    assertTrue( contentAfter.contains("<date xmlns=\"http://purl.org/dc/elements/1.1/\">2006-02-02</date>"));
 
     // release client
     client.release();
@@ -355,12 +356,12 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
       waitForPropertyPropagate();
     } catch (Exception e) {
       System.out.println(e.toString());
-      assertTrue("Haven't deleted Invalid path", e.toString().contains(" invalid path: //InvalidPath"));
+      assertTrue(e.toString().contains(" invalid path: //InvalidPath"));
     }
     String contentAfter = xmlDocMgr.read(docId, new StringHandle()).get();
 
     System.out.println("After Updating" + contentAfter);
-    assertFalse("Element is not Deleted", contentAfter.contains("<date xmlns=\"http://purl.org/dc/elements/1.1/\">2005-01-01</date>"));
+    assertFalse( contentAfter.contains("<date xmlns=\"http://purl.org/dc/elements/1.1/\">2005-01-01</date>"));
 
     // release client
     client.release();
@@ -396,10 +397,10 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
 
     System.out.println(content);
 
-    assertTrue("fragment is not inserted Before", content.contains("<start>Hi</start>"));
-    assertTrue("fragment is not inserted After", content.contains("<modified>2013-03-21</modified>"));
-    assertTrue("fragment is not inserted as Last Child", content.contains("<End>bye</End>"));
-    assertFalse("fragment with invalid path has entered", content.contains("<false>Entry</false>"));
+    assertTrue( content.contains("<start>Hi</start>"));
+    assertTrue( content.contains("<modified>2013-03-21</modified>"));
+    assertTrue( content.contains("<End>bye</End>"));
+    assertFalse( content.contains("<false>Entry</false>"));
     // release client
     client.release();
   }
@@ -432,9 +433,9 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
 
     System.out.println(content);
 
-    assertTrue("fragment is not Replaced", content.contains("<replaced>foo</replaced>"));
-    assertFalse("fragment is not Replaced", content.contains("<replaced>FalseEntry</replaced>"));
-    assertTrue("replaceInsertFragment has Failed", content.contains("<foo>bar</foo>"));
+    assertTrue( content.contains("<replaced>foo</replaced>"));
+    assertFalse( content.contains("<replaced>FalseEntry</replaced>"));
+    assertTrue( content.contains("<foo>bar</foo>"));
     // release client
     client.release();
   }
@@ -466,9 +467,9 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
 
     System.out.println(content);
 
-    assertTrue("replaceInsertFragment Failed at Position.LAST_CHILD", content.contains("<foo>LastChild</foo>"));
-    assertTrue("replaceInsertFragment Failed at Position.BEFORE", content.contains("<foo>Before</foo>"));
-    assertTrue("replaceInsertFragment Failed at Position.AFTER", content.contains("<foo>After</foo>"));
+    assertTrue(content.contains("<foo>LastChild</foo>"));
+    assertTrue( content.contains("<foo>Before</foo>"));
+    assertTrue( content.contains("<foo>After</foo>"));
 
     // release client
     client.release();
@@ -516,17 +517,17 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
 
     System.out.println("After Update" + content);
     // Check
-    assertTrue("Add Failed", content.contains("<add>15</add>"));
-    assertTrue("Subtract Failed", content.contains("<subtract>3</subtract>"));
-    assertTrue("Multiplication Failed", content.contains("<multiply>4</multiply>"));
-    assertTrue("Division Failed", content.contains("<divide>10</divide>"));
-    assertTrue("concatenateAfter Failed", content.contains("<concatenateAfter>Hi ML7</concatenateAfter>"));
-    assertTrue("concatenateBefore Failed", content.contains("<concatenateBefore>ML 7</concatenateBefore>"));
-    assertTrue("substringAfter Failed", content.contains(" <substringAfter> 7</substringAfter>"));
-    assertTrue("substringBefore Failed", content.contains("<substringBefore>ML </substringBefore>"));
-    assertTrue("concatenateBetween Failed", content.contains("<concatenateBetween>ML Version 7</concatenateBetween>"));
-    assertTrue("Ragex Failed", content.contains("<replaceRegex>C111nt</replaceRegex>"));
-    assertTrue("Apply Library Fragments Failed ", content.contains("<applyLibrary>APIAPI</applyLibrary>"));
+    assertTrue( content.contains("<add>15</add>"));
+    assertTrue( content.contains("<subtract>3</subtract>"));
+    assertTrue( content.contains("<multiply>4</multiply>"));
+    assertTrue( content.contains("<divide>10</divide>"));
+    assertTrue( content.contains("<concatenateAfter>Hi ML7</concatenateAfter>"));
+    assertTrue( content.contains("<concatenateBefore>ML 7</concatenateBefore>"));
+    assertTrue( content.contains(" <substringAfter> 7</substringAfter>"));
+    assertTrue( content.contains("<substringBefore>ML </substringBefore>"));
+    assertTrue( content.contains("<concatenateBetween>ML Version 7</concatenateBetween>"));
+    assertTrue( content.contains("<replaceRegex>C111nt</replaceRegex>"));
+    assertTrue( content.contains("<applyLibrary>APIAPI</applyLibrary>"));
 
     String docId2 = "/partial-update/constraint6.json";
 
@@ -544,7 +545,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
     waitForPropertyPropagate();
     String content1 = xmlDocMgr.read(docId2, new StringHandle()).get();
     System.out.println("After Update on divide with fn() values " + content1);
-    assertTrue("Division Failed", content1.contains("\"divide\":18"));
+    assertTrue( content1.contains("\"divide\":18"));
 
     // Work on the different element with different values and another patch update
     DocumentPatchBuilder patchBldrSJS1 = jdm.newPatchBuilder();
@@ -555,7 +556,6 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
     		patchBldrSJS1.call().applyLibraryValues("Mymin", -12, 21));
     ObjectMapper mapper = new ObjectMapper();
     ObjectNode fragmentNode = mapper.createObjectNode();
-    fragmentNode = mapper.createObjectNode();
     fragmentNode.put("modulo", 2);
     String fragment = mapper.writeValueAsString(fragmentNode);
     patchBldrSJS1.insertFragment("root.divide", Position.AFTER, fragment);
@@ -567,8 +567,8 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
     waitForPropertyPropagate();
     String content2 = xmlDocMgr.read(docId2, new StringHandle()).get();
     System.out.println("After Update on add with fn() values " + content2);
-    assertTrue("Add Failed", content2.contains("\"add\":-12"));
-    assertTrue("Modulo Failed", content2.contains("\"modulo\":2"));
+    assertTrue( content2.contains("\"add\":-12"));
+    assertTrue( content2.contains("\"modulo\":2"));
 
     // Error condition checks
     DocumentPatchBuilder patchBldrSJSErr = jdm.newPatchBuilder();
@@ -591,7 +591,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
     waitForPropertyPropagate();
     String content3 = xmlDocMgr.read(docId2, new StringHandle()).get();
     System.out.println("After Update on divide with fn() values " + content3);
-    assertTrue("No exception should be available", strErr.toString().isEmpty());
+    assertTrue( strErr.toString().isEmpty());
 
     // release client
     libsMgr.delete("/ext/patch/custom-lib.xqy");
@@ -624,9 +624,9 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
 
     System.out.println(" After Updating " + content);
     // Check
-    assertTrue("Multiplication Failed", content.contains("<popularity>10</popularity>"));
-    assertFalse("Deletion Failed", content.contains("<date xmlns=\"http://purl.org/dc/elements/1.1/\">2005-01-01</date>"));
-    assertTrue("Insertion Failed", content.contains("<modified>2012-11-5</modified>"));
+    assertTrue( content.contains("<popularity>10</popularity>"));
+    assertFalse( content.contains("<date xmlns=\"http://purl.org/dc/elements/1.1/\">2005-01-01</date>"));
+    assertTrue( content.contains("<modified>2012-11-5</modified>"));
     // release client
     client.release();
   }
@@ -661,9 +661,9 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
     System.out.println(" After Updating " + content);
 
     // Check
-    assertTrue("Multiplication Failed", content.contains("<popularity>10</popularity>"));
-    assertFalse("Deletion Failed", content.contains("<date xmlns=\"http://purl.org/dc/elements/1.1/\">2005-01-01</date>"));
-    assertTrue("Insertion Failed", content.contains("<modified>2012-11-5</modified>"));
+    assertTrue( content.contains("<popularity>10</popularity>"));
+    assertFalse( content.contains("<date xmlns=\"http://purl.org/dc/elements/1.1/\">2005-01-01</date>"));
+    assertTrue( content.contains("<modified>2012-11-5</modified>"));
 
     // release client
     client.release();
@@ -754,9 +754,9 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
 
     System.out.println("After" + content);
 
-    assertTrue("fragment is not inserted", content.contains("{\"insertedKey\":9}"));
-    assertTrue("fragment is not inserted", content.contains("{\"firstName\":\"AnnHi\", \"lastName\":\"Smith\"}"));
-    assertFalse("fragment is not deleted", content.contains("{\"firstName\":\"Bob\", \"lastName\":\"Foo\"}"));
+    assertTrue( content.contains("{\"insertedKey\":9}"));
+    assertTrue( content.contains("{\"firstName\":\"AnnHi\", \"lastName\":\"Smith\"}"));
+    assertFalse( content.contains("{\"firstName\":\"Bob\", \"lastName\":\"Foo\"}"));
 
     // release client
     client.release();
@@ -790,9 +790,9 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
     System.out.println(" After Changing " + contentMetadata1);
 
     // Check
-    assertTrue("Collection not added", contentMetadata1.contains("<rapi:collection>/document/collection3</rapi:collection>"));
-    assertTrue("Permission not added", contentMetadata1.contains("<rapi:role-name>replaceRoleTest</rapi:role-name>"));
-    assertTrue("Property not added", contentMetadata1.contains("<Hello xsi:type=\"xs:string\">Hi</Hello>"));
+    assertTrue( contentMetadata1.contains("<rapi:collection>/document/collection3</rapi:collection>"));
+    assertTrue( contentMetadata1.contains("<rapi:role-name>replaceRoleTest</rapi:role-name>"));
+    assertTrue( contentMetadata1.contains("<Hello xsi:type=\"xs:string\">Hi</Hello>"));
 
     // //
     // replacing Metadata Values
@@ -808,9 +808,9 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
     System.out.println(" After Updating " + contentMetadataRep);
 
     // Check
-    assertTrue("Collection not added", contentMetadataRep.contains("<rapi:collection>/document/collection4</rapi:collection>"));
-    assertTrue("Permission not added", contentMetadata1.contains("<rapi:role-name>replaceRoleTest</rapi:role-name>"));
-    assertTrue("Property not added", contentMetadataRep.contains("<Hello xsi:type=\"xs:string\">Bye</Hello>"));
+    assertTrue( contentMetadataRep.contains("<rapi:collection>/document/collection4</rapi:collection>"));
+    assertTrue( contentMetadata1.contains("<rapi:role-name>replaceRoleTest</rapi:role-name>"));
+    assertTrue( contentMetadataRep.contains("<Hello xsi:type=\"xs:string\">Bye</Hello>"));
 
     // //
     // Deleting Metadata Values
@@ -826,9 +826,9 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
     System.out.println(" After Deleting " + contentMetadataDel);
 
     // Check
-    assertFalse("Collection not deleted", contentMetadataDel.contains("<rapi:collection>/document/collection4</rapi:collection>"));
-    assertFalse("Permission not deleted", contentMetadataDel.contains("<rapi:role-name>admin</rapi:role-name>"));
-    assertFalse("Property not deleted", contentMetadataDel.contains("<Hello xsi:type=\"xs:string\">Bye</Hello>"));
+    assertFalse( contentMetadataDel.contains("<rapi:collection>/document/collection4</rapi:collection>"));
+    assertFalse( contentMetadataDel.contains("<rapi:role-name>admin</rapi:role-name>"));
+    assertFalse( contentMetadataDel.contains("<Hello xsi:type=\"xs:string\">Bye</Hello>"));
 
     // release client
     client.release();
@@ -865,7 +865,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
 
     System.out.println("After" + content);
 
-    assertTrue("fragment is not inserted", content.contains("<modified>2013-03-21</modified></root>"));
+    assertTrue( content.contains("<modified>2013-03-21</modified></root>"));
 
     // release client
     client.release();
@@ -910,7 +910,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
 
     System.out.println("After" + content);
 
-    assertTrue("fragment is not inserted", content.contains("{\"insertedKey\":9}]"));
+    assertTrue( content.contains("{\"insertedKey\":9}]"));
 
     // release client
     client.release();
@@ -949,7 +949,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
 
     System.out.println("After" + content);
 
-    assertTrue("fragment is not inserted", content.contains("<modified>2013-03-21</modified></root>"));
+    assertTrue( content.contains("<modified>2013-03-21</modified></root>"));
 
     // release client
     client.release();
@@ -994,7 +994,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
 
     System.out.println("After" + content);
 
-    assertTrue("fragment is not inserted", content.contains("{\"insertedKey\":9}]"));
+    assertTrue( content.contains("{\"insertedKey\":9}]"));
 
     // release client
     client.release();
@@ -1027,7 +1027,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
     String contentBefore = xmlDocMgr.read(docId, new StringHandle()).get();
 
     System.out.println(" Content after Updating with Cardinality.ONE : " + contentBefore);
-    assertTrue("Insertion Failed ", contentBefore.contains("</modified></root>"));
+    assertTrue( contentBefore.contains("</modified></root>"));
     // Updating again
     DocumentPatchBuilder xmlPatchBldr = xmlDocMgr.newPatchBuilder();
     DocumentPatchHandle xmlPatchForNode = xmlPatchBldr.insertFragment("/root/id", Position.BEFORE, Cardinality.ONE_OR_MORE, "<modified>1989-04-06</modified>").build();
@@ -1036,7 +1036,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
     String contentAfter = xmlDocMgr.read(docId, new StringHandle()).get();
 
     System.out.println("Content after Updating with Cardinality.ONE_OR_MORE" + contentAfter);
-    assertTrue("Insertion Failed ", contentAfter.contains("1989-04-06"));
+    assertTrue( contentAfter.contains("1989-04-06"));
     // Updating again
     DocumentPatchBuilder xmlPatchBldr1 = xmlDocMgr.newPatchBuilder();
     DocumentPatchHandle xmlPatchForNode1 = xmlPatchBldr1.insertFragment("/root/id", Position.AFTER, Cardinality.ZERO_OR_ONE, "<modified>2013-07-29</modified>").build();
@@ -1045,7 +1045,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
     contentAfter = xmlDocMgr.read(docId, new StringHandle()).get();
 
     System.out.println("Content after Updating with Cardinality.ZERO_OR_ONE" + contentAfter);
-    assertTrue("Insertion Failed ", contentAfter.contains("</id><modified>2013-07-29"));
+    assertTrue( contentAfter.contains("</id><modified>2013-07-29"));
 
     // release client
     client.release();
@@ -1351,7 +1351,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
               for (ExtractedItem item : extracted) {
                   String extractItem = item.getAs(String.class);
                   System.out.println("Extracted item from Number node element search " + extractItem);
-                  assertTrue("Extracted Number node items incorrect", extractItem.matches("\\{\"Pop\":328\\}"));
+                  assertTrue( extractItem.matches("\\{\"Pop\":328\\}"));
               }
           }
       }
@@ -1371,7 +1371,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
       // Verify the results again. Poppulation should be 500 for second document
       String content = docMgr.read(docId, new StringHandle()).get();
       System.out.println("Patched Number node element is " + content);
-      assertTrue("Patched Number node element incorrect", content.contains("\"Pop\":500"));
+      assertTrue( content.contains("\"Pop\":500"));
   }
 
   /*
@@ -1426,9 +1426,9 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
     String actualCollections = getDocumentCollectionsString(collections);
     System.out.println("Returned collections: " + actualCollections);
 
-    assertTrue("Document collections difference in size value", actualCollections.contains("size:2"));
-    assertTrue("JSONPatch1 not found", actualCollections.contains("JSONPatch1"));
-    assertTrue("JSONPatch3 not found", actualCollections.contains("JSONPatch3"));
+    assertTrue( actualCollections.contains("size:2"));
+    assertTrue( actualCollections.contains("JSONPatch1"));
+    assertTrue( actualCollections.contains("JSONPatch3"));
 
     // Construct a Patch From Raw JSON
     /*
@@ -1460,7 +1460,7 @@ public class TestPartialUpdate extends AbstractFunctionalTest {
     client.release();
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() throws Exception {
     deleteRESTUser("eval-user");
     deleteUserRole("test-eval");

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPatchCardinality.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPatchCardinality.java
@@ -27,20 +27,19 @@ import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.io.marker.DocumentPatchHandle;
 import org.custommonkey.xmlunit.XMLAssert;
 import org.custommonkey.xmlunit.XMLUnit;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 public class TestPatchCardinality extends AbstractFunctionalTest {
 
-  @After
+  @AfterEach
   public void testCleanUp() throws Exception
   {
     deleteDocuments(connectAsAdmin());
@@ -79,7 +78,7 @@ public class TestPatchCardinality extends AbstractFunctionalTest {
 
     String expectedException = "Local message: write failed: Bad Request. Server Message: RESTAPI-INVALIDREQ: (err:FOER0000) Invalid request:  reason: invalid content patch operations for uri /cardinal/cardinal1.xml: invalid cardinality of 5 nodes for: /root/foo";
 
-    assertTrue("Exception is not thrown", exception.contains(expectedException));
+    assertTrue( exception.contains(expectedException));
 
     // release client
     client.release();
@@ -111,7 +110,7 @@ public class TestPatchCardinality extends AbstractFunctionalTest {
 
     System.out.println(content);
 
-    assertTrue("fragment is not inserted", content.contains("<bar>added</bar>"));
+    assertTrue( content.contains("<bar>added</bar>"));
 
     // release client
     client.release();
@@ -143,11 +142,11 @@ public class TestPatchCardinality extends AbstractFunctionalTest {
 
     System.out.println(content);
 
-    assertTrue("fragment is not inserted", content.contains("<foo>one</foo><bar>added</bar>"));
-    assertTrue("fragment is not inserted", content.contains("<foo>two</foo><bar>added</bar>"));
-    assertTrue("fragment is not inserted", content.contains("<foo>three</foo><bar>added</bar>"));
-    assertTrue("fragment is not inserted", content.contains("<foo>four</foo><bar>added</bar>"));
-    assertTrue("fragment is not inserted", content.contains("<foo>five</foo><bar>added</bar>"));
+    assertTrue( content.contains("<foo>one</foo><bar>added</bar>"));
+    assertTrue( content.contains("<foo>two</foo><bar>added</bar>"));
+    assertTrue( content.contains("<foo>three</foo><bar>added</bar>"));
+    assertTrue( content.contains("<foo>four</foo><bar>added</bar>"));
+    assertTrue( content.contains("<foo>five</foo><bar>added</bar>"));
 
     // release client
     client.release();
@@ -186,7 +185,7 @@ public class TestPatchCardinality extends AbstractFunctionalTest {
 
     String expectedException = "Local message: write failed: Bad Request. Server Message: RESTAPI-INVALIDREQ: (err:FOER0000) Invalid request:  reason: invalid content patch operations for uri /cardinal/cardinal3.xml: invalid cardinality of 0 nodes for: /root/foo";
 
-    assertTrue("Exception is not thrown", exception.contains(expectedException));
+    assertTrue( exception.contains(expectedException));
 
     // release client
     client.release();
@@ -225,7 +224,7 @@ public class TestPatchCardinality extends AbstractFunctionalTest {
 
     String expectedException = "Local message: write failed: Bad Request. Server Message: RESTAPI-INVALIDREQ: (err:FOER0000) Invalid request:  reason: invalid content patch operations for uri /cardinal/cardinal1.xml: invalid cardinality of 5 nodes for: /root/foo";
 
-    assertTrue("Exception is not thrown", exception.contains(expectedException));
+    assertTrue( exception.contains(expectedException));
 
     // release client
     client.release();
@@ -257,7 +256,7 @@ public class TestPatchCardinality extends AbstractFunctionalTest {
 
     System.out.println(content);
 
-    assertTrue("fragment is not inserted", content.contains("<foo>one</foo><bar>added</bar>"));
+    assertTrue( content.contains("<foo>one</foo><bar>added</bar>"));
 
     // release client
     client.release();
@@ -289,7 +288,7 @@ public class TestPatchCardinality extends AbstractFunctionalTest {
 
     System.out.println(content);
 
-    assertFalse("fragment is inserted", content.contains("<baz>one</baz><bar>added</bar>"));
+    assertFalse(content.contains("<baz>one</baz><bar>added</bar>"));
 
     // release client
     client.release();
@@ -321,11 +320,11 @@ public class TestPatchCardinality extends AbstractFunctionalTest {
 
     System.out.println(content);
 
-    assertTrue("fragment is not inserted", content.contains("<foo>one</foo><bar>added</bar>"));
-    assertTrue("fragment is not inserted", content.contains("<foo>two</foo><bar>added</bar>"));
-    assertTrue("fragment is not inserted", content.contains("<foo>three</foo><bar>added</bar>"));
-    assertTrue("fragment is not inserted", content.contains("<foo>four</foo><bar>added</bar>"));
-    assertTrue("fragment is not inserted", content.contains("<foo>five</foo><bar>added</bar>"));
+    assertTrue( content.contains("<foo>one</foo><bar>added</bar>"));
+    assertTrue( content.contains("<foo>two</foo><bar>added</bar>"));
+    assertTrue( content.contains("<foo>three</foo><bar>added</bar>"));
+    assertTrue( content.contains("<foo>four</foo><bar>added</bar>"));
+    assertTrue( content.contains("<foo>five</foo><bar>added</bar>"));
 
     // release client
     client.release();
@@ -375,10 +374,6 @@ public class TestPatchCardinality extends AbstractFunctionalTest {
           assertXpathEvaluatesTo("1",
               "count(/*[local-name()='metadata']/*[local-name()='permissions']/*[local-name()='permission']/*[local-name()='role-name' and string(.)='rest-writer'])", actual);
           assertXpathEvaluatesTo("1", "count(/*[local-name()='metadata']/*[local-name()='quality' and string(.)='0'])", actual);
-
-          XMLUnit.getControlDocumentBuilderFactory().setNamespaceAware(false);
-          XMLAssert.assertXpathEvaluatesTo("rest-readerread", "//permissions/permission[role-name[. = 'rest-reader'] and capability[. = 'read']]", actual);
-          XMLAssert.assertXpathEvaluatesTo("rest-writerupdate", "//permissions/permission[role-name[. = 'rest-writer'] and capability[. = 'update']]", actual);
         } catch (Exception e)
         {
           System.out.println(e.getMessage());
@@ -401,10 +396,6 @@ public class TestPatchCardinality extends AbstractFunctionalTest {
           assertXpathEvaluatesTo("1",
               "count(/*[local-name()='metadata']/*[local-name()='permissions']/*[local-name()='permission']/*[local-name()='role-name' and string(.)='rest-writer'])", actual);
           assertXpathEvaluatesTo("1", "count(/*[local-name()='metadata']/*[local-name()='quality' and string(.)='0'])", actual);
-
-          XMLUnit.getControlDocumentBuilderFactory().setNamespaceAware(false);
-          XMLAssert.assertXpathEvaluatesTo("rest-readerread", "//permissions/permission[role-name[. = 'rest-reader'] and capability[. = 'read']]", actual);
-          XMLAssert.assertXpathEvaluatesTo("rest-writerupdate", "//permissions/permission[role-name[. = 'rest-writer'] and capability[. = 'update']]", actual);
         } catch (Exception e)
         {
           System.out.println(e.getMessage());

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestQueryByExample.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestQueryByExample.java
@@ -25,8 +25,9 @@ import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.query.RawCombinedQueryDefinition;
 import com.marklogic.client.query.RawQueryByExampleDefinition;
 import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 import org.w3c.dom.Document;
 
 import javax.xml.transform.TransformerException;
@@ -36,12 +37,12 @@ import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+
+
 
 public class TestQueryByExample extends AbstractFunctionalTest {
 
-  @After
+  @AfterEach
   public void testCleanUp() throws Exception
   {
     deleteDocuments(connectAsAdmin());
@@ -151,7 +152,6 @@ public class TestQueryByExample extends AbstractFunctionalTest {
     System.out.println("testQueryByExampleJSON Result : " + resultDoc);
 
     assertTrue(
-        "doc returned is not correct",
         resultDoc
             .contains("<search:result index=\"1\" uri=\"/qbe/constraint1.json\" path=\"fn:doc(&quot;/qbe/constraint1.json&quot;)\""));
 
@@ -280,7 +280,7 @@ public class TestQueryByExample extends AbstractFunctionalTest {
     for (MatchDocumentSummary result : results.getMatchResults())
     {
       System.out.println(result.getUri() + ": Uri");
-      assertEquals("Wrong Document Searched", result.getUri(), "/qbe/constraint1.xml");
+      assertEquals( result.getUri(), "/qbe/constraint1.xml");
     }
 
     // release client
@@ -310,7 +310,7 @@ public class TestQueryByExample extends AbstractFunctionalTest {
     RawQueryByExampleDefinition qbyex = queryMgr.newRawQueryByExampleDefinition(fileHandle.withFormat(Format.JSON));
     String resultDoc = queryMgr.search(qbyex, new StringHandle()).get();
     System.out.println(resultDoc);
-    assertTrue("Result is not proper", resultDoc.contains("/qbe/constraint1.json"));
+    assertTrue( resultDoc.contains("/qbe/constraint1.json"));
 
     // release client
     client.release();
@@ -344,7 +344,7 @@ public class TestQueryByExample extends AbstractFunctionalTest {
       for (MatchDocumentSummary result : results.getMatchResults())
       {
         System.out.println(result.getUri() + ": Uri");
-        assertEquals("Wrong Document Searched", result.getUri(), "/qbe/constraint1.xml");
+        assertEquals( result.getUri(), "/qbe/constraint1.xml");
       }
     } catch (Exception e) {
       System.out.println("Negative Test Passed of executing nonreadable file");
@@ -377,7 +377,7 @@ public class TestQueryByExample extends AbstractFunctionalTest {
       for (MatchDocumentSummary result : results.getMatchResults())
       {
         System.out.println(result.getUri() + ": Uri");
-        // assertEquals("Wrong Document Searched",result.getUri() ,
+        // assertEquals(result.getUri() ,
         // "/qbe/constraint1.xml");
       }
     } catch (FailedRequestException e) {
@@ -415,8 +415,8 @@ public class TestQueryByExample extends AbstractFunctionalTest {
 
       System.out.println(resultDoc);
 
-      assertTrue("total result is not correct", resultDoc.contains("\"total\":1"));
-      assertTrue("doc returned is not correct",
+      assertTrue( resultDoc.contains("\"total\":1"));
+      assertTrue(
           resultDoc.contains("\"metadata\":[{\"title\":\"Vannevar Bush\"},{\"id\":11},{\"p\":\"Vannevar Bush wrote an article for The Atlantic Monthly\"},{\"popularity\":5}]"));
     } catch (FailedRequestException e) {
       System.out.println("Negative test passed as JSON with invalid structure gave FailedRequestException ");
@@ -452,7 +452,7 @@ public class TestQueryByExample extends AbstractFunctionalTest {
     for (MatchDocumentSummary result : results.getMatchResults())
     {
       System.out.println(result.getUri() + ": Uri");
-      assertEquals("Wrong Document Searched", result.getUri(), "/qbe/constraint1.xml");
+      assertEquals( result.getUri(), "/qbe/constraint1.xml");
     }
     try {
       File wrongFile = new File("src/test/java/com/marklogic/client/functionaltest/qbe/WrongQbe.xml");
@@ -465,7 +465,7 @@ public class TestQueryByExample extends AbstractFunctionalTest {
       for (MatchDocumentSummary result : newResults.getMatchResults())
       {
         System.out.println(result.getUri() + ": Uri");
-        assertEquals("Wrong Document Searched", result.getUri(), "/qbe/constraint1.xml");
+        assertEquals( result.getUri(), "/qbe/constraint1.xml");
       }
     } catch (FailedRequestException e) {
       System.out.println("Negative test passed as Query with improper Xml format gave FailedRequestException ");
@@ -505,9 +505,9 @@ public class TestQueryByExample extends AbstractFunctionalTest {
 
     System.out.println("Result of Correct Query" + resultDoc);
 
-    // assertTrue("total result is not correct",
+    // assertTrue(
     // resultDoc.contains("\"total\":1"));
-    // assertTrue("doc returned is not correct",
+    // assertTrue(
     // resultDoc.contains("\"metadata\":[{\"title\":\"Vannevar Bush\"},{\"id\":11},{\"p\":\"Vannevar Bush wrote an article for The Atlantic Monthly\"},{\"popularity\":5}]"));
 
     // get the query with Wrong Format
@@ -526,8 +526,8 @@ public class TestQueryByExample extends AbstractFunctionalTest {
 
       System.out.println("Result of Wrong Query" + newResultDoc);
 
-      assertTrue("total result is not correct", resultDoc.contains("\"total\":1"));
-      assertTrue("doc returned is not correct",
+      assertTrue( resultDoc.contains("\"total\":1"));
+      assertTrue(
           resultDoc.contains("\"metadata\":[{\"title\":\"Vannevar Bush\"},{\"id\":11},{\"p\":\"Vannevar Bush wrote an article for The Atlantic Monthly\"},{\"popularity\":5}]"));
     } catch (FailedRequestException e) {
       System.out.println("Negative test passed as Query with improper JSON format gave FailedRequestException ");

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestQueryOptionBuilder.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestQueryOptionBuilder.java
@@ -27,10 +27,11 @@ import com.marklogic.client.document.XMLDocumentManager;
 import com.marklogic.client.io.*;
 import com.marklogic.client.query.*;
 import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
@@ -46,24 +47,24 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+
+
 
 public class TestQueryOptionBuilder extends AbstractFunctionalTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
     createUserRolesWithPrevilages("evalSearchRole", "eval-search-string", "xdbc:eval", "xdbc:eval-in", "xdmp:eval-in", "any-uri", "xdbc:invoke");
     createRESTUser("evalSearchUser", "evalSearch", "tde-admin", "tde-view", "evalSearchRole", "rest-admin", "rest-writer",
             "rest-reader", "rest-extension-user", "manage-user");
   }
 
-  @After
+  @AfterEach
   public void testCleanUp() throws Exception {
     deleteDocuments(connectAsAdmin());
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() throws Exception {
     deleteUserRole("evalSearchRole");
     deleteRESTUser("evalSearchUser");
@@ -564,38 +565,38 @@ public class TestQueryOptionBuilder extends AbstractFunctionalTest {
    * TransformerException, ParserConfigurationException, SAXException,
    * IOException {
    * System.out.println("testExtractMetadataWithStructuredSearchAndConstraint");
-   * 
+   *
    * String filename = "xml-original.xml"; String uri = "/extract-metadata/";
-   * 
+   *
    * DatabaseClient client = getDatabaseClient("rest-admin", "x",
    * getConnType());
-   * 
+   *
    * ServerConfigurationManager scMgr = client.newServerConfigManager();
    * scMgr.setServerRequestLogging(true); scMgr.writeConfiguration();
-   * 
+   *
    * // get the original metadata Document docMetadata =
    * getXMLMetadata("metadata-original.xml");
-   * 
+   *
    * // create doc manager XMLDocumentManager docMgr =
    * client.newXMLDocumentManager();
-   * 
+   *
    * // write the doc writeDocumentUsingInputStreamHandle(client, filename, uri,
    * "XML");
-   * 
+   *
    * // create handle to write metadata DOMHandle writeMetadataHandle = new
    * DOMHandle(); writeMetadataHandle.set(docMetadata);
-   * 
+   *
    * // create doc id String docId = uri + filename;
-   * 
+   *
    * // write metadata docMgr.writeMetadata(docId, writeMetadataHandle);
-   * 
+   *
    * // create query options manager QueryOptionsManager optionsMgr =
    * client.newServerConfigManager().newQueryOptionsManager();
-   * 
+   *
    * // create query options String opts1 = new QueryOptionsBuilder();
-   * 
+   *
    * // create query options handle StringHandle handle = new StringHandle();
-   * 
+   *
    * // build query options
    * handle.withConfiguration(builder.configure().fragmentScope
    * (FragmentScope.PROPERTIES));
@@ -603,13 +604,13 @@ public class TestQueryOptionBuilder extends AbstractFunctionalTest {
    * QName("", "Author")), builder.constraintValue("appname")));
    * handle.withConstraints(builder.constraint("appname",
    * builder.word(builder.elementTermIndex(new QName("AppName")))));
-   * 
+   *
    * // write query options
    * optionsMgr.writeOptions("ExtractMetadataWithStructuredSearchAndConstraint",
    * handle);
-   * 
+   *
    * // create query manager QueryManager queryMgr = client.newQueryManager();
-   * 
+   *
    * // create query def StructuredQueryBuilder qb =
    * queryMgr.newStructuredQueryBuilder
    * ("ExtractMetadataWithStructuredSearchAndConstraint");
@@ -617,19 +618,19 @@ public class TestQueryOptionBuilder extends AbstractFunctionalTest {
    * StructuredQueryDefinition queryWord = qb.wordConstraint("appname",
    * "Microsoft"); StructuredQueryDefinition queryFinal = qb.and(queryTerm,
    * queryWord);
-   * 
+   *
    * // create handle DOMHandle resultsHandle = new DOMHandle();
    * queryMgr.search(queryFinal, resultsHandle);
-   * 
+   *
    * // get the result Document resultDoc = resultsHandle.get();
    * System.out.println(convertXMLDocumentToString(resultDoc));
-   * 
+   *
    * //assertXpathEvaluatesTo("MarkLogic",
    * "string(//*[local-name()='result']//*[local-name()='metadata']/*[local-name()='Author'])"
    * , resultDoc); //assertXpathEvaluatesTo("Microsoft Office Word",
    * "string(//*[local-name()='result']//*[local-name()='metadata']/*[local-name()='AppName'])"
    * , resultDoc);
-   * 
+   *
    * // release client client.release(); }
    */
 
@@ -1552,9 +1553,9 @@ public class TestQueryOptionBuilder extends AbstractFunctionalTest {
       JsonNode result1 = results.get(0).get("uri");
       JsonNode result2 = results.get(1).get("uri");
       System.out.println("Testing eval-string privilege without searchable-expression");
-      assertTrue("Row 1 uri value incorrect",  result1.asText().contains("/search-expr-func/constraint1.xml")
+      assertTrue(  result1.asText().contains("/search-expr-func/constraint1.xml")
               || result1.asText().contains("/search-expr-func/constraint3.xml"));
-      assertTrue("Row 1 uri value incorrect",  result2.asText().contains("/search-expr-func/constraint1.xml")
+      assertTrue(  result2.asText().contains("/search-expr-func/constraint1.xml")
               || result2.asText().contains("/search-expr-func/constraint3.xml"));
     }
     catch(Exception ex) {
@@ -1845,7 +1846,7 @@ public class TestQueryOptionBuilder extends AbstractFunctionalTest {
     // System.out.println(resultDoc);
     System.out.println(jn.get("results").findValue("uri").textValue());
 
-    assertTrue("Result is wrong", jn.get("results").findValue("uri").textValue().contains("/trans-res-with-snip-func/constraint3.xml"));
+    assertTrue( jn.get("results").findValue("uri").textValue().contains("/trans-res-with-snip-func/constraint3.xml"));
 
     // release client
     client.release();
@@ -1963,7 +1964,7 @@ public class TestQueryOptionBuilder extends AbstractFunctionalTest {
     String outputPOJO = readHandle.toString();
 
     boolean isQueryOptionsSame = output.equals(outputPOJO);
-    assertTrue("Query options is not the same", isQueryOptionsSame);
+    assertTrue( isQueryOptionsSame);
 
     QueryManager queryMgr = client.newQueryManager();
 
@@ -2034,7 +2035,7 @@ public class TestQueryOptionBuilder extends AbstractFunctionalTest {
     System.out.println(outputPOJO);
 
     boolean isQueryOptionsSame = output.equals(outputPOJO);
-    assertTrue("Query options is not the same", isQueryOptionsSame);
+    assertTrue( isQueryOptionsSame);
 
     QueryManager queryMgr = client.newQueryManager();
 
@@ -2105,7 +2106,7 @@ public class TestQueryOptionBuilder extends AbstractFunctionalTest {
     System.out.println(outputPOJO);
 
     boolean isQueryOptionsSame = output.equals(outputPOJO);
-    assertTrue("Query options is not the same", isQueryOptionsSame);
+    assertTrue( isQueryOptionsSame);
 
     QueryManager queryMgr = client.newQueryManager();
 

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestRawAlert.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestRawAlert.java
@@ -31,8 +31,9 @@ import com.marklogic.client.query.StringQueryDefinition;
 import com.marklogic.client.query.StructuredQueryBuilder;
 import com.marklogic.client.query.StructuredQueryDefinition;
 import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 import org.xml.sax.SAXException;
 
 import javax.xml.parsers.ParserConfigurationException;
@@ -45,11 +46,11 @@ import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Iterator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+
+
 
 public class TestRawAlert extends AbstractFunctionalTest {
-  @After
+  @AfterEach
   public void testCleanUp() throws Exception
   {
     deleteDocuments(connectAsAdmin());
@@ -115,7 +116,7 @@ public class TestRawAlert extends AbstractFunctionalTest {
 
     System.out.println(expected);
 
-    assertTrue("incorrect rule", expected.contains("RULE-TEST-1 - {rule-number=one} |"));
+    assertTrue( expected.contains("RULE-TEST-1 - {rule-number=one} |"));
 
     // release client
     client.release();
@@ -165,7 +166,7 @@ public class TestRawAlert extends AbstractFunctionalTest {
 
     System.out.println(matchedRules.size());
 
-    assertEquals("incorrect matching rule", 0, matchedRules.size());
+    assertEquals( 0, matchedRules.size());
 
     // release client
     client.release();
@@ -237,7 +238,7 @@ public class TestRawAlert extends AbstractFunctionalTest {
 
     System.out.println(expected);
 
-    assertTrue("incorrect rules", expected.contains("RULE-TEST-1 - {rule-number=one}") && expected.contains("RULE-TEST-2 - {rule-number=two}"));
+    assertTrue( expected.contains("RULE-TEST-1 - {rule-number=one}") && expected.contains("RULE-TEST-2 - {rule-number=two}"));
 
     // release client
     client.release();
@@ -284,7 +285,7 @@ public class TestRawAlert extends AbstractFunctionalTest {
 
     String expectedException = "Invalid content: If provided, rule name in payload must match rule name in URL";
 
-    assertTrue("Exception is not thrown", exception.contains(expectedException));
+    assertTrue( exception.contains(expectedException));
 
     // release client
     client.release();
@@ -363,7 +364,7 @@ public class TestRawAlert extends AbstractFunctionalTest {
 
     System.out.println(expected);
 
-    assertTrue("rule is not correct", expected.contains("RULE-TEST-1-JSON - {{http://marklogic.com/rest-api}rule-number=one json}"));
+    assertTrue( expected.contains("RULE-TEST-1-JSON - {{http://marklogic.com/rest-api}rule-number=one json}"));
 
     // release client
     client.release();
@@ -412,7 +413,7 @@ public class TestRawAlert extends AbstractFunctionalTest {
 
     System.out.println(matchedRules.size()); // bug, should return 1
 
-    assertEquals("result count is not correct", 1, matchedRules.size());
+    assertEquals( 1, matchedRules.size());
 
     // iterate over the matched rules
     Iterator<RuleDefinition> ruleItr = matchedRules.iterator();
@@ -478,7 +479,7 @@ public class TestRawAlert extends AbstractFunctionalTest {
 
     System.out.println(matchedRules.size()); // bug, should return 1
 
-    assertEquals("result count is not correct", 1, matchedRules.size());
+    assertEquals( 1, matchedRules.size());
 
     // iterate over the matched rules
     Iterator<RuleDefinition> ruleItr = matchedRules.iterator();
@@ -581,15 +582,15 @@ public class TestRawAlert extends AbstractFunctionalTest {
 
     if (expected.equals("RULE-TEST-3 - {rule-number=three} | RULE-TEST-3-JSON - {{http://marklogic.com/rest-api}rule-number=three json} | "))
     {
-      assertTrue("rule is incorrect", expected.contains("RULE-TEST-3 - {rule-number=three} | RULE-TEST-3-JSON - {{http://marklogic.com/rest-api}rule-number=three json}"));
+      assertTrue( expected.contains("RULE-TEST-3 - {rule-number=three} | RULE-TEST-3-JSON - {{http://marklogic.com/rest-api}rule-number=three json}"));
     }
     else if (expected.equals("RULE-TEST-3-JSON - {{http://marklogic.com/rest-api}rule-number=three json} | RULE-TEST-3 - {rule-number=three} | "))
     {
-      assertTrue("rule is incorrect", expected.contains("RULE-TEST-3-JSON - {{http://marklogic.com/rest-api}rule-number=three json} | RULE-TEST-3 - {rule-number=three}"));
+      assertTrue( expected.contains("RULE-TEST-3-JSON - {{http://marklogic.com/rest-api}rule-number=three json} | RULE-TEST-3 - {rule-number=three}"));
     }
     else
     {
-      assertTrue("there is no matching rule", false);
+      assertTrue( false);
     }
 
     // release client
@@ -665,7 +666,7 @@ public class TestRawAlert extends AbstractFunctionalTest {
 
     System.out.println(matchedRules.size());
 
-    assertEquals("match rule is incorrect", 0, matchedRules.size());
+    assertEquals( 0, matchedRules.size());
 
     // release client
     client.release();
@@ -733,7 +734,7 @@ public class TestRawAlert extends AbstractFunctionalTest {
 
     System.out.println(expected);
 
-    assertTrue("rule is incorrect", expected.contains("RULE-TEST-1 - {rule-number=one}"));
+    assertTrue( expected.contains("RULE-TEST-1 - {rule-number=one}"));
 
     // release client
     client.release();
@@ -798,7 +799,7 @@ public class TestRawAlert extends AbstractFunctionalTest {
 
     System.out.println(expected);
 
-    assertTrue("rule is incorrect", expected.contains("RULE-TEST-2 - {rule-number=two}"));
+    assertTrue( expected.contains("RULE-TEST-2 - {rule-number=two}"));
 
     // release client
     client.release();

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestRawCombinedQuery.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestRawCombinedQuery.java
@@ -23,10 +23,9 @@ import com.marklogic.client.io.*;
 import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.query.RawCombinedQueryDefinition;
 import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.junit.After;
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
@@ -38,12 +37,11 @@ import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
-import static org.junit.Assert.*;
 
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@TestMethodOrder(MethodOrderer.MethodName.class)
 public class TestRawCombinedQuery extends AbstractFunctionalTest {
 
-  @After
+  @AfterEach
   public void testCleanUp()
   {
     deleteDocuments(connectAsAdmin());
@@ -309,7 +307,7 @@ public class TestRawCombinedQuery extends AbstractFunctionalTest {
 
     System.out.println(resultDoc);
 
-    assertTrue("document is not returned", resultDoc.contains("/raw-combined-query/constraint1.xml"));
+    assertTrue( resultDoc.contains("/raw-combined-query/constraint1.xml"));
 
     // release client
     client.release();
@@ -362,7 +360,7 @@ public class TestRawCombinedQuery extends AbstractFunctionalTest {
 
     System.out.println(resultDoc);
 
-    assertTrue("document is not returned", resultDoc.contains("/raw-combined-query/constraint5.xml"));
+    assertTrue( resultDoc.contains("/raw-combined-query/constraint5.xml"));
 
     // release client
     client.release();
@@ -707,7 +705,6 @@ public class TestRawCombinedQuery extends AbstractFunctionalTest {
 
     System.out.println(resultDoc);
     assertTrue(
-        "Returned result is not correct",
         resultDoc
             .contains("<search:result index=\"1\" uri=\"/collection-constraint/constraint1.xml\" path=\"fn:doc(&quot;/collection-constraint/constraint1.xml&quot;)\""));
 
@@ -716,8 +713,7 @@ public class TestRawCombinedQuery extends AbstractFunctionalTest {
   }
 
   @Test
-  public void test12RawCombinedQueryFieldJSON() throws KeyManagementException, NoSuchAlgorithmException, IOException, ParserConfigurationException, SAXException, XpathException,
-      TransformerException
+  public void test12RawCombinedQueryFieldJSON() throws KeyManagementException, NoSuchAlgorithmException, IOException
   {
     System.out.println("Running testRawCombinedQueryFieldJSON");
 
@@ -760,9 +756,9 @@ public class TestRawCombinedQuery extends AbstractFunctionalTest {
 
     System.out.println(resultDoc);
 
-    assertTrue("total document returned is incorrect", resultDoc.contains("total=\"2\""));
-    assertTrue("returned doc is incorrect", resultDoc.contains("uri=\"/field-constraint/constraint5.xml\""));
-    assertTrue("returned doc is incorrect", resultDoc.contains("uri=\"/field-constraint/constraint1.xml\""));
+    assertTrue( resultDoc.contains("total=\"2\""));
+    assertTrue( resultDoc.contains("uri=\"/field-constraint/constraint5.xml\""));
+    assertTrue( resultDoc.contains("uri=\"/field-constraint/constraint1.xml\""));
 
     // release client
     client.release();
@@ -776,7 +772,7 @@ public class TestRawCombinedQuery extends AbstractFunctionalTest {
    */
 
   @Test
-  public void testBug43940() throws KeyManagementException, NoSuchAlgorithmException, IOException, ParserConfigurationException, SAXException, XpathException, TransformerException
+  public void testBug43940() throws KeyManagementException, NoSuchAlgorithmException, IOException
   {
     // Negative test
     System.out.println("Running testBug43940");

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestRawCombinedQueryGeo.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestRawCombinedQueryGeo.java
@@ -25,8 +25,9 @@ import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.query.RawCombinedQueryDefinition;
 import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
@@ -38,11 +39,11 @@ import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
-import static org.junit.Assert.assertTrue;
+
 
 public class TestRawCombinedQueryGeo extends AbstractFunctionalTest {
 
-  @After
+  @AfterEach
   public void testCleanUp() throws Exception
   {
     deleteDocuments(connectAsAdmin());
@@ -132,9 +133,9 @@ public class TestRawCombinedQueryGeo extends AbstractFunctionalTest {
 
     System.out.println(resultDoc);
 
-    assertTrue("total document returned is incorrect", resultDoc.contains("total=\"1\""));
-    assertTrue("returned doc is incorrect", resultDoc.contains("uri=\"/geo-constraint/geo-constraint1.xml\""));
-    assertTrue("matched text is incorrect", resultDoc.contains("karl_kara 12,5 12,5 12 5"));
+    assertTrue( resultDoc.contains("total=\"1\""));
+    assertTrue( resultDoc.contains("uri=\"/geo-constraint/geo-constraint1.xml\""));
+    assertTrue( resultDoc.contains("karl_kara 12,5 12,5 12 5"));
 
     // release client
     client.release();
@@ -180,8 +181,8 @@ public class TestRawCombinedQueryGeo extends AbstractFunctionalTest {
 
     System.out.println(resultDoc);
 
-    assertTrue("total document returned is incorrect", resultDoc.contains("total=\"1\""));
-    assertTrue("returned doc is incorrect", resultDoc.contains("uri=\"/geo-constraint/geo-constraint20.xml\""));
+    assertTrue( resultDoc.contains("total=\"1\""));
+    assertTrue( resultDoc.contains("uri=\"/geo-constraint/geo-constraint20.xml\""));
 
     // release client
     client.release();

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestRawStructuredQuery.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestRawStructuredQuery.java
@@ -23,8 +23,9 @@ import com.marklogic.client.io.*;
 import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.query.RawStructuredQueryDefinition;
 import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
@@ -36,11 +37,11 @@ import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+
+
 
 public class TestRawStructuredQuery extends AbstractFunctionalTest {
-  @After
+  @AfterEach
   public void testCleanUp() throws Exception {
     deleteDocuments(connectAsAdmin());
   }
@@ -137,7 +138,7 @@ public class TestRawStructuredQuery extends AbstractFunctionalTest {
 
     System.out.println(resultDoc);
 
-    assertTrue("document is not returned", resultDoc.contains("/raw-combined-query/constraint5.xml"));
+    assertTrue( resultDoc.contains("/raw-combined-query/constraint5.xml"));
 
     // release client
     client.release();
@@ -241,7 +242,7 @@ public class TestRawStructuredQuery extends AbstractFunctionalTest {
 
     System.out.println(resultDoc);
 
-    assertTrue("document is not returned", resultDoc.contains("/raw-combined-query/constraint1.xml"));
+    assertTrue( resultDoc.contains("/raw-combined-query/constraint1.xml"));
 
     // release client
     client.release();
@@ -468,7 +469,7 @@ public class TestRawStructuredQuery extends AbstractFunctionalTest {
    * setCriteria and withCriteria Make sure a query using those query
    * definitions selects only documents that match both the query definition and
    * the string query
-   * 
+   *
    * Uses setCriteria. Uses combinedQueryOption.xml options file QD and string
    * query should return 1 URI in the response. constraint5.xml positive case
    */
@@ -511,8 +512,8 @@ public class TestRawStructuredQuery extends AbstractFunctionalTest {
 
     JsonNode node = results.get();
     // Return 1 node
-    assertEquals("Number of results returned incorrect in response", "1", node.path("total").asText());
-    assertTrue("Results returned incorrect in response", node.path("results").get(0).path("uri").asText().contains("/raw-combined-query/constraint5.xml"));
+    assertEquals( "1", node.path("total").asText());
+    assertTrue( node.path("results").get(0).path("uri").asText().contains("/raw-combined-query/constraint5.xml"));
 
     // Multiple setCriteria on query def
     RawStructuredQueryDefinition querydef2 = queryMgr.newRawStructuredQueryDefinition(rawHandle);
@@ -525,8 +526,8 @@ public class TestRawStructuredQuery extends AbstractFunctionalTest {
 
     JsonNode node2 = results2.get();
     // Return 1 node
-    assertEquals("Number of results returned incorrect in response", "1", node2.path("total").asText());
-    assertTrue("Results returned incorrect in response", node2.path("results").get(0).path("uri").asText().contains("/raw-combined-query/constraint5.xml"));
+    assertEquals( "1", node2.path("total").asText());
+    assertTrue( node2.path("results").get(0).path("uri").asText().contains("/raw-combined-query/constraint5.xml"));
 
     // setCriteria on query def - negative
     RawStructuredQueryDefinition querydefNeg = queryMgr.newRawStructuredQueryDefinition(rawHandle);
@@ -538,7 +539,7 @@ public class TestRawStructuredQuery extends AbstractFunctionalTest {
 
     JsonNode nodeNeg = resultsNeg.get();
     // Return 0 nodes
-    assertEquals("Number of results returned incorrect in response", "0", nodeNeg.path("total").asText());
+    assertEquals( "0", nodeNeg.path("total").asText());
 
     // Multiple setCriteria on query def - negative
     RawStructuredQueryDefinition querydefNeg2 = queryMgr.newRawStructuredQueryDefinition(rawHandle);
@@ -551,7 +552,7 @@ public class TestRawStructuredQuery extends AbstractFunctionalTest {
 
     JsonNode nodeNeg2 = resultsNeg2.get();
     // Return 0 node
-    assertEquals("Number of results returned incorrect in response", "0", nodeNeg2.path("total").asText());
+    assertEquals( "0", nodeNeg2.path("total").asText());
 
     // release client
     client.release();
@@ -562,7 +563,7 @@ public class TestRawStructuredQuery extends AbstractFunctionalTest {
    * setCriteria and withCriteria Make sure a query using those query
    * definitions selects only documents that match both the query definition and
    * the string query
-   * 
+   *
    * Uses withCriteria. Uses combinedQueryPopularityOption.xml options file
    */
 
@@ -602,10 +603,10 @@ public class TestRawStructuredQuery extends AbstractFunctionalTest {
     JacksonHandle results = queryMgr.search(querydef1, strHandle.withFormat(Format.JSON));
 
     JsonNode node = results.get();
-    assertEquals("Number of results returned incorrect in response", "2", node.path("total").asText());
-    assertTrue("Results returned incorrect in response", node.path("results").get(0).path("uri").asText().contains("/raw-combined-query/constraint1.xml") ||
+    assertEquals( "2", node.path("total").asText());
+    assertTrue( node.path("results").get(0).path("uri").asText().contains("/raw-combined-query/constraint1.xml") ||
         node.path("results").get(1).path("uri").asText().contains("/raw-combined-query/constraint1.xml"));
-    assertTrue("Results returned incorrect in response", node.path("results").get(0).path("uri").asText().contains("/raw-combined-query/constraint4.xml") ||
+    assertTrue( node.path("results").get(0).path("uri").asText().contains("/raw-combined-query/constraint4.xml") ||
         node.path("results").get(1).path("uri").asText().contains("/raw-combined-query/constraint4.xml"));
 
     /*
@@ -622,8 +623,8 @@ public class TestRawStructuredQuery extends AbstractFunctionalTest {
 
     JsonNode nodePos = resultsPos.get();
     // Return 2 nodes.
-    assertEquals("Number of results returned incorrect in response", "1", nodePos.path("total").asText());
-    assertTrue("Results returned incorrect in response", nodePos.path("results").get(0).path("uri").asText().contains("/raw-combined-query/constraint4.xml"));
+    assertEquals( "1", nodePos.path("total").asText());
+    assertTrue( nodePos.path("results").get(0).path("uri").asText().contains("/raw-combined-query/constraint4.xml"));
 
     /*
      * With multiple withCriteria - negativeThis is an invalid scenario--you can
@@ -638,7 +639,7 @@ public class TestRawStructuredQuery extends AbstractFunctionalTest {
 
     JsonNode nodeNeg = resultsNeg.get();
     // Return 0 nodes.
-    assertEquals("Number of results returned incorrect in response", "0", nodeNeg.path("total").asText());
+    assertEquals( "0", nodeNeg.path("total").asText());
 
     // create query def2 with both criteria methods and check fluent return
 
@@ -651,8 +652,8 @@ public class TestRawStructuredQuery extends AbstractFunctionalTest {
 
     JsonNode node2 = results2.get();
     // Returns 1 node. constraint1.xml
-    assertEquals("Number of results returned incorrect in response", "1", node2.path("total").asText());
-    assertEquals("Result returned incorrect in response", "/raw-combined-query/constraint1.xml", node2.path("results").get(0).path("uri").asText());
+    assertEquals( "1", node2.path("total").asText());
+    assertEquals( "/raw-combined-query/constraint1.xml", node2.path("results").get(0).path("uri").asText());
 
     // release client
     client.release();

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestRequestLogger.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestRequestLogger.java
@@ -21,14 +21,15 @@ import com.marklogic.client.Transaction;
 import com.marklogic.client.document.XMLDocumentManager;
 import com.marklogic.client.io.FileHandle;
 import com.marklogic.client.util.RequestLogger;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.File;
 import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 
-import static org.junit.Assert.assertEquals;
+
 
 public class TestRequestLogger extends AbstractFunctionalTest {
 
@@ -74,7 +75,7 @@ public class TestRequestLogger extends AbstractFunctionalTest {
     docMgr.stopLogging();
 
     String expectedContentMax = "9223372036854775807";
-    assertEquals("Content log is not equal", expectedContentMax, Long.toString(logger.getContentMax()));
+    assertEquals( expectedContentMax, Long.toString(logger.getContentMax()));
 
     // release client
     client.release();

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestResponseTransform.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestResponseTransform.java
@@ -26,7 +26,8 @@ import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.query.RawCombinedQueryDefinition;
 import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 import org.xml.sax.SAXException;
 
 import javax.xml.parsers.ParserConfigurationException;
@@ -36,7 +37,7 @@ import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 
-import static org.junit.Assert.assertTrue;
+
 
 public class TestResponseTransform extends AbstractFunctionalTest {
 
@@ -104,9 +105,9 @@ public class TestResponseTransform extends AbstractFunctionalTest {
 
     System.out.println(resultDoc);
 
-    assertTrue("transform on title is not found", resultDoc.contains("<title>Custom Search Results</title>"));
-    assertTrue("transform on header is not found", resultDoc.contains("MyURI"));
-    assertTrue("transform on doc return is not found", resultDoc.contains("<td align=\"left\">/response-transform/constraint5.xml</td>"));
+    assertTrue( resultDoc.contains("<title>Custom Search Results</title>"));
+    assertTrue( resultDoc.contains("MyURI"));
+    assertTrue( resultDoc.contains("<td align=\"left\">/response-transform/constraint5.xml</td>"));
 
     transMgr.deleteTransform("search2html");
 
@@ -184,9 +185,9 @@ public class TestResponseTransform extends AbstractFunctionalTest {
     }
 
     String expectedException = "Local message: search failed: Bad Request. Server Message: RESTAPI-INVALIDREQ: (err:FOER0000)";
-    assertTrue("exception is not thrown", exception.contains(expectedException));
+    assertTrue( exception.contains(expectedException));
     // bug 22356
-    assertTrue("Value should be null", resultsHandle.get() == null);
+    assertTrue( resultsHandle.get() == null);
 
     transMgr.deleteTransform("search2html");
 

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestRollbackTransaction.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestRollbackTransaction.java
@@ -25,7 +25,8 @@ import com.marklogic.client.io.DOMHandle;
 import com.marklogic.client.io.FileHandle;
 import com.marklogic.client.io.Format;
 import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
@@ -37,7 +38,7 @@ import java.security.NoSuchAlgorithmException;
 
 import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
-import static org.junit.Assert.assertTrue;
+
 
 public class TestRollbackTransaction extends AbstractFunctionalTest {
 
@@ -155,7 +156,7 @@ public class TestRollbackTransaction extends AbstractFunctionalTest {
     // get expected contents
     JsonNode expectedContent = expectedJSONDocument(filename);
 
-    assertTrue("Rollback on document update failed", readContent.equals(expectedContent));
+    assertTrue( readContent.equals(expectedContent));
 
     // release client
     client.release();
@@ -290,7 +291,7 @@ public class TestRollbackTransaction extends AbstractFunctionalTest {
       exception = e.toString();
     }
 
-    assertTrue("Exception is not thrown", exception.contains(expectedException));
+    assertTrue( exception.contains(expectedException));
 
     // release client
     client.release();

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestRuntimeDBselection.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestRuntimeDBselection.java
@@ -18,25 +18,27 @@ package com.marklogic.client.fastfunctest;
 
 import com.marklogic.client.DatabaseClientFactory;
 import com.marklogic.client.DatabaseClientFactory.SecurityContext;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
+
+
+
 
 public class TestRuntimeDBselection extends AbstractFunctionalTest {
   private static String appServerHostname = null;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpBeforeClass() throws Exception {
     createUserRolesWithPrevilages("test-eval", "xdbc:eval", "xdbc:eval-in", "xdmp:eval-in", "any-uri", "xdbc:invoke");
     createRESTUser("eval-user", "x", "test-eval", "rest-admin", "rest-writer", "rest-reader");
     appServerHostname = getRestAppServerHostName();
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownAfterClass() throws Exception {
     deleteRESTUser("eval-user");
     deleteUserRole("test-eval");
@@ -57,11 +59,11 @@ public class TestRuntimeDBselection extends AbstractFunctionalTest {
         client.newServerEval().xquery(insertJSON).eval();
         String query1 = "fn:count(fn:doc())";
         int response = client.newServerEval().xquery(query1).eval().next().getNumber().intValue();
-        assertEquals("count of documents ", 1, response);
+        assertEquals( 1, response);
         String query2 = "declareUpdate();xdmp.documentDelete(\"test2.json\");";
         client.newServerEval().javascript(query2).eval();
         int response2 = client.newServerEval().xquery(query1).eval().next().getNumber().intValue();
-        assertEquals("count of documents ", 0, response2);
+        assertEquals( 0, response2);
         client.release();
       } finally {
 		  setAuthentication(originalServerAuthentication, getRestServerName());
@@ -82,7 +84,7 @@ public class TestRuntimeDBselection extends AbstractFunctionalTest {
       fail("Exception should have been thrown");
     } catch (Exception e) {
       e.printStackTrace();
-      Assert.assertTrue(e instanceof com.marklogic.client.FailedRequestException);
+      assertTrue(e instanceof com.marklogic.client.FailedRequestException);
     }
       finally {
           client.release();

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestSearchMultibyte.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestSearchMultibyte.java
@@ -21,8 +21,9 @@ import com.marklogic.client.io.DOMHandle;
 import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.query.StringQueryDefinition;
 import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
@@ -36,7 +37,7 @@ import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
 
 public class TestSearchMultibyte extends AbstractFunctionalTest {
 
-  @After
+  @AfterEach
   public void testCleanUp() throws Exception
   {
     deleteDocuments(connectAsAdmin());

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestSearchMultipleForests.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestSearchMultipleForests.java
@@ -23,13 +23,14 @@ import com.marklogic.client.io.SearchHandle;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.query.StringQueryDefinition;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 
-import static org.junit.Assert.assertTrue;
+
 
 public class TestSearchMultipleForests extends AbstractFunctionalTest {
 
@@ -71,18 +72,18 @@ public class TestSearchMultipleForests extends AbstractFunctionalTest {
     // Do forest specific searches.
     queryMgr.search(querydef, sHandleOnForest1, fNames[0]);
     System.out.println("Documents available on Forest 1 is " + sHandleOnForest1.getTotalResults());
-    assertTrue("Documents count on Forest 1 is ", sHandleOnForest1.getTotalResults() >= 0);
+    assertTrue( sHandleOnForest1.getTotalResults() >= 0);
 
     queryMgr.search(querydef, sHandleOnForest2, fNames[1]);
     System.out.println("Documents available on Forest 2 is " + sHandleOnForest2.getTotalResults());
-    assertTrue("Documents count on Forest 2 is ", sHandleOnForest2.getTotalResults() >= 0);
+    assertTrue( sHandleOnForest2.getTotalResults() >= 0);
 
     // Assert on the total from individual forest counts. Assignment scheme changed as of 10.0.2 ML Server.
 
-    assertTrue("Document count is incorrect", sHandleOnForest1.getTotalResults() + sHandleOnForest2.getTotalResults() == 20);
+    assertTrue( sHandleOnForest1.getTotalResults() + sHandleOnForest2.getTotalResults() == 20);
 
     System.out.println(sHandle.getTotalResults());
-    assertTrue("Document count is incorrect", sHandle.getTotalResults() == 20);
+    assertTrue( sHandle.getTotalResults() == 20);
 
     // Test other overloaded methods of QueryManager search with forest name.
 
@@ -94,13 +95,13 @@ public class TestSearchMultipleForests extends AbstractFunctionalTest {
 
     queryMgr.search(querydef, sHandleOnForest1, 2, fNames[0]);
     System.out.println("Start Page on first search on Forest 1 is " + sHandleOnForest1.getStart());
-    assertTrue("Start Page on first search on Forest 1 is incorrect", sHandleOnForest1.getStart() == 2);
+    assertTrue( sHandleOnForest1.getStart() == 2);
 
     queryMgr.search(querydef, sHandleOnForest2, 3, fNames[1]);
     System.out.println("Start Page on second search on Forest 2 is " + sHandleOnForest2.getStart());
-    assertTrue("Start Page on second search on Forest 2 is incorrect", sHandleOnForest2.getStart() == 3);
+    assertTrue( sHandleOnForest2.getStart() == 3);
 
-    assertTrue("Document count is incorrect", sHandleOnForest1.getTotalResults() + sHandleOnForest2.getTotalResults() == 20);
+    assertTrue( sHandleOnForest1.getTotalResults() + sHandleOnForest2.getTotalResults() == 20);
 
     // Verify in a transaction.
     Transaction t = client.openTransaction();
@@ -109,9 +110,9 @@ public class TestSearchMultipleForests extends AbstractFunctionalTest {
     sHandleOnForest2 = new SearchHandle();
 
     queryMgr.search(querydef, sHandleOnForest1, 0, t, fNames[0]);
-    assertTrue("Documents count on Forest 1 is ", sHandleOnForest1.getTotalResults() >= 0);
+    assertTrue( sHandleOnForest1.getTotalResults() >= 0);
     queryMgr.search(querydef, sHandleOnForest2, 0, t, fNames[1]);
-    assertTrue("Documents count on Forest 2 is ", sHandleOnForest2.getTotalResults() >= 0);
+    assertTrue( sHandleOnForest2.getTotalResults() >= 0);
     t.rollback();
 
     client.release();

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestSearchOnJSON.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestSearchOnJSON.java
@@ -22,8 +22,9 @@ import com.marklogic.client.io.*;
 import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.query.StringQueryDefinition;
 import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 import org.xml.sax.SAXException;
 
 import javax.xml.parsers.ParserConfigurationException;
@@ -34,12 +35,12 @@ import java.io.InputStream;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+
+
 
 public class TestSearchOnJSON extends AbstractFunctionalTest {
 
-  @After
+  @AfterEach
   public void testCleanUp() throws Exception
   {
     deleteDocuments(connectAsAdmin());
@@ -80,7 +81,7 @@ public class TestSearchOnJSON extends AbstractFunctionalTest {
 
     String expectedOutput = "{\"options\":{\"return-metrics\":false, \"return-qtext\":false, \"debug\":true, \"transform-results\":{\"apply\":\"raw\"}, \"constraint\":[{\"name\":\"id\", \"value\":{\"element\":{\"ns\":\"\", \"name\":\"id\"}}}]}}";
 
-    assertEquals("query option in JSON is difference", expectedOutput, output.trim());
+    assertEquals( expectedOutput, output.trim());
 
     // create handle to write back option in json
     String queryOptionNameJson = queryOptionName.replaceAll(".xml", ".json");

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestSearchOnProperties.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestSearchOnProperties.java
@@ -22,7 +22,8 @@ import com.marklogic.client.document.XMLDocumentManager;
 import com.marklogic.client.io.*;
 import com.marklogic.client.query.*;
 import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
@@ -36,7 +37,7 @@ import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
-import static org.junit.Assert.assertEquals;
+
 
 public class TestSearchOnProperties extends AbstractFunctionalTest {
 
@@ -127,20 +128,20 @@ public class TestSearchOnProperties extends AbstractFunctionalTest {
     queryMgr.search(queryDef, resultsHandle);
 
     long totalResults = resultsHandle.getTotalResults();
-    assertEquals("Total results difference", 1, totalResults);
+    assertEquals( 1, totalResults);
 
     // iterate over the result documents
     MatchDocumentSummary[] docSummaries = resultsHandle.getMatchResults();
 
     int docSummaryLength = docSummaries.length;
-    assertEquals("Document summary list difference", 1, docSummaryLength);
+    assertEquals( 1, docSummaryLength);
 
     for (MatchDocumentSummary docSummary : docSummaries) {
       String uri = docSummary.getUri();
 
       // iterate over the match locations within a result document
       MatchLocation[] locations = docSummary.getMatchLocations();
-      assertEquals("Document location difference", "/searchOnProps/" + file.getPath(), uri);
+      assertEquals( "/searchOnProps/" + file.getPath(), uri);
 
       for (MatchLocation location : locations) {
 
@@ -153,7 +154,7 @@ public class TestSearchOnProperties extends AbstractFunctionalTest {
           highlightedText = highlightedText + snippet.getText();
           highlightedText = highlightedText + "]";
 
-          assertEquals("Document highlight snippet difference", "[embarcadero]", highlightedText);
+          assertEquals( "[embarcadero]", highlightedText);
         }
       }
     }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestSearchOptions.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestSearchOptions.java
@@ -25,8 +25,9 @@ import com.marklogic.client.io.DocumentMetadataHandle.Capability;
 import com.marklogic.client.query.*;
 import com.marklogic.client.query.QueryManager.QueryView;
 import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
@@ -36,13 +37,14 @@ import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 
-import static org.custommonkey.xmlunit.XMLAssert.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathNotExists;
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathExists;
+
 
 public class TestSearchOptions extends AbstractFunctionalTest {
 
-  @After
+  @AfterEach
   public void testCleanUp() throws Exception
   {
       deleteDocuments(connectAsAdmin());
@@ -303,8 +305,8 @@ public class TestSearchOptions extends AbstractFunctionalTest {
     // release client
     client.release();
   }
-  
-  
+
+
   //Tests for simple restricted xpath
   @Test
   public void testRestrictedXPaths() throws KeyManagementException, NoSuchAlgorithmException, IOException, ParserConfigurationException, SAXException, XpathException,
@@ -324,7 +326,7 @@ public class TestSearchOptions extends AbstractFunctionalTest {
     content1.append("{ \"RegionId\": \"1003\", \"Direction\": \"NW\" },");
     content1.append("{ \"RegionId\": \"1004\", \"Direction\": \"SW\" }");
     content1.append("]}}]}");
-    
+
     StringBuilder content2 = new StringBuilder();
     content2.append("{\"World\":[{\"CountyId\": \"0002\",");
     content2.append("\"Govt\": \"Monarchy\",");
@@ -355,7 +357,7 @@ public class TestSearchOptions extends AbstractFunctionalTest {
     if (count % BATCH_SIZE > 0) {
         docMgr.write(writeset1);
     }
-    
+
     // Write docs
     DocumentWriteSet writeset2 = docMgr.newWriteSet();
     docStr = content2.toString();
@@ -371,13 +373,13 @@ public class TestSearchOptions extends AbstractFunctionalTest {
     if (count % BATCH_SIZE > 0) {
         docMgr.write(writeset2);
     }
-    
+
     QueryManager queryMgr = client.newQueryManager();
-    
+
     String head = "<search:search xmlns:search=\"http://marklogic.com/appservices/search\">";
     String tail = "</search:search>";
     String qtext1 = "<search:qtext>Presidential</search:qtext>";
-    
+
     String options1 ="<search:options>" +
                     "<search:extract-document-data selected=\"include\">" +
                     "</search:extract-document-data>" +
@@ -394,7 +396,7 @@ public class TestSearchOptions extends AbstractFunctionalTest {
     // get the result
     JsonNode resultNode = resultsHandle.get();
     System.out.println(resultNode.toString());
-    assertEquals("Total search elements for incorrect", "11", resultNode.get("total").asText());
+    assertEquals( "11", resultNode.get("total").asText());
 
     String options2 ="<search:options>" +
             "<search:extract-document-data selected=\"include\">" +
@@ -407,14 +409,14 @@ public class TestSearchOptions extends AbstractFunctionalTest {
     String qtext2 = "<search:qtext>Presidential</search:qtext>";
 
     combinedSearch = head + qtext2 + options2 + tail;
-    
+
      rawCombinedQueryDefinition =
             queryMgr.newRawCombinedQueryDefinition(new StringHandle(combinedSearch).withMimetype("application/xml"));
 
     // create handle
     SearchHandle resSearchHandle = new SearchHandle();
     resSearchHandle = queryMgr.search(rawCombinedQueryDefinition, new SearchHandle());
-    
+
     MatchDocumentSummary[] summaries = resSearchHandle.getMatchResults();
 
     for (MatchDocumentSummary summary : summaries) {
@@ -423,12 +425,11 @@ public class TestSearchOptions extends AbstractFunctionalTest {
             for (ExtractedItem item : extracted) {
                 String extractItem = item.getAs(String.class);
                 System.out.println("Extracted item from element search " + extractItem);
-                assertTrue("Extracted items incorrect", extractItem.contains("{\"Govt\":\"Presidential\"}")
-                                                         || extractItem.contains("{\"Pop\":328}"));
+                assertTrue( extractItem.contains("{\"Govt\":\"Presidential\"}") || extractItem.contains("{\"Pop\":328}"));
             }
         }
     }
-    // Extract path with array element 
+    // Extract path with array element
     String qtext3 = "<search:qtext>2002</search:qtext>";
     String options3 ="<search:options>" +
             "<search:extract-document-data selected=\"include\">" +
@@ -438,7 +439,7 @@ public class TestSearchOptions extends AbstractFunctionalTest {
             "</search:options>";
 
     combinedSearch = head + qtext3 + options3 + tail;
-    
+
      rawCombinedQueryDefinition =
             queryMgr.newRawCombinedQueryDefinition(new StringHandle(combinedSearch).withMimetype("application/xml"));
 
@@ -456,10 +457,10 @@ public class TestSearchOptions extends AbstractFunctionalTest {
                 String extractItem = item.getAs(String.class);
                 System.out.println("Extracted item from array element search " + extractItem);
                 if (extractItem.startsWith("{\"R")) {
-                assertTrue("Extracted items incorrect", extractItem.matches(RegionPatternStr));
+                assertTrue( extractItem.matches(RegionPatternStr));
                 }
                 else {
-                    assertTrue("Extracted items incorrect", extractItem.matches(DirectionPatternStr));
+                    assertTrue( extractItem.matches(DirectionPatternStr));
                 }
             }
         }
@@ -486,11 +487,11 @@ public class TestSearchOptions extends AbstractFunctionalTest {
             for (ExtractedItem item : extracted) {
                 String extractItem = item.getAs(String.class);
                 System.out.println("Extracted item from named node element search " + extractItem);
-                    assertTrue("Extracted Named node items incorrect", extractItem.matches(DirectionPatternStr));
+                    assertTrue( extractItem.matches(DirectionPatternStr));
             }
         }
     }
-    
+
     // object-node - Unnamed Node
     String qtext5 = "<search:qtext>1001</search:qtext>";
     String options5 ="<search:options>" +
@@ -512,11 +513,11 @@ public class TestSearchOptions extends AbstractFunctionalTest {
             for (ExtractedItem item : extracted) {
                 String extractItem = item.getAs(String.class);
                 System.out.println("Extracted item from Unnamed node element search " + extractItem);
-                    assertTrue("Extracted Unnamed node items incorrect", extractItem.matches(DirectionPatternStr));
+                    assertTrue( extractItem.matches(DirectionPatternStr));
             }
         }
     }
-    
+
     // object-node - Number Node
     String qtext6 = "<search:qtext>1001</search:qtext>";
     String options6 ="<search:options>" +
@@ -538,15 +539,15 @@ public class TestSearchOptions extends AbstractFunctionalTest {
             for (ExtractedItem item : extracted) {
                 String extractItem = item.getAs(String.class);
                 System.out.println("Extracted item from Number node element search " + extractItem);
-                    assertTrue("Extracted Number node items incorrect", extractItem.matches("\\{\"Pop\":328\\}"));
+                    assertTrue( extractItem.matches("\\{\"Pop\":328\\}"));
             }
         }
     }
     // release client
     client.release();
   }
-  
-  // Note : Test asserts changed due to the fact that different serialization and parsers produce diff NS 
+
+  // Note : Test asserts changed due to the fact that different serialization and parsers produce diff NS
   @Test
   public void testXmlFilesRestrictedXPaths() throws KeyManagementException, NoSuchAlgorithmException, IOException, ParserConfigurationException, SAXException, XpathException,
       TransformerException
@@ -585,11 +586,11 @@ public class TestSearchOptions extends AbstractFunctionalTest {
     }
 
     QueryManager queryMgr = client.newQueryManager();
-    
+
     String head = "<search:search xmlns:search=\"http://marklogic.com/appservices/search\">";
     String tail = "</search:search>";
     String qtext1 = "<search:qtext>0011</search:qtext>";
-    
+
     String options1 ="<search:options>" +
                     "<search:extract-document-data selected=\"include\">" +
                     "</search:extract-document-data>" +
@@ -606,7 +607,7 @@ public class TestSearchOptions extends AbstractFunctionalTest {
     // get the result
     JsonNode resultNode = resultsHandle.get();
     System.out.println(resultNode.toString());
-    assertEquals("Total search elements for incorrect", "11", resultNode.get("total").asText());
+    assertEquals( "11", resultNode.get("total").asText());
 
     String options2 ="<search:options>" +
             "<search:extract-document-data selected=\"include\">" +
@@ -618,14 +619,14 @@ public class TestSearchOptions extends AbstractFunctionalTest {
     String qtext2 = "<search:qtext>0011</search:qtext>";
 
     combinedSearch = head + qtext2 + options2 + tail;
-    
+
      rawCombinedQueryDefinition =
             queryMgr.newRawCombinedQueryDefinition(new StringHandle(combinedSearch).withMimetype("application/xml"));
 
     // create handle
     SearchHandle resSearchHandle = new SearchHandle();
     resSearchHandle = queryMgr.search(rawCombinedQueryDefinition, new SearchHandle());
-    
+
     MatchDocumentSummary[] summaries = resSearchHandle.getMatchResults();
 
     for (MatchDocumentSummary summary : summaries) {
@@ -634,8 +635,8 @@ public class TestSearchOptions extends AbstractFunctionalTest {
             for (ExtractedItem item : extracted) {
                 String extractItem = item.getAs(String.class);
                 System.out.println("Extracted item from price element search " + extractItem);
-                assertTrue("Extracted price items incorrect", extractItem.contains("http://cloudbank.com"));
-                assertTrue("Extracted price items incorrect", extractItem.contains("amt=\"0.1\""));
+                assertTrue( extractItem.contains("http://cloudbank.com"));
+                assertTrue( extractItem.contains("amt=\"0.1\""));
             }
         }
     }
@@ -648,7 +649,7 @@ public class TestSearchOptions extends AbstractFunctionalTest {
             "</search:options>";
 
     combinedSearch = head + qtext3 + options3 + tail;
-    
+
      rawCombinedQueryDefinition =
             queryMgr.newRawCombinedQueryDefinition(new StringHandle(combinedSearch).withMimetype("application/xml"));
 
@@ -656,22 +657,22 @@ public class TestSearchOptions extends AbstractFunctionalTest {
     resSearchHandle = new SearchHandle();
     resSearchHandle = queryMgr.search(rawCombinedQueryDefinition, new SearchHandle());
     summaries = resSearchHandle.getMatchResults();
-    
+
     for (MatchDocumentSummary summary : summaries) {
         ExtractedResult extracted = summary.getExtracted();
         if ( Format.XML == summary.getFormat() ) {
             for (ExtractedItem item : extracted) {
                 String extractItem = item.getAs(String.class);
                 System.out.println("Extracted item from date and ancestor element search " + extractItem);
-                assertTrue("Extracted date and ancestor items incorrect", 
+                assertTrue(
                             extractItem.contains("http://purl.org/dc/elements/1.1"));
-                assertTrue("Extracted date and ancestor items incorrect", 
+                assertTrue(
                         extractItem.contains("2005-01-01"));
 
             }
         }
     }
-    
+
  // Extract path with array element - include-with-ancestors - Negative
     String qtext4 = "<search:qtext>0011</search:qtext>";
     String options4 ="<search:options>" +
@@ -681,7 +682,7 @@ public class TestSearchOptions extends AbstractFunctionalTest {
             "</search:options>";
 
     combinedSearch = head + qtext4 + options4 + tail;
-    
+
      rawCombinedQueryDefinition =
             queryMgr.newRawCombinedQueryDefinition(new StringHandle(combinedSearch).withMimetype("application/xml"));
 
@@ -689,10 +690,10 @@ public class TestSearchOptions extends AbstractFunctionalTest {
     resSearchHandle = new SearchHandle();
     resSearchHandle = queryMgr.search(rawCombinedQueryDefinition, new SearchHandle());
     summaries = resSearchHandle.getMatchResults();
-    
-    MatchDocumentSummary summary = summaries[0]; 
+
+    MatchDocumentSummary summary = summaries[0];
     ExtractedResult extracted = summary.getExtracted();
-    assertTrue("Extracted date and ancestor items incorrect", extracted.isEmpty());
+    assertTrue( extracted.isEmpty());
 
     // release client
     client.release();

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestSearchSuggestion.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestSearchSuggestion.java
@@ -19,18 +19,19 @@ package com.marklogic.client.fastfunctest;
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.query.SuggestDefinition;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 
-import static org.junit.Assert.assertTrue;
+
 
 public class TestSearchSuggestion extends AbstractFunctionalTest {
 
-  @After
+  @AfterEach
   public void testCleanUp() throws Exception
   {
     deleteDocuments(connectAsAdmin());
@@ -65,8 +66,8 @@ public class TestSearchSuggestion extends AbstractFunctionalTest {
       System.out.println(suggestions[i]);
     }
 
-    assertTrue("suggestion is wrong", suggestions[0].contains("Vannevar Bush"));
-    assertTrue("suggestion is wrong", suggestions[1].contains("Vannevar served"));
+    assertTrue( suggestions[0].contains("Vannevar Bush"));
+    assertTrue( suggestions[1].contains("Vannevar served"));
 
     // release client
     client.release();
@@ -105,7 +106,7 @@ public class TestSearchSuggestion extends AbstractFunctionalTest {
       System.out.println(suggestions[i]);
     }
 
-    assertTrue("suggestion is wrong", suggestions[0].contains("Vannevar served"));
+    assertTrue( suggestions[0].contains("Vannevar served"));
 
     // release client
     client.release();
@@ -140,7 +141,7 @@ public class TestSearchSuggestion extends AbstractFunctionalTest {
       System.out.println(suggestions[i]);
     }
 
-    assertTrue("suggestion is wrong", suggestions[0].contains("上海"));
+    assertTrue( suggestions[0].contains("上海"));
 
     // release client
     client.release();
@@ -176,8 +177,8 @@ public class TestSearchSuggestion extends AbstractFunctionalTest {
       System.out.println(suggestions[i]);
     }
 
-    assertTrue("suggestion is wrong", suggestions[0].contains("12.34"));
-    assertTrue("suggestion is wrong", suggestions[1].contains("123.45"));
+    assertTrue( suggestions[0].contains("12.34"));
+    assertTrue( suggestions[1].contains("123.45"));
 
     // release client
     client.release();
@@ -212,7 +213,7 @@ public class TestSearchSuggestion extends AbstractFunctionalTest {
       System.out.println(suggestions[i]);
     }
 
-    assertTrue("suggestion is wrong", suggestions[0].contains("2005-01-01"));
+    assertTrue( suggestions[0].contains("2005-01-01"));
 
     // release client
     client.release();
@@ -250,9 +251,9 @@ public class TestSearchSuggestion extends AbstractFunctionalTest {
       System.out.println(suggestions[i]);
     }
 
-    assertTrue("suggestion is wrong", suggestions[0].contains("noun:actor"));
-    assertTrue("suggestion is wrong", suggestions[1].contains("noun:actress"));
-    assertTrue("suggestion is wrong", suggestions[2].contains("noun:apricott"));
+    assertTrue( suggestions[0].contains("noun:actor"));
+    assertTrue( suggestions[1].contains("noun:actress"));
+    assertTrue( suggestions[2].contains("noun:apricott"));
 
     // release client
     client.release();
@@ -289,8 +290,8 @@ public class TestSearchSuggestion extends AbstractFunctionalTest {
       System.out.println(suggestions[i]);
     }
 
-    assertTrue("suggestion is wrong", suggestions[0].contains("act"));
-    assertTrue("suggestion is wrong", suggestions[1].contains("acting"));
+    assertTrue( suggestions[0].contains("act"));
+    assertTrue( suggestions[1].contains("acting"));
 
     // release client
     client.release();

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestSemanticsGraphManager.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestSemanticsGraphManager.java
@@ -27,15 +27,15 @@ import com.marklogic.client.semantics.Capability;
 import com.marklogic.client.semantics.GraphManager;
 import com.marklogic.client.semantics.GraphPermissions;
 import com.marklogic.client.semantics.RDFMimeTypes;
-import org.junit.*;
-import org.junit.runners.MethodSorters;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.*;
 
 import java.io.*;
 import java.util.Iterator;
 
-import static org.junit.Assert.*;
 
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+
+@TestMethodOrder(MethodOrderer.MethodName.class)
 public class TestSemanticsGraphManager extends AbstractFunctionalTest {
 
   // private static final String DEFAULT_GRAPH =
@@ -49,13 +49,13 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
   private DatabaseClient readerClient = null;
   private static String datasource = "src/test/java/com/marklogic/client/functionaltest/data/semantics/";
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpBeforeClass() throws Exception {
     System.out.println("In setup");
     appServerHostname = getRestAppServerHostName();
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownAfterClass() throws Exception {
     System.out.println("In tear down");
     deleteRESTUser("eval-user");
@@ -63,7 +63,7 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
     deleteUserRole("test-perm2");
   }
 
-  @After
+  @AfterEach
   public void testCleanUp() throws Exception {
     deleteDocuments(connectAsAdmin());
     adminClient.release();
@@ -72,7 +72,7 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
     System.out.println("Running clear script");
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     createUserRolesWithPrevilages("test-eval", "xdbc:eval", "xdbc:eval-in", "xdmp:eval-in", "any-uri", "xdbc:invoke");
     createRESTUser("eval-user", "x", "test-eval", "rest-admin", "rest-writer", "rest-reader");
@@ -108,7 +108,7 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
     } catch (Exception e) {
       exp = e;
     }
-    assertTrue("Read after detele did not throw expected Exception, Received ::" + exp,
+    assertTrue(
         exp.toString().contains("Could not read resource at graphs."));
 
     // Delete non existing graph
@@ -119,8 +119,8 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
       exp = e;
     }
     assertTrue(
-        "Deleting non-existing Graph did not throw expected Exception:: http://bugtrack.marklogic.com/35064 , Received ::" + exp,
-        exp.toString().contains("Could not delete resource at graphs"));
+        exp.toString().contains("Could not delete resource at graphs"),
+		"Deleting non-existing Graph did not throw expected Exception:: http://bugtrack.marklogic.com/35064 , Received ::" + exp);
   }
 
   /*
@@ -164,8 +164,7 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
       exp = e;
     }
     assertTrue(
-        "Unexpected Error Message, \n Expecting:: com.marklogic.client.ForbiddenUserException: Local message: User is not allowed to write resource at graphs. Server Message: "
-            + "You do not have permission to this method and URL \n BUT Received :: " + exp.toString(), exp.toString()
+        exp.toString()
             .contains(
                 "com.marklogic.client.ForbiddenUserException: Local message: User is not allowed to write resource at graphs. Server Message: "
                     + "You do not have permission to this method and URL"));
@@ -192,12 +191,11 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
     }
     if (exceptionThrown)
       assertTrue(
-          "Unexpected Error Message, \n Expecting:: com.marklogic.client.ForbiddenUserException: Local message: User is not allowed to delete resource at graphs. Server Message: "
-              + "You do not have permission to this method and URL \n BUT Received :: " + exp.toString(), exp.toString()
+          exp.toString()
               .contains(
                   "com.marklogic.client.ForbiddenUserException: Local message: User is not allowed to delete resource at graphs. Server Message: "
                       + "You do not have permission to this method and URL"));
-    assertTrue("Expected Exception but Received NullPointer", exceptionThrown);
+    assertTrue( exceptionThrown);
 
   }
 
@@ -212,7 +210,7 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
     filehandle.set(file);
     gmWriter.write("htp://test.sem.graph/n", filehandle.withMimetype("application/n-triples"));
     StringHandle handle = gmWriter.read("htp://test.sem.graph/n", new StringHandle().withMimetype(RDFMimeTypes.NTRIPLES));
-    assertTrue("Did not insert document or inserted empty doc", handle.toString().contains("<http://jibbering.com/foaf/santa.rdf#bod>"));
+    assertTrue( handle.toString().contains("<http://jibbering.com/foaf/santa.rdf#bod>"));
 
   }
 
@@ -231,7 +229,7 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
     ReaderHandle read = gmWriter.read("http://test.reader.handle/bufferreadtrig", new ReaderHandle().withMimetype(RDFMimeTypes.RDFXML));
     Reader readFile = read.get();
     String readContent = convertReaderToString(readFile);
-    assertTrue("Did not get receive expected string content, Received:: " + readContent,
+    assertTrue(
         readContent.contains("http://www.daml.org/2001/12/factbook/vi#A113932"));
     handle.close();
     read.close();
@@ -260,7 +258,7 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
     BytesHandle byteHandle = gmWriter.read("http://test.turtle.com/byteHandle", new BytesHandle().withMimetype(RDFMimeTypes.TURTLE));
     byte[] readInBytes = byteHandle.get();
     String readInString = new String(readInBytes);
-    assertTrue("Did not insert document or inserted empty doc", readInString.contains("#relativeIRI"));
+    assertTrue( readInString.contains("#relativeIRI"));
   }
 
   /*
@@ -281,7 +279,7 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
     File readFile = handle.get();
     JsonNode readContent = mapper.readTree(readFile);
     // Verify read content with inserted content
-    assertTrue("Did not insert document or inserted empty doc", readContent.toString()
+    assertTrue( readContent.toString()
         .contains("http://purl.org/dc/elements/1.1/title"));
   }
 
@@ -309,11 +307,10 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
 	try {
 		 ins = new InputStreamHandle().withMimetype(RDFMimeTypes.N3);
 		 read = gmWriter.read("http://test.n3.com/byte", ins);
-	
+
     fileRead = read.get();
     String readContent = convertInputStreamToString(fileRead);
-    assertTrue("Did not find expected content after inserting the triples:: Found: " + readContent,
-        readContent.contains("/publications/journals/Journal1/1940"));
+    assertTrue(readContent.contains("/publications/journals/Journal1/1940"));
 	} catch (Exception e) {
 		e.printStackTrace();
 	}
@@ -334,7 +331,7 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
     filehandle.set(file);
     gmWriter.write("htp://test.sem.graph/nquads", filehandle.withMimetype("application/n-quads"));
     StringHandle handle = gmWriter.read("htp://test.sem.graph/nquads", new StringHandle().withMimetype(RDFMimeTypes.NQUADS));
-    assertTrue("Did not insert document or inserted empty doc", handle.toString().contains("<#electricVehicle2>"));
+    assertTrue( handle.toString().contains("<#electricVehicle2>"));
   }
 
   /*
@@ -353,7 +350,7 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
     FileHandle handle = gmWriter.read("htp://test.sem.graph/trig", new FileHandle());
     File readFile = handle.get();
     String expectedContent = convertFileToString(readFile);
-    assertTrue("Did not insert document or inserted empty doc",
+    assertTrue(
         expectedContent.contains("http://www.example.org/exampleDocument#Monica"));
 
   }
@@ -377,7 +374,7 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
     gmWriter.write("htp://test.sem.graph/tripxml", filehandle.withMimetype(RDFMimeTypes.TRIPLEXML), trx);
     // Validate graph written to DB by reading within the same transaction
     StringHandle handle = gmWriter.read("htp://test.sem.graph/tripxml", new StringHandle().withMimetype(RDFMimeTypes.TRIPLEXML), trx);
-    assertTrue("Did not insert document or inserted empty doc", handle.toString().contains("Anna's Homepage"));
+    assertTrue( handle.toString().contains("Anna's Homepage"));
     // Delete Graph in the same transaction
     gmWriter.delete("htp://test.sem.graph/tripxml", trx);
     // Validate Graph is deleted
@@ -414,8 +411,7 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
     } catch (Exception e) {
       exp = e;
     }
-    assertTrue("Did not throw expected Exception, Expecting ::XDMP-BASEURI (err:FOER0000): Undeclared base URI " + "\n Received::"
-        + exp, exp.toString().contains("XDMP-BASEURI (err:FOER0000): Undeclared base URI"));
+    assertTrue(exp.toString().contains("XDMP-BASEURI (err:FOER0000): Undeclared base URI"));
 
   }
 
@@ -437,11 +433,9 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
       handle = gmWriter.read("htp://test.sem.graph/tripxmlnoniri", new StringHandle());
 
     } catch (Exception e) {
-      assertTrue("Did not receive expected Error message, Expecting ::SEM-NOTRDF \n  Received::" + e,
-          e.toString().contains("SEM-NOTRDF") && e != null);
-
+      assertTrue(e.toString().contains("SEM-NOTRDF") && e != null);
     }
-    assertTrue("Read content has un-expected content ", handle.get().toString().contains("5.11"));
+    assertTrue( handle.get().toString().contains("5.11"));
   }
 
   /*
@@ -458,11 +452,10 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
 
       handle = gmWriter.read("htp://test.sem.graph/n3noniri", new StringHandle().withMimetype(RDFMimeTypes.N3));
     } catch (Exception e) {
-      assertTrue("Did not receive expected Error message, Expecting ::SEM-NOTRDF \n  Received::" + e,
-          e.toString().contains("SEM-NOTRDF") && e != null);
+      assertTrue(e.toString().contains("SEM-NOTRDF") && e != null);
 
     }
-    assertTrue("Read content has un-expected content ", handle.get().toString().contains("p0:named_graph"));
+    assertTrue( handle.get().toString().contains("p0:named_graph"));
   }
 
   /*
@@ -476,8 +469,7 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
     gmWriter.writeAs("htp://test.sem.graph/ntAs", filehandle.withMimetype(RDFMimeTypes.NTRIPLES));
     File read = gmWriter.readAs("htp://test.sem.graph/ntAs", File.class);
     String expectedContent = convertFileToString(read);
-    assertTrue("writeAs & readAs  test did not return expected content",
-        expectedContent.contains("http://www.w3.org/2001/sw/RDFCore/ntriples/"));
+    assertTrue(expectedContent.contains("http://www.w3.org/2001/sw/RDFCore/ntriples/"));
   }
 
   /*
@@ -495,7 +487,7 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
     // Validate graph written to DB by reading within the same transaction
     File readFile = gmWriter.readAs("htp://test.sem.graph/ttlas", File.class, trx);
     String expectedContent = convertFileToString(readFile);
-    assertTrue("Did not insert document or inserted empty doc", expectedContent.contains("http://www.w3.org/2004/02/skos/core#Concept"));
+    assertTrue( expectedContent.contains("http://www.w3.org/2004/02/skos/core#Concept"));
     // Delete Graph in the same transaction
     gmWriter.delete("htp://test.sem.graph/ttlas", trx);
     trx.commit();
@@ -505,7 +497,7 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
       String readContent = gmWriter.readAs("htp://test.sem.graph/ttlas", String.class, trx);
       trx.commit();
       trx = null;
-      assertTrue("Unexpected content read, expecting Resource not found exception", readContent == null);
+      assertTrue(readContent == null);
     } catch (ResourceNotFoundException e) {
       System.out.println(e);
     } finally {
@@ -536,7 +528,6 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
     File readFile = handle.get();
     String expectedContent = convertFileToString(readFile);
     assertTrue(
-        "Did not insert document or inserted empty doc",
         expectedContent.contains("http://www.example.org/exampleDocument#Monica")
             && expectedContent.contains("http://purl.org/dc/elements/1.1/publisher"));
   }
@@ -559,7 +550,7 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
     FileHandle handle = gmWriter.read("htp://test.sem.graph/trigM", new FileHandle().withMimetype(RDFMimeTypes.RDFJSON));
     File readFile = handle.get();
     String expectedContent = convertFileToString(readFile);
-    assertTrue("Did not insert document or inserted empty doc", expectedContent.contains("http://example.com/ns/person#firstName")
+    assertTrue( expectedContent.contains("http://example.com/ns/person#firstName")
         && expectedContent.contains("Anna's Homepage"));
   }
 
@@ -580,7 +571,7 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
     gmWriter.mergeAs("htp://test.sem.graph/jsonMergeAs", graphData2);
     File readFile = gmWriter.readAs("htp://test.sem.graph/jsonMergeAs", File.class);
     String expectedContent = convertFileToString(readFile);
-    assertTrue("Did not insert document or inserted empty doc", expectedContent.contains("http://example.com/ns/person#firstName")
+    assertTrue( expectedContent.contains("http://example.com/ns/person#firstName")
         && expectedContent.contains("Anna's Homepage"));
   }
 
@@ -604,7 +595,7 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
     gmWriter.mergeAs("htp://test.sem.graph/jsonMergeAsTrx", graphData2, trx);
     File readFile = gmWriter.readAs("htp://test.sem.graph/jsonMergeAsTrx", File.class, trx);
     String expectedContent = convertFileToString(readFile);
-    assertTrue("Did not insert document or inserted empty doc", expectedContent.contains("http://example.com/ns/person#firstName")
+    assertTrue( expectedContent.contains("http://example.com/ns/person#firstName")
         && expectedContent.contains("Anna's Homepage"));
     try {
       trx.commit();
@@ -636,7 +627,6 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
     File readFile = handle.get();
     String expectedContent = convertFileToString(readFile);
     assertTrue(
-        "Did not insert document or inserted empty doc",
         expectedContent
             .equals("{\"http://example.com/ns/directory#m\":{\"http://example.com/ns/person#firstName\":[{\"value\":\"Michelle\", \""
                 + "type\":\"literal\", \"datatype\":\"http://www.w3.org/2001/XMLSchema#string\"}]}}"));
@@ -657,15 +647,15 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
     File readFile = handle.get();
     String expectedContent = convertFileToString(readFile);
     try {
-      assertTrue("Did not Merge document or inserted empty doc",
+      assertTrue(
           expectedContent.contains("Michelle") && expectedContent.contains("Anna's Homepage"));
       gmWriter.delete("htp://test.sem.graph/mergetrx", trx);
       trx.commit();
       trx = null;
       StringHandle readContent = gmWriter.read("htp://test.sem.graph/mergetrx", new StringHandle(), trx);
-      assertTrue("Unexpected Content from read, expecting null", readContent == null);
+      assertTrue(readContent == null);
     } catch (Exception e) {
-      assertTrue("Unexpected Exception Thrown", e.toString().contains("ResourceNotFoundException"));
+      assertTrue( e.toString().contains("ResourceNotFoundException"));
     } finally {
       if (trx != null)
         trx.commit();
@@ -694,10 +684,8 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
     File readFile = handle.get();
     String expectedContent = convertFileToString(readFile);
     System.out.println(gmWriter.listGraphUris().next().toString());
-    assertTrue("" + gmWriter.listGraphUris().next().toString(),
-        gmWriter.listGraphUris().next().toString().equals("http://marklogic.com/semantics#default-graph"));
-    assertTrue("Did not insert document or inserted empty doc",
-        expectedContent.contains("http://www.example.org/exampleDocument#Monica"));
+    assertTrue(gmWriter.listGraphUris().next().toString().equals("http://marklogic.com/semantics#default-graph"));
+    assertTrue(expectedContent.contains("http://www.example.org/exampleDocument#Monica"));
   }
 
   /*
@@ -717,21 +705,21 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
     FileHandle handle = gmWriter.read(uri, new FileHandle());
     File readFile = handle.get();
     String expectedContent = convertFileToString(readFile);
-    assertTrue("Did not merge Quad", expectedContent.contains("<http://example.com/mergeQuadP"));
+    assertTrue( expectedContent.contains("<http://example.com/mergeQuadP"));
 
     file = new File(datasource + "relative2.nq");
     gmWriter.replaceGraphs(new FileHandle(file).withMimetype(RDFMimeTypes.NQUADS));
     uri = "http://originalGraph";
     StringHandle readQuads = gmWriter.read(uri, new StringHandle());
-    assertTrue("Did not Replace Quads", readQuads.toString().contains("#electricVehicle2"));
+    assertTrue( readQuads.toString().contains("#electricVehicle2"));
     gmWriter.deleteGraphs();
 
     try {
       StringHandle readContent = gmWriter.read(uri, new StringHandle());
-      assertTrue("Unexpected content read, expecting Resource not found exception", readContent.get() == null);
+      assertTrue( readContent.get() == null);
 
     } catch (Exception e) {
-      assertTrue("Unexpected Exception Thrown", e.toString().contains("ResourceNotFoundException"));
+      assertTrue( e.toString().contains("ResourceNotFoundException"));
     }
   }
 
@@ -748,22 +736,22 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
     gmWriter.replaceGraphsAs(file);
     String uri = "http://en.wikipedia.org/wiki/Alexander_I_of_Serbia?oldid=492189987#absolute-line=1";
     StringHandle readQuads = gmWriter.read(uri, new StringHandle());
-    assertTrue("Did not Replace Quads", readQuads.toString().contains("http://dbpedia.org/ontology/Monarch"));
+    assertTrue( readQuads.toString().contains("http://dbpedia.org/ontology/Monarch"));
 
     file = new File(datasource + "relative2.nq");
     gmWriter.mergeGraphsAs(file);
     uri = "http://originalGraph";
     readQuads = gmWriter.read(uri, new StringHandle());
-    assertTrue("Did not Replace Quads", readQuads.toString().contains("#electricVehicle2"));
+    assertTrue( readQuads.toString().contains("#electricVehicle2"));
 
     gmWriter.deleteGraphs();
     try {
       StringHandle readContent = gmWriter.read(uri, new StringHandle());
-      assertTrue("Unexpected content read, expecting Resource not found exception", readContent.get() == null);
+      assertTrue( readContent.get() == null);
 
     } catch (Exception e) {
 
-      assertTrue("Unexpected Exception Thrown", e.toString().contains("ResourceNotFoundException"));
+      assertTrue( e.toString().contains("ResourceNotFoundException"));
     }
   }
 
@@ -776,7 +764,6 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
     gmWriter.write("http://test.things.com/", filehandle);
     String things = gmWriter.thingsAs(String.class, "http://www.w3.org/1999/02/22-rdf-syntax-ns#type");
     assertTrue(
-        "Did not return Expected graph Uri's",
         things.equals("<#electricVehicle2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://people.aifb.kit.edu/awa/2011/smartgrid/schema/smartgrid#ElectricVehicle> ."));
   }
 
@@ -787,8 +774,7 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
     File file = new File(datasource + "relative5.xml");
     gmWriter.write(tripleGraphUri, new FileHandle(file));
     TriplesReadHandle things = gmWriter.things(new StringHandle(), "about");
-    assertTrue("Things did not return expected Uri's",
-        things.toString().contains("<about> <http://purl.org/dc/elements/1.1/title> \"Anna's Homepage\" ."));
+    assertTrue(things.toString().contains("<about> <http://purl.org/dc/elements/1.1/title> \"Anna's Homepage\" ."));
     gmWriter.delete(tripleGraphUri);
   }
 
@@ -800,7 +786,7 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
     gmWriter.write("htp://test.sem.graph/rdfjson", filehandle.withMimetype("application/rdf+json"));
     JacksonHandle handle1 = gmWriter.read("htp://test.sem.graph/rdfjson", new JacksonHandle());
     JsonNode readFile = handle1.get();
-    assertTrue("Did not insert document or inserted empty doc", readFile.toString().contains("http://purl.org/dc/elements/1.1/title"));
+    assertTrue( readFile.toString().contains("http://purl.org/dc/elements/1.1/title"));
   }
 
   @Test
@@ -810,7 +796,7 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
     filehandle.set(file);
     gmWriter.write("htp://test.sem.graph/rdfjson", filehandle.withMimetype("application/rdf+json"));
     TriplesReadHandle handle1 = gmWriter.read("htp://test.sem.graph/rdfjson", new JacksonHandle());
-    assertTrue("Did not insert document or inserted empty doc", handle1.toString().contains("http://purl.org/dc/elements/1.1/title"));
+    assertTrue( handle1.toString().contains("http://purl.org/dc/elements/1.1/title"));
   }
 
   @Test
@@ -822,7 +808,7 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
     Exception exp = null;
     try {
       TriplesReadHandle things = gmWriter.things(new StringHandle(), "noMatch");
-      assertTrue("Things did not return expected Uri's", things == null);
+      assertTrue(things == null);
     } catch (Exception e) {
       exp = e;
     }
@@ -839,7 +825,7 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
     file = new File(datasource + "semantics.ttl");
     gmWriter.merge(tripleGraphUri, new FileHandle(file).withMimetype(RDFMimeTypes.TURTLE));
     StringHandle things = gmWriter.things(new StringHandle(), "http://dbpedia.org/resource/Hadoop");
-    assertTrue("Things did not return expected Uri's", things.get().contains("Apache Hadoop"));
+    assertTrue(things.get().contains("Apache Hadoop"));
     gmWriter.delete(tripleGraphUri);
   }
 
@@ -868,7 +854,7 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
     System.out.println("Permissions after create , Should not see Execute" + gmTestPerm.getPermissions(uri));
     perms = gmTestPerm.getPermissions(uri);
     for (Capability capability : perms.get("test-perm")) {
-      assertTrue("capability should be UPDATE, not [" + capability + "]", capability == Capability.UPDATE);
+      assertTrue(capability == Capability.UPDATE);
     }
 
     // Create another Role to check for builder style permissions support.
@@ -883,24 +869,24 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
     perms = gmTestPerm.getPermissions(uri);
     System.out.println("Permissions after setting execute , Should  see Execute & Update" + gmTestPerm.getPermissions(uri));
     for (Capability capability : perms.get("test-perm")) {
-      assertTrue("capability for role test-perm should be UPDATE && Execute, not [" + capability + "]", capability == Capability.UPDATE
+      assertTrue(capability == Capability.UPDATE
           || capability == Capability.EXECUTE);
     }
     for (Capability capability : perms.get("test-perm2")) {
-      assertTrue("capability for role test-perm2 should be EXECUTE && READ, not [" + capability + "]", capability == Capability.READ
+      assertTrue(capability == Capability.READ
           || capability == Capability.EXECUTE);
     }
-    assertTrue("Did not have expected capabilities", perms.get("test-perm").size() == 2);
-    assertTrue("Did not have expected capabilities", perms.get("test-perm2").size() == 2);
+    assertTrue( perms.get("test-perm").size() == 2);
+    assertTrue( perms.get("test-perm2").size() == 2);
 
     // Write Read permission to uri and validate permissions are overwritten
     // with write
     perms = gmTestPerm.permission("test-perm", Capability.READ);
     gmTestPerm.write(uri, handle.withMimetype(RDFMimeTypes.RDFXML), perms);
     for (Capability capability : perms.get("test-perm")) {
-      assertTrue("capability should be READ, not [" + capability + "]", capability == Capability.READ);
+      assertTrue(capability == Capability.READ);
     }
-    assertTrue("Did not have expected capabilities", perms.get("test-perm").size() == 1);
+    assertTrue( perms.get("test-perm").size() == 1);
 
     // Delete Permissions and Validate
     gmTestPerm.deletePermissions(uri);
@@ -918,8 +904,7 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
       ReaderHandle read = gmTestPerm.read(uri, new ReaderHandle());
       Reader readFile = read.get();
       String readContent = convertReaderToString(readFile);
-      assertTrue("Did not get receive expected string content, Received:: " + readContent,
-          readContent.contains("http://www.daml.org/2001/12/factbook/vi#A113932"));
+      assertTrue(readContent.contains("http://www.daml.org/2001/12/factbook/vi#A113932"));
     } catch (Exception e) {
       System.out.println("Tried to Read  and validate triples, should  see this exception ::" + e);
     }
@@ -954,8 +939,7 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
     ReaderHandle read = gmTestPerm.read(uri, new ReaderHandle());
     Reader readFile = read.get();
     String readContent = convertReaderToString(readFile);
-    assertTrue("Did not get receive expected string content, Received:: " + readContent,
-        readContent.contains("http://www.daml.org/2001/12/factbook/vi#A113932"));
+    assertTrue(readContent.contains("http://www.daml.org/2001/12/factbook/vi#A113932"));
 
     // Delete the role
     deleteUserRole("test-perm2");
@@ -995,7 +979,7 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
       System.out.println("OUTSIDE TRX , SHOULD NOT SEE test-perm EXECUTE" + perm);
       assertNull(perm.get("test-perm"));
       perms = gmTestPerm.getPermissions(uri, trx);
-      assertTrue("Permission within trx should have Update capability", perms.get("test-perm").contains(Capability.UPDATE));
+      assertTrue( perms.get("test-perm").contains(Capability.UPDATE));
       trx.rollback();
       trx = null;
       perms = gmTestPerm.getPermissions(uri);
@@ -1038,7 +1022,7 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
       System.out.println("Permissions after create , Should not see Execute" + gmTestPerm.getPermissions(uri, trx));
       perms = gmTestPerm.getPermissions(uri, trx);
       for (Capability capability : perms.get("test-perm")) {
-        assertTrue("capability should be UPDATE, not [" + capability + "]", capability == Capability.UPDATE);
+        assertTrue(capability == Capability.UPDATE);
       }
 
       // Set Capability for the User
@@ -1049,8 +1033,7 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
       perms = gmTestPerm.getPermissions(uri, trx);
       System.out.println("Permissions after setting execute , Should  see Execute & Update" + gmTestPerm.getPermissions(uri, trx));
       for (Capability capability : perms.get("test-perm")) {
-        assertTrue("capability should be UPDATE && Execute, not [" + capability + "]", capability == Capability.UPDATE
-            || capability == Capability.EXECUTE);
+        assertTrue(capability == Capability.UPDATE || capability == Capability.EXECUTE);
       }
 
       // Validate write with Update and Execute permissions
@@ -1081,12 +1064,12 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
       // Read and Validate triples
       try {
         ReaderHandle read = gmTestPerm.read(uri, new ReaderHandle().withMimetype(RDFMimeTypes.RDFXML), trx);
-        
-        Reader readFile = read.get();        
+
+        Reader readFile = read.get();
         StringBuilder readContentSB = new StringBuilder();
         BufferedReader br = null;
 		try {
-			br = new BufferedReader(readFile);			
+			br = new BufferedReader(readFile);
 			String line = null;
 			while ((line = br.readLine()) != null)
 				readContentSB.append(line);
@@ -1098,8 +1081,7 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
 		}
 		String readContent = readContentSB.toString();
 		System.out.println("Triples read back from Server is " + readContent);
-        assertTrue("Did not get receive expected string content, Received:: " + readContent,
-            readContent.contains("http://www.daml.org/2001/12/factbook/vi#A113932"));
+        assertTrue(readContent.contains("http://www.daml.org/2001/12/factbook/vi#A113932"));
       } catch (Exception e) {
         System.out.println("Tried to Read  and validate triples, should not see this exception ::" + e);
       }
@@ -1138,8 +1120,7 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
       ReaderHandle read = gmTestPerm.read(uri, new ReaderHandle(), trx);
       Reader readFile = read.get();
       String readContent = convertReaderToString(readFile);
-      assertTrue("Did not get receive expected string content, Received:: " + readContent,
-          readContent.contains("http://www.daml.org/2001/12/factbook/vi#A113932"));
+      assertTrue(readContent.contains("http://www.daml.org/2001/12/factbook/vi#A113932"));
       trx.commit();
       trx = null;
 
@@ -1156,7 +1137,7 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
   /*
    * Write Triples of Type JSON Merge NTriples into the same graph and validate
    * mergeGraphs with transactions.
-   * 
+   *
    * Merge within same write transaction Write and merge Triples within
    * different transactions. Commit the merge transaction Write and merge
    * Triples within different transactions. Rollback the merge transaction Write
@@ -1183,8 +1164,8 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
       FileHandle handle = gmWriter.read(uri, new FileHandle());
       File readFile = handle.get();
       String expectedContent = convertFileToString(readFile);
-      assertTrue("Did not write Quad in transaction", expectedContent.contains("<http://example.com/ns/person#firstName"));
-      assertTrue("Did not merge Quad", expectedContent.contains("<http://example.com/mergeQuadP"));
+      assertTrue( expectedContent.contains("<http://example.com/ns/person#firstName"));
+      assertTrue( expectedContent.contains("<http://example.com/mergeQuadP"));
       trxIn = null;
       handle = null;
       readFile = null;
@@ -1207,7 +1188,7 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
       handle = gmWriter.read(uri, new FileHandle());
       readFile = handle.get();
       expectedContent = convertFileToString(readFile);
-      assertTrue("Did not write Quad in transaction", expectedContent.contains("<http://example.com/ns/person#firstName"));
+      assertTrue( expectedContent.contains("<http://example.com/ns/person#firstName"));
       handle = null;
       readFile = null;
       expectedContent = null;
@@ -1219,8 +1200,8 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
       handle = gmWriter.read(uri, new FileHandle());
       readFile = handle.get();
       expectedContent = convertFileToString(readFile);
-      assertTrue("Merge corrupted original Quad in transaction", expectedContent.contains("<http://example.com/ns/person#firstName"));
-      assertTrue("Did not merge Quad in separate transaction", expectedContent.contains("<http://example.com/mergeQuadP"));
+      assertTrue( expectedContent.contains("<http://example.com/ns/person#firstName"));
+      assertTrue( expectedContent.contains("<http://example.com/mergeQuadP"));
 
       trxIn = null;
       trxInMergeGraph = null;
@@ -1247,7 +1228,7 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
       handle = gmWriter.read(uri, new FileHandle());
       readFile = handle.get();
       expectedContent = convertFileToString(readFile);
-      assertTrue("Did not write Quad in transaction", expectedContent.contains("<http://example.com/ns/person#firstName"));
+      assertTrue( expectedContent.contains("<http://example.com/ns/person#firstName"));
       handle = null;
       readFile = null;
       expectedContent = null;
@@ -1259,8 +1240,8 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
       expectedContent = convertFileToString(readFile);
 
       // Verify if original quad is available.
-      assertTrue("Merge corrupted original Quad in transaction", expectedContent.contains("<http://example.com/ns/person#firstName"));
-      assertFalse("Did merge Quad when it should not have, since transaction was rolled back", expectedContent.contains("<http://example.com/mergeQuadP"));
+      assertTrue( expectedContent.contains("<http://example.com/ns/person#firstName"));
+      assertFalse(expectedContent.contains("<http://example.com/mergeQuadP"));
 
       trxIn = null;
       trxInMergeGraph = null;
@@ -1286,7 +1267,7 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
       handle = gmWriter.read(uri, new FileHandle());
       readFile = handle.get();
       expectedContent = convertFileToString(readFile);
-      assertTrue("Did not write Quad in transaction", expectedContent.contains("<http://example.com/ns/person#firstName"));
+      assertTrue( expectedContent.contains("<http://example.com/ns/person#firstName"));
       handle = null;
       readFile = null;
       expectedContent = null;
@@ -1300,8 +1281,8 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
       expectedContent = convertFileToString(readFile);
 
       // Verify if original quad is available.
-      assertTrue("Merge corrupted original Quad in transaction", expectedContent.contains("<http://example.com/ns/person#firstName"));
-      assertFalse("Did merge Quad when it should not have, since transaction was rolled back", expectedContent.contains("<http://example.com/mergeQuadP"));
+      assertTrue( expectedContent.contains("<http://example.com/ns/person#firstName"));
+      assertFalse(expectedContent.contains("<http://example.com/mergeQuadP"));
 
       trxIn = null;
       trxInMergeGraph = null;
@@ -1317,8 +1298,8 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
       readFile = handle.get();
       expectedContent = convertFileToString(readFile);
       // Verify if original quad is available.
-      assertTrue("Merge corrupted original Quad in transaction", expectedContent.contains("<http://example.com/ns/person#firstName"));
-      assertTrue("Did not merge Quad in second commit transaction", expectedContent.contains("<http://example.com/mergeQuadP"));
+      assertTrue( expectedContent.contains("<http://example.com/ns/person#firstName"));
+      assertTrue( expectedContent.contains("<http://example.com/mergeQuadP"));
 
       // Delete Graphs inside the transaction.
       trxDelIn = writerClient.openTransaction();
@@ -1352,7 +1333,7 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
   /*
    * Write Triples of Type JSON replace NTriples into the same graph and
    * validate replaceGraphs with transactions.
-   * 
+   *
    * Replace within same write transaction Write and replace Triples within
    * different transactions. Commit the replace transaction Write and replace
    * Triples within different transactions. Rollback the replace transaction
@@ -1382,9 +1363,9 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
       String expectedContent = convertFileToString(readFile);
 
       // Should not contain original triples
-      assertFalse("Did not replace Quad", expectedContent.contains("http://example.com/ns/person#firstName"));
+      assertFalse( expectedContent.contains("http://example.com/ns/person#firstName"));
       // Should contain new triples
-      assertTrue("Did not replace Quad", expectedContent.contains("<http://example.com/mergeQuadP"));
+      assertTrue( expectedContent.contains("<http://example.com/mergeQuadP"));
 
       trxIn = null;
       handle = null;
@@ -1407,7 +1388,7 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
       readFile = handle.get();
       expectedContent = convertFileToString(readFile);
       // Should contain original triples
-      assertTrue("Write Quad not successful", expectedContent.contains("http://example.com/ns/person#firstName"));
+      assertTrue( expectedContent.contains("http://example.com/ns/person#firstName"));
 
       // Replace Graphs inside another transaction.
       trxInReplaceGraph = writerClient.openTransaction();
@@ -1421,9 +1402,9 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
       readFile = handle.get();
       expectedContent = convertFileToString(readFile);
       // Should not contain original triples
-      assertFalse("Did not replace Quad", expectedContent.contains("http://example.com/ns/person#firstName"));
+      assertFalse( expectedContent.contains("http://example.com/ns/person#firstName"));
       // Should contain new triples
-      assertTrue("Did not replace Quad", expectedContent.contains("<http://example.com/mergeQuadP"));
+      assertTrue( expectedContent.contains("<http://example.com/mergeQuadP"));
 
       trxIn = null;
       trxInReplaceGraph = null;
@@ -1448,7 +1429,7 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
       readFile = handle.get();
       expectedContent = convertFileToString(readFile);
       // Should contain original triples
-      assertTrue("Write Quad not successful", expectedContent.contains("http://example.com/ns/person#firstName"));
+      assertTrue( expectedContent.contains("http://example.com/ns/person#firstName"));
 
       handle = null;
       readFile = null;
@@ -1463,9 +1444,9 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
       expectedContent = convertFileToString(readFile);
 
       // Should not contain original triples
-      assertTrue("Original Quad not available after transaction rolled back", expectedContent.contains("http://example.com/ns/person#firstName"));
+      assertTrue( expectedContent.contains("http://example.com/ns/person#firstName"));
       // Should contain new triples
-      assertFalse("Did not replace Quad", expectedContent.contains("<http://example.com/mergeQuadP"));
+      assertFalse( expectedContent.contains("<http://example.com/mergeQuadP"));
 
       trxIn = null;
       trxInReplaceGraph = null;
@@ -1490,7 +1471,7 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
       readFile = handle.get();
       expectedContent = convertFileToString(readFile);
       // Should contain original triples
-      assertTrue("Write Quad not successful", expectedContent.contains("http://example.com/ns/person#firstName"));
+      assertTrue( expectedContent.contains("http://example.com/ns/person#firstName"));
       handle = null;
       readFile = null;
       expectedContent = null;
@@ -1502,9 +1483,9 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
       expectedContent = convertFileToString(readFile);
 
       // Should not contain original triples
-      assertTrue("Original Quad not available after transaction rolled back", expectedContent.contains("http://example.com/ns/person#firstName"));
+      assertTrue( expectedContent.contains("http://example.com/ns/person#firstName"));
       // Should contain new triples
-      assertFalse("Did not replace Quad", expectedContent.contains("<http://example.com/mergeQuadP"));
+      assertFalse( expectedContent.contains("<http://example.com/mergeQuadP"));
 
       trxIn = null;
       trxInReplaceGraph = null;
@@ -1520,9 +1501,9 @@ public class TestSemanticsGraphManager extends AbstractFunctionalTest {
       readFile = handle.get();
       expectedContent = convertFileToString(readFile);
       // Should not contain original triples
-      assertFalse("Did not replace Quad", expectedContent.contains("http://example.com/ns/person#firstName"));
+      assertFalse( expectedContent.contains("http://example.com/ns/person#firstName"));
       // Should contain new triples
-      assertTrue("Did not replace Quad", expectedContent.contains("<http://example.com/mergeQuadP"));
+      assertTrue( expectedContent.contains("<http://example.com/mergeQuadP"));
 
       // Delete Graphs inside the transaction.
       trxDelIn = writerClient.openTransaction();

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestServerAssignedDocumentURI.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestServerAssignedDocumentURI.java
@@ -28,7 +28,8 @@ import com.marklogic.client.io.DOMHandle;
 import com.marklogic.client.io.FileHandle;
 import com.marklogic.client.io.SourceHandle;
 import com.marklogic.client.io.StringHandle;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
@@ -41,7 +42,7 @@ import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 
-import static org.junit.Assert.assertTrue;
+
 
 public class TestServerAssignedDocumentURI extends AbstractFunctionalTest {
 
@@ -79,7 +80,7 @@ public class TestServerAssignedDocumentURI extends AbstractFunctionalTest {
     String content = docMgr.read(desc, new StringHandle()).get();
     System.out.println(content);
 
-    assertTrue("document is not created", content.contains("Flipper"));
+    assertTrue( content.contains("Flipper"));
 
     // release the client
     client.release();
@@ -120,7 +121,7 @@ public class TestServerAssignedDocumentURI extends AbstractFunctionalTest {
       content = docMgr.read(desc, new StringHandle()).get();
       System.out.println(content);
 
-      assertTrue("document is not created", content.contains("Flipper"));
+      assertTrue( content.contains("Flipper"));
     } catch (ResourceNotFoundException e) {
       System.out.println("Because of Special Characters in uri, it is throwing exception");
     }
@@ -203,7 +204,7 @@ public class TestServerAssignedDocumentURI extends AbstractFunctionalTest {
       System.out.println(docId);
     } catch (IllegalArgumentException i) {
       i.printStackTrace();
-      assertTrue("Expected error didnt came up", i.toString().contains("Directory is not valid: /:?#[]@/"));
+      assertTrue( i.toString().contains("Directory is not valid: /:?#[]@/"));
     }
     // release the client
     client.release();
@@ -280,7 +281,7 @@ public class TestServerAssignedDocumentURI extends AbstractFunctionalTest {
     }
 
     String expectedException = "com.marklogic.client.ResourceNotFoundException: Local message: Could not read non-existent document. Server Message: RESTAPI-NODOCUMENT";
-    assertTrue("Exception is not thrown", exception.contains(expectedException));
+    assertTrue( exception.contains(expectedException));
 
     System.out.println("After commit:");
     transaction.commit();
@@ -288,13 +289,13 @@ public class TestServerAssignedDocumentURI extends AbstractFunctionalTest {
     String content1 = docMgr.read(desc, new StringHandle()).get();
     System.out.println(content1);
 
-    assertTrue("document is not created", content1.contains("firstname"));
+    assertTrue( content1.contains("firstname"));
 
     // read metadata
     String metadataContent = docMgr.readMetadata(docId, new StringHandle()).get();
     System.out.println(metadataContent);
 
-    assertTrue("metadata is not created", metadataContent.contains("<Author>MarkLogic</Author>"));
+    assertTrue( metadataContent.contains("<Author>MarkLogic</Author>"));
     handle.close();
 
     // release client

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestSparqlQueryManager.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestSparqlQueryManager.java
@@ -32,9 +32,10 @@ import com.marklogic.client.io.DocumentMetadataHandle.DocumentProperties;
 import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.query.StringQueryDefinition;
 import com.marklogic.client.semantics.*;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 import org.w3c.dom.Document;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
@@ -46,7 +47,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.*;
 import java.util.Map.Entry;
 
-import static org.junit.Assert.*;
+
 
 public class TestSparqlQueryManager extends AbstractFunctionalTest {
 
@@ -90,7 +91,7 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
         // Verify result in t2 transaction.
         boolean bAskInTransT2 = sparqlQmgrTh.executeAsk(qdefTh, t2);
         System.out.println("Method ExecuteAskSecondThreadFalse Run result is " + bAskInTransT2);
-        assertFalse("Class ExecuteAskSecondThreadFalse Run result is incorrect. No Records should be returned.", bAskInTransT2);
+        assertFalse( bAskInTransT2);
         setbCompleted(true);
 
       } catch (ForbiddenUserException e) {
@@ -144,7 +145,7 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
         // commited.
         boolean bAskInTransT2 = sparqlQmgrTh.executeAsk(qdefTh, t2);
         System.out.println("Method ExecuteAskSecondThreadTrue Run result is " + bAskInTransT2);
-        assertTrue("Class ExecuteAskSecondThreadTrue Run result is incorrect. Records should be returned.", bAskInTransT2);
+        assertTrue( bAskInTransT2);
         setbCompleted(true);
 
       } catch (ForbiddenUserException e) {
@@ -159,7 +160,7 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
     }
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception
   {
     System.out.println("In SPARQL Query Manager Test setup");
@@ -259,7 +260,7 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
     /*
      * Build custom data for Locale test. From Google translation We have Ling
      * in Chinese as 凌 We have Fei in Chinese as 飞
-     * 
+     *
      * We will have these triples in a graph called 北京 (beijing) in Chinese.
      */
     writeNTriplesFromFile("chineselocale.ttl", zhlocaleGraphName);
@@ -301,13 +302,13 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
   /*
    * This test checks a simple SPARQL query results from named graph. The
    * database should contain triples from foaf1.nt.
-   * 
+   *
    * The query should be returning two results ordered by name.
-   * 
+   *
    * Uses JacksonHandle
    */
   @Test
-  public void testNamedExecuteSelectQuery() 
+  public void testNamedExecuteSelectQuery()
   {
     System.out.println("In SPARQL Query Manager Test testNamedExecuteSelectQuery method");
     SPARQLQueryManager sparqlQmgr = readclient.newSPARQLQueryManager();
@@ -326,35 +327,35 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodes = jsonResults.path("results").path("bindings");
 
     // Should have 2 nodes returned.
-    assertEquals("Two names not returned from testNamedExecuteSelectQuery method ", 2, jsonBindingsNodes.size());
+    assertEquals( 2, jsonBindingsNodes.size());
 
     Iterator<JsonNode> nameNodesItr = jsonBindingsNodes.elements();
     JsonNode jsonNameNode = null;
     if (nameNodesItr.hasNext()) {
       jsonNameNode = nameNodesItr.next();
       // Verify result 1's values.
-      assertEquals("Element 1 name value incorrect", "Karen Schouten", jsonNameNode.path("name").path("value").asText());
-      assertEquals("Element 1 type is incorrect", "literal", jsonNameNode.path("name").path("type").asText());
+      assertEquals( "Karen Schouten", jsonNameNode.path("name").path("value").asText());
+      assertEquals( "literal", jsonNameNode.path("name").path("type").asText());
     }
 
     if (nameNodesItr.hasNext()) {
       // Verify result 2's values.
       jsonNameNode = nameNodesItr.next();
-      assertEquals("Element 2 name value incorrect", "Nick Aster", jsonNameNode.path("name").path("value").asText());
-      assertEquals("Element 2 type is incorrect", "literal", jsonNameNode.path("name").path("type").asText());
+      assertEquals( "Nick Aster", jsonNameNode.path("name").path("value").asText());
+      assertEquals( "literal", jsonNameNode.path("name").path("type").asText());
     }
   }
 
   /*
    * This test checks a simple SPARQL query results from default graph. The
    * database should contain triples from livesIn.ttl.
-   * 
+   *
    * The query should be returning three results ordered by name.
-   * 
+   *
    * Uses JacksonHandle
    */
   @Test
-  public void testDefaultExecuteSelectQuery() 
+  public void testDefaultExecuteSelectQuery()
   {
     System.out.println("In SPARQL Query Manager Test testDefaultExecuteSelectQuery method");
     SPARQLQueryManager sparqlQmgr = readclient.newSPARQLQueryManager();
@@ -365,43 +366,43 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodes = jsonResults.path("results").path("bindings");
 
     // Should have 3 nodes returned.
-    assertEquals("Three results not returned from testDefaultExecuteSelectQuery method ", 3, jsonBindingsNodes.size());
+    assertEquals( 3, jsonBindingsNodes.size());
 
     Iterator<JsonNode> nameNodesItr = jsonBindingsNodes.elements();
     JsonNode jsonNameNode = null;
     if (nameNodesItr.hasNext()) {
       jsonNameNode = nameNodesItr.next();
       // Verify result 1 values.
-      assertEquals("Element 1 name value incorrect", "http://example.org/ml/people/Jack_Smith", jsonNameNode.path("name").path("value").asText());
-      assertEquals("Element 1 lives is incorrect", "livesIn", jsonNameNode.path("lives").path("value").asText());
-      assertEquals("Element 1 city is incorrect", "Glasgow", jsonNameNode.path("city").path("value").asText());
+      assertEquals( "http://example.org/ml/people/Jack_Smith", jsonNameNode.path("name").path("value").asText());
+      assertEquals( "livesIn", jsonNameNode.path("lives").path("value").asText());
+      assertEquals( "Glasgow", jsonNameNode.path("city").path("value").asText());
     }
     if (nameNodesItr.hasNext()) {
       // Verify result 2 values.
       jsonNameNode = nameNodesItr.next();
-      assertEquals("Element 2 name value incorrect", "http://example.org/ml/people/Jane_Smith", jsonNameNode.path("name").path("value").asText());
-      assertEquals("Element 2 lives is incorrect", "livesIn", jsonNameNode.path("lives").path("value").asText());
-      assertEquals("Element 2 city is incorrect", "London", jsonNameNode.path("city").path("value").asText());
+      assertEquals( "http://example.org/ml/people/Jane_Smith", jsonNameNode.path("name").path("value").asText());
+      assertEquals( "livesIn", jsonNameNode.path("lives").path("value").asText());
+      assertEquals( "London", jsonNameNode.path("city").path("value").asText());
     }
     if (nameNodesItr.hasNext()) {
       // Verify result 3 values.
       jsonNameNode = nameNodesItr.next();
-      assertEquals("Element 3 name value incorrect", "http://example.org/ml/people/John_Smith", jsonNameNode.path("name").path("value").asText());
-      assertEquals("Element 3 lives is incorrect", "livesIn", jsonNameNode.path("lives").path("value").asText());
-      assertEquals("Element 3 city is incorrect", "London", jsonNameNode.path("city").path("value").asText());
+      assertEquals( "http://example.org/ml/people/John_Smith", jsonNameNode.path("name").path("value").asText());
+      assertEquals( "livesIn", jsonNameNode.path("lives").path("value").asText());
+      assertEquals( "London", jsonNameNode.path("city").path("value").asText());
     }
   }
 
   /*
    * This test checks a simple SPARQL query results from named graph in a
    * transaction. The database should contain triples from geo-states.n3.
-   * 
+   *
    * The query should be returning one result.
-   * 
+   *
    * Uses StringHandle (XMLReadHandle)
    */
   @Test
-  public void testExecuteQueryInTransaction() 
+  public void testExecuteQueryInTransaction()
   {
     System.out.println("In SPARQL Query Manager Test testExecuteQueryInTransaction method");
     Transaction t = writeclient.openTransaction();
@@ -433,12 +434,12 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
       System.out.println(jsonStrResults);
       JsonNode jsonBindingsNodes = jsonNodesFromStr.path("results").path("bindings");
       // Should have 1 node returned.
-      assertEquals("Result returned from testExecuteQueryInTransaction method size is incorrect ", 1, jsonBindingsNodes.size());
+      assertEquals( 1, jsonBindingsNodes.size());
 
       // Verify results.
-      assertEquals("Element statecode value is incorrect", "http://www.rdfabout.com/rdf/usgov/geo/us/al", jsonBindingsNodes.get(0).path("stateCode").path("value").asText());
-      assertEquals("Element lives is incorrect", "4447100", jsonBindingsNodes.get(0).path("population").path("value").asText());
-      assertEquals("Element city is incorrect", "Alabama", jsonBindingsNodes.get(0).path("statename").path("value").asText());
+      assertEquals( "http://www.rdfabout.com/rdf/usgov/geo/us/al", jsonBindingsNodes.get(0).path("stateCode").path("value").asText());
+      assertEquals( "4447100", jsonBindingsNodes.get(0).path("population").path("value").asText());
+      assertEquals( "Alabama", jsonBindingsNodes.get(0).path("statename").path("value").asText());
       // Handle the transaction.
       t.commit();
       t = null;
@@ -457,14 +458,14 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
   /*
    * This test checks a simple SPARQL query pagination from named graph in a
    * transaction. The database should contain triples from geo-states.n3.
-   * 
+   *
    * The query should be returning states where population is greater than 5
    * million ordered by population count ascending.
-   * 
+   *
    * Uses StringHandle (XMLReadHandle)
    */
   @Test
-  public void testPaginationInTransaction() 
+  public void testPaginationInTransaction()
   {
     System.out.println("In SPARQL Query Manager Test testPaginationInTransaction method");
     Transaction t = writeclient.openTransaction();
@@ -498,13 +499,13 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
       System.out.println(jsonStrResults);
       JsonNode jsonBindingsNodes = jsonNodesFromStr.path("results").path("bindings");
       // Should have 1 node returned. Details of State - Arizona.
-      assertEquals("Result returned from testPaginationInTransaction query 1 has incorrect size ", 1, jsonBindingsNodes.size());
+      assertEquals( 1, jsonBindingsNodes.size());
       System.out.println("testPaginationInTransaction query 1 result size is " + jsonBindingsNodes.size());
 
       // Verify results.
-      assertEquals("Element statecode value incorrect", "http://www.rdfabout.com/rdf/usgov/geo/us/az", jsonBindingsNodes.get(0).path("stateCode").path("value").asText());
-      assertEquals("Element lives is incorrect", "5130632", jsonBindingsNodes.get(0).path("population").path("value").asText());
-      assertEquals("Element city is incorrect", "Arizona", jsonBindingsNodes.get(0).path("statename").path("value").asText());
+      assertEquals( "http://www.rdfabout.com/rdf/usgov/geo/us/az", jsonBindingsNodes.get(0).path("stateCode").path("value").asText());
+      assertEquals( "5130632", jsonBindingsNodes.get(0).path("population").path("value").asText());
+      assertEquals( "Arizona", jsonBindingsNodes.get(0).path("statename").path("value").asText());
 
       // Select in a transaction with start = 2 and page length = 1.
       /*
@@ -520,13 +521,13 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
       System.out.println(jsonStrResults2);
       JsonNode jsonBindingsNodes2 = jsonNodesFromStr2.path("results").path("bindings");
 
-      assertEquals("Result returned from testPaginationInTransaction query 2 has incorrect size ", 1, jsonBindingsNodes2.size());
+      assertEquals( 1, jsonBindingsNodes2.size());
       System.out.println("testPaginationInTransaction query 2 result size is " + jsonBindingsNodes2.size());
 
       // Verify results - Details of State - Maryland.
-      assertEquals("Element statecode value incorrect", "http://www.rdfabout.com/rdf/usgov/geo/us/md", jsonBindingsNodes2.get(0).path("stateCode").path("value").asText());
-      assertEquals("Element lives is incorrect", "5296486", jsonBindingsNodes2.get(0).path("population").path("value").asText());
-      assertEquals("Element city is incorrect", "Maryland", jsonBindingsNodes2.get(0).path("statename").path("value").asText());
+      assertEquals( "http://www.rdfabout.com/rdf/usgov/geo/us/md", jsonBindingsNodes2.get(0).path("stateCode").path("value").asText());
+      assertEquals( "5296486", jsonBindingsNodes2.get(0).path("population").path("value").asText());
+      assertEquals( "Maryland", jsonBindingsNodes2.get(0).path("statename").path("value").asText());
 
       // Select in a transaction with start = 2 and page length = 3.
       /*
@@ -541,32 +542,32 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
       JsonNode jsonNodesFromStr3 = mapper.readTree(jsonStrResults3);
       System.out.println(jsonStrResults3);
 
-      assertEquals("Result returned from testPaginationInTransaction query 3 has incorrect size ", 3, jsonNodesFromStr3.path("results").path("bindings").size());
+      assertEquals( 3, jsonNodesFromStr3.path("results").path("bindings").size());
       System.out.println("testPaginationInTransaction query 3 result is " + jsonNodesFromStr3.path("results").path("bindings").size());
 
       Iterator<JsonNode> jsonBindingsNodesItr3 = jsonNodesFromStr3.path("results").path("bindings").elements();
       JsonNode jsonItrNode1 = jsonBindingsNodesItr3.next();
       // Verify results - Details of State - Maryland.
-      assertEquals("Element statecode value incorrect", "http://www.rdfabout.com/rdf/usgov/geo/us/md", jsonItrNode1.path("stateCode").path("value").asText());
-      assertEquals("Element lives is incorrect", "5296486", jsonItrNode1.path("population").path("value").asText());
-      assertEquals("Element city is incorrect", "Maryland", jsonItrNode1.path("statename").path("value").asText());
+      assertEquals( "http://www.rdfabout.com/rdf/usgov/geo/us/md", jsonItrNode1.path("stateCode").path("value").asText());
+      assertEquals( "5296486", jsonItrNode1.path("population").path("value").asText());
+      assertEquals( "Maryland", jsonItrNode1.path("statename").path("value").asText());
 
       JsonNode jsonItrNode2 = jsonBindingsNodesItr3.next();
       // Verify results - Details of State - Wisconsin.
-      assertEquals("Element statecode value incorrect", "http://www.rdfabout.com/rdf/usgov/geo/us/wi", jsonItrNode2.path("stateCode").path("value").asText());
-      assertEquals("Element lives is incorrect", "5363675", jsonItrNode2.path("population").path("value").asText());
-      assertEquals("Element city is incorrect", "Wisconsin", jsonItrNode2.path("statename").path("value").asText());
+      assertEquals( "http://www.rdfabout.com/rdf/usgov/geo/us/wi", jsonItrNode2.path("stateCode").path("value").asText());
+      assertEquals( "5363675", jsonItrNode2.path("population").path("value").asText());
+      assertEquals( "Wisconsin", jsonItrNode2.path("statename").path("value").asText());
 
       JsonNode jsonItrNode3 = jsonBindingsNodesItr3.next();
       // Verify results - Details of State - Wisconsin.
-      assertEquals("Element statecode value incorrect", "http://www.rdfabout.com/rdf/usgov/geo/us/mo", jsonItrNode3.path("stateCode").path("value").asText());
-      assertEquals("Element lives is incorrect", "5595211", jsonItrNode3.path("population").path("value").asText());
-      assertEquals("Element city is incorrect", "Missouri", jsonItrNode3.path("statename").path("value").asText());
+      assertEquals( "http://www.rdfabout.com/rdf/usgov/geo/us/mo", jsonItrNode3.path("stateCode").path("value").asText());
+      assertEquals( "5595211", jsonItrNode3.path("population").path("value").asText());
+      assertEquals( "Missouri", jsonItrNode3.path("statename").path("value").asText());
 
-      assertEquals("Result returned from testPaginationInTransaction Page Length incorrect", 3, sparqlQmgr.getPageLength());
+      assertEquals( 3, sparqlQmgr.getPageLength());
       // Verify clear page length.
       sparqlQmgr.clearPageLength();
-      assertEquals("Result returned from testPaginationInTransaction Page Length incorrect", -1, sparqlQmgr.getPageLength());
+      assertEquals( -1, sparqlQmgr.getPageLength());
       // Test negative cases.
 
       // Select in a transaction with (java index) start = 21 and page length =
@@ -579,12 +580,12 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
       System.out.println(jsonStrResultsNeg1);
       JsonNode jsonBindingsNodesNeg1 = jsonNodesFromStrNeg1.path("results").path("bindings");
       // Should have 1 node returned. Details of United States.
-      assertEquals("Result returned from testPaginationInTransaction negative query 1 has incorrect size ", 1, jsonBindingsNodesNeg1.size());
+      assertEquals( 1, jsonBindingsNodesNeg1.size());
       System.out.println("testPaginationInTransaction negative query 1 result size is " + jsonBindingsNodesNeg1.size());
       // Verify results - Details of United States.
-      assertEquals("Element statecode value incorrect", "http://www.rdfabout.com/rdf/usgov/geo/us", jsonBindingsNodesNeg1.get(0).path("stateCode").path("value").asText());
-      assertEquals("Element lives is incorrect", "281421906", jsonBindingsNodesNeg1.get(0).path("population").path("value").asText());
-      assertEquals("Element city is incorrect", "United States", jsonBindingsNodesNeg1.get(0).path("statename").path("value").asText());
+      assertEquals( "http://www.rdfabout.com/rdf/usgov/geo/us", jsonBindingsNodesNeg1.get(0).path("stateCode").path("value").asText());
+      assertEquals( "281421906", jsonBindingsNodesNeg1.get(0).path("population").path("value").asText());
+      assertEquals( "United States", jsonBindingsNodesNeg1.get(0).path("statename").path("value").asText());
 
       // Select in a transaction with (java index) start = 100 and page length =
       // 100.
@@ -596,7 +597,7 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
       System.out.println(jsonStrResultsNeg2);
       JsonNode jsonBindingsNodesNeg2 = jsonNodesFromStrNeg2.path("results").path("bindings");
       // Should have 0 nodes returned.
-      assertEquals("Result returned from testPaginationInTransaction negative query 2 has incorrect size ", 0, jsonBindingsNodesNeg2.size());
+      assertEquals( 0, jsonBindingsNodesNeg2.size());
       System.out.println("testPaginationInTransaction negative query 2 result size is " + jsonBindingsNodesNeg2.size());
       // Pass negative values.
       String expectedException = "IllegalArgumentException";
@@ -610,7 +611,7 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
         exception = e.toString();
       }
       System.out.println("Exception thrown from testQueryBindingsNullString is \n" + exception);
-      assertTrue("Test testQueryBindingsNullString method exception is not thrown", exception.contains(expectedException));
+      assertTrue( exception.contains(expectedException));
 
       // Handle the transaction.
       t.commit();
@@ -630,13 +631,13 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
    * contain triples from foaf1.nt file. The data format in this file is XML.
    * Results are returned in a sequence of sem:triple values as triples in
    * memory.
-   * 
+   *
    * The query should be returning one result.
-   * 
+   *
    * Uses StringHandle (TriplesReadHandle)
    */
   @Test
-  public void testExecuteConstruct() 
+  public void testExecuteConstruct()
   {
     System.out.println("In SPARQL Query Manager Test testExecuteConstruct method");
     SPARQLQueryManager sparqlQmgr = readclient.newSPARQLQueryManager();
@@ -654,10 +655,10 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
     String[] jsonResults = sparqlQmgr.executeConstruct(qdef, new StringHandle()).get().split(" ");
 
     // Account for the dot at the end of the triple. Hence size is 4.
-    assertEquals("Method testExecuteConstruct in-memory Triple part size is incorrect", 4, jsonResults.length);
-    assertEquals("Method testExecuteConstruct in-memory subject is incorrect", "<http://www.ucsb.edu/random-alum>", jsonResults[0]);
-    assertEquals("Method testExecuteConstruct in-memory predicate is incorrect", "<http://xmlns.com/foaf/0.1/knows>", jsonResults[1]);
-    assertEquals("Method testExecuteConstruct in-memory object is incorrect", "<1bfbfb8:ff2d706919:-7fa9>", jsonResults[2]);
+    assertEquals( 4, jsonResults.length);
+    assertEquals( "<http://www.ucsb.edu/random-alum>", jsonResults[0]);
+    assertEquals( "<http://xmlns.com/foaf/0.1/knows>", jsonResults[1]);
+    assertEquals( "<1bfbfb8:ff2d706919:-7fa9>", jsonResults[2]);
   }
 
   /*
@@ -665,14 +666,14 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
    * contain triples from foaf1.nt file. The data format in this file is XML.
    * Results are returned in a sequence of sem:triple values as triples in
    * memory.
-   * 
+   *
    * The query should be returning one result. This test also verifies Base URI
    * and Git Issue 356, 358.
-   * 
+   *
    * Uses JacksonHandle and DOMHandle
    */
   @Test
-  public void testBaseUri() 
+  public void testBaseUri()
   {
     System.out.println("In SPARQL Query Manager Test testBaseUri method");
     SPARQLQueryManager sparqlQmgr = writeclient.newSPARQLQueryManager();
@@ -696,10 +697,10 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
     JsonNode o = jsonResults.get(s).get(p);
 
     // Verify the mimetype of the handle.
-    assertEquals("Method testBaseUri MIME type is incorrect", RDFMimeTypes.RDFJSON, jh.getMimetype());
-    assertEquals("Method testBaseUri in-memory subject base URI is incorrect", "http://qa.marklogic.com/functional/tests/one/qatest1", s);
-    assertEquals("Method testBaseUri in-memory predicte base URI is incorrect", "http://qa.marklogic.com/functional/tests/one/qatest2", p);
-    assertEquals("Method testBaseUri in-memory object base URI is incorrect", "http://qa.marklogic.com/functional/tests/one/qatest3", o.path(0).path("value").asText());
+    assertEquals( RDFMimeTypes.RDFJSON, jh.getMimetype());
+    assertEquals( "http://qa.marklogic.com/functional/tests/one/qatest1", s);
+    assertEquals( "http://qa.marklogic.com/functional/tests/one/qatest2", p);
+    assertEquals( "http://qa.marklogic.com/functional/tests/one/qatest3", o.path(0).path("value").asText());
 
     // Verify if defaulting to RDFJSON when XMLHandle is used. Git Issue 356.
     DOMHandle handle = new DOMHandle();
@@ -709,11 +710,11 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
 
     String oXML = attrs.getNamedItemNS("http://www.w3.org/1999/02/22-rdf-syntax-ns#", "resource").getTextContent();
 
-    assertEquals("Method testBaseUri MIME type is incorrect", RDFMimeTypes.RDFXML, handle.getMimetype());
-    assertEquals("Method testBaseUri in-memory subject base URI is incorrect", "http://qa.marklogic.com/functional/tests/one/qatest1", description.getAttributes().item(0)
+    assertEquals( RDFMimeTypes.RDFXML, handle.getMimetype());
+    assertEquals( "http://qa.marklogic.com/functional/tests/one/qatest1", description.getAttributes().item(0)
         .getTextContent());
-    assertEquals("Method testBaseUri in-memory predicate base URI is incorrect", "qatest2", description.getFirstChild().getNodeName());
-    assertEquals("Method testBaseUri in-memory object base URI is incorrect", "http://qa.marklogic.com/functional/tests/one/qatest3", oXML);
+    assertEquals( "qatest2", description.getFirstChild().getNodeName());
+    assertEquals( "http://qa.marklogic.com/functional/tests/one/qatest3", oXML);
   }
 
   /*
@@ -721,13 +722,13 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
    * contain triples from foaf1.nt file. The data format in this file is XML.
    * Results are returned in a sequence of sem:triple values as triples in
    * memory.
-   * 
+   *
    * The query should be returning one result.
-   * 
+   *
    * Uses StringHandle (TriplesReadHandle)
    */
   @Test
-  public void testExecuteConstructInTransaction() 
+  public void testExecuteConstructInTransaction()
   {
     System.out.println("In SPARQL Query Manager Test testExecuteConstructInTransaction method");
     Transaction t = writeclient.openTransaction();
@@ -748,10 +749,10 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
       String[] jsonResults = sparqlQmgr.executeConstruct(qdef, new StringHandle().withMimetype(RDFMimeTypes.NTRIPLES), t).get().split(" ");
 
       // Account for the dot at the end of the triple. Hence size is 4.
-      assertEquals("Method testExecuteConstructInTransaction in-memory Triple part size is incorrect", 4, jsonResults.length);
-      assertEquals("Method testExecuteConstructInTransaction in-memory subject is incorrect", "<http://www.ucsb.edu/random-alum>", jsonResults[0]);
-      assertEquals("Method testExecuteConstructInTransaction in-memory predicate is incorrect", "<http://xmlns.com/foaf/0.1/knows>", jsonResults[1]);
-      assertEquals("Method testExecuteConstructInTransaction in-memory object is incorrect", "<1bfbfb8:ff2d706919:-7fa9>", jsonResults[2]);
+      assertEquals( 4, jsonResults.length);
+      assertEquals( "<http://www.ucsb.edu/random-alum>", jsonResults[0]);
+      assertEquals( "<http://xmlns.com/foaf/0.1/knows>", jsonResults[1]);
+      assertEquals( "<1bfbfb8:ff2d706919:-7fa9>", jsonResults[2]);
 
       // Tests for additional MIME Type.
 
@@ -763,26 +764,26 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
       // Parsing results using JsonNode.
       JsonNode jsonNodesFromStr = mapper.readTree(strRDFJSON);
       String strValue = jsonNodesFromStr.path("http://www.ucsb.edu/random-alum").path("http://xmlns.com/foaf/0.1/knows").get(0).path("value").asText();
-      assertEquals("RDFJSON value output is incorrect ", "1bfbfb8:ff2d706919:-7fa9", strValue);
+      assertEquals( "1bfbfb8:ff2d706919:-7fa9", strValue);
 
       String strRDFXML = sparqlQmgr.executeConstruct(qdef, new StringHandle().withMimetype(RDFMimeTypes.RDFXML), t).get().toString();
 
       System.out.println("\n RDFXML Format is " + strRDFXML);
-      assertTrue("RDFXML subject value output is incorrect ", strRDFXML.contains("rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\""));
-      assertTrue("RDFXML predicate value output is incorrect ", strRDFXML.contains("rdf:Description rdf:about=\"http://www.ucsb.edu/random-alum\""));
-      assertTrue("RDFXML object value output is incorrect ", strRDFXML.contains("knows rdf:resource=\"1bfbfb8:ff2d706919:-7fa9\""));
+      assertTrue( strRDFXML.contains("rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\""));
+      assertTrue( strRDFXML.contains("rdf:Description rdf:about=\"http://www.ucsb.edu/random-alum\""));
+      assertTrue( strRDFXML.contains("knows rdf:resource=\"1bfbfb8:ff2d706919:-7fa9\""));
 
       String strTRIPLEXML = sparqlQmgr.executeConstruct(qdef, new StringHandle().withMimetype(RDFMimeTypes.TRIPLEXML), t).get().toString();
       System.out.println("\n TRIPLEXML format is " + strTRIPLEXML);
-      assertTrue("TRIPLEXML subject value output is incorrect ", strTRIPLEXML.contains("<sem:subject>http://www.ucsb.edu/random-alum</sem:subject>"));
-      assertTrue("TRIPLEXML predicate value output is incorrect ", strTRIPLEXML.contains("<sem:predicate>http://xmlns.com/foaf/0.1/knows</sem:predicate>"));
-      assertTrue("TRIPLEXML object value output is incorrect ", strTRIPLEXML.contains("<sem:object>1bfbfb8:ff2d706919:-7fa9</sem:object>"));
+      assertTrue( strTRIPLEXML.contains("<sem:subject>http://www.ucsb.edu/random-alum</sem:subject>"));
+      assertTrue( strTRIPLEXML.contains("<sem:predicate>http://xmlns.com/foaf/0.1/knows</sem:predicate>"));
+      assertTrue( strTRIPLEXML.contains("<sem:object>1bfbfb8:ff2d706919:-7fa9</sem:object>"));
 
       String strTURTLE = sparqlQmgr.executeConstruct(qdef, new StringHandle().withMimetype(RDFMimeTypes.TURTLE), t).get().toString();
       System.out.println("\n TURTLE format is " + strTURTLE);
-      assertTrue("TURTLE subject value output is incorrect ", strTURTLE.contains("<http://www.ucsb.edu/random-alum>"));
-      assertTrue("TURTLE predicate value output is incorrect ", strTURTLE.contains("foaf:knows"));
-      assertTrue("TURTLE object value output is incorrect ", strTURTLE.contains("<1bfbfb8:ff2d706919:-7fa9>"));
+      assertTrue( strTURTLE.contains("<http://www.ucsb.edu/random-alum>"));
+      assertTrue( strTURTLE.contains("foaf:knows"));
+      assertTrue( strTURTLE.contains("<1bfbfb8:ff2d706919:-7fa9>"));
 
       // String strN3 = sparqlQmgr.executeConstruct(qdef, new
       // StringHandle().withMimetype(RDFMimeTypes.N3), t).get().toString();
@@ -790,9 +791,9 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
 
       String strNTriples = sparqlQmgr.executeConstruct(qdef, new StringHandle().withMimetype(RDFMimeTypes.NTRIPLES), t).get().toString();
       System.out.println("\n NTRIPLES format is " + strNTriples);
-      assertTrue("NTRIPLES subject value output is incorrect ", strNTriples.contains("<http://www.ucsb.edu/random-alum>"));
-      assertTrue("NTRIPLES predicate value output is incorrect ", strNTriples.contains("<http://xmlns.com/foaf/0.1/knows>"));
-      assertTrue("NTRIPLES object value output is incorrect ", strNTriples.contains("<1bfbfb8:ff2d706919:-7fa9>"));
+      assertTrue( strNTriples.contains("<http://www.ucsb.edu/random-alum>"));
+      assertTrue( strNTriples.contains("<http://xmlns.com/foaf/0.1/knows>"));
+      assertTrue( strNTriples.contains("<1bfbfb8:ff2d706919:-7fa9>"));
 
       // Handle the transaction.
       t.commit();
@@ -811,14 +812,14 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
    * This test checks a simple SPARQL DESCRIBE results from named graph. The
    * database should contain triples from rdfjson.json. Verifies Git Issue 356,
    * 358
-   * 
+   *
    * The DESCRIBE query should be returning one result. Result includes all
    * triples which have the IRI as a subject
-   * 
+   *
    * Uses Stringhandle and JacksonHandle.
    */
   @Test
-  public void testExecuteDescribeFromRDFJSON() 
+  public void testExecuteDescribeFromRDFJSON()
   {
     System.out.println("In SPARQL Query Manager Test testExecuteDescribeFromRDFJSON method");
     SPARQLQueryManager sparqlQmgr = readclient.newSPARQLQueryManager();
@@ -829,10 +830,10 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
     // Verify result 1 value.
     System.out.println(jsonResults);
     String[] resultString = jsonResults.split(" ");
-    assertEquals("Method testExecuteDescribeFromRDFJSON subject is incorrect", "<http://example.org/about>", resultString[0]);
-    assertEquals("Method testExecuteDescribeFromRDFJSON predicate is incorrect", "<http://purl.org/dc/elements/1.1/title>", resultString[1]);
+    assertEquals( "<http://example.org/about>", resultString[0]);
+    assertEquals( "<http://purl.org/dc/elements/1.1/title>", resultString[1]);
     String objectStr = resultString[2] + " " + resultString[3];
-    assertEquals("Method testExecuteDescribeFromRDFJSON object is incorrect", "\"Anna's Homepage\"", objectStr);
+    assertEquals( "\"Anna's Homepage\"", objectStr);
 
     // Verifying default mime types- Using JacksonHandle
     JacksonHandle jh = new JacksonHandle();
@@ -841,8 +842,8 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
 
     // Verify Mime type on the handle and value.
     System.out.println("testQueryOnMultibyeGraphName query result size is " + jsonNodeValue.get("value"));
-    assertEquals("Element person's value incorrect", RDFMimeTypes.RDFJSON, jh.getMimetype());
-    assertEquals("Result returned from testQueryOnMultibyeGraphName query is incorrect ", "Anna\'s Homepage", jsonNodeValue.get("value").asText());
+    assertEquals(RDFMimeTypes.RDFJSON, jh.getMimetype());
+    assertEquals( "Anna\'s Homepage", jsonNodeValue.get("value").asText());
 
     // Verifying default mime types- Using DOMHandle
     DOMHandle dh = new DOMHandle();
@@ -851,33 +852,33 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
     Node description = xmlDoc.getFirstChild().getFirstChild();
     NamedNodeMap attrs = description.getFirstChild().getAttributes();
     // attrs NodeMap should have two nodes.
-    assertEquals("Attribute length value incorrect", 2, attrs.getLength());
+    assertEquals( 2, attrs.getLength());
 
     if (attrs.item(0).getNodeName().equalsIgnoreCase("rdf:datatype"))
     {
-      assertEquals("Element rdf:datatype value incorrect", "http://www.w3.org/2001/XMLSchema#string", attrs.item(0).getNodeValue());
-      assertEquals("Element xmlns data value incorrect", "http://purl.org/dc/elements/1.1/", attrs.item(1).getNodeValue());
+      assertEquals( "http://www.w3.org/2001/XMLSchema#string", attrs.item(0).getNodeValue());
+      assertEquals( "http://purl.org/dc/elements/1.1/", attrs.item(1).getNodeValue());
     }
     else if (attrs.item(0).getNodeName().equalsIgnoreCase("xmlns"))
     {
-      assertEquals("Element rdf:datatype value incorrect", "http://www.w3.org/2001/XMLSchema#string", attrs.item(1).getNodeValue());
-      assertEquals("Element xmlns data value incorrect", "http://purl.org/dc/elements/1.1/", attrs.item(0).getNodeValue());
+      assertEquals( "http://www.w3.org/2001/XMLSchema#string", attrs.item(1).getNodeValue());
+      assertEquals( "http://purl.org/dc/elements/1.1/", attrs.item(0).getNodeValue());
     }
     String value = description.getFirstChild().getFirstChild().getNodeValue();
-    assertEquals("Expected value read from DOMHandle incorrect", "Anna\'s Homepage", value);
+    assertEquals( "Anna\'s Homepage", value);
   }
 
   /*
    * This test checks a simple SPARQL DESCRIBE results from named graph in
    * transaction. The database should contain triples from geo-states.n3.
-   * 
+   *
    * The DESCRIBE query should be returning result. Result includes all triples
    * which have the IRI as a subject.
-   * 
+   *
    * Uses Stringhandle
    */
   @Test
-  public void testExecuteDescribeInTransaction() 
+  public void testExecuteDescribeInTransaction()
   {
     System.out.println("In SPARQL Query Manager Test testExecuteDescribeInTransaction method");
     Transaction t = writeclient.openTransaction();
@@ -894,7 +895,7 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
 
       // Verify result 1 value.
       System.out.println(jsonResults);
-      assertEquals("Method testExecuteDescribeInTransaction size is incorrect for WI", 13, jsonResults.split(" \\.").length);
+      assertEquals( 13, jsonResults.split(" \\.").length);
 
       // Negative test cases.
       // Have Invalid URI
@@ -910,7 +911,7 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
 
       // Verify result 0 elements exists.
       System.out.println("DESCRIBE with Invalid URI size is : " + jsonBindingsNodes.size());
-      assertEquals("Method testExecuteDescribeInTransaction size is incorrect ", 0, jsonBindingsNodes.size());
+      assertEquals( 0, jsonBindingsNodes.size());
 
       // Have missing enclosing
       StringBuffer sparqlInvalidQuery1 = new StringBuffer().append("DESCRIBE http://www.rdfabout.com/rdf/usgov/geo/us/wi");
@@ -923,7 +924,7 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
         exception = e.toString();
       }
       System.out.println("Exception thrown from testExecuteDescribeInTransaction is \n" + exception);
-      assertTrue("Test testExecuteDescribeInTransaction method exception is not thrown",
+      assertTrue(
           exception.contains(expectedException));
 
       // Handle the transaction.
@@ -943,13 +944,13 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
    * This test checks a simple SPARQL ASK results from named graph. The database
    * should contain triples from foaf1.nt file. The data format in this file is
    * XML.
-   * 
+   *
    * The ASK query should be returning result in boolean. Expected value True
-   * 
+   *
    * Uses Stringhandle
    */
   @Test
-  public void testExecuteAsk() 
+  public void testExecuteAsk()
   {
     System.out.println("In SPARQL Query Manager Test testExecuteAsk method");
     SPARQLQueryManager sparqlQmgr = readclient.newSPARQLQueryManager();
@@ -962,7 +963,7 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
 
     // Verify result 1 value.
     System.out.println("Checking for true value in testexecuteAsk method : " + bAskTrue);
-    assertTrue("Method testExecuteAsk result is incorrect. Expected true", bAskTrue);
+    assertTrue( bAskTrue);
 
     StringBuffer sparqlQueryfalse = new StringBuffer().append("PREFIX foaf: <http://xmlns.com/foaf/0.1/>");
     sparqlQueryfalse.append(newline);
@@ -972,7 +973,7 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
 
     // Verify result 1 value.
     System.out.println("Checking for false value in testExecuteAsk method : " + bAskFalse);
-    assertFalse("Method testExecuteAsk result is incorrect. Expected false", bAskFalse);
+    assertFalse( bAskFalse);
 
     // Negative test case - An empty ASK returns true.
     StringBuffer sparqlQueryEmpty = new StringBuffer().append("PREFIX foaf: <http://xmlns.com/foaf/0.1/>");
@@ -983,18 +984,18 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
 
     // Verify result 1 value.
     System.out.println("Checking for true value in testExecuteAsk method with empty ASK : " + bAskEmpty);
-    assertTrue("Method testExecuteAsk result is incorrect. Expected true for empty ASK query", bAskEmpty);
+    assertTrue( bAskEmpty);
   }
 
   /*
    * This test checks a simple SPARQL ASK results from named graph in a
    * transaction. The database contains triples from rdfxml1.rdf file. The data
    * format in this file is RDFXML.
-   * 
+   *
    * The ASK query should be returning result in boolean.
    */
   @Test
-  public void testExecuteAskInTransactions() 
+  public void testExecuteAskInTransactions()
   {
     System.out.println("In SPARQL Query Manager Test testExecuteAskInTransactions method");
     Transaction t1 = null;
@@ -1012,7 +1013,7 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
 
       // Verify result.
       System.out.println(bAskNoWrite);
-      assertFalse("Method testExecuteAskInTransactions result is incorrect. No records should be returned.", bAskNoWrite);
+      assertFalse( bAskNoWrite);
 
       // RDFXML "application/rdf+xml". Get the content into FileHandle
       File file = new File(datasource + "rdfxml1.rdf");
@@ -1028,7 +1029,7 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
       // Verify result in t1 transaction.
       boolean bAskInTransT1 = sparqlQmgr.executeAsk(qdef, t1);
       System.out.println(bAskInTransT1);
-      assertTrue("Method testExecuteAskInTransactions result is incorrect. Records should be returned.", bAskInTransT1);
+      assertTrue( bAskInTransT1);
 
       // Thread1 should be blocked due to ML Server holding a write lock on the
       // record and returns false.
@@ -1040,7 +1041,7 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
 
       boolean bAskTransRolledback = sparqlQmgr.executeAsk(qdef);
       System.out.println(bAskTransRolledback);
-      assertFalse("Method testExecuteAskInTransactions result is incorrect. No records should be returned.", bAskTransRolledback);
+      assertFalse( bAskTransRolledback);
 
       // After rollback. Open another transaction and verify ASK on that
       // transaction.
@@ -1071,7 +1072,7 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
 
       boolean bAskAfterCommit = sparqlQmgr.executeAsk(qdef);
       System.out.println(bAskAfterCommit);
-      assertTrue("Method testExecuteAskInTransactions result is incorrect. Records should be returned.", bAskAfterCommit);
+      assertTrue( bAskAfterCommit);
 
       // After commit. Open another transaction and verify ASK on that
       // transaction.
@@ -1079,7 +1080,7 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
       // Verify result.
       boolean bAskInAnotherTrans = sparqlQmgr.executeAsk(qdef, tAnother);
       System.out.println(bAskInAnotherTrans);
-      assertTrue("Method testExecuteAskInTransactions result is incorrect. Records should be returned.", bAskInAnotherTrans);
+      assertTrue( bAskInAnotherTrans);
 
       // Handle the transaction.
       tAnother.commit();
@@ -1105,13 +1106,13 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
   /*
    * This test checks if Exceptions are throw when qdef is null. The database
    * should contain triples from geo-states.n3.
-   * 
+   *
    * Expected Result : IllegalArgumentException Exception thrown
-   * 
+   *
    * Uses JacksonHandle
    */
   @Test
-  public void testExecuteSelectQueryNullQDEF() 
+  public void testExecuteSelectQueryNullQDEF()
   {
     System.out.println("In SPARQL Query Manager Test testExecuteSelectQueryNullQDEF method");
     SPARQLQueryManager sparqlQmgr = readclient.newSPARQLQueryManager();
@@ -1124,19 +1125,19 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
       exception = e.toString();
     }
     System.out.println("Exception thrown from testExecuteSelectQueryNullQDEF is \n" + exception);
-    assertTrue(" Test testExecuteSelectQueryNullQDEF method exception is not thrown", exception.contains(expectedException));
+    assertTrue( exception.contains(expectedException));
   }
 
   /*
    * This test checks if Exceptions are throw when qdef is empty. The database
    * should contain triples from geo-states.n3.
-   * 
+   *
    * Expected Result : FailedRequestException Exception thrown
-   * 
+   *
    * Uses JacksonHandle
    */
   @Test
-  public void testExecuteEmptySelectQuery() 
+  public void testExecuteEmptySelectQuery()
   {
     System.out.println("In SPARQL Query Manager Test testExecuteEmptySelectQuery method");
     SPARQLQueryManager sparqlQmgr = readclient.newSPARQLQueryManager();
@@ -1152,16 +1153,16 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
       exception = e.toString();
     }
     System.out.println("Exception thrown from testExecuteEmptySelectQuery is \n" + exception);
-    assertTrue("Test testExecuteEmptySelectQuery method exception is not thrown", exception.contains(expectedException));
+    assertTrue( exception.contains(expectedException));
   }
 
   /*
    * This test verifies query clauses with OPTIONAL and FILTER keywords on a
    * graph name with multi-byte characters. The database should contain triples
    * from multibyteGraphName graph.
-   * 
+   *
    * Expected Result : 1 solution contaiining person with id 4444
-   * 
+   *
    * Uses StringHandle (XMLReadHandle)
    */
   @Test
@@ -1197,16 +1198,16 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodes = jsonNodesFromStr.path("results").path("bindings");
     // Should have 1 node returned.
     System.out.println("testQueryOnMultibyeGraphName query result size is " + jsonBindingsNodes.size());
-    assertEquals("Result returned from testQueryOnMultibyeGraphName query is incorrect ", 1, jsonBindingsNodes.size());
-    assertEquals("Element person's value incorrect", "http://marklogicsparql.com/id#4444", jsonBindingsNodes.get(0).path("person").path("value").asText());
+    assertEquals( 1, jsonBindingsNodes.size());
+    assertEquals("http://marklogicsparql.com/id#4444", jsonBindingsNodes.get(0).path("person").path("value").asText());
   }
 
   /*
    * This test verifies query clauses with OPTIONAL and FILTER keywords. The
    * database should contain triples from testcustom graph.
-   * 
+   *
    * Expected Result : 1 solution contaiining person with id 4444
-   * 
+   *
    * Uses StringHandle (XMLReadHandle)
    */
   @Test
@@ -1242,18 +1243,18 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodes = jsonNodesFromStr.path("results").path("bindings");
     // Should have 1 node returned.
     System.out.println("testQueryClauseOptionalFilter query result size is " + jsonBindingsNodes.size());
-    assertEquals("Result returned from testQueryClauseOptionalFilter query is incorrect ", 1, jsonBindingsNodes.size());
-    assertEquals("Element person's value incorrect", "http://marklogicsparql.com/id#4444", jsonBindingsNodes.get(0).path("person").path("value").asText());
+    assertEquals( 1, jsonBindingsNodes.size());
+    assertEquals("http://marklogicsparql.com/id#4444", jsonBindingsNodes.get(0).path("person").path("value").asText());
   }
 
   /*
    * This test verifies query definition with bindings on string. The database
    * should contain triples from TestCustomeGraph.
-   * 
+   *
    * Uses JacksonHandle
    */
   @Test
-  public void testQueryBindingsOnString() 
+  public void testQueryBindingsOnString()
   {
     System.out.println("In SPARQL Query Manager Test testQueryBindingString method");
     SPARQLQueryManager sparqlQmgr = writeclient.newSPARQLQueryManager();
@@ -1291,23 +1292,23 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
     System.out.println(jsonStrResults);
 
     // Verify the bindings.
-    assertTrue("Bindings Map do not have expected key ", qdef1.getBindings().containsKey("firstname"));
+    assertTrue( qdef1.getBindings().containsKey("firstname"));
 
-    assertEquals("Result count from  testQueryBindingsOnString is incorrect", 1, jsonStrResults.path("results").path("bindings").size());
+    assertEquals( 1, jsonStrResults.path("results").path("bindings").size());
     JsonNode jsonBindingsNodes = jsonStrResults.path("results").path("bindings").get(0);
 
-    assertEquals("Element person's value incorrect", "http://marklogicsparql.com/id#4444", jsonBindingsNodes.path("person").path("value").asText());
+    assertEquals("http://marklogicsparql.com/id#4444", jsonBindingsNodes.path("person").path("value").asText());
   }
 
   /*
    * This test verifies query definition with bindings on string. Verify with
    * withBindings method The database should contain triples from
    * TestCustomeGraph.
-   * 
+   *
    * Uses JacksonHandle
    */
   @Test
-  public void testQueryWithBindingsOnString() 
+  public void testQueryWithBindingsOnString()
   {
     System.out.println("In SPARQL Query Manager Test testQueryWithBindingsOnString method");
     SPARQLQueryManager sparqlQmgr = writeclient.newSPARQLQueryManager();
@@ -1343,12 +1344,12 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
     System.out.println(jsonStrResults);
 
     // Verify the bindings.
-    assertTrue("Bindings Map do not have expected key ", qdef1.getBindings().containsKey("firstname"));
+    assertTrue( qdef1.getBindings().containsKey("firstname"));
 
-    assertEquals("Result count from  testQueryWithBindingsOnString is incorrect", 1, jsonStrResults.path("results").path("bindings").size());
+    assertEquals( 1, jsonStrResults.path("results").path("bindings").size());
     JsonNode jsonBindingsNodes = jsonStrResults.path("results").path("bindings").get(0);
 
-    assertEquals("Element person's value incorrect", "http://marklogicsparql.com/id#4444", jsonBindingsNodes.path("person").path("value").asText());
+    assertEquals("http://marklogicsparql.com/id#4444", jsonBindingsNodes.path("person").path("value").asText());
   }
 
   /*
@@ -1357,7 +1358,7 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
    * TestDateCustomGraph. Verifies Git Issue 378. Uses JacksonHandle
    */
   @Test
-  public void testQueryWithBindingsOnDate() 
+  public void testQueryWithBindingsOnDate()
   {
     System.out.println("In SPARQL Query Manager Test testQueryWithBindingsOnDate method");
     SPARQLQueryManager sparqlQmgr = writeclient.newSPARQLQueryManager();
@@ -1398,22 +1399,22 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
     System.out.println(jsonStrResults);
 
     // Verify the bindings.
-    assertTrue("Bindings Map do not have expected key ", qdef1.getBindings().containsKey("bdate"));
+    assertTrue( qdef1.getBindings().containsKey("bdate"));
 
-    assertEquals("Result count from  testQueryWithBindingsOnString is incorrect", 1, jsonStrResults.path("results").path("bindings").size());
+    assertEquals( 1, jsonStrResults.path("results").path("bindings").size());
     JsonNode jsonBindingsNodes = jsonStrResults.path("results").path("bindings").get(0);
 
-    assertEquals("Element person's value incorrect", "http://marklogic.com/baseball/players#7", jsonBindingsNodes.path("person").path("value").asText());
+    assertEquals("http://marklogic.com/baseball/players#7", jsonBindingsNodes.path("person").path("value").asText());
   }
 
   /*
    * This test verifies query definition with bindings on string. The database
    * should contain triples from englishLocale graph.
-   * 
+   *
    * Uses JacksonHandle. Locale language used is en.
    */
   @Test
-  public void testQueryBindingsOnStringWithENLocale() 
+  public void testQueryBindingsOnStringWithENLocale()
   {
     System.out.println("In SPARQL Query Manager Test testQueryBindingsOnStringWithENLocale method");
     SPARQLQueryManager sparqlQmgr = writeclient.newSPARQLQueryManager();
@@ -1455,26 +1456,26 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
     System.out.println(jsonStrResults);
 
     // Verify the bindings.
-    assertTrue("Bindings Map do not have expected key ", qdef1.getBindings().containsKey("firstname"));
+    assertTrue( qdef1.getBindings().containsKey("firstname"));
 
-    assertEquals("Result count from  testQueryBindingsOnStringWithENLocale is incorrect", 1, jsonStrResults.path("results").path("bindings").size());
+    assertEquals( 1, jsonStrResults.path("results").path("bindings").size());
     JsonNode jsonBindingsNodes = jsonStrResults.path("results").path("bindings").get(0);
 
-    assertEquals("Element person's value incorrect", "http://marklogicsparql.com/id#4444", jsonBindingsNodes.path("person").path("value").asText());
+    assertEquals("http://marklogicsparql.com/id#4444", jsonBindingsNodes.path("person").path("value").asText());
   }
 
   /*
    * This test verifies query definition with bindings on string with Locale.
    * Verify with withBindings method The database should contain triples from
    * zhlocaleGraphName variable's value.
-   * 
+   *
    * We have Ling in Chinese as 凌 We have Fei in Chinese as 飞
-   * 
+   *
    * We will have these triples in a graph called 北京 (beijing) in Chinese.
    * Uses JacksonHandle
    */
   @Test
-  public void testQueryWithBindingsOnMultiByteString() 
+  public void testQueryWithBindingsOnMultiByteString()
   {
     System.out.println("In SPARQL Query Manager Test testQueryWithBindingsOnMultiByteString method");
     SPARQLQueryManager sparqlQmgr = writeclient.newSPARQLQueryManager();
@@ -1511,22 +1512,22 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
     System.out.println(jsonStrResults);
 
     // Verify the bindings.
-    assertTrue("Bindings Map do not have expected key ", qdef1.getBindings().containsKey("firstname"));
+    assertTrue( qdef1.getBindings().containsKey("firstname"));
 
-    assertEquals("Result count from  testQueryWithBindingsOnMultiByteString is incorrect", 1, jsonStrResults.path("results").path("bindings").size());
+    assertEquals( 1, jsonStrResults.path("results").path("bindings").size());
     JsonNode jsonBindingsNodes = jsonStrResults.path("results").path("bindings").get(0);
 
-    assertEquals("Element person's value incorrect", "http://marklogicsparql.com/id#4444", jsonBindingsNodes.path("person").path("value").asText());
+    assertEquals("http://marklogicsparql.com/id#4444", jsonBindingsNodes.path("person").path("value").asText());
   }
 
   /*
    * This test verifies query definition with bindings on integer. The database
    * should contain triples from TestCustomeGraph.
-   * 
+   *
    * Uses JacksonHandle
    */
   @Test
-  public void testQueryBindingsOnInteger() 
+  public void testQueryBindingsOnInteger()
   {
     System.out.println("In SPARQL Query Manager Test testQueryBindingsOnInteger method");
     SPARQLQueryManager sparqlQmgr = writeclient.newSPARQLQueryManager();
@@ -1566,18 +1567,18 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
     System.out.println(jsonStrResults);
 
     // Verify the bindings.
-    assertTrue("Bindings Map do not have expected key ", qdef1.getBindings().containsKey("cost"));
-    assertEquals("Result count from  testQueryBindingsOnInteger is incorrect", 8, jsonStrResults.path("results").path("bindings").size());
+    assertTrue( qdef1.getBindings().containsKey("cost"));
+    assertEquals( 8, jsonStrResults.path("results").path("bindings").size());
   }
 
   /*
    * This test verifies ASK query definition with bindings on multiple string
    * values. The database should contain triples from TestCustomeGraph.
-   * 
+   *
    * Expected return : true Uses JacksonHandle
    */
   @Test
-  public void testQueryBindingsAskOnStrings() 
+  public void testQueryBindingsAskOnStrings()
   {
     System.out.println("In SPARQL Query Manager Test testQueryBindingsAskOnStrings method");
     SPARQLQueryManager sparqlQmgr = writeclient.newSPARQLQueryManager();
@@ -1618,18 +1619,18 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
     JsonNode jsonStrResults = sparqlQmgr.executeSelect(qdef1, new JacksonHandle()).get();
     System.out.println(jsonStrResults);
     // Verify the bindings.
-    assertEquals("Bindings Map do not have expected number of values ", 1, qdef1.getBindings().entrySet().size());
-    assertEquals("Result count from  testQueryBindingsAskOnStrings is incorrect", "true", jsonStrResults.path("boolean").asText());
+    assertEquals( 1, qdef1.getBindings().entrySet().size());
+    assertEquals( "true", jsonStrResults.path("boolean").asText());
   }
 
   /*
    * This test verifies query definition with bindings on string variable with
    * null value. The database should contain triples from TestCustomeGraph.
-   * 
+   *
    * Expected result : IllegalArgumentException Uses JacksonHandle
    */
   @Test
-  public void testQueryBindingsNullString() 
+  public void testQueryBindingsNullString()
   {
     System.out.println("In SPARQL Query Manager Test testQueryBindingsNullString method");
     SPARQLQueryManager sparqlQmgr = writeclient.newSPARQLQueryManager();
@@ -1669,18 +1670,18 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
       exception = e.toString();
     }
     System.out.println("Exception thrown from testQueryBindingsNullString is \n" + exception);
-    assertTrue("Test testQueryBindingsNullString method exception is not thrown", exception.contains(expectedException));
+    assertTrue( exception.contains(expectedException));
   }
 
   /*
    * This test verifies query definition with bindings on string. The database
    * should contain triples from TestCustomeGraph.
-   * 
+   *
    * Expected result : SPARQL considers that there is no binding and all results
    * are returned. Uses JacksonHandle
    */
   @Test
-  public void testQueryBindingsDifferentVariableName() 
+  public void testQueryBindingsDifferentVariableName()
   {
     System.out.println("In SPARQL Query Manager Test testQueryBindingsDifferentVariableName method");
     SPARQLQueryManager sparqlQmgr = writeclient.newSPARQLQueryManager();
@@ -1720,31 +1721,31 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
     System.out.println(jsonStrResults);
 
     // Verify the bindings.
-    assertTrue("Bindings Map do not have expected key ", qdef1.getBindings().containsKey("blahblah"));
+    assertTrue( qdef1.getBindings().containsKey("blahblah"));
 
-    assertEquals("Result count from  testQueryBindingsDifferentVariableName is incorrect", 8, jsonStrResults.path("results").path("bindings").size());
+    assertEquals( 8, jsonStrResults.path("results").path("bindings").size());
     JsonNode jsonBindingsNodes = jsonStrResults.path("results").path("bindings");
     // The results are ordered.
-    assertEquals("First person's value incorrect", "http://marklogicsparql.com/id#3333", jsonBindingsNodes.get(0).path("person").path("value").asText());
-    assertEquals("Second person's value incorrect", "http://marklogicsparql.com/id#5555", jsonBindingsNodes.get(1).path("person").path("value").asText());
-    assertEquals("Third person's value incorrect", "http://marklogicsparql.com/id#1111", jsonBindingsNodes.get(2).path("person").path("value").asText());
-    assertEquals("Fourth person's value incorrect", "http://marklogicsparql.com/id#6666", jsonBindingsNodes.get(3).path("person").path("value").asText());
-    assertEquals("Fifth person's value incorrect", "http://marklogicsparql.com/id#8888", jsonBindingsNodes.get(4).path("person").path("value").asText());
-    assertEquals("Sixth person's value incorrect", "http://marklogicsparql.com/id#4444", jsonBindingsNodes.get(5).path("person").path("value").asText());
-    assertEquals("Seventh person's value incorrect", "http://marklogicsparql.com/id#7777", jsonBindingsNodes.get(6).path("person").path("value").asText());
-    assertEquals("Eighth person's value incorrect", "http://marklogicsparql.com/id#2222", jsonBindingsNodes.get(7).path("person").path("value").asText());
+    assertEquals("http://marklogicsparql.com/id#3333", jsonBindingsNodes.get(0).path("person").path("value").asText());
+    assertEquals("http://marklogicsparql.com/id#5555", jsonBindingsNodes.get(1).path("person").path("value").asText());
+    assertEquals("http://marklogicsparql.com/id#1111", jsonBindingsNodes.get(2).path("person").path("value").asText());
+    assertEquals( "http://marklogicsparql.com/id#6666", jsonBindingsNodes.get(3).path("person").path("value").asText());
+    assertEquals( "http://marklogicsparql.com/id#8888", jsonBindingsNodes.get(4).path("person").path("value").asText());
+    assertEquals( "http://marklogicsparql.com/id#4444", jsonBindingsNodes.get(5).path("person").path("value").asText());
+    assertEquals( "http://marklogicsparql.com/id#7777", jsonBindingsNodes.get(6).path("person").path("value").asText());
+    assertEquals( "http://marklogicsparql.com/id#2222", jsonBindingsNodes.get(7).path("person").path("value").asText());
   }
 
   /*
    * This test verifies query definition with bindings on SPARQL Update query
    * with integer data type. The database should contain triples from
    * TestCustomeGraph.
-   * 
+   *
    * Expected result : Id should have 30 in query results returned. Uses
    * JacksonHandle
    */
   @Test
-  public void testSparqlUpdateInsertDataBinding() 
+  public void testSparqlUpdateInsertDataBinding()
   {
     System.out.println("In SPARQL Query Manager Test testSparqlUpdateInsertDataBinding method");
     SPARQLQueryManager sparqlQmgr = writeclient.newSPARQLQueryManager();
@@ -1799,10 +1800,10 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodes = sparqlQmgr.executeSelect(qdef1, new JacksonHandle()).get().path("results").path("bindings").get(0);
 
     // Should have 1 nodes returned.
-    assertEquals("Number of nodes returned from testSparqlUpdateInsertDataBinding method after query is incorrect", 3, jsonBindingsNodes.size());
-    assertEquals("Subject is incorrect", "http://marklogic.com/baseball/players#35", jsonBindingsNodes.path("s").path("value").asText());
-    assertEquals("Predicate is incorrect", "http://marklogic.com/baseball/players#playerid", jsonBindingsNodes.path("p").path("value").asText());
-    assertEquals("Object is incorrect", "30", jsonBindingsNodes.path("o").path("value").asText());
+    assertEquals( 3, jsonBindingsNodes.size());
+    assertEquals( "http://marklogic.com/baseball/players#35", jsonBindingsNodes.path("s").path("value").asText());
+    assertEquals( "http://marklogic.com/baseball/players#playerid", jsonBindingsNodes.path("p").path("value").asText());
+    assertEquals( "30", jsonBindingsNodes.path("o").path("value").asText());
 
     // Verify BaseURI - Insert triples with valid URI
     SPARQLQueryDefinition qdef2 = sparqlQmgr.newQueryDefinition(queryInsStr.toString());
@@ -1821,10 +1822,10 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodes21 = sparqlQmgr.executeSelect(qdefValid, new JacksonHandle()).get().path("results").path("bindings").get(0);
 
     // Should have 1 nodes returned.
-    assertEquals("Number of nodes returned from testSparqlUpdateInsertDataBinding method after query is incorrect", 3, jsonBindingsNodes21.size());
-    assertEquals("Subject is incorrect", "http://marklogic.com/baseball/players#35", jsonBindingsNodes21.path("s").path("value").asText());
-    assertEquals("Predicate is incorrect", "http://marklogic.com/baseball/players#playerid", jsonBindingsNodes21.path("p").path("value").asText());
-    assertEquals("Object is incorrect", "30", jsonBindingsNodes21.path("o").path("value").asText());
+    assertEquals( 3, jsonBindingsNodes21.size());
+    assertEquals( "http://marklogic.com/baseball/players#35", jsonBindingsNodes21.path("s").path("value").asText());
+    assertEquals( "http://marklogic.com/baseball/players#playerid", jsonBindingsNodes21.path("p").path("value").asText());
+    assertEquals( "30", jsonBindingsNodes21.path("o").path("value").asText());
 
     // Verify with base URI set to null;
     SPARQLQueryDefinition qdefNull = sparqlQmgr.newQueryDefinition(queryInsStr.toString());
@@ -1843,7 +1844,7 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodesNull = sparqlQmgr.executeSelect(qdefNullExeSel, new JacksonHandle()).get().path("results").path("bindings").get(0);
 
     // Zero nodes returned.
-    assertNull("Number of nodes returned from testSparqlUpdateInsertDataBinding method after query is incorrect", jsonBindingsNodesNull);
+    assertNull( jsonBindingsNodesNull);
 
     // Verify with base URI set to empty;
     SPARQLQueryDefinition qdefEmpty = sparqlQmgr.newQueryDefinition(queryInsStr.toString());
@@ -1867,7 +1868,7 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
       exception = e.toString();
     }
     System.out.println(exception);
-    assertTrue("Test testSparqlUpdateInsertDataBinding: Exception is not thrown when Base URI is empty", exception.contains(expectedException));
+    assertTrue( exception.contains(expectedException));
 
     String multibyteName = new String("万里长城");
     // Verify BaseURI - Insert triples with valid base URI containing MB string
@@ -1888,22 +1889,22 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodesMB = sparqlQmgr.executeSelect(qdefValidMB, new JacksonHandle()).get().path("results").path("bindings").get(0);
 
     // Should have 1 nodes returned.
-    assertEquals("Number of nodes returned from testSparqlUpdateInsertDataBinding method after query is incorrect", 3, jsonBindingsNodesMB.size());
-    assertEquals("Subject is incorrect", "http://marklogic.com/baseball/players#35", jsonBindingsNodesMB.path("s").path("value").asText());
-    assertEquals("Predicate is incorrect", "http://marklogic.com/baseball/players#playerid", jsonBindingsNodesMB.path("p").path("value").asText());
-    assertEquals("Object is incorrect", "30", jsonBindingsNodesMB.path("o").path("value").asText());
+    assertEquals( 3, jsonBindingsNodesMB.size());
+    assertEquals( "http://marklogic.com/baseball/players#35", jsonBindingsNodesMB.path("s").path("value").asText());
+    assertEquals( "http://marklogic.com/baseball/players#playerid", jsonBindingsNodesMB.path("p").path("value").asText());
+    assertEquals( "30", jsonBindingsNodesMB.path("o").path("value").asText());
 
   }
 
   /*
    * This test verifies query definition bindings on SPARQL UPDATE command. The
    * test inserts a graph with triples and then verifies the binding value.
-   * 
+   *
    * Expected result : IllegalArgumentException and Invalid parameter: Bind
    * variable type parameter requires XSD type message Uses JacksonHandle
    */
   @Test
-  public void testQueryBindingsIncorrectDataType() 
+  public void testQueryBindingsIncorrectDataType()
   {
     System.out.println("In SPARQL Query Manager Test testQueryBindingsIncorrectDataType method");
     SPARQLQueryManager sparqlQmgr = writeclient.newSPARQLQueryManager();
@@ -1947,8 +1948,8 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
       exception = e.toString();
     }
     System.out.println("Exception thrown from testQueryBindingsIncorrectDataType is \n" + exception);
-    assertTrue("Test testQueryBindingsIncorrectDataType method exception is not thrown", exception.contains(expectedException));
-    assertTrue("Message Incorrect", exception.contains("Invalid cast: \"Ling\" cast as xs:dateTime"));
+    assertTrue( exception.contains(expectedException));
+    assertTrue( exception.contains("Invalid cast: \"Ling\" cast as xs:dateTime"));
   }
 
   /*
@@ -1956,15 +1957,15 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
    * validates SPARQL EXISTS. The test creates an empty graph first, INSERTS
    * DATA, checks for EXISTS and then tries create it again with SILENT option
    * enabled and disabled.
-   * 
+   *
    * Expected Result : When SILENT disabled error reported, if same graph is
    * created again. When SILENT enabled no error reported, if same graph is
    * created again.
-   * 
+   *
    * Uses JacksonHandle
    */
   @Test
-  public void testExecuteUpdateCreateSilent() 
+  public void testExecuteUpdateCreateSilent()
   {
     System.out.println("In SPARQL Query Manager Test testExecuteUpdateCreateSilent method");
     // Form a query
@@ -2030,12 +2031,12 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodes = jsonResults.path("results").path("bindings");
 
     // Should have 1 node returned.
-    assertEquals("One result not returned from testExecuteUpdateCreateSilent method ", 1, jsonBindingsNodes.size());
+    assertEquals( 1, jsonBindingsNodes.size());
     Iterator<JsonNode> nameNodesItr = jsonBindingsNodes.elements();
     JsonNode jsonPersonNode = null;
     if (nameNodesItr.hasNext()) {
       jsonPersonNode = nameNodesItr.next();
-      assertEquals("Exist query solution returned is incorrect", "http://example.org/alice", jsonPersonNode.path("person").path("value").asText());
+      assertEquals( "http://example.org/alice", jsonPersonNode.path("person").path("value").asText());
     }
     qdef = null;
 
@@ -2051,7 +2052,7 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
       exception = e.toString();
     }
     System.out.println(exception);
-    assertTrue("Test testExecuteUpdateCreateSilent exception is not thrown", exception.contains(expectedException));
+    assertTrue( exception.contains(expectedException));
 
     qdef = null;
 
@@ -2069,7 +2070,7 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
       exceptionSilent = e.toString();
     }
 
-    assertTrue("Test testExecuteUpdateCreateSilent exception is not thrown", exceptionSilent.equals(expectedSilentException));
+    assertTrue( exceptionSilent.equals(expectedSilentException));
     qdef = null;
 
     // Verify the EXISTS again. Should have one solution returned.
@@ -2080,13 +2081,13 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodesSilent = jsonResultsSil.path("results").path("bindings");
 
     // Should have 1 node returned.
-    assertEquals("One result not returned from testExecuteUpdateCreateSilent method ", 1, jsonBindingsNodesSilent.size());
+    assertEquals( 1, jsonBindingsNodesSilent.size());
 
     Iterator<JsonNode> nameNodesSilentItr = jsonBindingsNodesSilent.elements();
     JsonNode jsonPersonNodeSilent = null;
     if (nameNodesSilentItr.hasNext()) {
       jsonPersonNodeSilent = nameNodesSilentItr.next();
-      assertEquals("Exist query solution returned is incorrect", "http://example.org/alice", jsonPersonNodeSilent.path("person").path("value").asText());
+      assertEquals( "http://example.org/alice", jsonPersonNodeSilent.path("person").path("value").asText());
     }
   }
 
@@ -2094,15 +2095,15 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
    * This test verifies sparql update DROP GRAPH. The test tries to DROP an
    * non-existent graph first, CREATES a NAMED GRAPH, INSERTS DATA, and then
    * tries drop it. DROP with SILENT option is tested.
-   * 
+   *
    * Expected Result : When SILENT disabled error reported, if non existent
    * graph is dropped. When SILENT enabled no error reported, if non existent
    * graph is dropped.
-   * 
+   *
    * Uses StringHandle (XMLReadHandle)
    */
   @Test
-  public void testExecuteUpdateDropSilent() 
+  public void testExecuteUpdateDropSilent()
   {
     System.out.println("In SPARQL Query Manager Test testExecuteUpdateDropSilent method");
     SPARQLQueryManager sparqlQmgr = writeclient.newSPARQLQueryManager();
@@ -2121,7 +2122,7 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
       exception = e.toString();
     }
     System.out.println(exception);
-    assertTrue("Test testExecuteUpdateDropSilent exception is not thrown", exception.contains(expectedException));
+    assertTrue( exception.contains(expectedException));
 
     qdef = null;
 
@@ -2144,13 +2145,13 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
     } catch (Exception e) {
       exception = e.toString();
     }
-    assertTrue("Test testExecuteUpdateDropSilent exception is thrown", exceptionNamed.equals(expectedNamedException));
+    assertTrue( exceptionNamed.equals(expectedNamedException));
   }
 
   /*
    * This test verifies read and write of Triples within transactions using
    * executeUpdate method.
-   * 
+   *
    * Insert data ina transaction using write client. Read using read client
    * outside - No results should be returned. Read using write client within
    * transaction (transaction object passed in) - Should have results. Read
@@ -2160,7 +2161,7 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
    * client. - Both returns data. Uses JacksonHandle.
    */
   @Test
-  public void testExecuteUpdateInTransactions() 
+  public void testExecuteUpdateInTransactions()
   {
     System.out.println("In SPARQL Query Manager Test testExecuteUpdateInTransactions method");
     Transaction tWrite = null;
@@ -2184,7 +2185,7 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
       JsonNode jsonBindingsNodes = jsonResults.path("results").path("bindings");
 
       // Should have 0 nodes returned.
-      assertEquals("No result should have returned from testExecuteUpdateInTransactions method on read client", 0, jsonBindingsNodes.size());
+      assertEquals( 0, jsonBindingsNodes.size());
       jsonResults = null;
       jsonBindingsNodes = null;
 
@@ -2195,7 +2196,7 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
       jsonBindingsNodes = jsonResults.path("results").path("bindings");
 
       // Should have 1 nodes returned.
-      assertEquals("Result should have been returned from testExecuteUpdateInTransactions method ", 1, jsonBindingsNodes.size());
+      assertEquals( 1, jsonBindingsNodes.size());
       jsonResults = null;
       jsonBindingsNodes = null;
 
@@ -2205,7 +2206,7 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
       jsonBindingsNodes = jsonResults.path("results").path("bindings");
 
       // Should have 0 nodes returned.
-      assertEquals("No result should have returned from testExecuteUpdateInTransactions method ", 0, jsonBindingsNodes.size());
+      assertEquals( 0, jsonBindingsNodes.size());
       jsonResults = null;
       jsonBindingsNodes = null;
 
@@ -2218,7 +2219,7 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
       jsonBindingsNodes = jsonResults.path("results").path("bindings");
 
       // Should have 0 nodes returned.
-      assertEquals("No result should have returned from testExecuteUpdateInTransactions method ", 0, jsonBindingsNodes.size());
+      assertEquals( 0, jsonBindingsNodes.size());
       jsonResults = null;
       jsonBindingsNodes = null;
       tWrite = writeclient.openTransaction();
@@ -2234,10 +2235,10 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
       jsonBindingsNodes = jsonResults.path("results").path("bindings");
 
       // Should have 1 nodes returned.
-      assertEquals("Result should have returned from testExecuteUpdateInTransactions method after commit for read client", 1, jsonBindingsNodes.size());
-      assertEquals("Value Data from read client is incorrect", "Bob", jsonBindingsNodes.get(0).path("s").path("value").asText());
-      assertEquals("Value Data from read client is incorrect", "LivesIn", jsonBindingsNodes.get(0).path("p").path("value").asText());
-      assertEquals("Value Data from read client is incorrect", "London", jsonBindingsNodes.get(0).path("o").path("value").asText());
+      assertEquals( 1, jsonBindingsNodes.size());
+      assertEquals( "Bob", jsonBindingsNodes.get(0).path("s").path("value").asText());
+      assertEquals( "LivesIn", jsonBindingsNodes.get(0).path("p").path("value").asText());
+      assertEquals( "London", jsonBindingsNodes.get(0).path("o").path("value").asText());
       jsonResults = null;
       jsonBindingsNodes = null;
 
@@ -2247,10 +2248,10 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
       jsonBindingsNodes = jsonResults.path("results").path("bindings");
 
       // Should have 1 nodes returned.
-      assertEquals("Result should have been returned from testExecuteUpdateInTransactions method after commit for write client", 1, jsonBindingsNodes.size());
-      assertEquals("Value Data from read client is incorrect", "Bob", jsonBindingsNodes.get(0).path("s").path("value").asText());
-      assertEquals("Value Data from read client is incorrect", "LivesIn", jsonBindingsNodes.get(0).path("p").path("value").asText());
-      assertEquals("Value Data from read client is incorrect", "London", jsonBindingsNodes.get(0).path("o").path("value").asText());
+      assertEquals( 1, jsonBindingsNodes.size());
+      assertEquals( "Bob", jsonBindingsNodes.get(0).path("s").path("value").asText());
+      assertEquals( "LivesIn", jsonBindingsNodes.get(0).path("p").path("value").asText());
+      assertEquals( "London", jsonBindingsNodes.get(0).path("o").path("value").asText());
       tWrite = null;
 
       // Execute a write with Read Client to validate the error message.
@@ -2266,8 +2267,8 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
         exception = e.toString();
       }
       System.out.println(exception);
-      assertTrue("Test testExecuteUpdateInTransactions method exception is not thrown", exception.contains(expectedException));
-      assertTrue("Test testExecuteUpdateInTransactions method exception is not thrown", exception.contains(localMessage));
+      assertTrue( exception.contains(expectedException));
+      assertTrue( exception.contains(localMessage));
     } catch (Exception ex) {
       tWrite = null;
       throw ex;
@@ -2281,7 +2282,7 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
   /*
    * This test verifies set and get methods on SPARQLQueryDefinition class. Do a
    * COPY GRAPH and verify if values set on the original and copied Graph
-   * 
+   *
    * Uses StringHandle (XMLReadHandle)
    */
   @Test
@@ -2315,11 +2316,11 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
 
     // Verify SPARQLQueryDefinition get methods.
     for (String collections : qdef.getCollections())
-      assertTrue("QueryDefinition Collections incorrectlty set ", collections.contains("my-collections1") || collections.contains("my-collections2"));
-    assertEquals("QueryDefinition Directory incorrectlty set ", "my-Directory", qdef.getDirectory());
-    assertNull("QueryDefinition DefaultRulesets incorrectlty set. Should be Null.", qdef.getIncludeDefaultRulesets());
-    assertTrue("QueryDefinition Bindings incorrectlty set. Should be Empty.", qdef.getBindings().isEmpty());
-    assertNull("QueryDefinition Options incorrectlty set. Should be Null.", qdef.getOptionsName());
+      assertTrue( collections.contains("my-collections1") || collections.contains("my-collections2"));
+    assertEquals( "my-Directory", qdef.getDirectory());
+    assertNull( qdef.getIncludeDefaultRulesets());
+    assertTrue( qdef.getBindings().isEmpty());
+    assertNull( qdef.getOptionsName());
 
     // Now read the graph back using GraphManager and Check Permissions.
     StringHandle graphStr = graphManagerPerm.read("OriginalGraph", new StringHandle());
@@ -2336,17 +2337,17 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
     }
     System.out.println("Returned permissions from OriginalGraph : " + stringPermissions);
 
-    assertTrue("Document permissions difference in size value", stringPermissions.contains("size:5"));
-    assertTrue("Document permissions difference in harmonized-updater permission", stringPermissions.contains("harmonized-updater:[UPDATE]"));
-    assertTrue("Document permissions difference in harmonized-reader permission", stringPermissions.contains("harmonized-reader:[READ]"));
-    assertTrue("Document permissions difference in rest-reader permission", stringPermissions.contains("rest-reader:[READ]"));
-    assertTrue("Document permissions difference in rest-writer permission", stringPermissions.contains("rest-writer:[UPDATE]"));
-    assertTrue("Document permissions difference in sem-query-role permission", stringPermissions.contains("sem-query-role:"));
+    assertTrue( stringPermissions.contains("size:5"));
+    assertTrue( stringPermissions.contains("harmonized-updater:[UPDATE]"));
+    assertTrue( stringPermissions.contains("harmonized-reader:[READ]"));
+    assertTrue( stringPermissions.contains("rest-reader:[READ]"));
+    assertTrue( stringPermissions.contains("rest-writer:[UPDATE]"));
+    assertTrue( stringPermissions.contains("sem-query-role:"));
     // sem-query-role:[UPDATE, EXECUTE] --> Order of UPDATE, EXECUTE not
     // certain. Split on role, then pipe char and replace trailing ]
     // Better way?
     String capab = stringPermissions.split("sem-query-role:\\[")[1].split("\\|")[0].replace("]", "");
-    assertTrue("Document permissions difference in sem-query-role permission", capab.contains("UPDATE, EXECUTE") || capab.contains("EXECUTE, UPDATE"));
+    assertTrue( capab.contains("UPDATE, EXECUTE") || capab.contains("EXECUTE, UPDATE"));
 
     // Insert data into OriginalGraph.
     StringBuffer sparqlInsertData = new StringBuffer().append("PREFIX : <http://example.org/>");
@@ -2399,22 +2400,22 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
 
     System.out.println("Returned permissions from Copy graph is : " + stringPermissionsCopy);
 
-    assertTrue("Document permissions difference in size value", stringPermissions.contains("size:5"));
-    assertTrue("Document permissions difference in harmonized-updater permission", stringPermissionsCopy.contains("harmonized-updater:[UPDATE]"));
-    assertTrue("Document permissions difference in harmonized-reader permission", stringPermissionsCopy.contains("harmonized-reader:[READ]"));
-    assertTrue("Document permissions difference in rest-reader permission", stringPermissionsCopy.contains("rest-reader:[READ]"));
-    assertTrue("Document permissions difference in rest-writer permission", stringPermissionsCopy.contains("rest-writer:[UPDATE]"));
+    assertTrue( stringPermissions.contains("size:5"));
+    assertTrue( stringPermissionsCopy.contains("harmonized-updater:[UPDATE]"));
+    assertTrue( stringPermissionsCopy.contains("harmonized-reader:[READ]"));
+    assertTrue( stringPermissionsCopy.contains("rest-reader:[READ]"));
+    assertTrue( stringPermissionsCopy.contains("rest-writer:[UPDATE]"));
 
     // Better way?
     String capabCpy = stringPermissionsCopy.split("sem-query-role:\\[")[1].split("\\|")[0].replace("]", "");
-    assertTrue("Document permissions difference in sem-query-role permission", capabCpy.contains("UPDATE, EXECUTE") || capabCpy.contains("EXECUTE, UPDATE"));
+    assertTrue( capabCpy.contains("UPDATE, EXECUTE") || capabCpy.contains("EXECUTE, UPDATE"));
 
     // Validate the meta data through DocumentMetadataHandle also.
     TextDocumentManager docMgr = readclient.newTextDocumentManager();
     DocumentMetadataHandle mhRead = new DocumentMetadataHandle();
     DocumentPage page = docMgr.read("CopiedGraph");
 
-    assertTrue("DocumentPage Size did not return expected value:: returned ==  " + page.size(), page.size() == 1);
+    assertTrue(page.size() == 1);
 
     while (page.hasNext()) {
       DocumentRecord rec = page.next();
@@ -2426,28 +2427,28 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
       DocumentCollections collections = mhRead.getCollections();
 
       // Properties - None.
-      assertTrue("Document properties difference in size value", properties.size() == 0);
+      assertTrue( properties.size() == 0);
 
       // Permissions
       String actualPermissions = getDocumentPermissionsString(permissions);
       System.out.println("Returned permissions from DocumentMetadataHandle : " + actualPermissions);
 
-      assertTrue("Document permissions difference in size value", actualPermissions.contains("size:5"));
-      assertTrue("Document permissions difference in harmonized-updater permission", actualPermissions.contains("harmonized-updater:[UPDATE]"));
-      assertTrue("Document permissions difference in harmonized-reader permission", actualPermissions.contains("harmonized-reader:[READ]"));
-      assertTrue("Document permissions difference in rest-reader permission", actualPermissions.contains("rest-reader:[READ]"));
-      assertTrue("Document permissions difference in rest-writer permission", actualPermissions.contains("rest-writer:[UPDATE]"));
+      assertTrue( actualPermissions.contains("size:5"));
+      assertTrue( actualPermissions.contains("harmonized-updater:[UPDATE]"));
+      assertTrue( actualPermissions.contains("harmonized-reader:[READ]"));
+      assertTrue( actualPermissions.contains("rest-reader:[READ]"));
+      assertTrue( actualPermissions.contains("rest-writer:[UPDATE]"));
       // Better way?
       String capabAct = actualPermissions.split("sem-query-role:\\[")[1].split("\\|")[0].replace("]", "");
-      assertTrue("Document permissions difference in sem-query-role permission", capabAct.contains("UPDATE, EXECUTE") || capabAct.contains("EXECUTE, UPDATE"));
+      assertTrue( capabAct.contains("UPDATE, EXECUTE") || capabAct.contains("EXECUTE, UPDATE"));
 
       // Collections
       String actualCollections = getDocumentCollectionsString(collections);
       System.out.println("Returned collections: " + actualCollections);
 
-      assertTrue("Document collections difference in size value", actualCollections.contains("size:2"));
-      assertTrue("Semantic Graphs not found in collections", actualCollections.contains("http://marklogic.com/semantics#graphs"));
-      assertTrue("CopiedGraph not found in collections", actualCollections.contains("CopiedGraph"));
+      assertTrue( actualCollections.contains("size:2"));
+      assertTrue( actualCollections.contains("http://marklogic.com/semantics#graphs"));
+      assertTrue( actualCollections.contains("CopiedGraph"));
     }
     // Release resources.
     deleteRESTUser("sem-query-user");
@@ -2457,12 +2458,12 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
 
   /*
    * This test verifies MarkLogic Java API support for Inference and Ruleset.
-   * 
+   *
    * No default ruleset, no inference triples Add one ruleset, verify inference
    * triples Add two rulesets, verify inference triples
    */
   @Test
-  public void testInferenceAndRuleSet() 
+  public void testInferenceAndRuleSet()
   {
     System.out.println("In SPARQL Query Manager Test testInferenceAndRuleSet method");
     SPARQLQueryManager sparqlQmgr = writeclient.newSPARQLQueryManager();
@@ -2490,7 +2491,7 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodes18 = jsonResults18.path("results").path("bindings");
 
     // Should have 18 nodes returned. No inference triples returned.
-    assertEquals("18 results not returned from testInferenceAndRuleSet method ", 18, jsonBindingsNodes18.size());
+    assertEquals( 18, jsonBindingsNodes18.size());
     qdef = null;
     jacksonHandle = null;
 
@@ -2499,9 +2500,9 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
     qdef.setRulesets(SPARQLRuleset.SUBCLASS_OF);
     qdef.setIncludeDefaultRulesets(true);
     qdef.setSparql(sparqlInferQuery.toString());
-    assertEquals("One Ruleset should have been returned from testInferenceAndRuleSet method ", 1, qdef.getRulesets().length);
+    assertEquals( 1, qdef.getRulesets().length);
     SPARQLRuleset[] rulesets = qdef.getRulesets();
-    assertEquals("Ruleset name returned from testInferenceAndRuleSet method is incorrect", "subClassOf.rules", rulesets[0].getName());
+    assertEquals( "subClassOf.rules", rulesets[0].getName());
 
     // Execute with default Rulesets enabled. - We need to get Inference triples
     // now.
@@ -2510,7 +2511,7 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
     JsonNode jsonResultsSubClass = sparqlQmgr.executeSelect(qdef, jacksonHandle).get();
 
     // Should have 31 nodes returned.
-    assertEquals("31 results not returned from testInferenceAndRuleSet method ", 31, jsonResultsSubClass.path("results").path("bindings").size());
+    assertEquals( 31, jsonResultsSubClass.path("results").path("bindings").size());
 
     // Enable two rulesets
     qdef = null;
@@ -2522,30 +2523,30 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
     qdef.setRulesets(SPARQLRuleset.SUBCLASS_OF, SPARQLRuleset.SUBPROPERTY_OF);
     qdef.setIncludeDefaultRulesets(true);
     qdef.setSparql(sparqlInferQuery.toString());
-    assertEquals("Two Rulesets should have been returned from testInferenceAndRuleSet method ", 2, qdef.getRulesets().length);
+    assertEquals( 2, qdef.getRulesets().length);
     // Have an ordered collection.
     Collection<SPARQLRuleset> list = Arrays.asList(qdef.getRulesets());
     // Iterate over the list two times. Items more or less, would have asserted
     // by now.
     Iterator<SPARQLRuleset> itr = list.iterator();
-    assertEquals("First Ruleset name from testInferenceAndRuleSet is incorrect", "subClassOf.rules", itr.next().getName());
-    assertEquals("Second Ruleset name from testInferenceAndRuleSet is incorrect", "subPropertyOf.rules", itr.next().getName());
+    assertEquals( "subClassOf.rules", itr.next().getName());
+    assertEquals( "subPropertyOf.rules", itr.next().getName());
     jacksonHandle = new JacksonHandle();
     jacksonHandle.setMimetype("application/json");
     JsonNode jsonResultsTwoRules = sparqlQmgr.executeSelect(qdef, jacksonHandle).get();
 
     // Should have 44 nodes returned.
-    assertEquals("44 results not returned from testInferenceAndRuleSet method ", 44, jsonResultsTwoRules.path("results").path("bindings").size());
+    assertEquals( 44, jsonResultsTwoRules.path("results").path("bindings").size());
   }
 
   /*
    * This test verifies setConstrainingQueryDefinition method on
    * SPARQLQueryDefinition class.
-   * 
+   *
    * Uses JacksonHandle
    */
   @Test
-  public void testConstrainingQuery() 
+  public void testConstrainingQuery()
   {
     System.out.println("In SPARQL Query Manager Test testConstrainingQuery method");
     SPARQLQueryManager sparqlQmgr = writeclient.newSPARQLQueryManager();
@@ -2594,9 +2595,9 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
     JsonNode jsonBindings = jsonStrResults.path("results").path("bindings").get(0);
 
     // Verify the results.
-    assertEquals("Result value from  testConstrainingQuery is incorrect", "http://marklogicsparql.com/id#6666", jsonBindings.path("person").path("value").asText());
-    assertEquals("Result fn from  testConstrainingQuery is incorrect", "Lei", jsonBindings.path("fn").path("value").asText());
-    assertEquals("Result lastname from  testConstrainingQuery is incorrect", "Pei", jsonBindings.path("lastname").path("value").asText());
+    assertEquals( "http://marklogicsparql.com/id#6666", jsonBindings.path("person").path("value").asText());
+    assertEquals( "Lei", jsonBindings.path("fn").path("value").asText());
+    assertEquals( "Pei", jsonBindings.path("lastname").path("value").asText());
   }
 
   /*
@@ -2606,7 +2607,7 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
    * JacksonHandle
    */
   @Test
-  public void testConstrainingQueryNull() 
+  public void testConstrainingQueryNull()
   {
     System.out.println("In SPARQL Query Manager Test testConstrainingQueryNull method");
     SPARQLQueryManager sparqlQmgr = writeclient.newSPARQLQueryManager();
@@ -2653,10 +2654,10 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
     JsonNode jsonBindings = jsonStrResults.path("results").path("bindings");
 
     // Verify the results. Returns results.
-    assertEquals("Result size from  testConstrainingQueryNull is incorrect", 1, jsonBindings.size());
-    assertEquals("Result value from  testConstrainingQueryNull is incorrect", "http://marklogicsparql.com/id#6666", jsonBindings.get(0).path("person").path("value").asText());
-    assertEquals("Result fn from  testConstrainingQueryNull is incorrect", "Lei", jsonBindings.get(0).path("fn").path("value").asText());
-    assertEquals("Result lastname from  testConstrainingQueryNull is incorrect", "Pei", jsonBindings.get(0).path("lastname").path("value").asText());
+    assertEquals( 1, jsonBindings.size());
+    assertEquals( "http://marklogicsparql.com/id#6666", jsonBindings.get(0).path("person").path("value").asText());
+    assertEquals( "Lei", jsonBindings.get(0).path("fn").path("value").asText());
+    assertEquals( "Pei", jsonBindings.get(0).path("lastname").path("value").asText());
 
     SPARQLQueryDefinition qdef1 = sparqlQmgr.newQueryDefinition(queryStr.toString()).withConstrainingQuery(strquerydef);
     // Parsing results using JsonNode.
@@ -2666,16 +2667,16 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
     JsonNode jsonBindings1 = jsonStrResults1.path("results").path("bindings");
 
     // Verify the results. Returns No results.
-    assertEquals("Result size from  testConstrainingQueryNull is incorrect", 0, jsonBindings1.size());
+    assertEquals( 0, jsonBindings1.size());
   }
 
   /*
    * This test verifies SPARQL query with cts:contains
-   * 
+   *
    * Uses JacksonHandle
    */
   @Test
-  public void testSparqlQueryCtsContains() 
+  public void testSparqlQueryCtsContains()
   {
     System.out.println("In SPARQL Query Manager Test testSparqlQueryCtsContains method");
     SPARQLQueryManager sparqlQmgr = writeclient.newSPARQLQueryManager();
@@ -2714,11 +2715,11 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
     JsonNode jsonBindings2 = jsonStrResults.path("results").path("bindings").get(1);
 
     // Verify the results.
-    assertEquals("Result 1 value from  testSparqlQueryCtsContains is incorrect", "http://marklogicsparql.com/id#6666", jsonBindings1.path("person").path("value").asText());
-    assertEquals("Result 1 lastname from  testSparqlQueryCtsContains is incorrect", "Pei", jsonBindings1.path("lastname").path("value").asText());
+    assertEquals( "http://marklogicsparql.com/id#6666", jsonBindings1.path("person").path("value").asText());
+    assertEquals( "Pei", jsonBindings1.path("lastname").path("value").asText());
 
-    assertEquals("Result 2 value from  testSparqlQueryCtsContains is incorrect", "http://marklogicsparql.com/id#4444", jsonBindings2.path("person").path("value").asText());
-    assertEquals("Result 2 lastname from  testSparqlQueryCtsContains is incorrect", "Ling", jsonBindings2.path("lastname").path("value").asText());
+    assertEquals( "http://marklogicsparql.com/id#4444", jsonBindings2.path("person").path("value").asText());
+    assertEquals( "Ling", jsonBindings2.path("lastname").path("value").asText());
   }
 
   /*
@@ -2760,11 +2761,11 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
     JsonNode jsonBindingsNodes = jsonResults.path("results").path("bindings");
 
     // Should have 4 nodes returned.
-    assertEquals("Result should have been returned from testNamedExecuteSelectQuery method after commit for write client", 4, jsonBindingsNodes.size());
-    assertEquals("Value Data from read client is incorrect", "Ling", jsonBindingsNodes.get(0).path("name").path("value").asText());
-    assertEquals("Value Data from read client is incorrect", "Ling", jsonBindingsNodes.get(1).path("name").path("value").asText());
-    assertEquals("Value Data from read client is incorrect", "Wang", jsonBindingsNodes.get(2).path("name").path("value").asText());
-    assertEquals("Value Data from read client is incorrect", "Xiang", jsonBindingsNodes.get(3).path("name").path("value").asText());
+    assertEquals( 4, jsonBindingsNodes.size());
+    assertEquals( "Ling", jsonBindingsNodes.get(0).path("name").path("value").asText());
+    assertEquals( "Ling", jsonBindingsNodes.get(1).path("name").path("value").asText());
+    assertEquals( "Wang", jsonBindingsNodes.get(2).path("name").path("value").asText());
+    assertEquals( "Xiang", jsonBindingsNodes.get(3).path("name").path("value").asText());
 
     qdef = null;
     jacksonHandle = null;
@@ -2804,8 +2805,8 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
 
     jsonBindingsNodes = jsonResults.path("results").path("bindings");
     // Should have 1 nodes returned.
-    assertEquals("Result should have been returned from testNamedExecuteSelectQuery method after commit for write client", 1, jsonBindingsNodes.size());
-    assertEquals("Value Data from read client is incorrect", "Ling", jsonBindingsNodes.get(0).path("name").path("value").asText());
+    assertEquals( 1, jsonBindingsNodes.size());
+    assertEquals( "Ling", jsonBindingsNodes.get(0).path("name").path("value").asText());
 
     qdef = null;
     jacksonHandle = null;
@@ -2843,11 +2844,11 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
 
     jsonBindingsNodes = jsonResults.path("results").path("bindings");
     // Should have 4 nodes returned.
-    assertEquals("Result should have been returned from testNamedExecuteSelectQuery method after commit for write client", 4, jsonBindingsNodes.size());
-    assertEquals("Value Data from read client is incorrect", "John", jsonBindingsNodes.get(0).path("name").path("value").asText());
-    assertEquals("Value Data from read client is incorrect", "Lei", jsonBindingsNodes.get(1).path("name").path("value").asText());
-    assertEquals("Value Data from read client is incorrect", "Meng", jsonBindingsNodes.get(2).path("name").path("value").asText());
-    assertEquals("Value Data from read client is incorrect", "Micah", jsonBindingsNodes.get(3).path("name").path("value").asText());
+    assertEquals( 4, jsonBindingsNodes.size());
+    assertEquals( "John", jsonBindingsNodes.get(0).path("name").path("value").asText());
+    assertEquals( "Lei", jsonBindingsNodes.get(1).path("name").path("value").asText());
+    assertEquals( "Meng", jsonBindingsNodes.get(2).path("name").path("value").asText());
+    assertEquals( "Micah", jsonBindingsNodes.get(3).path("name").path("value").asText());
   }
 
   /*
@@ -2886,7 +2887,7 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
 
   /**
    * Write document using FileHandle
-   * 
+   *
    * @param client
    * @param directoryPath
    * @param filename
@@ -2920,7 +2921,7 @@ public class TestSparqlQueryManager extends AbstractFunctionalTest {
           + " into the database with default graph");
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownAfterClass() throws Exception
   {
     writeclient.release();

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestStandaloneGeoQuery.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestStandaloneGeoQuery.java
@@ -24,7 +24,8 @@ import com.marklogic.client.query.StructuredQueryBuilder;
 import com.marklogic.client.query.StructuredQueryBuilder.FragmentScope;
 import com.marklogic.client.query.StructuredQueryDefinition;
 import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
@@ -35,7 +36,7 @@ import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
-import static org.junit.Assert.assertTrue;
+
 
 public class TestStandaloneGeoQuery extends AbstractFunctionalTest {
 
@@ -74,7 +75,7 @@ public class TestStandaloneGeoQuery extends AbstractFunctionalTest {
     Document resultDoc = resultsHandle.get();
     String result = convertXMLDocumentToString(resultDoc);
     System.out.println(result);
-    assertTrue("Results are not proper", result.contains("start=\"1\" total=\"5\""));
+    assertTrue( result.contains("start=\"1\" total=\"5\""));
 
     // release client
     client.release();
@@ -372,7 +373,7 @@ public class TestStandaloneGeoQuery extends AbstractFunctionalTest {
     Document resultDoc = resultsHandle.get();
     System.out.println("Results of Box :" + convertXMLDocumentToString(resultDoc));
     assertXpathEvaluatesTo("1", "string(//*[local-name()='result'][last()]//@*[local-name()='index'])", resultDoc);
-    assertTrue("Result returned is wrong", convertXMLDocumentToString(resultDoc).contains("beijing city in china bangkok city in thailand norh pole place where Santa lives"));
+    assertTrue( convertXMLDocumentToString(resultDoc).contains("beijing city in china bangkok city in thailand norh pole place where Santa lives"));
 
     // Circle Query
     QueryManager queryMgr1 = client.newQueryManager();
@@ -386,7 +387,7 @@ public class TestStandaloneGeoQuery extends AbstractFunctionalTest {
     // get the result
     Document resultDoc1 = resultsHandle1.get();
     System.out.println("Results of Circle :" + convertXMLDocumentToString(resultDoc1));
-    assertTrue("Result returned is wrong", convertXMLDocumentToString(resultDoc1).contains("beijing city in china bangkok city in thailand norh pole place where Santa lives"));
+    assertTrue( convertXMLDocumentToString(resultDoc1).contains("beijing city in china bangkok city in thailand norh pole place where Santa lives"));
     // Polygon Query
     QueryManager queryMgr2 = client.newQueryManager();
     // create query def
@@ -399,7 +400,7 @@ public class TestStandaloneGeoQuery extends AbstractFunctionalTest {
     // get the result
     Document resultDoc2 = resultsHandle2.get();
     System.out.println("Results of Polygon :" + convertXMLDocumentToString(resultDoc2));
-    assertTrue("Result returned is wrong", convertXMLDocumentToString(resultDoc2).contains("beijing city in china bangkok city in thailand norh pole place where Santa lives"));
+    assertTrue( convertXMLDocumentToString(resultDoc2).contains("beijing city in china bangkok city in thailand norh pole place where Santa lives"));
     // release client
     client.release();
   }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestStandaloneQuery.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestStandaloneQuery.java
@@ -25,7 +25,8 @@ import com.marklogic.client.query.StructuredQueryBuilder.FragmentScope;
 import com.marklogic.client.query.StructuredQueryBuilder.Operator;
 import com.marklogic.client.query.StructuredQueryDefinition;
 import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
@@ -37,7 +38,7 @@ import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
-import static org.junit.Assert.assertTrue;
+
 
 public class TestStandaloneQuery extends AbstractFunctionalTest {
 
@@ -78,7 +79,7 @@ public class TestStandaloneQuery extends AbstractFunctionalTest {
     System.out.println("Output of Search : " + convertXMLDocumentToString(resultDoc));
 
     assertXpathEvaluatesTo("1", "string(//*[local-name()='result'][last()]//@*[local-name()='index'])", resultDoc);
-    assertTrue("Proper result is not returned :", convertXMLDocumentToString(resultDoc).contains("<search:highlight>0026"));
+    assertTrue( convertXMLDocumentToString(resultDoc).contains("<search:highlight>0026"));
 
     // release client
     client.release();
@@ -126,7 +127,7 @@ public class TestStandaloneQuery extends AbstractFunctionalTest {
     System.out.println(output);
     System.out.println("Search Result : " + resultDoc.getDocumentURI());
     assertXpathEvaluatesTo("1", "string(//*[local-name()='result'][last()]//@*[local-name()='index'])", resultDoc);
-    assertTrue("Results are not proper", output.contains("uri=\"/standalone-query/constraint5.xml\""));
+    assertTrue( output.contains("uri=\"/standalone-query/constraint5.xml\""));
 
     // release client
     client.release();
@@ -517,7 +518,7 @@ public class TestStandaloneQuery extends AbstractFunctionalTest {
     System.out.println(output);
 
     assertXpathEvaluatesTo("1", "string(//*[local-name()='result'][last()]//@*[local-name()='index'])", resultDoc);
-    assertTrue("The result is not proper", output.contains("/standalone-query/constraint5.xml"));
+    assertTrue( output.contains("/standalone-query/constraint5.xml"));
 
     // release client
     client.release();

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestStructuredQuery.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestStructuredQuery.java
@@ -26,8 +26,9 @@ import com.marklogic.client.query.StructuredQueryBuilder;
 import com.marklogic.client.query.StructuredQueryBuilder.Operator;
 import com.marklogic.client.query.StructuredQueryDefinition;
 import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
@@ -40,12 +41,12 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+
+
 
 public class TestStructuredQuery extends AbstractFunctionalTest {
 
-  @After
+  @AfterEach
   public void testCleanUp() throws Exception {
     deleteDocuments(connectAsAdmin());
   }
@@ -246,7 +247,7 @@ public class TestStructuredQuery extends AbstractFunctionalTest {
 
     assertXpathEvaluatesTo("1", "string(//*[local-name()='result'][last()]//@*[local-name()='index'])", resultDoc);
     assertXpathEvaluatesTo("0113", "string(//*[local-name()='result']//*[local-name()='id'])", resultDoc);
-    
+
     // To test Git issue 908
     StructuredQueryDefinition termQuery11 = qb.term("Pacific");
     StructuredQueryDefinition termQuery21 = qb.term("Yearly");
@@ -263,8 +264,8 @@ public class TestStructuredQuery extends AbstractFunctionalTest {
     }
     long res = results.getTotalResults();
     System.out.println("No query results available. Total Results should be zero: " + res);
-    assertTrue("Exception should not have been thrown when no query results are available", searchHandleEx.toString().isEmpty());
-    assertEquals("No query results available. Should be zero.", 0, res);
+    assertTrue( searchHandleEx.toString().isEmpty());
+    assertEquals( 0, res);
 
     // release client
     client.release();
@@ -538,7 +539,7 @@ public class TestStructuredQuery extends AbstractFunctionalTest {
    * string query by calling setCriteria and withCriteria Make sure a query
    * using those query definitions selects only documents that match both the
    * query definition and the string query
-   * 
+   *
    * Uses setCriteria. Uses valueConstraintWildCardOpt.xml options file QD and
    * string query (Memex) should return 1 URI in the response.
    */
@@ -577,8 +578,8 @@ public class TestStructuredQuery extends AbstractFunctionalTest {
     JacksonHandle results = queryMgr.search(strutdDef, strHandle.withFormat(Format.JSON));
 
     JsonNode node = results.get();
-    assertEquals("Number of results returned incorrect in response", "1", node.path("total").asText());
-    assertEquals("Result returned incorrect in response", "/structured-query/constraint2.xml", node.path("results").get(0).path("uri").asText());
+    assertEquals( "1", node.path("total").asText());
+    assertEquals( "/structured-query/constraint2.xml", node.path("results").get(0).path("uri").asText());
 
     // With multiple setCriteria - positive
     StructuredQueryDefinition strutdDefPos = qb.valueConstraint("id", "0012");
@@ -591,8 +592,8 @@ public class TestStructuredQuery extends AbstractFunctionalTest {
 
     JsonNode nodePos = resultsPos.get();
     // Return 1 node - constraint2.xml
-    assertEquals("Number of results returned incorrect in response", "1", nodePos.path("total").asText());
-    assertEquals("Result returned incorrect in response", "/structured-query/constraint2.xml", nodePos.path("results").get(0).path("uri").asText());
+    assertEquals( "1", nodePos.path("total").asText());
+    assertEquals( "/structured-query/constraint2.xml", nodePos.path("results").get(0).path("uri").asText());
 
     // With setCriteria AND - positive
     StructuredQueryDefinition strutdDefPosAnd = qb.valueConstraint("id", "0012");
@@ -604,9 +605,9 @@ public class TestStructuredQuery extends AbstractFunctionalTest {
 
     JsonNode nodePosAnd = resultsPosAnd.get();
     // Return 1 node - constraint2.xml
-    assertEquals("Number of results returned incorrect in response", "1", nodePosAnd.path("total").asText());
-    assertEquals("Result returned incorrect in response", "/structured-query/constraint2.xml", nodePosAnd.path("results").get(0).path("uri").asText());
-    assertEquals("Get Criteria returned incorrect", "Memex AND described", strutdDefPosAnd.getCriteria());
+    assertEquals( "1", nodePosAnd.path("total").asText());
+    assertEquals( "/structured-query/constraint2.xml", nodePosAnd.path("results").get(0).path("uri").asText());
+    assertEquals( "Memex AND described", strutdDefPosAnd.getCriteria());
 
     // With multiple setCriteria - negative
     StructuredQueryDefinition strutdDefNeg = qb.valueConstraint("id", "0012");
@@ -619,7 +620,7 @@ public class TestStructuredQuery extends AbstractFunctionalTest {
 
     JsonNode nodeNeg = resultsNeg.get();
     // Return 0 nodes
-    assertEquals("Number of results returned incorrect in response", "0", nodeNeg.path("total").asText());
+    assertEquals( "0", nodeNeg.path("total").asText());
     // release client
     client.release();
   }
@@ -629,7 +630,7 @@ public class TestStructuredQuery extends AbstractFunctionalTest {
    * string query by calling setCriteria and withCriteria Make sure a query
    * using those query definitions selects only documents that match both the
    * query definition and the string query
-   * 
+   *
    * Uses withCriteria. Uses valueConstraintPopularityOpt.xml options file QD
    * and string query (Vannevar) should return 2 URIs in the response.
    * constraint1.xml and constraint4.xml
@@ -668,10 +669,10 @@ public class TestStructuredQuery extends AbstractFunctionalTest {
     JacksonHandle results = queryMgr.search(strutdDef, strHandle.withFormat(Format.JSON));
 
     JsonNode node = results.get();
-    assertEquals("Number of results returned incorrect in response", "2", node.path("total").asText());
-    assertTrue("Results returned incorrect in response", node.path("results").get(0).path("uri").asText().contains("/structured-query/constraint1.xml") ||
+    assertEquals( "2", node.path("total").asText());
+    assertTrue( node.path("results").get(0).path("uri").asText().contains("/structured-query/constraint1.xml") ||
         node.path("results").get(1).path("uri").asText().contains("/structured-query/constraint1.xml"));
-    assertTrue("Results returned incorrect in response", node.path("results").get(0).path("uri").asText().contains("/structured-query/constraint4.xml") ||
+    assertTrue( node.path("results").get(0).path("uri").asText().contains("/structured-query/constraint4.xml") ||
         node.path("results").get(1).path("uri").asText().contains("/structured-query/constraint4.xml"));
     // With multiple withCriteria - positive
     StructuredQueryDefinition strutdDefPos = (qb.valueConstraint("popularity", "5")).withCriteria("Vannevar").withCriteria("Atlantic").withCriteria("intellectual");
@@ -682,9 +683,9 @@ public class TestStructuredQuery extends AbstractFunctionalTest {
 
     JsonNode nodePos = resultsPos.get();
     // Return 2 nodes.
-    assertEquals("Number of results returned incorrect in response", "1", nodePos.path("total").asText());
-    assertTrue("Results returned incorrect in response", nodePos.path("results").get(0).path("uri").asText().contains("/structured-query/constraint4.xml"));
-    
+    assertEquals( "1", nodePos.path("total").asText());
+    assertTrue( nodePos.path("results").get(0).path("uri").asText().contains("/structured-query/constraint4.xml"));
+
     // With multiple withCriteria - negative
     StructuredQueryDefinition strutdDefNeg = (qb.valueConstraint("popularity", "5")).withCriteria("Vannevar").withCriteria("England");
 
@@ -694,8 +695,8 @@ public class TestStructuredQuery extends AbstractFunctionalTest {
 
     JsonNode nodeNeg = resultsNeg.get();
     // Return 0 nodes.
-    assertEquals("Number of results returned incorrect in response", "0", nodeNeg.path("total").asText());
-    assertEquals("Get Criteria returned incorrect in response", "England", strutdDefNeg.getCriteria());
+    assertEquals( "0", nodeNeg.path("total").asText());
+    assertEquals( "England", strutdDefNeg.getCriteria());
 
     // create query def2 with both criteria methods and check fluent return
 
@@ -708,13 +709,13 @@ public class TestStructuredQuery extends AbstractFunctionalTest {
 
     JsonNode node2 = results2.get();
     // Returns 1 node. constraint1.xml
-    assertEquals("Number of results returned incorrect in response", "1", node2.path("total").asText());
-    assertEquals("Result returned incorrect in response", "/structured-query/constraint1.xml", node2.path("results").get(0).path("uri").asText());
-    assertEquals("Get Criteria returned incorrect in response", "Bush", strutdDef2.getCriteria());
+    assertEquals( "1", node2.path("total").asText());
+    assertEquals( "/structured-query/constraint1.xml", node2.path("results").get(0).path("uri").asText());
+    assertEquals( "Bush", strutdDef2.getCriteria());
     // release client
     client.release();
   }
-  
+
   /*
    * Test to verify minimum distance parameter in near method. - Git issue 722
    * One word distance - q1 = The  q 2 = Atlantic :as in The Atlantic
@@ -731,7 +732,7 @@ public class TestStructuredQuery extends AbstractFunctionalTest {
    * Near query on last word min distance = 0 q1 = Monthly and q2 (nothing)  :as in Vannevar Bush wrote an article for The Atlantic Monthly
    * Partial word min distance = 1  - q1 = Th  q 2 = lant :as in The Atlantic
    */
-  
+
   @Test
   public void testNearQueryMinimumDistance() throws KeyManagementException, NoSuchAlgorithmException, IOException, ParserConfigurationException, SAXException, XpathException,
       TransformerException
@@ -761,7 +762,7 @@ public class TestStructuredQuery extends AbstractFunctionalTest {
     StructuredQueryBuilder qb = queryMgr.newStructuredQueryBuilder(queryOptionName);
     StructuredQueryDefinition termQuery1 = qb.term("The");
     StructuredQueryDefinition termQuery2 = qb.term("Atlantic");
-    
+
     StructuredQueryDefinition nearQuery1 = qb.near(1, 6, 1.0, StructuredQueryBuilder.Ordering.ORDERED, termQuery1, termQuery2);
     JacksonHandle resultsHandle = new JacksonHandle();
     queryMgr.search(nearQuery1, resultsHandle);
@@ -769,14 +770,14 @@ public class TestStructuredQuery extends AbstractFunctionalTest {
     // get the Result
     JsonNode result = resultsHandle.get();
     System.out.println("nearQuery1 Results " + result.toString());
-    
-    assertTrue("Search Results total incorrect", result.path("total").asInt() == 2);
-    
+
+    assertTrue( result.path("total").asInt() == 2);
+
     String uri1 = result.path("results").get(0).path("uri").asText().trim();
     String uri2 = result.path("results").get(1).path("uri").asText().trim();
-    assertTrue("URI returned incorrect", uri1.contains("/min-dist/constraint1.xml"));
-    assertTrue("URI returned incorrect", uri2.contains("/min-dist/constraint3.xml"));
-    
+    assertTrue( uri1.contains("/min-dist/constraint1.xml"));
+    assertTrue( uri2.contains("/min-dist/constraint3.xml"));
+
     // create handle - Zero word distance - q1 = The  q 2 = Atlantic :as in The Atlantic
     StructuredQueryDefinition nearQuery2 = qb.near(0, 6, 1.0, StructuredQueryBuilder.Ordering.ORDERED, termQuery1, termQuery2);
 
@@ -787,18 +788,18 @@ public class TestStructuredQuery extends AbstractFunctionalTest {
     // get the Result
     JsonNode result2 = resultsHandle2.get();
     System.out.println("nearQuery2 Results " + result2.toString());
-    
-    assertTrue("Search Results total incorrect", result2.path("total").asInt() == 2);
+
+    assertTrue( result2.path("total").asInt() == 2);
     uri1 = result2.path("results").get(0).path("uri").asText().trim();
     uri2 = result2.path("results").get(1).path("uri").asText().trim();
-    assertTrue("URI returned incorrect", uri1.contains("/min-dist/constraint1.xml"));
-    assertTrue("URI returned incorrect", uri2.contains("/min-dist/constraint3.xml"));
-    
+    assertTrue( uri1.contains("/min-dist/constraint1.xml"));
+    assertTrue( uri2.contains("/min-dist/constraint3.xml"));
+
     //Reverse One word distance - q1 = Atlantic q2 = The :as in  The Atlantic
-    
+
     StructuredQueryDefinition RevtermQuery1 = qb.term("Atlantic");
     StructuredQueryDefinition RevtermQuery2 = qb.term("The");
-    
+
     StructuredQueryDefinition RevnearQuery = qb.near(0, 6, 1.0, StructuredQueryBuilder.Ordering.ORDERED, RevtermQuery1, RevtermQuery2);
 
     // create handle
@@ -808,13 +809,13 @@ public class TestStructuredQuery extends AbstractFunctionalTest {
     // get the Result should be 0
     JsonNode RevResult = RevResultsHandle.get();
     System.out.println("RevnearQuery Results " + RevResult.toString());
-    
-    assertTrue("Search Results total incorrect", RevResult.path("total").asInt() == 0);
-    
+
+    assertTrue( RevResult.path("total").asInt() == 0);
+
     // > 1 min distance  and max distance(2) is less than the actual words in between - q1 = prominent and q2 = intellectual :as Vannevar served as a prominent policymaker and public intellectual
     StructuredQueryDefinition MaxtermQuery1 = qb.term("prominent");
     StructuredQueryDefinition MaxtermQuery2 = qb.term("intellectual");
-   
+
     StructuredQueryDefinition maxnearQuery = qb.near(1, 2, 1.0, StructuredQueryBuilder.Ordering.ORDERED, MaxtermQuery1, MaxtermQuery2);
 
     // create handle
@@ -824,9 +825,9 @@ public class TestStructuredQuery extends AbstractFunctionalTest {
     // get the Result - Should be 0.
     JsonNode resultMax = maxResultsHandle.get();
     System.out.println("maxnearQuery Results " + resultMax.toString());
-    
-    assertTrue("Search Results total incorrect", resultMax.path("total").asInt() == 0);
-    
+
+    assertTrue( resultMax.path("total").asInt() == 0);
+
     // > 1 min distance  and max distance (4) is equal to the actual words in between - q1 = prominent and q2 = intellectual :as Vannevar served as a prominent policymaker and public intellectual
     StructuredQueryDefinition maxnearQuery2 = qb.near(1, 4, 1.0, StructuredQueryBuilder.Ordering.ORDERED, MaxtermQuery1, MaxtermQuery2);
     // create handle
@@ -836,11 +837,11 @@ public class TestStructuredQuery extends AbstractFunctionalTest {
     // get the Result - Should be 0.
     JsonNode resultMax2 = maxResultsHandle2.get();
     System.out.println("maxnearQuery2 Results " + resultMax2.toString());
-    
-    assertTrue("Search Results total incorrect", resultMax2.path("total").asInt() == 1);
+
+    assertTrue( resultMax2.path("total").asInt() == 1);
     uri1 = resultMax2.path("results").get(0).path("uri").asText().trim();
-    assertTrue("URI returned incorrect", uri1.contains("/min-dist/constraint4.xml"));
-    
+    assertTrue( uri1.contains("/min-dist/constraint4.xml"));
+
     // < 1 min distance  and max distance (2) is less than the actual words in between - q1 = prominent and q2 = intellectual :as Vannevar served as a prominent policymaker and public intellectual
     StructuredQueryDefinition NegMinxnearQuery = qb.near(-1, 2, 1.0, StructuredQueryBuilder.Ordering.ORDERED, MaxtermQuery1, MaxtermQuery2);
 
@@ -851,9 +852,9 @@ public class TestStructuredQuery extends AbstractFunctionalTest {
     // get the Result - Should be 0.
     JsonNode ResultNegMin = NegMinxResultsHandle.get();
     System.out.println("NegMinxnearQuery Results " + ResultNegMin.toString());
-    
-    assertTrue("Search Results total incorrect", ResultNegMin.path("total").asInt() == 0);
-    
+
+    assertTrue( ResultNegMin.path("total").asInt() == 0);
+
     // < 1 min distance  and max distance (4) is equal to the actual words in between - q1 = prominent and q2 = intellectual :as Vannevar served as a prominent policymaker and public intellectual
     StructuredQueryDefinition NegMinxnearQuery2 = qb.near(-2, 4, 1.0, StructuredQueryBuilder.Ordering.ORDERED, MaxtermQuery1, MaxtermQuery2);
     // create handle
@@ -863,9 +864,9 @@ public class TestStructuredQuery extends AbstractFunctionalTest {
     // get the Result - Should be 0.
     JsonNode resultNegMin2 = NegMinxResultsHandle2.get();
     System.out.println("NegMinxnearQuery2 Results " + resultNegMin2.toString());
-    assertTrue("Search Results total incorrect", resultNegMin2.path("total").asInt() == 1);
+    assertTrue( resultNegMin2.path("total").asInt() == 1);
     uri1 = resultNegMin2.path("results").get(0).path("uri").asText().trim();
-    assertTrue("URI returned incorrect", uri1.contains("/min-dist/constraint4.xml"));
+    assertTrue( uri1.contains("/min-dist/constraint4.xml"));
 
     // 0 min distance  and 0 max distance words in between - q1 = prominent and q2 = intellectual :as Vannevar served as a prominent policymaker and public intellectual
     StructuredQueryDefinition zeroMinxnearQuery = qb.near(0, 0, 1.0, StructuredQueryBuilder.Ordering.ORDERED, MaxtermQuery1, MaxtermQuery2);
@@ -876,10 +877,10 @@ public class TestStructuredQuery extends AbstractFunctionalTest {
     // get the Result - Should be 0.
     JsonNode ResultZero = zeroMinxResultsHandle.get();
     System.out.println("zeroMinxnearQuery Results " + ResultZero.toString());
-    assertTrue("Search Results total incorrect", ResultZero.path("total").asInt() == 0);
-    
+    assertTrue( ResultZero.path("total").asInt() == 0);
+
     // Same queries One word distance - q1 = Atlantic  q 2 = Atlantic :as in For 1945, the thoughts expressed in The Atlantic Monthly were groundbreaking.
-    
+
     StructuredQueryDefinition SamenearQuery = qb.near(0, 6, 1.0, StructuredQueryBuilder.Ordering.ORDERED, termQuery2, termQuery2);
 
     // create handle
@@ -889,17 +890,17 @@ public class TestStructuredQuery extends AbstractFunctionalTest {
     // get the Result should be 0
     JsonNode SameResult = SameResultsHandle.get();
     System.out.println("SamenearQuery Results " + SameResult.toString());
-    
-    assertTrue("Search Results total incorrect", SameResult.path("total").asInt() == 2);
+
+    assertTrue( SameResult.path("total").asInt() == 2);
     uri1 = SameResult.path("results").get(0).path("uri").asText().trim();
     uri2 = SameResult.path("results").get(1).path("uri").asText().trim();
-    assertTrue("URI returned incorrect", uri1.contains("/min-dist/constraint1.xml"));
-    assertTrue("URI returned incorrect", uri2.contains("/min-dist/constraint3.xml"));
-    
+    assertTrue( uri1.contains("/min-dist/constraint1.xml"));
+    assertTrue( uri2.contains("/min-dist/constraint3.xml"));
+
     // Random queries One word distance - q1 = AAA  q 2 = BBB
     StructuredQueryDefinition randomQuery1 = qb.term("AAA");
     StructuredQueryDefinition randomQuery2 = qb.term("BBB");
-    
+
     StructuredQueryDefinition RandomnearQuery = qb.near(1, 6, 1.0, StructuredQueryBuilder.Ordering.ORDERED, randomQuery1, randomQuery2);
 
     // create handle
@@ -908,13 +909,13 @@ public class TestStructuredQuery extends AbstractFunctionalTest {
 
     // get the Result should be 0
     JsonNode randomResult = RandomResultsHandle.get();
-    System.out.println("RandomenearQuery Results " + randomResult.toString());    
-    assertTrue("Search Results total incorrect", randomResult.path("total").asInt() == 0);
-    
+    System.out.println("RandomenearQuery Results " + randomResult.toString());
+    assertTrue( randomResult.path("total").asInt() == 0);
+
     // Near query on first word min distance = 1 q1 = Vannevar and q2 = wrote :as in Vannevar Bush wrote an article for The Atlantic Monthly
     StructuredQueryDefinition firstQuery1 = qb.term("Vannevar");
     StructuredQueryDefinition firstQuery2 = qb.term("wrote");
-    
+
     StructuredQueryDefinition firstnearQuery = qb.near(1, 6, 1.0, StructuredQueryBuilder.Ordering.ORDERED, firstQuery1, firstQuery2);
 
     // create handle
@@ -923,14 +924,14 @@ public class TestStructuredQuery extends AbstractFunctionalTest {
 
     // get the Result should be 1
     JsonNode firstResult = firstResultsHandle.get();
-    System.out.println("firstnearQuery Results " + firstResult.toString());    
-    assertTrue("Search Results total incorrect", firstResult.path("total").asInt() == 1);
+    System.out.println("firstnearQuery Results " + firstResult.toString());
+    assertTrue( firstResult.path("total").asInt() == 1);
     uri1 = firstResult.path("results").get(0).path("uri").asText().trim();
-    assertTrue("URI returned incorrect", uri1.contains("/min-dist/constraint1.xml"));
-    
+    assertTrue( uri1.contains("/min-dist/constraint1.xml"));
+
     // Near query on last word min distance = 0 q1 = Monthly and q2 (nothing)  :as in Vannevar Bush wrote an article for The Atlantic Monthly
     StructuredQueryDefinition lastQuery1 = qb.term("Monthly");
-    
+
     StructuredQueryDefinition lastnearQuery = qb.near(0, 0, 1.0, StructuredQueryBuilder.Ordering.ORDERED, lastQuery1);
 
     // create handle
@@ -939,17 +940,17 @@ public class TestStructuredQuery extends AbstractFunctionalTest {
 
     // get the Result should be 2
     JsonNode lastResult = lastResultsHandle.get();
-    System.out.println("lastnearQuery Results " + lastResult.toString());    
-    assertTrue("Search Results total incorrect", lastResult.path("total").asInt() == 2);
+    System.out.println("lastnearQuery Results " + lastResult.toString());
+    assertTrue( lastResult.path("total").asInt() == 2);
     uri1 = lastResult.path("results").get(0).path("uri").asText().trim();
     uri2 = lastResult.path("results").get(1).path("uri").asText().trim();
-    assertTrue("URI returned incorrect", uri1.contains("/min-dist/constraint1.xml"));
-    assertTrue("URI returned incorrect", uri2.contains("/min-dist/constraint3.xml"));
-    
+    assertTrue( uri1.contains("/min-dist/constraint1.xml"));
+    assertTrue( uri2.contains("/min-dist/constraint3.xml"));
+
     // Partial word min distance = 1  - q1 = Th  q 2 = lant :as in The Atlantic
     StructuredQueryDefinition PartialQuery1 = qb.term("Th");
     StructuredQueryDefinition PartialQuery2 = qb.term("lant");
-    
+
     StructuredQueryDefinition PartialNearQuery = qb.near(1, 6, 1.0, StructuredQueryBuilder.Ordering.ORDERED, PartialQuery1, PartialQuery2);
     JacksonHandle PartialResultsHandle = new JacksonHandle();
     queryMgr.search(PartialNearQuery, PartialResultsHandle);
@@ -957,9 +958,9 @@ public class TestStructuredQuery extends AbstractFunctionalTest {
     // get the Result - Should be 0
     JsonNode resultpartial = PartialResultsHandle.get();
     System.out.println("PartialNearQuery Results " + resultpartial.toString());
-    
-    assertTrue("Search Results total incorrect", resultpartial.path("total").asInt() == 0);
-    
+
+    assertTrue( resultpartial.path("total").asInt() == 0);
+
     // release client
     client.release();
   }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestStructuredQueryMildNot.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestStructuredQueryMildNot.java
@@ -23,7 +23,8 @@ import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.query.StructuredQueryBuilder;
 import com.marklogic.client.query.StructuredQueryDefinition;
 import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestStructuredSearchGeo.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestStructuredSearchGeo.java
@@ -23,7 +23,8 @@ import com.marklogic.client.query.StructuredQueryBuilder;
 import com.marklogic.client.query.StructuredQueryDefinition;
 import com.marklogic.client.util.EditableNamespaceContext;
 import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
@@ -35,7 +36,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Collection;
 
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
-import static org.junit.Assert.assertEquals;
+
 
 public class TestStructuredSearchGeo extends AbstractFunctionalTest {
 
@@ -141,7 +142,7 @@ public class TestStructuredSearchGeo extends AbstractFunctionalTest {
 
     StructuredQueryDefinition geoQuery = qb.geospatial(qb.geoPath(qb.pathIndex("/doc/g-elem-point")), qb.box(-12, -5, -11, -4));
     Collection<String> nameSpaceCollection = qb.getNamespaces().getAllPrefixes();
-    assertEquals("getNamespace failed ", false, nameSpaceCollection.isEmpty());
+    assertEquals( false, nameSpaceCollection.isEmpty());
     for (String prefix : nameSpaceCollection) {
       System.out.println("Prefixes : " + prefix);
       System.out.println(qb.getNamespaces().getNamespaceURI(prefix));

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestTransformXMLWithXSLT.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestTransformXMLWithXSLT.java
@@ -20,7 +20,8 @@ import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.document.XMLDocumentManager;
 import com.marklogic.client.io.FileHandle;
 import com.marklogic.client.io.SourceHandle;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import javax.xml.transform.*;
 import javax.xml.transform.stream.StreamSource;
@@ -28,7 +29,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.Scanner;
 
-import static org.junit.Assert.assertTrue;
+
 
 public class TestTransformXMLWithXSLT extends AbstractFunctionalTest {
 
@@ -78,9 +79,9 @@ public class TestTransformXMLWithXSLT extends AbstractFunctionalTest {
         String readContent = scanner.next();
         // String transformedContent = readContent.replaceAll("^name$",
         // "firstname");
-        // assertEquals("XML document write difference", transformedContent,
+        // assertEquals( transformedContent,
         // readContent);
-        assertTrue("check document from DB has name element changed", readContent.contains("firstname"));
+        assertTrue( readContent.contains("firstname"));
         scanner.close();
         handle.close();
     }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestValueConstraint.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestValueConstraint.java
@@ -26,8 +26,9 @@ import com.marklogic.client.query.MatchDocumentSummary;
 import com.marklogic.client.query.MatchLocation;
 import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.query.StringQueryDefinition;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
@@ -35,13 +36,13 @@ import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 
-import static org.junit.Assert.assertEquals;
+
 
 public class TestValueConstraint extends AbstractFunctionalTest {
 
   static final private String[] filenames = { "value-constraint-doc.xml", "value-constraint-doc2.xml" };
 
-  @After
+  @AfterEach
   public void testCleanUp() throws Exception
   {
     deleteDocuments(connectAsAdmin());
@@ -128,7 +129,7 @@ public class TestValueConstraint extends AbstractFunctionalTest {
     }
 
     String expectedSearchMatch = "Matched 1 locations in /value-constraint/value-constraint-doc2.xml";
-    assertEquals("Search match difference", expectedSearchMatch, searchMatch);
+    assertEquals( expectedSearchMatch, searchMatch);
 
     // release client
     client.release();
@@ -215,7 +216,7 @@ public class TestValueConstraint extends AbstractFunctionalTest {
     }
 
     String expectedSearchMatch = "Matched 1 locations in /value-constraint/value-constraint-doc.xml";
-    assertEquals("Search match difference", expectedSearchMatch, searchMatch);
+    assertEquals( expectedSearchMatch, searchMatch);
 
     // release client
     client.release();

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestWordConstraint.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestWordConstraint.java
@@ -18,13 +18,14 @@ package com.marklogic.client.fastfunctest;
 
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.io.SearchHandle;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 
-import static org.junit.Assert.assertEquals;
+
 
 public class TestWordConstraint extends AbstractFunctionalTest {
 
@@ -55,7 +56,7 @@ public class TestWordConstraint extends AbstractFunctionalTest {
 
     System.out.println(searchResult);
 
-    assertEquals("Search result difference", expectedSearchResult, searchResult);
+    assertEquals( expectedSearchResult, searchResult);
 
     // release client
     client.release();

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestWriteTextDoc.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestWriteTextDoc.java
@@ -19,9 +19,10 @@ package com.marklogic.client.fastfunctest;
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.document.TextDocumentManager;
 import com.marklogic.client.io.StringHandle;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-import static org.junit.Assert.assertEquals;
+
 
 public class TestWriteTextDoc extends AbstractFunctionalTest {
 
@@ -32,6 +33,6 @@ public class TestWriteTextDoc extends AbstractFunctionalTest {
         String docId = "/foo/test/myFoo.txt";
         TextDocumentManager docMgr = client.newTextDocumentManager();
         docMgr.write(docId, new StringHandle().with("This is so foo"));
-        assertEquals("Text document write difference", "This is so foo", docMgr.read(docId, new StringHandle()).get());
+        assertEquals( "This is so foo", docMgr.read(docId, new StringHandle()).get());
     }
 }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestXMLDocumentRepair.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestXMLDocumentRepair.java
@@ -20,7 +20,8 @@ import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.document.XMLDocumentManager;
 import com.marklogic.client.document.XMLDocumentManager.DocumentRepair;
 import com.marklogic.client.io.FileHandle;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -28,7 +29,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.Scanner;
 
-import static org.junit.Assert.assertEquals;
+
 
 public class TestXMLDocumentRepair extends AbstractFunctionalTest {
 
@@ -92,7 +93,7 @@ public class TestXMLDocumentRepair extends AbstractFunctionalTest {
 
         Scanner scanner = new Scanner(fileRead).useDelimiter("\\Z");
         String readContent = scanner.next();
-        assertEquals("XML document write difference", repairedContent, readContent);
+        assertEquals( repairedContent, readContent);
         scanner.close();
 
         // release the client

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestXMLMultiByte.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestXMLMultiByte.java
@@ -18,7 +18,8 @@ package com.marklogic.client.fastfunctest;
 
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.io.DOMHandle;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
@@ -28,7 +29,7 @@ import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 
-import static org.junit.Assert.assertEquals;
+
 
 public class TestXMLMultiByte extends AbstractFunctionalTest {
 
@@ -55,16 +56,16 @@ public class TestXMLMultiByte extends AbstractFunctionalTest {
     // get xml document for expected result
     Document expectedDoc = expectedXMLDocument(filename);
 
-    assertEquals("Incorrect yen value", readDoc.getElementsByTagName("yen").item(0).getFirstChild().getNodeValue(),
+    assertEquals( readDoc.getElementsByTagName("yen").item(0).getFirstChild().getNodeValue(),
         expectedDoc.getElementsByTagName("yen").item(0).getFirstChild().getNodeValue());
 
-    assertEquals("Incorrect haba value", readDoc.getElementsByTagName("haba").item(0).getFirstChild().getNodeValue(),
+    assertEquals( readDoc.getElementsByTagName("haba").item(0).getFirstChild().getNodeValue(),
         expectedDoc.getElementsByTagName("haba").item(0).getFirstChild().getNodeValue());
 
-    assertEquals("Incorrect chinese value", readDoc.getElementsByTagName("chinese").item(0).getFirstChild().getNodeValue(),
+    assertEquals( readDoc.getElementsByTagName("chinese").item(0).getFirstChild().getNodeValue(),
         expectedDoc.getElementsByTagName("chinese").item(0).getFirstChild().getNodeValue());
 
-    assertEquals("Incorrect trademark value", readDoc.getElementsByTagName("trademark").item(0).getFirstChild().getNodeValue(),
+    assertEquals( readDoc.getElementsByTagName("trademark").item(0).getFirstChild().getNodeValue(),
         expectedDoc.getElementsByTagName("trademark").item(0).getFirstChild().getNodeValue());
 
     // update the doc
@@ -81,19 +82,19 @@ public class TestXMLMultiByte extends AbstractFunctionalTest {
     // get xml document for expected result
     Document expectedDocUpdate = expectedXMLDocument(updateFilename);
 
-    assertEquals("Incorrect yen value", readDocUpdate.getElementsByTagName("yen").item(0).getFirstChild().getNodeValue(),
+    assertEquals( readDocUpdate.getElementsByTagName("yen").item(0).getFirstChild().getNodeValue(),
         expectedDocUpdate.getElementsByTagName("yen").item(0).getFirstChild().getNodeValue());
 
-    assertEquals("Incorrect haba value", readDocUpdate.getElementsByTagName("haba").item(0).getFirstChild().getNodeValue(),
+    assertEquals( readDocUpdate.getElementsByTagName("haba").item(0).getFirstChild().getNodeValue(),
         expectedDocUpdate.getElementsByTagName("haba").item(0).getFirstChild().getNodeValue());
 
-    assertEquals("Incorrect chinese value", readDocUpdate.getElementsByTagName("chinese").item(0).getFirstChild().getNodeValue(),
+    assertEquals( readDocUpdate.getElementsByTagName("chinese").item(0).getFirstChild().getNodeValue(),
         expectedDocUpdate.getElementsByTagName("chinese").item(0).getFirstChild().getNodeValue());
 
-    assertEquals("Incorrect trademark value", readDocUpdate.getElementsByTagName("trademark").item(0).getFirstChild().getNodeValue(),
+    assertEquals( readDocUpdate.getElementsByTagName("trademark").item(0).getFirstChild().getNodeValue(),
         expectedDocUpdate.getElementsByTagName("trademark").item(0).getFirstChild().getNodeValue());
 
-    assertEquals("Incorrect kanji value", readDocUpdate.getElementsByTagName("kanji").item(0).getFirstChild().getNodeValue(),
+    assertEquals( readDocUpdate.getElementsByTagName("kanji").item(0).getFirstChild().getNodeValue(),
         expectedDocUpdate.getElementsByTagName("kanji").item(0).getFirstChild().getNodeValue());
 
     // delete the document

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/BulkIOCallersFnTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/BulkIOCallersFnTest.java
@@ -15,15 +15,6 @@
  */
 package com.marklogic.client.functionaltest;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import java.io.*;
-import java.nio.charset.StandardCharsets;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.stream.Stream;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -32,10 +23,6 @@ import com.marklogic.client.DatabaseClient.ConnectionType;
 import com.marklogic.client.DatabaseClientFactory;
 import com.marklogic.client.DatabaseClientFactory.SecurityContext;
 import com.marklogic.client.dataservices.*;
-import com.marklogic.client.dataservices.ExecEndpoint.BulkExecCaller;
-import com.marklogic.client.dataservices.InputEndpoint.BulkInputCaller;
-import com.marklogic.client.dataservices.InputOutputEndpoint.BulkInputOutputCaller;
-import com.marklogic.client.dataservices.OutputEndpoint.BulkOutputCaller;
 import com.marklogic.client.document.JSONDocumentManager;
 import com.marklogic.client.document.TextDocumentManager;
 import com.marklogic.client.io.*;
@@ -44,14 +31,16 @@ import com.marklogic.client.io.marker.BufferableHandle;
 import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.query.StructuredQueryBuilder;
 import com.marklogic.client.query.StructuredQueryDefinition;
+import org.junit.jupiter.api.*;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BulkIOCallersFnTest extends BasicJavaClientREST {
     private static String dbName = "DynamicIngestServicesDB";
@@ -124,7 +113,7 @@ public class BulkIOCallersFnTest extends BasicJavaClientREST {
     // Annotation size endpoint URI
     private static String BulkSizeCheckURI = "/dynamic/fntest/BulkSizeVerify/json/";
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() throws Exception {
         System.out.println("In setup");
         loadGradleProperties();
@@ -333,13 +322,13 @@ public class BulkIOCallersFnTest extends BasicJavaClientREST {
         handle = null;
     }
 
-    @Before
+    @BeforeEach
     public void before() throws Exception {
         System.out.println("In before");
         dbclient = DatabaseClientFactory.newClient(host, restTestport, secContext, ConnectionType.DIRECT);
     }
 
-    @After
+    @AfterEach
     public void after() throws Exception {
         System.out.println("In after");
         // Delete all docs
@@ -347,7 +336,7 @@ public class BulkIOCallersFnTest extends BasicJavaClientREST {
         dbclient.release();
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDownAfterClass() throws Exception {
         System.out.println("In tear down");
 
@@ -464,13 +453,13 @@ public class BulkIOCallersFnTest extends BasicJavaClientREST {
             // # of root elements should be 5.
             System.out.println("Batch results from TestIngestEgressOnJsonDocs " + res);
 
-            assertTrue("No of docs egressed incorrect. Expected 5.", (res.split("\\btitle\\b").length -1) == 5);
-            assertTrue("No of docs egressed incorrect. Expected only 1 wrote word.", (res.split("\\bwrote\\b").length - 1) == 1);
-            assertTrue("No of docs egressed incorrect. Expected only 1 described word.", (res.split("\\bdescribed\\b").length - 1) == 1);
-            assertTrue("No of docs egressed incorrect. Expected only 1 groundbreaking word.", (res.split("\\bgroundbreaking\\b").length - 1) == 1);
-            assertTrue("No of docs egressed incorrect. Expected only 1 intellectual word.", (res.split("\\bintellectual\\b").length - 1) == 1);
-            assertTrue("No of docs egressed incorrect. Expected only 1 unfortunately word.", (res.split("\\bunfortunately\\b").length - 1) == 1);
-            assertTrue("Unexpected Errors during egress. Should not have any errors.", err.toString().isEmpty());
+            assertTrue((res.split("\\btitle\\b").length -1) == 5);
+            assertTrue((res.split("\\bwrote\\b").length - 1) == 1);
+            assertTrue((res.split("\\bdescribed\\b").length - 1) == 1);
+            assertTrue((res.split("\\bgroundbreaking\\b").length - 1) == 1);
+            assertTrue((res.split("\\bintellectual\\b").length - 1) == 1);
+            assertTrue((res.split("\\bunfortunately\\b").length - 1) == 1);
+            assertTrue(err.toString().isEmpty());
             System.out.println("End of TestIngestEgressOnJsonDocs");
         }
     }
@@ -542,9 +531,9 @@ public class BulkIOCallersFnTest extends BasicJavaClientREST {
             String res = batchResults.toString();
             System.out.println(res);
 
-            assertTrue("Document returned from egressed incorrect.", res.contains("This is the return doc content"));
-            assertTrue("Document returned from egressed incorrect.", res.contains("Java Client API"));
-            assertTrue("Unexpected Errors during egress. ", err.toString().isEmpty());
+            assertTrue(res.contains("This is the return doc content"));
+            assertTrue(res.contains("Java Client API"));
+            assertTrue(err.toString().isEmpty());
 
             QueryManager queryMgr = dbclient.newQueryManager();
             StructuredQueryBuilder qb =  new StructuredQueryBuilder();
@@ -556,7 +545,7 @@ public class BulkIOCallersFnTest extends BasicJavaClientREST {
             // get the result
             JsonNode resultDoc = resultsHandle.get();
             int total = resultDoc.get("total").asInt();
-            assertTrue("No of Documents returned from egressed collection incorrect.", total == 5);
+            assertTrue(total == 5);
 
             System.out.println("End of TestIngestEgressSessionFields");
         }
@@ -597,7 +586,7 @@ public class BulkIOCallersFnTest extends BasicJavaClientREST {
             // Assert
             int docCnt = dbclient.newServerEval().xquery(query1).eval().next().getNumber().intValue();
             System.out.println("TestIngestEgressOnLargeNumJsonDocs - Doc count is " + docCnt);
-            Assert.assertTrue(docCnt == maxDocSize + 1);
+            assertTrue(docCnt == maxDocSize + 1);
 
             // Verify the Annotation value stored within a doc.
             JSONDocumentManager mgr = dbclient.newJSONDocumentManager();
@@ -606,7 +595,7 @@ public class BulkIOCallersFnTest extends BasicJavaClientREST {
             int nAnnotValue =  jh.get().get("length").asInt();
             // 100 is default value .api -> inputBatchSize property
             System.out.println("TestIngestEgressOnLargeNumJsonDocs - inputBatchSize property value is " + nAnnotValue);
-            Assert.assertTrue(nAnnotValue == 100);
+            assertTrue(nAnnotValue == 100);
 
         } catch (Exception e) {
             e.printStackTrace();
@@ -655,7 +644,7 @@ public class BulkIOCallersFnTest extends BasicJavaClientREST {
 
             int docCnt = dbclient.newServerEval().xquery(query1).eval().next().getNumber().intValue();
             System.out.println("No. of Xml docs is " + docCnt);
-            Assert.assertTrue(docCnt == 5);
+            assertTrue(docCnt == 5);
 
         } catch (Exception e) {
             e.printStackTrace();
@@ -697,7 +686,7 @@ public class BulkIOCallersFnTest extends BasicJavaClientREST {
             input.forEach(inputbulkCaller::accept);
             inputbulkCaller.awaitCompletion();
 
-            Assert.assertTrue(dbclient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 5);
+            assertTrue(dbclient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 5);
 
         } catch (Exception e) {
             e.printStackTrace();
@@ -751,8 +740,8 @@ public class BulkIOCallersFnTest extends BasicJavaClientREST {
             inputbulkCaller.awaitCompletion();
             String errStr = errorBuf.toString();
             //System.out.println("Error buffer when STOP_ALL_CALLS " + errorBuf.toString());
-            Assert.assertTrue(!errStr.contains("Exception"));
-            Assert.assertTrue(errStr.isEmpty());
+            assertTrue(!errStr.contains("Exception"));
+            assertTrue(errStr.isEmpty());
 
         } catch (Exception e) {
             e.printStackTrace();
@@ -795,7 +784,7 @@ public class BulkIOCallersFnTest extends BasicJavaClientREST {
             input.forEach(inputbulkCaller::accept);
             inputbulkCaller.awaitCompletion();
 
-            Assert.assertTrue(dbclient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 5);
+            assertTrue(dbclient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 5);
 
         } catch (Exception e) {
             e.printStackTrace();
@@ -869,7 +858,7 @@ public class BulkIOCallersFnTest extends BasicJavaClientREST {
             JsonNode results = resultsHandle.get();
             int total = results.get("total").asInt();
 
-            assertEquals("Incorrect exec. Total from query search incorrect." ,5, total);
+            assertEquals(5, total);
 
             Set<String> uriResulttSet = new TreeSet<String>();
             Set<String> uriExptdSet = new TreeSet<String>();
@@ -885,7 +874,7 @@ public class BulkIOCallersFnTest extends BasicJavaClientREST {
             uriResulttSet.add(results.get("results").get(2).get("uri").asText());
             uriResulttSet.add(results.get("results").get(3).get("uri").asText());
             uriResulttSet.add(results.get("results").get(4).get("uri").asText());
-            assertTrue("Incorrect exec. URIs returned mismatch.",uriExptdSet.containsAll(uriResulttSet));
+            assertTrue(uriExptdSet.containsAll(uriResulttSet));
 
         } catch (Exception e) {
             e.printStackTrace();
@@ -898,7 +887,7 @@ public class BulkIOCallersFnTest extends BasicJavaClientREST {
     // Use /dynamic/fntest/DynamicIngestServices/json/DynamicIngestServicesForJson.sjs endpoint to test JSON Documents ingest
     // The api file contents are in a JSON node; not in a file.
     @Test
-    public void TestBulkAnnotationSize() throws Exception {
+    public void TestBulkAnnotationSize() {
         System.out.println("Running TestBulkAnnotationSize");
         try {
             int startBatchIdx = 0;
@@ -930,7 +919,7 @@ public class BulkIOCallersFnTest extends BasicJavaClientREST {
             int docCnt = dbclient.newServerEval().xquery(query1).eval().next().getNumber().intValue();
             System.out.println("TestBulkAnnotationSize - Doc count is " + docCnt);
             // One additional document holds the $bulk annotation value.
-            Assert.assertTrue(docCnt == maxDocSize + 1);
+            assertTrue(docCnt == maxDocSize + 1);
 
             // Verify the Annotation value stored within a doc.
             JSONDocumentManager mgr = dbclient.newJSONDocumentManager();
@@ -939,7 +928,7 @@ public class BulkIOCallersFnTest extends BasicJavaClientREST {
             int nAnnotValue =  jh.get().get("length").asInt();
             // 8 is stored in BulkSizeCheckForJson.api -> inputBatchSize property
             System.out.println("TestBulkAnnotationSize - inputBatchSize property value is " + nAnnotValue);
-            Assert.assertTrue(nAnnotValue == 8);
+            assertTrue(nAnnotValue == 8);
 
         } catch (Exception e) {
             e.printStackTrace();
@@ -1035,7 +1024,7 @@ public class BulkIOCallersFnTest extends BasicJavaClientREST {
             e.printStackTrace();
         }
         finally {
-            assertTrue("Error returned incorrect", retryBuf.toString().contains("Internal Server Error."));
+            assertTrue(retryBuf.toString().contains("Internal Server Error."));
             System.out.println("Error buffer is " + retryBuf.toString());
             System.out.println("Unloader completed in TestIngestEgressOnJsonDocsError");
         }
@@ -1214,18 +1203,18 @@ public class BulkIOCallersFnTest extends BasicJavaClientREST {
             JsonNode resultDoc = resultsHandle.get();
             System.out.println(resultDoc.asText());
             int total = resultDoc.get("total").asInt();
-            assertTrue("No of Documents returned from egressed collection incorrect.", total == 5);
+            assertTrue(total == 5);
 
-            assertTrue("No of Json docs egressed incorrect. Expected 5.", (resJson.split("\\btitle\\b").length -1) == 5);
-            assertTrue("No of Json docs egressed incorrect. Expected only 1 wrote word.", (resJson.split("\\bwrote\\b").length - 1) == 1);
-            assertTrue("No of Json docs egressed incorrect. Expected only 1 described word.", (resJson.split("\\bdescribed\\b").length - 1) == 1);
-            assertTrue("No of Json docs egressed incorrect. Expected only 1 groundbreaking word.", (resJson.split("\\bgroundbreaking\\b").length - 1) == 1);
-            assertTrue("No of Json docs egressed incorrect. Expected only 1 intellectual word.", (resJson.split("\\bintellectual\\b").length - 1) == 1);
-            assertTrue("No of Json docs egressed incorrect. Expected only 1 unfortunately word.", (resJson.split("\\bunfortunately\\b").length - 1) == 1);
+            assertTrue((resJson.split("\\btitle\\b").length -1) == 5);
+            assertTrue((resJson.split("\\bwrote\\b").length - 1) == 1);
+            assertTrue((resJson.split("\\bdescribed\\b").length - 1) == 1);
+            assertTrue((resJson.split("\\bgroundbreaking\\b").length - 1) == 1);
+            assertTrue((resJson.split("\\bintellectual\\b").length - 1) == 1);
+            assertTrue((resJson.split("\\bunfortunately\\b").length - 1) == 1);
 
-            assertTrue("Xml docs egressed incorrect.", resXml.contains("baz"));
-            assertTrue("Xml docs egressed incorrect.", resXml.contains("three"));
-            assertTrue("Unexpected Errors during egress. Should not have any errors.", err.toString().isEmpty());
+            assertTrue(resXml.contains("baz"));
+            assertTrue(resXml.contains("three"));
+            assertTrue(err.toString().isEmpty());
             System.out.println("End of TestIngestEgressOnAnyDocument");
         }
     }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestAutomatedPathRangeIndex.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestAutomatedPathRangeIndex.java
@@ -16,28 +16,6 @@
 
 package com.marklogic.client.functionaltest;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.security.KeyManagementException;
-import java.security.NoSuchAlgorithmException;
-import java.util.List;
-
-import org.apache.http.HttpResponse;
-import org.apache.http.auth.AuthScope;
-import org.apache.http.auth.UsernamePasswordCredentials;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.DefaultHttpClient;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marklogic.client.DatabaseClient;
@@ -48,17 +26,32 @@ import com.marklogic.client.pojo.PojoQueryBuilder.Operator;
 import com.marklogic.client.pojo.PojoQueryDefinition;
 import com.marklogic.client.pojo.PojoRepository;
 import com.marklogic.client.pojo.util.GenerateIndexConfig;
+import org.apache.http.HttpResponse;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.junit.jupiter.api.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /*
  * Purpose : To test the following data type range path index can be created in a database.
- * 
- * int - Verifies that the configuration file is generated, which is then used by MarkLogic Admin user to generate range index. 
+ *
+ * int - Verifies that the configuration file is generated, which is then used by MarkLogic Admin user to generate range index.
  * String - Verifies that the configuration file is generated.
  * dateTime- Verifies that the configuration file is generated.
  * daytimeduration* - This needs Java SE 8. Not tested in this class
  * URI- Verifies that the configuration file is generated.
  * Numerals as Strings* - Verifies that the configuration file is generated.
- * Integer - This class has additional range index search test methods for Integer type (Git issue # 222). 
+ * Integer - This class has additional range index search test methods for Integer type (Git issue # 222).
  * Float - Same as for Integer type. This class has additional range index search test methods for Float type (Git issue # 222).
  */
 
@@ -70,7 +63,7 @@ public class TestAutomatedPathRangeIndex extends BasicJavaClientREST {
   private static String appServerHostname = null;
   private static int adminPort = 0;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpBeforeClass() throws Exception {
     System.out.println("In setup");
     configureRESTServer(dbName, fNames);
@@ -80,18 +73,18 @@ public class TestAutomatedPathRangeIndex extends BasicJavaClientREST {
     adminPort = getAdminPort();
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownAfterClass() throws Exception {
     System.out.println("In tear down");
     cleanupRESTServer(dbName, fNames);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     client = getDatabaseClient("admin", "admin", getConnType());
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     // release client
     client.release();
@@ -131,11 +124,11 @@ public class TestAutomatedPathRangeIndex extends BasicJavaClientREST {
 
           boolean contains = pathExpressValue.contains(propValueJsonDecorated);
           propertyAvailable = contains == true ? (" contains " + propValue) : (" does not contain " + propValue);
-          assertTrue(new StringBuffer("Database : " + dbName + propertyAvailable).toString(), contains);
+          assertTrue(contains, new StringBuffer("Database : " + dbName + propertyAvailable).toString());
         }
 
       } else {
-        assertTrue("Path range property not available or database properties not avilable", propFound);
+        assertTrue(propFound, "Path range property not available or database properties not avilable");
       }
     } catch (Exception e) {
       // writing error to Log
@@ -180,20 +173,18 @@ public class TestAutomatedPathRangeIndex extends BasicJavaClientREST {
           String propValueJsonDecorated1 = "[\"" + propValue[0];
 
           boolean contains1 = pathExpressValue1.contains(propValueJsonDecorated1);
-          propertyAvailable1 = contains1 == true ? (" contains " + propValue[0]) : (" does not contain " + propValue[0]);
-          assertTrue(new StringBuffer("Database : " + dbName + propertyAvailable1).toString(), contains1);
+          assertTrue(contains1);
 
           // Validate the second propValue at index 1. we have only two
           String pathExpressValue2 = (jsonStringList1.get(1)).findValues("path-expression").toString();
           String propValueJsonDecorated2 = propValue[1] + "\"]";
 
           boolean contains2 = pathExpressValue2.contains(propValueJsonDecorated2);
-          propertyAvailable2 = contains2 == true ? (" contains " + propValue[1]) : (" does not contain " + propValue[1]);
-          assertTrue(new StringBuffer("Database : " + dbName + propertyAvailable2).toString(), contains2);
+          assertTrue(contains2);
         }
 
       } else {
-        assertTrue("Path range property not available or database properties not avilable", propFound);
+        assertTrue(propFound);
       }
     } catch (Exception e) {
       // writing error to Log
@@ -221,9 +212,8 @@ public class TestAutomatedPathRangeIndex extends BasicJavaClientREST {
         succeeded = true;
         validateRangePathIndexInDatabase("range-path-index", "com.marklogic.client.functionaltest.ArtifactIndexedOnInt/inventory");
       } else {
-        assertTrue(
-            "testArtifactIndexedOnInt - No Json node available to insert into database",
-            succeeded);
+        assertTrue(succeeded,
+            "testArtifactIndexedOnInt - No Json node available to insert into database");
       }
 
     } catch (IOException e) {
@@ -260,9 +250,7 @@ public class TestAutomatedPathRangeIndex extends BasicJavaClientREST {
         succeeded = true;
         validateRangePathIndexInDatabase("range-path-index", "com.marklogic.client.functionaltest.ArtifactIndexedOnInteger/inventory");
       } else {
-        assertTrue(
-            "testArtifactIndexedOnInteger - No Json node available to insert into database",
-            succeeded);
+        assertTrue(succeeded, "testArtifactIndexedOnInteger - No Json node available to insert into database");
       }
     } catch (Exception e) {
       System.out.println(e.getMessage());
@@ -285,7 +273,7 @@ public class TestAutomatedPathRangeIndex extends BasicJavaClientREST {
       /*
        * The following exception was seen when there was no sleep. (broken into
        * multiple lines for easy reading):
-       * 
+       *
        * com.marklogic.client.FailedRequestException: Local message: search
        * failed: Bad Request. Server Message: XDMP-PATHRIDXNOTFOUND:
        * cts:search(fn:collection(), cts:and-query((cts:path-range-query(
@@ -300,7 +288,7 @@ public class TestAutomatedPathRangeIndex extends BasicJavaClientREST {
 
       pojoPage = products.search(qd, 1, jh);
 
-      assertEquals("total no of pages", 1, pojoPage.getTotalPages());
+      assertEquals(1, pojoPage.getTotalPages());
 
       long pageNo = 1, count = 0;
       do {
@@ -309,10 +297,10 @@ public class TestAutomatedPathRangeIndex extends BasicJavaClientREST {
         while (pojoPage.hasNext()) {
           ArtifactIndexedOnInteger a = pojoPage.next();
           validateArtifact(a);
-          assertTrue("Verifying document id is part of the search ids", a.getId() >= 55);
+          assertTrue(a.getId() >= 55);
           count++;
         }
-        assertEquals("Page size", count, pojoPage.size());
+        assertEquals(count, pojoPage.size());
         pageNo = pageNo + pojoPage.getPageSize();
       } while (!pojoPage.isLastPage() && pageNo <= pojoPage.getTotalSize());
 
@@ -345,9 +333,7 @@ public class TestAutomatedPathRangeIndex extends BasicJavaClientREST {
         succeeded = true;
         validateRangePathIndexInDatabase("range-path-index", "com.marklogic.client.functionaltest.ArtifactIndexedOnString/name");
       } else {
-        assertTrue(
-            "testArtifactIndexedOnString - No Json node available to insert into database",
-            succeeded);
+        assertTrue(succeeded, "testArtifactIndexedOnString - No Json node available to insert into database");
       }
 
     } catch (IOException e) {
@@ -379,9 +365,7 @@ public class TestAutomatedPathRangeIndex extends BasicJavaClientREST {
         succeeded = true;
         validateRangePathIndexInDatabase("range-path-index", "com.marklogic.client.functionaltest.ArtifactIndexedOnDateTime/expiryDate");
       } else {
-        assertTrue(
-            "testArtifactIndexedOnDateTime - No Json node available to insert into database",
-            succeeded);
+        assertTrue(succeeded, "testArtifactIndexedOnString - No Json node available to insert into database");
       }
 
     } catch (IOException e) {
@@ -413,9 +397,7 @@ public class TestAutomatedPathRangeIndex extends BasicJavaClientREST {
         succeeded = true;
         validateRangePathIndexInDatabase("range-path-index", "com.marklogic.client.functionaltest.ArtifactIndexedOnFloat/price");
       } else {
-        assertTrue(
-            "testArtifactIndexedOFloat - No Json node available to insert into database",
-            succeeded);
+        assertTrue(succeeded, "testArtifactIndexedOFloat - No Json node available to insert into database");
       }
 
     } catch (IOException e) {
@@ -447,9 +429,7 @@ public class TestAutomatedPathRangeIndex extends BasicJavaClientREST {
         succeeded = true;
         validateRangePathIndexInDatabase("range-path-index", "com.marklogic.client.functionaltest.ArtifactIndexedOnUri/artifactUri");
       } else {
-        assertTrue(
-            "testArtifactIndexedOnUri - No Json node available to insert into database",
-            succeeded);
+        assertTrue(succeeded, "testArtifactIndexedOnUri - No Json node available to insert into database");
       }
 
     } catch (IOException e) {
@@ -481,9 +461,7 @@ public class TestAutomatedPathRangeIndex extends BasicJavaClientREST {
         succeeded = true;
         validateRangePathIndexInDatabase("range-path-index", "com.marklogic.client.functionaltest.ArtifactIndexedOnIntAsString/inventory");
       } else {
-        assertTrue(
-            "testArtifactIndexedOnIntAsString - No Json node available to insert into database",
-            succeeded);
+        assertTrue(succeeded, "testArtifactIndexedOnIntAsString - No Json node available to insert into database");
       }
 
     } catch (IOException e) {
@@ -519,9 +497,7 @@ public class TestAutomatedPathRangeIndex extends BasicJavaClientREST {
         succeeded = true;
         validateMultipleRangePathIndexInDatabase("range-path-index", propValueStrArray);
       } else {
-        assertTrue(
-            "testArtifactIndexedOnIntAsString - No Json node available to insert into database",
-            succeeded);
+        assertTrue(succeeded, "testArtifactIndexedOnIntAsString - No Json node available to insert into database");
       }
 
     } catch (IOException e) {
@@ -557,9 +533,7 @@ public class TestAutomatedPathRangeIndex extends BasicJavaClientREST {
         succeeded = true;
         validateMultipleRangePathIndexInDatabase("range-path-index", propValueStrArray);
       } else {
-        assertTrue(
-            "testArtifactIndexedOnStringInSuperClass - No Json node available to insert into database",
-            succeeded);
+        assertTrue(succeeded, "testArtifactIndexedOnStringInSuperClass - No Json node available to insert into database");
       }
 
     } catch (IOException e) {
@@ -591,9 +565,7 @@ public class TestAutomatedPathRangeIndex extends BasicJavaClientREST {
         succeeded = true;
         validateRangePathIndexInDatabase("range-path-index", "com.marklogic.client.functionaltest.ArtifactMultipleIndexedOnInt/inventory");
       } else {
-        assertTrue(
-            "testArtifactMultipleIndexedOnInt - No Json node available to insert into database",
-            succeeded);
+        assertTrue(succeeded, "testArtifactMultipleIndexedOnInt - No Json node available to insert into database");
       }
 
     } catch (IOException e) {
@@ -612,16 +584,16 @@ public class TestAutomatedPathRangeIndex extends BasicJavaClientREST {
    * annotation declared on user defined data type will ONLY accept types from
    * scalarType class. Assigning a scalarType.Company to the class member in the
    * annotation like below, WILL NOT COMPILE:
-   * 
+   *
    * @PathIndexProperty(scalarType = ScalarType.Company) public Company
    * manufacture;
-   * 
+   *
    * However, for the following, we can declare for example for class property
    * Company (which is user defined type), the scalarType.STRING in the class.
-   * 
+   *
    * @PathIndexProperty(scalarType = ScalarType.STRING) public Company
    * manufacture;
-   * 
+   *
    * MarkLogic server accepts this range path index and this was verified
    * manually through the MarkLogic administration GUI on the database also.
    */
@@ -644,9 +616,7 @@ public class TestAutomatedPathRangeIndex extends BasicJavaClientREST {
         succeeded = true;
         validateRangePathIndexInDatabase("range-path-index", "com.marklogic.client.functionaltest.ArtifactIndexedUnSupportedDataType/manufacturer");
       } else {
-        assertTrue(
-            "testArtifactIndexedOnUnSupportedAsString - No Json node available to insert into database",
-            succeeded);
+        assertTrue(succeeded, "testArtifactIndexedOnUnSupportedAsString - No Json node available to insert into database");
       }
 
     } catch (IOException e) {
@@ -664,9 +634,9 @@ public class TestAutomatedPathRangeIndex extends BasicJavaClientREST {
    * The following three methods are used to validate "search on range index"
    * when POJO class ArtifactIndexedOnInteger has been annotated for path range
    * index as below:
-   * 
+   *
    * @PathIndexProperty(scalarType = ScalarType.INT) private Integer inventory;
-   * 
+   *
    * These methods are used to validate Git Issue # 222.
    */
   public void loadSimplePojos(PojoRepository<ArtifactIndexedOnInteger, String> products)
@@ -729,9 +699,9 @@ public class TestAutomatedPathRangeIndex extends BasicJavaClientREST {
 
   public void validateArtifact(ArtifactIndexedOnInteger art)
   {
-    assertNotNull("Artifact object should never be Null", art);
-    assertNotNull("Id should never be Null", art.id);
-    assertTrue("Inventry is always greater than 1000", art.getInventory() > 1000);
+    assertNotNull(art);
+    assertNotNull(art.id);
+    assertTrue(art.getInventory() > 1000);
   }
 
 }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBiTempMetaValues.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBiTempMetaValues.java
@@ -16,33 +16,13 @@
 
 package com.marklogic.client.functionaltest;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
-import java.util.Calendar;
-
-import javax.xml.bind.DatatypeConverter;
-import javax.xml.datatype.DatatypeFactory;
-
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.Transaction;
 import com.marklogic.client.bitemporal.TemporalDocumentManager.ProtectionLevel;
 import com.marklogic.client.document.DocumentManager.Metadata;
-import com.marklogic.client.document.DocumentMetadataPatchBuilder;
-import com.marklogic.client.document.DocumentPage;
-import com.marklogic.client.document.DocumentRecord;
-import com.marklogic.client.document.JSONDocumentManager;
-import com.marklogic.client.document.XMLDocumentManager;
+import com.marklogic.client.document.*;
 import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.DocumentMetadataHandle.Capability;
 import com.marklogic.client.io.Format;
@@ -53,6 +33,13 @@ import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.query.StructuredQueryBuilder;
 import com.marklogic.client.query.StructuredQueryBuilder.TemporalOperator;
 import com.marklogic.client.query.StructuredQueryDefinition;
+import org.junit.jupiter.api.*;
+
+import javax.xml.bind.DatatypeConverter;
+import javax.xml.datatype.DatatypeFactory;
+import java.util.Calendar;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestBiTempMetaValues extends BasicJavaClientREST {
 
@@ -85,7 +72,7 @@ public class TestBiTempMetaValues extends BasicJavaClientREST {
   private static String appServerHostname = null;
   private static int restPort = 0;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpBeforeClass() throws Exception {
     System.out.println("In setup");
     configureRESTServer(dbName, fNames);
@@ -119,18 +106,18 @@ public class TestBiTempMetaValues extends BasicJavaClientREST {
         temporalLsqtCollectionName, true);
     appServerHostname = getRestAppServerHostName();
     restPort = getRestServerPort();
-        
+
     createUserRolesWithPrevilages("test-eval-bitemp", "xdbc:eval", "xdbc:eval-in", "xdmp:eval-in", "any-uri", "xdbc:invoke", "temporal:statement-set-system-time",
             "temporal-document-protect", "temporal-document-wipe");
     createUserRolesWithPrevilages("replaceRoleTest", "xdbc:eval", "xdbc:eval-in", "xdmp:eval-in", "any-uri", "xdbc:invoke");
-    
+
     createRESTUser("eval-bitemp-meta-user", "x", "test-eval-bitemp", "replaceRoleTest", "rest-admin", "rest-writer", "rest-reader", "temporal-admin");
     createRESTUser("eval-readeruser", "x", "rest-reader");
 
     writerClient = getDatabaseClientOnDatabase(appServerHostname, restPort, dbName, "eval-bitemp-meta-user", "x", getConnType());
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownAfterClass() throws Exception {
     System.out.println("In tear down");
 
@@ -157,7 +144,7 @@ public class TestBiTempMetaValues extends BasicJavaClientREST {
     deleteForest(schemafNames[0]);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     clearDB();
   }
@@ -199,7 +186,7 @@ public class TestBiTempMetaValues extends BasicJavaClientREST {
 
     // Setup for JSON document
     /**
-     * 
+     *
      { "System": { systemStartERIName : "", systemEndERIName : "", }, "Valid":
      * { validStartERIName: "2001-01-01T00:00:00", validEndERIName:
      * "2011-12-31T23:59:59" }, "Address": "999 Skyway Park", "uri":
@@ -279,10 +266,10 @@ public class TestBiTempMetaValues extends BasicJavaClientREST {
     System.out.println(" After Changing " + contentMetadataXML);
 
     // Verify that patch succeeded.
-    assertTrue("Patch did not succeed - Meta data Values", contentMetadataXML.contains("<rapi:metadata-value key=\"MLVersion\">MarkLogic 9.0</rapi:metadata-value>"));
-    assertTrue("Patch did not succeed - Add Permission Values", contentMetadataXML.contains("<rapi:role-name>replaceRoleTest</rapi:role-name>"));
-    assertTrue("Patch did not succeed - Property", contentMetadataXML.contains("<Hello xsi:type=\"xs:string\">Hi</Hello>"));
-    assertTrue("Patch did not succeed - Collection", contentMetadataXML.contains("<rapi:collection>/document/collection3</rapi:collection>"));
+    assertTrue(contentMetadataXML.contains("<rapi:metadata-value key=\"MLVersion\">MarkLogic 9.0</rapi:metadata-value>"));
+    assertTrue(contentMetadataXML.contains("<rapi:role-name>replaceRoleTest</rapi:role-name>"));
+    assertTrue(contentMetadataXML.contains("<Hello xsi:type=\"xs:string\">Hi</Hello>"));
+    assertTrue(contentMetadataXML.contains("<rapi:collection>/document/collection3</rapi:collection>"));
 
     // Add the new meta data with JSON
     JSONDocumentManager jsonDocMgr = writerClient.newJSONDocumentManager();
@@ -300,16 +287,16 @@ public class TestBiTempMetaValues extends BasicJavaClientREST {
 
     // Verify the first patch's contents.
 
-    assertTrue("Patch did not succeed - Meta data Values", contentMetadataXML.contains("<rapi:metadata-value key=\"MLVersion\">MarkLogic 9.0</rapi:metadata-value>"));
-    assertTrue("Patch did not succeed - Add Permission Values", contentMetadataXML.contains("<rapi:role-name>replaceRoleTest</rapi:role-name>"));
-    assertTrue("Patch did not succeed - Property", contentMetadataXML.contains("<Hello xsi:type=\"xs:string\">Hi</Hello>"));
-    assertTrue("Patch did not succeed - Collection", contentMetadataXML.contains("<rapi:collection>/document/collection3</rapi:collection>"));
+    assertTrue(contentMetadataXML.contains("<rapi:metadata-value key=\"MLVersion\">MarkLogic 9.0</rapi:metadata-value>"));
+    assertTrue(contentMetadataXML.contains("<rapi:role-name>replaceRoleTest</rapi:role-name>"));
+    assertTrue(contentMetadataXML.contains("<Hello xsi:type=\"xs:string\">Hi</Hello>"));
+    assertTrue(contentMetadataXML.contains("<rapi:collection>/document/collection3</rapi:collection>"));
 
     // Verify that second patch with JSON succeeded.
-    assertTrue("Patch did not succeed - Meta data Values", contentMetadataJson.contains("<rapi:metadata-value key=\"MLVersionJson\">MarkLogic 9.0 Json</rapi:metadata-value>"));
-    assertTrue("Patch did not succeed - Add Permission Values", contentMetadataJson.contains("<rapi:role-name>replaceRoleTest</rapi:role-name>"));
-    assertTrue("Patch did not succeed - Property", contentMetadataJson.contains("<Hello xsi:type=\"xs:string\">Hi</Hello>"));
-    assertTrue("Patch did not succeed - Collection", contentMetadataJson.contains("<rapi:collection>/document/collection3Json</rapi:collection>"));
+    assertTrue(contentMetadataJson.contains("<rapi:metadata-value key=\"MLVersionJson\">MarkLogic 9.0 Json</rapi:metadata-value>"));
+    assertTrue(contentMetadataJson.contains("<rapi:role-name>replaceRoleTest</rapi:role-name>"));
+    assertTrue(contentMetadataJson.contains("<Hello xsi:type=\"xs:string\">Hi</Hello>"));
+    assertTrue(contentMetadataJson.contains("<rapi:collection>/document/collection3Json</rapi:collection>"));
 
     // Add multiple values at the same time.
     DocumentMetadataPatchBuilder patchBldrXMLMul = xmlDocMgr.newPatchBuilder(Format.XML);
@@ -325,12 +312,12 @@ public class TestBiTempMetaValues extends BasicJavaClientREST {
     System.out.println(" After Changing " + contentMetadataXMLMul);
 
     // Verify that patch succeeded.
-    assertTrue("Patch did not succeed - Meta data Values", contentMetadataXMLMul.contains("<rapi:metadata-value key=\"MLVersion\">MarkLogic 9.0</rapi:metadata-value>"));
-    assertTrue("Patch did not succeed - Meta data Values", contentMetadataXMLMul.contains("<rapi:metadata-value key=\"MlClientProg1\">Java</rapi:metadata-value>"));
-    assertTrue("Patch did not succeed - Meta data Values", contentMetadataXMLMul.contains("<rapi:metadata-value key=\"MlClientProg2\">Node/SJS</rapi:metadata-value>"));
-    assertTrue("Patch did not succeed - Add Permission Values", contentMetadataXMLMul.contains("<rapi:role-name>replaceRoleTest</rapi:role-name>"));
-    assertTrue("Patch did not succeed - Property", contentMetadataXMLMul.contains("<Hello xsi:type=\"xs:string\">Hi</Hello>"));
-    assertTrue("Patch did not succeed - Collection", contentMetadataXMLMul.contains("<rapi:collection>/document/collection3</rapi:collection>"));
+    assertTrue(contentMetadataXMLMul.contains("<rapi:metadata-value key=\"MLVersion\">MarkLogic 9.0</rapi:metadata-value>"));
+    assertTrue(contentMetadataXMLMul.contains("<rapi:metadata-value key=\"MlClientProg1\">Java</rapi:metadata-value>"));
+    assertTrue(contentMetadataXMLMul.contains("<rapi:metadata-value key=\"MlClientProg2\">Node/SJS</rapi:metadata-value>"));
+    assertTrue(contentMetadataXMLMul.contains("<rapi:role-name>replaceRoleTest</rapi:role-name>"));
+    assertTrue(contentMetadataXMLMul.contains("<Hello xsi:type=\"xs:string\">Hi</Hello>"));
+    assertTrue(contentMetadataXMLMul.contains("<rapi:collection>/document/collection3</rapi:collection>"));
   }
 
   @Test
@@ -378,20 +365,20 @@ public class TestBiTempMetaValues extends BasicJavaClientREST {
     String contentMetadataXML = xmlDocMgr.readMetadata(docId, new StringHandle(), transPatch).get();
     System.out.println(" After Changing " + contentMetadataXML);
     // Verify that patch succeeded.
-    assertTrue("Patch did not succeed - Meta data Values", contentMetadataXML.contains("<rapi:metadata-value key=\"MLVersion\">MarkLogic 9.0</rapi:metadata-value>"));
-    assertTrue("Patch did not succeed - Add Permission Values", contentMetadataXML.contains("<rapi:role-name>replaceRoleTest</rapi:role-name>"));
-    assertTrue("Patch did not succeed - Property", contentMetadataXML.contains("<Hello xsi:type=\"xs:string\">Hi</Hello>"));
-    assertTrue("Patch did not succeed - Collection", contentMetadataXML.contains("<rapi:collection>/document/collection3</rapi:collection>"));
+    assertTrue(contentMetadataXML.contains("<rapi:metadata-value key=\"MLVersion\">MarkLogic 9.0</rapi:metadata-value>"));
+    assertTrue(contentMetadataXML.contains("<rapi:role-name>replaceRoleTest</rapi:role-name>"));
+    assertTrue(contentMetadataXML.contains("<Hello xsi:type=\"xs:string\">Hi</Hello>"));
+    assertTrue(contentMetadataXML.contains("<rapi:collection>/document/collection3</rapi:collection>"));
 
     // Roll back the transaction
     transPatch.rollback();
 
     String contentMetadataRollXML = xmlDocMgr.readMetadata(docId, new StringHandle()).get();
     System.out.println(" After Changing " + contentMetadataRollXML);
-    assertFalse("Patch should not be available - Meta data Values", contentMetadataRollXML.contains("<rapi:metadata-value key=\"MLVersion\">MarkLogic 9.0</rapi:metadata-value>"));
-    assertFalse("Patch should not be available - Add Permission Values", contentMetadataRollXML.contains("<rapi:role-name>admin</rapi:role-name>"));
-    assertFalse("Patch should not be available - Property", contentMetadataRollXML.contains("<Hello xsi:type=\"xs:string\">Hi</Hello>"));
-    assertFalse("Patch should not be available - Collection", contentMetadataRollXML.contains("<rapi:collection>/document/collection3</rapi:collection>"));
+    assertFalse( contentMetadataRollXML.contains("<rapi:metadata-value key=\"MLVersion\">MarkLogic 9.0</rapi:metadata-value>"));
+    assertFalse( contentMetadataRollXML.contains("<rapi:role-name>admin</rapi:role-name>"));
+    assertFalse( contentMetadataRollXML.contains("<Hello xsi:type=\"xs:string\">Hi</Hello>"));
+    assertFalse( contentMetadataRollXML.contains("<rapi:collection>/document/collection3</rapi:collection>"));
   }
 
   /*
@@ -438,10 +425,10 @@ public class TestBiTempMetaValues extends BasicJavaClientREST {
     System.out.println(" After Changing " + contentMetadataXML);
 
     // Verify that patch succeeded.
-    assertTrue("Patch did not succeed - Meta data Values", contentMetadataXML.contains("<rapi:metadata-value key=\"MLVersion\">MLVersion</rapi:metadata-value>"));
-    assertTrue("Patch did not succeed - Add Permission Values", contentMetadataXML.contains("<rapi:role-name>replaceRoleTest</rapi:role-name>"));
-    assertTrue("Patch did not succeed - Property", contentMetadataXML.contains("<Hello xsi:type=\"xs:string\">Hi</Hello>"));
-    assertTrue("Patch did not succeed - Collection", contentMetadataXML.contains("<rapi:collection>/document/collection3</rapi:collection>"));
+    assertTrue(contentMetadataXML.contains("<rapi:metadata-value key=\"MLVersion\">MLVersion</rapi:metadata-value>"));
+    assertTrue(contentMetadataXML.contains("<rapi:role-name>replaceRoleTest</rapi:role-name>"));
+    assertTrue(contentMetadataXML.contains("<Hello xsi:type=\"xs:string\">Hi</Hello>"));
+    assertTrue(contentMetadataXML.contains("<rapi:collection>/document/collection3</rapi:collection>"));
 
     DocumentMetadataPatchBuilder patchBldrXML2 = xmlDocMgr.newPatchBuilder(Format.XML);
 
@@ -454,8 +441,8 @@ public class TestBiTempMetaValues extends BasicJavaClientREST {
     System.out.println(" After Changing " + contentMetadataXML2);
 
     // Verify that patch succeeded. Seems to work. Replaces the key value.
-    assertTrue("Patch did not succeed - Meta data Values", contentMetadataXML2.contains("<rapi:metadata-value key=\"MLVersion\">MLVersionNew</rapi:metadata-value>"));
-    assertTrue("Patch did not succeed - Add Permission Values", contentMetadataXML2.contains("<rapi:role-name>replaceRoleTest</rapi:role-name>"));
+    assertTrue(contentMetadataXML2.contains("<rapi:metadata-value key=\"MLVersion\">MLVersionNew</rapi:metadata-value>"));
+    assertTrue(contentMetadataXML2.contains("<rapi:role-name>replaceRoleTest</rapi:role-name>"));
   }
 
   /*
@@ -502,10 +489,10 @@ public class TestBiTempMetaValues extends BasicJavaClientREST {
     System.out.println("After Changing " + contentMetadataXML);
 
     // Verify that patch succeeded.
-    assertTrue("Patch did not succeed - Meta data Values", contentMetadataXML.contains("<rapi:metadata-value key=\"MLVersion\">9.0</rapi:metadata-value>"));
-    assertTrue("Patch did not succeed - Permission Values", contentMetadataXML.contains("<rapi:role-name>replaceRoleTest</rapi:role-name>"));
-    assertTrue("Patch did not succeed - Property", contentMetadataXML.contains("<Hello xsi:type=\"xs:string\">Hi</Hello>"));
-    assertTrue("Patch did not succeed - Collection", contentMetadataXML.contains("<rapi:collection>/document/collection3</rapi:collection>"));
+    assertTrue(contentMetadataXML.contains("<rapi:metadata-value key=\"MLVersion\">9.0</rapi:metadata-value>"));
+    assertTrue(contentMetadataXML.contains("<rapi:role-name>replaceRoleTest</rapi:role-name>"));
+    assertTrue(contentMetadataXML.contains("<Hello xsi:type=\"xs:string\">Hi</Hello>"));
+    assertTrue(contentMetadataXML.contains("<rapi:collection>/document/collection3</rapi:collection>"));
 
     DocumentMetadataPatchBuilder patchBldrXML2 = xmlDocMgr.newPatchBuilder(Format.XML);
     // Do an delete with key value.
@@ -517,8 +504,8 @@ public class TestBiTempMetaValues extends BasicJavaClientREST {
     System.out.println("After Changing 2 " + contentMetadataXML2);
 
     // Verify that patch succeeded. Seems to work. Replaces the key value.
-    assertFalse("Patch did not succeed - Meta data Delete Values", contentMetadataXML2.contains("<rapi:metadata-value key=\"MLVersion\">9.0</rapi:metadata-value>"));
-    assertTrue("Patch did not succeed - Add Permission Values", contentMetadataXML2.contains("<rapi:role-name>replaceRoleTest</rapi:role-name>"));
+    assertFalse( contentMetadataXML2.contains("<rapi:metadata-value key=\"MLVersion\">9.0</rapi:metadata-value>"));
+    assertTrue(contentMetadataXML2.contains("<rapi:role-name>replaceRoleTest</rapi:role-name>"));
 
     // Add back the same key
     DocumentMetadataPatchBuilder patchBldrXML3 = xmlDocMgr.newPatchBuilder(Format.XML);
@@ -532,12 +519,12 @@ public class TestBiTempMetaValues extends BasicJavaClientREST {
     System.out.println("After Changing 3 " + contentMetadataXML3);
 
     // Verify that patch succeeded.
-    assertTrue("Patch did not succeed - Meta data Values", contentMetadataXML3.contains("<rapi:metadata-value key=\"MLVersion\">10.0</rapi:metadata-value>"));
-    assertTrue("Patch did not succeed - Meta data Values", contentMetadataXML3.contains("<rapi:metadata-value key=\"MLVersion11\">11.0</rapi:metadata-value>"));
-    assertTrue("Patch did not succeed - Meta data Values", contentMetadataXML3.contains("<rapi:metadata-value key=\"MLVersion12\">12.0</rapi:metadata-value>"));
-    assertTrue("Patch did not succeed - Permission Values", contentMetadataXML3.contains("<rapi:role-name>replaceRoleTest</rapi:role-name>"));
-    assertTrue("Patch did not succeed - Property", contentMetadataXML3.contains("<Hello xsi:type=\"xs:string\">Hi</Hello>"));
-    assertTrue("Patch did not succeed - Collection", contentMetadataXML3.contains("<rapi:collection>/document/collection3</rapi:collection>"));
+    assertTrue(contentMetadataXML3.contains("<rapi:metadata-value key=\"MLVersion\">10.0</rapi:metadata-value>"));
+    assertTrue(contentMetadataXML3.contains("<rapi:metadata-value key=\"MLVersion11\">11.0</rapi:metadata-value>"));
+    assertTrue(contentMetadataXML3.contains("<rapi:metadata-value key=\"MLVersion12\">12.0</rapi:metadata-value>"));
+    assertTrue(contentMetadataXML3.contains("<rapi:role-name>replaceRoleTest</rapi:role-name>"));
+    assertTrue(contentMetadataXML3.contains("<Hello xsi:type=\"xs:string\">Hi</Hello>"));
+    assertTrue(contentMetadataXML3.contains("<rapi:collection>/document/collection3</rapi:collection>"));
 
     // Delete non existent key
     DocumentMetadataPatchBuilder patchBldrXML4 = xmlDocMgr.newPatchBuilder(Format.XML);
@@ -549,12 +536,12 @@ public class TestBiTempMetaValues extends BasicJavaClientREST {
     System.out.println("After Changing 4 " + contentMetadataXML4);
 
     // Verify that patch did not delete existing values..
-    assertTrue("Patch did not succeed - Meta data Values", contentMetadataXML4.contains("<rapi:metadata-value key=\"MLVersion\">10.0</rapi:metadata-value>"));
-    assertTrue("Patch did not succeed - Meta data Values", contentMetadataXML4.contains("<rapi:metadata-value key=\"MLVersion11\">11.0</rapi:metadata-value>"));
-    assertTrue("Patch did not succeed - Meta data Values", contentMetadataXML4.contains("<rapi:metadata-value key=\"MLVersion12\">12.0</rapi:metadata-value>"));
-    assertTrue("Patch did not succeed - Permission Values", contentMetadataXML4.contains("<rapi:role-name>replaceRoleTest</rapi:role-name>"));
-    assertTrue("Patch did not succeed - Property", contentMetadataXML4.contains("<Hello xsi:type=\"xs:string\">Hi</Hello>"));
-    assertTrue("Patch did not succeed - Collection", contentMetadataXML4.contains("<rapi:collection>/document/collection3</rapi:collection>"));
+    assertTrue(contentMetadataXML4.contains("<rapi:metadata-value key=\"MLVersion\">10.0</rapi:metadata-value>"));
+    assertTrue(contentMetadataXML4.contains("<rapi:metadata-value key=\"MLVersion11\">11.0</rapi:metadata-value>"));
+    assertTrue(contentMetadataXML4.contains("<rapi:metadata-value key=\"MLVersion12\">12.0</rapi:metadata-value>"));
+    assertTrue(contentMetadataXML4.contains("<rapi:role-name>replaceRoleTest</rapi:role-name>"));
+    assertTrue(contentMetadataXML4.contains("<Hello xsi:type=\"xs:string\">Hi</Hello>"));
+    assertTrue(contentMetadataXML4.contains("<rapi:collection>/document/collection3</rapi:collection>"));
 
     // Delete multiple keys.
     DocumentMetadataPatchBuilder patchBldrXML5 = xmlDocMgr.newPatchBuilder(Format.XML);
@@ -565,12 +552,12 @@ public class TestBiTempMetaValues extends BasicJavaClientREST {
     waitForPropertyPropagate();
     String contentMetadataXML5 = xmlDocMgr.readMetadata(docId, new StringHandle()).get();
     System.out.println("After Changing 5 " + contentMetadataXML5);
-    assertTrue("Patch did not succeed - Meta data Values", contentMetadataXML5.contains("<rapi:metadata-value key=\"MLVersion\">10.0</rapi:metadata-value>"));
-    assertFalse("Patch did not succeed - Meta data Values", contentMetadataXML5.contains("<rapi:metadata-value key=\"MLVersion11\">11.0</rapi:metadata-value>"));
-    assertFalse("Patch did not succeed - Meta data Values", contentMetadataXML5.contains("<rapi:metadata-value key=\"MLVersion12\">12.0</rapi:metadata-value>"));
-    assertTrue("Patch did not succeed - Permission Values", contentMetadataXML5.contains("<rapi:role-name>replaceRoleTest</rapi:role-name>"));
-    assertTrue("Patch did not succeed - Property", contentMetadataXML5.contains("<Hello xsi:type=\"xs:string\">Hi</Hello>"));
-    assertTrue("Patch did not succeed - Collection", contentMetadataXML5.contains("<rapi:collection>/document/collection3</rapi:collection>"));
+    assertTrue(contentMetadataXML5.contains("<rapi:metadata-value key=\"MLVersion\">10.0</rapi:metadata-value>"));
+    assertFalse( contentMetadataXML5.contains("<rapi:metadata-value key=\"MLVersion11\">11.0</rapi:metadata-value>"));
+    assertFalse( contentMetadataXML5.contains("<rapi:metadata-value key=\"MLVersion12\">12.0</rapi:metadata-value>"));
+    assertTrue(contentMetadataXML5.contains("<rapi:role-name>replaceRoleTest</rapi:role-name>"));
+    assertTrue(contentMetadataXML5.contains("<Hello xsi:type=\"xs:string\">Hi</Hello>"));
+    assertTrue(contentMetadataXML5.contains("<rapi:collection>/document/collection3</rapi:collection>"));
   }
 
   /*
@@ -621,13 +608,13 @@ public class TestBiTempMetaValues extends BasicJavaClientREST {
     System.out.println(" After Changing " + contentMetadataXML);
 
     // Verify that patch succeeded.
-    assertTrue("Patch did not succeed - Meta data Values", contentMetadataXML.contains("<rapi:metadata-value key=\"MLVersion\">9.0</rapi:metadata-value>"));
-    assertTrue("Patch did not succeed - Meta data Values", contentMetadataXML.contains("<rapi:metadata-value key=\"MLVersion10\">9.0</rapi:metadata-value>"));
-    assertTrue("Patch did not succeed - Meta data Values", contentMetadataXML.contains("<rapi:metadata-value key=\"MLVersion11\">9.0</rapi:metadata-value>"));
-    assertTrue("Patch did not succeed - Meta data Values", contentMetadataXML.contains("<rapi:metadata-value key=\"MLVersion12\">12.0</rapi:metadata-value>"));
-    assertTrue("Patch did not succeed - Permission Values", contentMetadataXML.contains("<rapi:role-name>replaceRoleTest</rapi:role-name>"));
-    assertTrue("Patch did not succeed - Property", contentMetadataXML.contains("<Hello xsi:type=\"xs:string\">Hi</Hello>"));
-    assertTrue("Patch did not succeed - Collection", contentMetadataXML.contains("<rapi:collection>/document/collection3</rapi:collection>"));
+    assertTrue(contentMetadataXML.contains("<rapi:metadata-value key=\"MLVersion\">9.0</rapi:metadata-value>"));
+    assertTrue(contentMetadataXML.contains("<rapi:metadata-value key=\"MLVersion10\">9.0</rapi:metadata-value>"));
+    assertTrue(contentMetadataXML.contains("<rapi:metadata-value key=\"MLVersion11\">9.0</rapi:metadata-value>"));
+    assertTrue(contentMetadataXML.contains("<rapi:metadata-value key=\"MLVersion12\">12.0</rapi:metadata-value>"));
+    assertTrue(contentMetadataXML.contains("<rapi:role-name>replaceRoleTest</rapi:role-name>"));
+    assertTrue(contentMetadataXML.contains("<Hello xsi:type=\"xs:string\">Hi</Hello>"));
+    assertTrue(contentMetadataXML.contains("<rapi:collection>/document/collection3</rapi:collection>"));
 
     DocumentMetadataPatchBuilder patchBldrXML2 = xmlDocMgr.newPatchBuilder(Format.XML);
     // Do a multiple replace with key value.
@@ -640,13 +627,13 @@ public class TestBiTempMetaValues extends BasicJavaClientREST {
     System.out.println(" After Changing 2 " + contentMetadataXML2);
 
     // Verify that patch succeeded.
-    assertTrue("Patch did not succeed - Meta data Values", contentMetadataXML2.contains("<rapi:metadata-value key=\"MLVersion\">9.0</rapi:metadata-value>"));
-    assertTrue("Patch did not succeed - Meta data Values", contentMetadataXML2.contains("<rapi:metadata-value key=\"MLVersion10\">10.0</rapi:metadata-value>"));
-    assertTrue("Patch did not succeed - Meta data Values", contentMetadataXML2.contains("<rapi:metadata-value key=\"MLVersion11\">11.0</rapi:metadata-value>"));
-    assertTrue("Patch did not succeed - Meta data Values", contentMetadataXML2.contains("<rapi:metadata-value key=\"MLVersion12\">12.0</rapi:metadata-value>"));
-    assertTrue("Patch did not succeed - Permission Values", contentMetadataXML2.contains("<rapi:role-name>replaceRoleTest</rapi:role-name>"));
-    assertTrue("Patch did not succeed - Property", contentMetadataXML2.contains("<Hello xsi:type=\"xs:string\">Hi</Hello>"));
-    assertTrue("Patch did not succeed - Collection", contentMetadataXML2.contains("<rapi:collection>/document/collection3</rapi:collection>"));
+    assertTrue(contentMetadataXML2.contains("<rapi:metadata-value key=\"MLVersion\">9.0</rapi:metadata-value>"));
+    assertTrue(contentMetadataXML2.contains("<rapi:metadata-value key=\"MLVersion10\">10.0</rapi:metadata-value>"));
+    assertTrue(contentMetadataXML2.contains("<rapi:metadata-value key=\"MLVersion11\">11.0</rapi:metadata-value>"));
+    assertTrue(contentMetadataXML2.contains("<rapi:metadata-value key=\"MLVersion12\">12.0</rapi:metadata-value>"));
+    assertTrue(contentMetadataXML2.contains("<rapi:role-name>replaceRoleTest</rapi:role-name>"));
+    assertTrue(contentMetadataXML2.contains("<Hello xsi:type=\"xs:string\">Hi</Hello>"));
+    assertTrue(contentMetadataXML2.contains("<rapi:collection>/document/collection3</rapi:collection>"));
 
     // Replace non existent key
     DocumentMetadataPatchBuilder patchBldrXML3 = xmlDocMgr.newPatchBuilder(Format.XML);
@@ -658,13 +645,13 @@ public class TestBiTempMetaValues extends BasicJavaClientREST {
     System.out.println(" After Changing 3 " + contentMetadataXML3);
 
     // Verify that none of the other values are incorrect or affected.
-    assertTrue("Patch did not succeed - Meta data Values", contentMetadataXML3.contains("<rapi:metadata-value key=\"MLVersion\">9.0</rapi:metadata-value>"));
-    assertTrue("Patch did not succeed - Meta data Values", contentMetadataXML3.contains("<rapi:metadata-value key=\"MLVersion10\">10.0</rapi:metadata-value>"));
-    assertTrue("Patch did not succeed - Meta data Values", contentMetadataXML3.contains("<rapi:metadata-value key=\"MLVersion11\">11.0</rapi:metadata-value>"));
-    assertTrue("Patch did not succeed - Meta data Values", contentMetadataXML3.contains("<rapi:metadata-value key=\"MLVersion12\">12.0</rapi:metadata-value>"));
-    assertTrue("Patch did not succeed - Permission Values", contentMetadataXML3.contains("<rapi:role-name>replaceRoleTest</rapi:role-name>"));
-    assertTrue("Patch did not succeed - Property", contentMetadataXML3.contains("<Hello xsi:type=\"xs:string\">Hi</Hello>"));
-    assertTrue("Patch did not succeed - Collection", contentMetadataXML3.contains("<rapi:collection>/document/collection3</rapi:collection>"));
+    assertTrue(contentMetadataXML3.contains("<rapi:metadata-value key=\"MLVersion\">9.0</rapi:metadata-value>"));
+    assertTrue(contentMetadataXML3.contains("<rapi:metadata-value key=\"MLVersion10\">10.0</rapi:metadata-value>"));
+    assertTrue(contentMetadataXML3.contains("<rapi:metadata-value key=\"MLVersion11\">11.0</rapi:metadata-value>"));
+    assertTrue(contentMetadataXML3.contains("<rapi:metadata-value key=\"MLVersion12\">12.0</rapi:metadata-value>"));
+    assertTrue(contentMetadataXML3.contains("<rapi:role-name>replaceRoleTest</rapi:role-name>"));
+    assertTrue(contentMetadataXML3.contains("<Hello xsi:type=\"xs:string\">Hi</Hello>"));
+    assertTrue(contentMetadataXML3.contains("<rapi:collection>/document/collection3</rapi:collection>"));
 
     // Perform add new, replace in same patch
     DocumentMetadataPatchBuilder patchBldrXML4 = xmlDocMgr.newPatchBuilder(Format.XML);
@@ -678,14 +665,14 @@ public class TestBiTempMetaValues extends BasicJavaClientREST {
     System.out.println(" After Changing 4 " + contentMetadataXML4);
 
     // Verify that none of the other values are incorrect or affected.
-    assertTrue("Patch did not succeed - Meta data Values", contentMetadataXML4.contains("<rapi:metadata-value key=\"MLVersion\">9.0</rapi:metadata-value>"));
-    assertTrue("Patch did not succeed - Meta data Values", contentMetadataXML4.contains("<rapi:metadata-value key=\"MLVersion10\">10.0</rapi:metadata-value>"));
-    assertTrue("Patch did not succeed - Meta data Values", contentMetadataXML4.contains("<rapi:metadata-value key=\"MLVersion11\">11.0</rapi:metadata-value>"));
-    assertTrue("Patch did not succeed - Meta data Values", contentMetadataXML4.contains("<rapi:metadata-value key=\"MLVersion12\">12.0</rapi:metadata-value>"));
-    assertTrue("Patch did not succeed - Meta data Values", contentMetadataXML4.contains("<rapi:metadata-value key=\"NewAndReplace\">Added</rapi:metadata-value>"));
-    assertTrue("Patch did not succeed - Permission Values", contentMetadataXML4.contains("<rapi:role-name>replaceRoleTest</rapi:role-name>"));
-    assertTrue("Patch did not succeed - Property", contentMetadataXML4.contains("<Hello xsi:type=\"xs:string\">Hi</Hello>"));
-    assertTrue("Patch did not succeed - Collection", contentMetadataXML4.contains("<rapi:collection>/document/collection3</rapi:collection>"));
+    assertTrue(contentMetadataXML4.contains("<rapi:metadata-value key=\"MLVersion\">9.0</rapi:metadata-value>"));
+    assertTrue(contentMetadataXML4.contains("<rapi:metadata-value key=\"MLVersion10\">10.0</rapi:metadata-value>"));
+    assertTrue(contentMetadataXML4.contains("<rapi:metadata-value key=\"MLVersion11\">11.0</rapi:metadata-value>"));
+    assertTrue(contentMetadataXML4.contains("<rapi:metadata-value key=\"MLVersion12\">12.0</rapi:metadata-value>"));
+    assertTrue(contentMetadataXML4.contains("<rapi:metadata-value key=\"NewAndReplace\">Added</rapi:metadata-value>"));
+    assertTrue(contentMetadataXML4.contains("<rapi:role-name>replaceRoleTest</rapi:role-name>"));
+    assertTrue(contentMetadataXML4.contains("<Hello xsi:type=\"xs:string\">Hi</Hello>"));
+    assertTrue(contentMetadataXML4.contains("<rapi:collection>/document/collection3</rapi:collection>"));
   }
 
   /*
@@ -701,24 +688,24 @@ public class TestBiTempMetaValues extends BasicJavaClientREST {
      * System.out.println("Inside testInsertFragement");
      * ConnectedRESTQA.updateTemporalCollectionForLSQT(dbName,
      * temporalLsqtCollectionName, true);
-     * 
+     *
      * Calendar insertTime =
      * DatatypeConverter.parseDateTime("2005-01-01T00:00:01");
-     * 
+     *
      * String docId = "javaSingleJSONDoc.json";
      * JacksonDatabindHandle<ObjectNode> handle =
      * getJSONDocumentHandle("2001-01-01T00:00:00", "2011-12-31T23:59:59",
      * "999 Skyway Park - JSON", docId );
-     * 
+     *
      * JSONDocumentManager docMgr = writerClient.newJSONDocumentManager();
-     * 
+     *
      * // put meta-data docMgr.setMetadataCategories(Metadata.ALL);
      * DocumentMetadataHandle mh = setMetadata(false); docMgr.write(docId, mh,
      * handle, null, null, temporalLsqtCollectionName, insertTime);
-     * 
+     *
      * // Apply the patch XMLDocumentManager xmlDocMgr =
      * writerClient.newXMLDocumentManager();
-     * 
+     *
      * DocumentMetadataPatchBuilder patchBldrXML =
      * xmlDocMgr.newPatchBuilder(Format.XML);
      */
@@ -758,7 +745,7 @@ public class TestBiTempMetaValues extends BasicJavaClientREST {
       str.append(ex.getMessage());
       System.out.println("Exception when delete within 30 sec is " + str.toString());
     }
-    assertTrue("Doc should not be deleted", str.toString().contains("The document javaSingleJSONDoc.json is protected noDelete"));
+    assertTrue(str.toString().contains("The document javaSingleJSONDoc.json is protected noDelete"));
     str = null;
     // Added the word "Updated" to doc from 2007-01-01T00:00:00 to
     // 2008-12-30T23:59:59
@@ -816,7 +803,7 @@ public class TestBiTempMetaValues extends BasicJavaClientREST {
       System.out.println("Exception when delete within 40 sec is " + str.toString());
     }
     String docDelMessage = "The document " + toDeleteURI + " is protected noDelete";
-    assertTrue("Doc should not be deleted", str.toString().contains(docDelMessage));
+    assertTrue(str.toString().contains(docDelMessage));
     // Sleep for 40 secs and try to delete the same docId.
     Thread.sleep(40000);
     docMgr.delete(docId, null, temporalLsqtCollectionName, deleteTime);
@@ -825,7 +812,7 @@ public class TestBiTempMetaValues extends BasicJavaClientREST {
     JSONDocumentManager jsonDocMgr = writerClient.newJSONDocumentManager();
     DocumentPage readResults = jsonDocMgr.read(docId);
     System.out.println("Number of results = " + readResults.size());
-    assertEquals("Wrong number of results", 1, readResults.size());
+    assertEquals(1, readResults.size());
   }
 
   @Test
@@ -864,7 +851,7 @@ public class TestBiTempMetaValues extends BasicJavaClientREST {
       str.append(ex.getMessage());
       System.out.println("Exception when update within 30 sec is " + str.toString());
     }
-    assertTrue("Doc should not be updated", str.toString().contains("The document javaSingleJSONDoc.json is protected noUpdate"));
+    assertTrue(str.toString().contains("The document javaSingleJSONDoc.json is protected noUpdate"));
 
     // Sleep for 40 secs and try to update the same docId.
     Thread.sleep(40000);
@@ -874,7 +861,7 @@ public class TestBiTempMetaValues extends BasicJavaClientREST {
     JSONDocumentManager jsonDocMgr = writerClient.newJSONDocumentManager();
     DocumentPage readResults = jsonDocMgr.read(docId);
     System.out.println("Number of results = " + readResults.size());
-    assertEquals("Wrong number of results", 1, readResults.size());
+    assertEquals(1, readResults.size());
 
     QueryManager queryMgr = writerClient.newQueryManager();
 
@@ -885,7 +872,7 @@ public class TestBiTempMetaValues extends BasicJavaClientREST {
     DocumentPage termQueryResults = docMgr.search(termQuery, start);
     System.out
         .println("Number of results = " + termQueryResults.getTotalSize());
-    assertEquals("Wrong number of results", 4, termQueryResults.getTotalSize());
+    assertEquals(4, termQueryResults.getTotalSize());
   }
 
   @Test
@@ -926,7 +913,7 @@ public class TestBiTempMetaValues extends BasicJavaClientREST {
       str.append(ex.getMessage());
       System.out.println("Exception when update within 30 sec is " + str.toString());
     }
-    assertTrue("Doc should not be updated", str.toString().contains("The document javaSingleJSONDoc.json is protected noUpdate"));
+    assertTrue(str.toString().contains("The document javaSingleJSONDoc.json is protected noUpdate"));
     try {
       // Sleep for 40 secs and try to update the same docId.
       Thread.sleep(40000);
@@ -936,7 +923,7 @@ public class TestBiTempMetaValues extends BasicJavaClientREST {
       JSONDocumentManager jsonDocMgr = writerClient.newJSONDocumentManager();
       DocumentPage readResults = jsonDocMgr.read(t1, docId);
       System.out.println("Number of results = " + readResults.size());
-      assertEquals("Wrong number of results", 1, readResults.size());
+      assertEquals(1, readResults.size());
 
       QueryManager queryMgr = writerClient.newQueryManager();
 
@@ -949,7 +936,7 @@ public class TestBiTempMetaValues extends BasicJavaClientREST {
       DocumentPage termQueryResults = docMgr.search(termQuery, start, t2);
       System.out
           .println("Number of results = " + termQueryResults.getTotalSize());
-      assertEquals("Wrong number of results", 4, termQueryResults.getTotalSize());
+      assertEquals(4, termQueryResults.getTotalSize());
     } catch (Exception e) {
       System.out.println("Exception when update within 30 sec is " + e.getMessage());
     } finally {
@@ -958,7 +945,7 @@ public class TestBiTempMetaValues extends BasicJavaClientREST {
     }
   }
 
-  @Ignore
+  @Disabled
   /*
    * Test bitemporal protections - NOUPDATE With different transactions. Write
    * doc in T1. Protect in T2. Update doc in T1 within 30 sec duration. TODO
@@ -1012,7 +999,7 @@ public class TestBiTempMetaValues extends BasicJavaClientREST {
     JSONDocumentManager jsonDocMgr = writerClient.newJSONDocumentManager();
     DocumentPage readResults = jsonDocMgr.read(t1, docId);
     System.out.println("Number of results = " + readResults.size());
-    assertEquals("Wrong number of results", 1, readResults.size());
+    assertEquals(1, readResults.size());
 
     QueryManager queryMgr = writerClient.newQueryManager();
 
@@ -1023,7 +1010,7 @@ public class TestBiTempMetaValues extends BasicJavaClientREST {
     DocumentPage termQueryResults = docMgr.search(termQuery, start, t1);
     System.out
         .println("Number of results = " + termQueryResults.getTotalSize());
-    assertEquals("Wrong number of results", 4, termQueryResults.getTotalSize());
+    assertEquals(4, termQueryResults.getTotalSize());
     t1.rollback();
     t2.rollback();
   }
@@ -1087,7 +1074,7 @@ public class TestBiTempMetaValues extends BasicJavaClientREST {
         JSONDocumentManager jsonDocMgr = writerClient.newJSONDocumentManager();
         DocumentPage readResults = jsonDocMgr.read(t1, docId);
         System.out.println("Number of results = " + readResults.size());
-        assertEquals("Wrong number of results", 1, readResults.size());
+        assertEquals(1, readResults.size());
         t1.commit();
 
         QueryManager queryMgr = writerClient.newQueryManager();
@@ -1099,7 +1086,7 @@ public class TestBiTempMetaValues extends BasicJavaClientREST {
         DocumentPage termQueryResults = docMgr.search(termQuery, start);
         System.out
             .println("Number of results = " + termQueryResults.getTotalSize());
-        assertEquals("Wrong number of results", 4, termQueryResults.getTotalSize());
+        assertEquals(4, termQueryResults.getTotalSize());
       }
     }
   }
@@ -1137,7 +1124,7 @@ public class TestBiTempMetaValues extends BasicJavaClientREST {
       str.append(ex.getMessage());
       System.out.println("Exception not thrown when user does not have permissions" + str.toString());
     }
-    assertTrue("Exception not thrown when user does not have permissions ", str.toString().contains("User is not allowed to protect resource"));
+    assertTrue(str.toString().contains("User is not allowed to protect resource"));
   }
 
   @Test
@@ -1179,11 +1166,12 @@ public class TestBiTempMetaValues extends BasicJavaClientREST {
       System.out.println("Exception when delete within 60 sec is " + str.toString());
     }
 
-    assertTrue("Did not receive Expected Exception, Expecting TEMPORAL-PROTECTED, received " + str.toString(), str.toString().contains("TEMPORAL-PROTECTED"));
+    assertTrue(str.toString().contains("TEMPORAL-PROTECTED"),
+		"Did not receive Expected Exception, Expecting TEMPORAL-PROTECTED, received " + str);
     JSONDocumentManager jsonDocMgr = writerClient.newJSONDocumentManager();
     DocumentPage readResults = jsonDocMgr.read(docId);
     String content = jsonDocMgr.read(docId, new StringHandle()).get();
-    assertTrue("Wrong number of results", content.contains("1999 Skyway Park - Updated - JSON"));
+    assertTrue(content.contains("1999 Skyway Park - Updated - JSON"));
 
     // Sleep for 60 secs and try to delete the same docId.
     Thread.sleep(60000);
@@ -1198,6 +1186,6 @@ public class TestBiTempMetaValues extends BasicJavaClientREST {
 
     readResults = jsonDocMgr.read(docId);
     System.out.println("Number of results = " + readResults.size());
-    assertEquals("Wrong number of results", 0, readResults.size());
+    assertEquals(0, readResults.size());
   }
 }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBiTemporal.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBiTemporal.java
@@ -16,33 +16,6 @@
 
 package com.marklogic.client.functionaltest;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
-import java.io.File;
-import java.util.Calendar;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.TreeMap;
-
-import javax.xml.bind.DatatypeConverter;
-import javax.xml.parsers.DocumentBuilderFactory;
-
-import com.marklogic.client.expression.CtsQueryBuilder;
-import com.marklogic.client.query.*;
-import com.marklogic.client.type.*;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-import org.w3c.dom.ls.DOMImplementationLS;
-
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -53,25 +26,28 @@ import com.marklogic.client.Transaction;
 import com.marklogic.client.admin.ExtensionMetadata;
 import com.marklogic.client.admin.TransformExtensionsManager;
 import com.marklogic.client.bitemporal.TemporalDescriptor;
-import com.marklogic.client.document.DocumentDescriptor;
+import com.marklogic.client.document.*;
 import com.marklogic.client.document.DocumentManager.Metadata;
-import com.marklogic.client.document.DocumentPage;
-import com.marklogic.client.document.DocumentRecord;
-import com.marklogic.client.document.DocumentUriTemplate;
-import com.marklogic.client.document.DocumentWriteSet;
-import com.marklogic.client.document.JSONDocumentManager;
-import com.marklogic.client.document.ServerTransform;
-import com.marklogic.client.document.XMLDocumentManager;
-import com.marklogic.client.io.DOMHandle;
-import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.client.expression.CtsQueryBuilder;
+import com.marklogic.client.io.*;
 import com.marklogic.client.io.DocumentMetadataHandle.Capability;
 import com.marklogic.client.io.DocumentMetadataHandle.DocumentPermissions;
 import com.marklogic.client.io.DocumentMetadataHandle.DocumentProperties;
-import com.marklogic.client.io.FileHandle;
-import com.marklogic.client.io.Format;
-import com.marklogic.client.io.JacksonDatabindHandle;
-import com.marklogic.client.io.StringHandle;
+import com.marklogic.client.query.*;
 import com.marklogic.client.query.StructuredQueryBuilder.TemporalOperator;
+import com.marklogic.client.type.*;
+import org.junit.jupiter.api.*;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.ls.DOMImplementationLS;
+
+import javax.xml.bind.DatatypeConverter;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.File;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestBiTemporal extends BasicJavaClientREST {
 
@@ -107,7 +83,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
   private final static String updateCollectionName = "updateCollection";
   private final static String insertCollectionName = "insertCollection";
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpBeforeClass() throws Exception {
     System.out.println("In setup");
     configureRESTServer(dbName, fNames);
@@ -143,7 +119,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
         temporalLsqtCollectionName, true);
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownAfterClass() throws Exception {
     System.out.println("In tear down");
 
@@ -168,12 +144,12 @@ public class TestBiTemporal extends BasicJavaClientREST {
     deleteForest(schemafNames[0]);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     createUserRolesWithPrevilages("test-eval", "xdbc:eval", "xdbc:eval-in", "xdmp:eval-in", "any-uri",
         "xdbc:invoke", "temporal:statement-set-system-time");
     createRESTUser("eval-user", "x", "test-eval", "rest-admin", "rest-writer", "rest-reader", "temporal-admin");
-    
+
     adminClient = getDatabaseClient("rest-admin", "x", getConnType());
     //adminClient = getDatabaseClientOnDatabase(appServerHostname, restPort, dbName, "rest-admin", "x", getConnType());
     //writerClient = getDatabaseClientOnDatabase(appServerHostname, restPort, dbName, "eval-user", "x", getConnType());
@@ -182,7 +158,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
     readerClient = getDatabaseClient("rest-reader", "x", getConnType());
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     clearDB();
     adminClient.release();
@@ -229,7 +205,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
     // "size:5|reviewed:true|myInteger:10|myDecimal:34.56678|myCalendar:2014|myString:foo|";
     String actualProperties = getDocumentPropertiesString(properties);
     boolean result = actualProperties.contains("size:5|");
-    assertTrue("Document properties count", result);
+    assertTrue(result);
 
     // Permissions
     String actualPermissions = getDocumentPermissionsString(permissions);
@@ -301,7 +277,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
         System.out.println("validStartDate = " + validStartDate);
         System.out.println("validEndDate = " + validEndDate);
 
-        assertTrue("Valid start date check failed",
+        assertTrue(
             (validStartDate.equals("2001-01-01T00:00:00") &&
                 validEndDate.equals("2011-12-31T23:59:59") &&
                 systemStartDate.equals("2005-01-01T00:00:01-08:00") &&
@@ -310,7 +286,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
     }
 
     System.out.println("Number of results using SQB = " + count);
-    assertEquals("Wrong number of results", 1, count);
+    assertEquals(1, count);
   }
 
   // This covers passing transforms and descriptor
@@ -646,7 +622,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
 
     // Setup for JSON document
     /**
-     * 
+     *
      { "System": { systemStartERIName : "", systemEndERIName : "", }, "Valid":
      * { validStartERIName: "2001-01-01T00:00:00", validEndERIName:
      * "2011-12-31T23:59:59" }, "Address": "999 Skyway Park", "uri":
@@ -684,7 +660,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
 
     return handle;
   }
-  
+
   public void insertSimpleDocument(String docId, String transformName, Transaction transaction) throws Exception {
 
       System.out.println("Inside getDocumentDescriptor");
@@ -777,7 +753,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
       docMgr = readerClient.newXMLDocumentManager();
       docMgr.setMetadataCategories(Metadata.ALL); // Get all metadata
       termQueryResults = docMgr.search(termQuery, start);
-      assertEquals("Records counts is incorrect", 4, termQueryResults.size());
+      assertEquals(4, termQueryResults.size());
       // Verify the Document Record content with map contents for each record.
       while (termQueryResults.hasNext()) {
 
@@ -794,7 +770,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
         DOMHandle readDOMHandle = map.get(record.getUri());
         String mapContent = readDOMHandle.evaluateXPath("/root/Address/text()", String.class);
 
-        assertTrue("Address value is incorrect ", recordContent.contains(mapContent));
+        assertTrue(recordContent.contains(mapContent));
 
         readDOMHandle = null;
         mapContent = null;
@@ -892,7 +868,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
       docMgr = readerClient.newXMLDocumentManager();
       docMgr.setMetadataCategories(Metadata.ALL); // Get all metadata
       termQueryResults = docMgr.search(termQuery, start);
-      assertEquals("Records counts is incorrect", 8, termQueryResults.size());
+      assertEquals(8, termQueryResults.size());
     } catch (Exception e) {
       System.out.println(e.getMessage());
       tstatus = true;
@@ -954,7 +930,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
       docMgr = readerClient.newXMLDocumentManager();
       docMgr.setMetadataCategories(Metadata.ALL); // Get all metadata
       termQueryResults = docMgr.search(termQuery, start);
-      assertEquals("Records counts is incorrect", 4, termQueryResults.size());
+      assertEquals(4, termQueryResults.size());
 
       // Read one document to make sure that addAs worked.
       DocumentPage page = docMgr.read(docId[2]);
@@ -963,9 +939,9 @@ public class TestBiTemporal extends BasicJavaClientREST {
         DocumentRecord rec = page.next();
         rec.getContent(dh);
 
-        assertEquals("URI returned is wrong", docId[2], rec.getUri());
-        assertEquals("URI returned is wrong", Format.XML, rec.getFormat());
-        assertTrue("Comparing the content", convertXMLDocumentToString(dh.get()).contains("XML3"));
+        assertEquals(docId[2], rec.getUri());
+        assertEquals(Format.XML, rec.getFormat());
+        assertTrue(convertXMLDocumentToString(dh.get()).contains("XML3"));
       }
     } catch (Exception e) {
       System.out.println(e.getMessage());
@@ -1021,12 +997,12 @@ public class TestBiTemporal extends BasicJavaClientREST {
       System.out.println("URI = " + uri);
 
       if (!uri.contains(dirName) && !uri.contains(fileSuffix)) {
-        assertFalse("Uri name does not have the right prefix or suffix", true);
+        fail("Uri name does not have the right prefix or suffix");
       }
     }
 
     System.out.println("Number of results = " + count);
-    assertEquals("Wrong number of results", 1, count);
+    assertEquals(1, count);
 
     System.out.println("Done");
   }
@@ -1055,11 +1031,11 @@ public class TestBiTemporal extends BasicJavaClientREST {
       System.out.println(message);
       System.out.println(statusCode);
 
-      assertTrue("Error Message", message.equals("XDMP-MULTIMATCH"));
-      assertTrue("Status code", (statusCode == 400));
+      assertTrue(message.equals("XDMP-MULTIMATCH"));
+      assertTrue((statusCode == 400));
     }
 
-    assertTrue("Exception not thrown for invalid transform", exceptionThrown);
+    assertTrue(exceptionThrown);
   }
 
   @Test
@@ -1085,7 +1061,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
     XMLDocumentManager xmlDocMgr = readerClient.newXMLDocumentManager();
     DocumentPage readResults = xmlDocMgr.read(xmlDocId);
     System.out.println("Number of results = " + readResults.size());
-    assertEquals("Wrong number of results", 1, readResults.size());
+    assertEquals(1, readResults.size());
 
     // Now insert a JSON document
     String jsonDocId = "javaSingleJSONDoc.json";
@@ -1095,7 +1071,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
     JSONDocumentManager jsonDocMgr = readerClient.newJSONDocumentManager();
     readResults = jsonDocMgr.read(jsonDocId);
     System.out.println("Number of results = " + readResults.size());
-    assertEquals("Wrong number of results", 1, readResults.size());
+    assertEquals(1, readResults.size());
 
     // =============================================================================
     // Check update works
@@ -1112,7 +1088,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
     DocumentPage termQueryResults = xmlDocMgr.search(termQuery, start);
     System.out
         .println("Number of results = " + termQueryResults.getTotalSize());
-    assertEquals("Wrong number of results", 2, termQueryResults.getTotalSize());
+    assertEquals(2, termQueryResults.getTotalSize());
 
     // Make sure there are 4 documents in xmlDocId collection with term XML
     queryMgr = readerClient.newQueryManager();
@@ -1123,7 +1099,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
     termQueryResults = xmlDocMgr.search(termQuery, start);
     System.out
         .println("Number of results = " + termQueryResults.getTotalSize());
-    assertEquals("Wrong number of results", 4, termQueryResults.getTotalSize());
+    assertEquals(4, termQueryResults.getTotalSize());
 
     // Make sure transform on insert worked
     while (termQueryResults.hasNext()) {
@@ -1131,7 +1107,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
       System.out.println("URI = " + record.getUri());
 
       if (record.getFormat() != Format.XML) {
-        assertFalse("Format is not JSON: " + Format.JSON, true);
+        fail("Format is not JSON: " + Format.JSON);
       } else {
 
         DOMHandle recordHandle = new DOMHandle();
@@ -1145,7 +1121,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
             && content.contains("2011-12-31T23:59:59") && record.getFormat() != Format.XML)
             && (!content.contains("new-element") || !content
                 .contains("2007-12-31T23:59:59"))) {
-          assertFalse("Transform did not work", true);
+          fail("Transform did not work");
         } else {
           System.out.println("Transform Worked!");
         }
@@ -1164,7 +1140,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
     termQueryResults = xmlDocMgr.search(termQuery, start);
     System.out
         .println("Number of results = " + termQueryResults.getTotalSize());
-    assertEquals("Wrong number of results", 2, termQueryResults.getTotalSize());
+    assertEquals(2, termQueryResults.getTotalSize());
 
     // Docu URIs in latest collection must be the same as the one as the
     // original document
@@ -1175,7 +1151,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
       System.out.println("URI = " + uri);
 
       if (!uri.equals(xmlDocId) && !uri.equals(jsonDocId)) {
-        assertFalse("URIs are not what is expected", true);
+        fail("URIs are not what is expected");
       }
     }
 
@@ -1188,7 +1164,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
     termQueryResults = xmlDocMgr.search(termQuery, start);
     System.out
         .println("Number of results = " + termQueryResults.getTotalSize());
-    assertEquals("Wrong number of results", 4, termQueryResults.getTotalSize());
+    assertEquals(4, termQueryResults.getTotalSize());
 
     // Make sure there are 8 documents in temporal collection
     queryMgr = readerClient.newQueryManager();
@@ -1199,7 +1175,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
     termQueryResults = xmlDocMgr.search(termQuery, start);
     System.out
         .println("Number of results = " + termQueryResults.getTotalSize());
-    assertEquals("Wrong number of results", 8, termQueryResults.getTotalSize());
+    assertEquals(8, termQueryResults.getTotalSize());
 
     // Make sure there are 8 documents in total. Use string search for this
     queryMgr = readerClient.newQueryManager();
@@ -1210,7 +1186,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
     termQueryResults = xmlDocMgr.search(stringQD, start);
     System.out
         .println("Number of results = " + termQueryResults.getTotalSize());
-    assertEquals("Wrong number of results", 8, termQueryResults.getTotalSize());
+    assertEquals(8, termQueryResults.getTotalSize());
 
     // =============================================================================
     // Check delete works
@@ -1227,14 +1203,14 @@ public class TestBiTemporal extends BasicJavaClientREST {
     termQueryResults = xmlDocMgr.search(termQuery, start);
     System.out
         .println("Number of results = " + termQueryResults.getTotalSize());
-    assertEquals("Wrong number of readerClientresults", 4, termQueryResults.getTotalSize());
+    assertEquals(4, termQueryResults.getTotalSize());
 
     // Make sure there is one document with xmlDocId uri
     XMLDocumentManager docMgr = readerClient.newXMLDocumentManager();
     readResults = docMgr.read(xmlDocId);
 
     System.out.println("Number of results = " + readResults.size());
-    assertEquals("Wrong number of results", 1, readResults.size());
+    assertEquals(1, readResults.size());
 
     // Make sure there is only 1 document in latest collection
     queryMgr = readerClient.newQueryManager();
@@ -1245,7 +1221,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
     termQueryResults = xmlDocMgr.search(termQuery, start);
     System.out
         .println("Number of results = " + termQueryResults.getTotalSize());
-    assertEquals("Wrong number of results", 1, termQueryResults.getTotalSize());
+    assertEquals(1, termQueryResults.getTotalSize());
 
     // Docu URIs in latest collection must be the same as the one as the
     // original document
@@ -1256,7 +1232,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
       System.out.println("URI = " + uri);
 
       if (!uri.equals(jsonDocId)) {
-        assertFalse("URIs are not what is expected", true);
+        fail("URIs are not what is expected");
       }
     }
 
@@ -1269,7 +1245,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
     termQueryResults = xmlDocMgr.search(termQuery, start);
     System.out
         .println("Number of results = " + termQueryResults.getTotalSize());
-    assertEquals("Wrong number of results", 8, termQueryResults.getTotalSize());
+    assertEquals(8, termQueryResults.getTotalSize());
   }
 
   @Test
@@ -1288,11 +1264,11 @@ public class TestBiTemporal extends BasicJavaClientREST {
     DocumentPage readResults = docMgr.read(docId);
 
     System.out.println("Number of results = " + readResults.size());
-    assertEquals("Wrong number of results", 1, readResults.size());
+    assertEquals(1, readResults.size());
 
     DocumentRecord latestDoc = readResults.next();
     System.out.println("URI after insert = " + latestDoc.getUri());
-    assertEquals("Document uri wrong after insert", docId, latestDoc.getUri());
+    assertEquals( docId, latestDoc.getUri());
 
     // Check if properties have been set. User XML DOcument Manager since
     // properties are written as XML
@@ -1316,7 +1292,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
     DocumentPage termQueryResults = docMgr.search(termQuery, start);
     System.out
         .println("Number of results = " + termQueryResults.getTotalSize());
-    assertEquals("Wrong number of results", 1, termQueryResults.getTotalSize());
+    assertEquals(1, termQueryResults.getTotalSize());
 
     // Docu URIs in latest collection must be the same as the one as the
     // original document
@@ -1327,7 +1303,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
       System.out.println("URI = " + uri);
 
       if (!uri.equals(docId)) {
-        assertFalse("URIs are not what is expected", true);
+        fail("URIs are not what is expected");
       }
     }
 
@@ -1340,7 +1316,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
     termQueryResults = docMgr.search(termQuery, start);
     System.out
         .println("Number of results = " + termQueryResults.getTotalSize());
-    assertEquals("Wrong number of results", 4, termQueryResults.getTotalSize());
+    assertEquals(4, termQueryResults.getTotalSize());
 
     // Make sure there are 4 documents in temporal collection
     queryMgr = writerClient.newQueryManager();
@@ -1351,7 +1327,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
     termQueryResults = docMgr.search(termQuery, start);
     System.out
         .println("Number of results = " + termQueryResults.getTotalSize());
-    assertEquals("Wrong number of results", 4, termQueryResults.getTotalSize());
+    assertEquals(4, termQueryResults.getTotalSize());
 
     // Make sure there are 4 documents in total. Use string search for this
     queryMgr = writerClient.newQueryManager();
@@ -1363,7 +1339,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
     termQueryResults = docMgr.search(stringQD, start);
     System.out
         .println("Number of results = " + termQueryResults.getTotalSize());
-    assertEquals("Wrong number of results", 4, termQueryResults.getTotalSize());
+    assertEquals(4, termQueryResults.getTotalSize());
 
     while (termQueryResults.hasNext()) {
       DocumentRecord record = termQueryResults.next();
@@ -1385,24 +1361,24 @@ public class TestBiTemporal extends BasicJavaClientREST {
             && !collection.equals(updateCollectionName)
             && !collection.equals(insertCollectionName)
             && !collection.equals(temporalCollectionName)) {
-          assertFalse("Collection not what is expected: " + collection, true);
+          fail("Collection not what is expected: " + collection);
         }
 
         if (collection.equals(latestCollectionName)) {
           // If there is a latest collection, docId must match the URI
-          assertTrue("Document URI", record.getUri().equals(docId));
+          assertTrue(record.getUri().equals(docId));
         }
       }
 
       if (record.getUri().equals(docId)) {
         // Must belong to latest collection as well. So, count must be 4
-        assertTrue("Count of collections", (count == 4));
+        assertTrue((count == 4));
       } else {
-        assertTrue("Count of collections", (count == 3));
+        assertTrue((count == 3));
       }
 
       if (record.getFormat() != Format.JSON) {
-        assertFalse("Format is not JSON: " + Format.JSON, true);
+        fail("Format is not JSON: " + Format.JSON);
       } else {
         JacksonDatabindHandle<ObjectNode> recordHandle = new JacksonDatabindHandle<>(
             ObjectNode.class);
@@ -1426,14 +1402,14 @@ public class TestBiTemporal extends BasicJavaClientREST {
     termQueryResults = docMgr.search(termQuery, start);
     System.out
         .println("Number of results = " + termQueryResults.getTotalSize());
-    assertEquals("Wrong number of results", 4, termQueryResults.getTotalSize());
+    assertEquals(4, termQueryResults.getTotalSize());
 
     // Make sure there is one document with docId uri
     docMgr = writerClient.newJSONDocumentManager();
     readResults = docMgr.read(docId);
 
     System.out.println("Number of results = " + readResults.size());
-    assertEquals("Wrong number of results", 1, readResults.size());
+    assertEquals(1, readResults.size());
 
     // Make sure there are no documents in latest collection
     queryMgr = writerClient.newQueryManager();
@@ -1444,7 +1420,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
     termQueryResults = docMgr.search(termQuery, start);
     System.out
         .println("Number of results = " + termQueryResults.getTotalSize());
-    assertEquals("Wrong number of results", 0, termQueryResults.getTotalSize());
+    assertEquals(0, termQueryResults.getTotalSize());
 
     // Make sure there are 4 documents in temporal collection
     queryMgr = writerClient.newQueryManager();
@@ -1455,7 +1431,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
     termQueryResults = docMgr.search(termQuery, start);
     System.out
         .println("Number of results = " + termQueryResults.getTotalSize());
-    assertEquals("Wrong number of results", 4, termQueryResults.getTotalSize());
+    assertEquals(4, termQueryResults.getTotalSize());
 
     // Make sure there are 4 documents in total. Use string search for this
     queryMgr = writerClient.newQueryManager();
@@ -1464,10 +1440,10 @@ public class TestBiTemporal extends BasicJavaClientREST {
     termQueryResults = docMgr.search(stringQD, start);
     System.out
         .println("Number of results = " + termQueryResults.getTotalSize());
-    assertEquals("Wrong number of results", 4, termQueryResults.getTotalSize());
+    assertEquals(4, termQueryResults.getTotalSize());
   }
 
-  // Test LSQT advance manually. Should have automation set to false on the temporal collection used. 
+  // Test LSQT advance manually. Should have automation set to false on the temporal collection used.
   @Test
   public void testAdvancingLSQT() throws Exception {
       try {
@@ -1495,7 +1471,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
               extMsg = ex.getMessage();
               System.out.println("Permissions exception message for LSQT advance is " + extMsg);
           }
-          assertTrue("Expected exception message incorrect for LSQT advance user permission", extMsg.contains(permnExceptMsg));
+          assertTrue(extMsg.contains(permnExceptMsg));
 
           QueryManager queryMgrLSQT = adminClient.newQueryManager();
           StructuredQueryBuilder sqbLSQT = queryMgrLSQT.newStructuredQueryBuilder();
@@ -1515,14 +1491,14 @@ public class TestBiTemporal extends BasicJavaClientREST {
               actualNoAdvanceMsg = ex.getMessage();
               System.out.println("Exception message for LSQT without advance set is " + actualNoAdvanceMsg);
           }
-          assertTrue("Expected exception message not available for LSQT advance user permission", actualNoAdvanceMsg.contains(WithoutAdvaceSetExceptMsg));
+          assertTrue(actualNoAdvanceMsg.contains(WithoutAdvaceSetExceptMsg));
 
           // Set the Advance manually.
           docMgr.advanceLsqt(temporalLsqtCollectionName);
           termQueryResultsLSQT = docMgrQy.search(periodQueryLSQT, startLSQT);
 
-          assertTrue("LSQT Query results (Total Pages) before advance is incorrect", termQueryResultsLSQT.getTotalPages() == 0);
-          assertTrue("LSQT Query results (Size) before advance is incorrect", termQueryResultsLSQT.size() == 0);
+          assertTrue(termQueryResultsLSQT.getTotalPages() == 0);
+          assertTrue(termQueryResultsLSQT.size() == 0);
 
           // After Advance of the LSQT, query again with new query time greater than LSQT
 
@@ -1542,7 +1518,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
           catch(Exception ex) {
               actGrMsg = ex.getMessage();
           }
-          assertTrue("Expected exception message not available for LSQT advance user permission", actGrMsg.contains(excepMsgGrtr));
+          assertTrue(actGrMsg.contains(excepMsgGrtr));
 
           // Query again with query time less than LSQT. 10 minutes less than the LSQT
           Calendar lessTime = DatatypeConverter.parseDateTime("2009-01-01T00:00:01");
@@ -1552,8 +1528,8 @@ public class TestBiTemporal extends BasicJavaClientREST {
 
           System.out.println("LSQT Query results (Total Pages) after advance " + termQueryResultsLSQT2.getTotalPages());
           System.out.println("LSQT Query results (Size) after advance " + termQueryResultsLSQT2.size());
-          assertTrue("LSQT Query results (Total Pages) after advance is incorrect", termQueryResultsLSQT2.getTotalPages() == 0);
-          assertTrue("LSQT Query results (Size) after advance is incorrect", termQueryResultsLSQT2.size() == 0);
+          assertTrue(termQueryResultsLSQT2.getTotalPages() == 0);
+          assertTrue(termQueryResultsLSQT2.size() == 0);
 
           // Query again with query time equal to LSQT.
           queryTimeLSQT2 = DatatypeConverter.parseDateTime(afterLSQTAdvance);
@@ -1562,8 +1538,8 @@ public class TestBiTemporal extends BasicJavaClientREST {
 
           System.out.println("LSQT Query results (Total Pages) after advance " + termQueryResultsLSQT2.getTotalPages());
           System.out.println("LSQT Query results (Size) after advance " + termQueryResultsLSQT2.size());
-          assertTrue("LSQT Query results (Total Pages) after advance is incorrect", termQueryResultsLSQT2.getTotalPages() == 1);
-          assertTrue("LSQT Query results (Size) after advance is incorrect", termQueryResultsLSQT2.size() == 1);
+          assertTrue(termQueryResultsLSQT2.getTotalPages() == 1);
+          assertTrue(termQueryResultsLSQT2.size() == 1);
 
           while (termQueryResultsLSQT2.hasNext()) {
               DocumentRecord record = termQueryResultsLSQT2.next();
@@ -1582,16 +1558,16 @@ public class TestBiTemporal extends BasicJavaClientREST {
           DocumentPage readResults = docMgr.read(docId);
 
           System.out.println("Number of results = " + readResults.size());
-          assertEquals("Wrong number of results", 1, readResults.size());
+          assertEquals(1, readResults.size());
 
           DocumentRecord record = readResults.next();
           System.out.println("URI after insert = " + record.getUri());
-          assertEquals("Document uri wrong after insert", docId, record.getUri());
+          assertEquals( docId, record.getUri());
           System.out.println("Content = " + recordHandle.toString());
 
           // Make sure System start time was what was set ("2010-01-01T00:00:01")
           if (record.getFormat() != Format.JSON) {
-              assertFalse("Invalid document format: " + record.getFormat(), true);
+              fail("Invalid document format: " + record.getFormat());
           } else {
               JsonFactory factory = new JsonFactory();
               ObjectMapper mapper = new ObjectMapper(factory);
@@ -1607,8 +1583,8 @@ public class TestBiTemporal extends BasicJavaClientREST {
               System.out.println("systemStartDate = " + systemStartDate);
               System.out.println("systemEndDate = " + systemEndDate);
 
-              assertTrue("System start date check failed", (systemStartDate.contains("2010-01-01T00:00:01")));
-              assertTrue("System end date check failed", (systemEndDate.contains("9999-12-31T11:59:59")));
+              assertTrue((systemStartDate.contains("2010-01-01T00:00:01")));
+              assertTrue((systemEndDate.contains("9999-12-31T11:59:59")));
 
               // Validate collections
               Iterator<String> resCollections = metadataHandle.getCollections().iterator();
@@ -1620,7 +1596,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
                           && !collection.equals(insertCollectionName)
                           && !collection.equals(temporalLsqtCollectionName)
                           && !collection.equals(latestCollectionName)) {
-                      assertFalse("Collection not what is expected: " + collection, true);
+                      fail("Collection not what is expected: " + collection);
                   }
               }
 
@@ -1631,29 +1607,27 @@ public class TestBiTemporal extends BasicJavaClientREST {
               String actualPermissions = getDocumentPermissionsString(permissions);
               System.out.println("actualPermissions: " + actualPermissions);
 
-              assertTrue("Document permissions difference in size value",
-                      actualPermissions.contains("size:6"));
-              assertTrue("Document permissions difference in harmonized-updater permission", actualPermissions.contains("harmonized-updater:[UPDATE]"));
-              assertTrue("Document permissions difference in harmonized-reader permission", actualPermissions.contains("harmonized-reader:[READ]"));
+              assertTrue(actualPermissions.contains("size:6"));
+              assertTrue(actualPermissions.contains("harmonized-updater:[UPDATE]"));
+              assertTrue(actualPermissions.contains("harmonized-reader:[READ]"));
 
-              assertTrue("Document permissions difference in rest-reader permission",
-                      actualPermissions.contains("rest-reader:[READ]"));
+              assertTrue(actualPermissions.contains("rest-reader:[READ]"));
               // Split up rest-writer:[READ, EXECUTE, UPDATE] string
               String[] writerPerms = actualPermissions.split("rest-writer:\\[")[1].split("\\]")[0].split(",");
 
-              assertTrue("Document permissions difference in rest-writer permission - first permission",
+              assertTrue(
                       writerPerms[0].contains("UPDATE") || writerPerms[1].contains("UPDATE") || writerPerms[2].contains("UPDATE"));
-              assertTrue("Document permissions difference in rest-writer permission - second permission",
+              assertTrue(
                       writerPerms[0].contains("EXECUTE") || writerPerms[1].contains("EXECUTE") || writerPerms[2].contains("EXECUTE"));
-              assertTrue("Document permissions difference in rest-writer permission - third permission",
+              assertTrue(
                       writerPerms[0].contains("READ") || writerPerms[1].contains("READ") || writerPerms[2].contains("READ"));
 
               // Split up temporal-admin=[READ, UPDATE] string
               String[] temporalAdminPerms = actualPermissions.split("temporal-admin:\\[")[1].split("\\]")[0].split(",");
 
-              assertTrue("Document permissions difference in temporal-admin permission - first permission",
+              assertTrue(
                       temporalAdminPerms[0].contains("UPDATE") || temporalAdminPerms[1].contains("UPDATE"));
-              assertTrue("Document permissions difference in rest-writer permission - second permission",
+              assertTrue(
                       temporalAdminPerms[0].contains("READ") || temporalAdminPerms[1].contains("READ"));
           }
 
@@ -1673,9 +1647,9 @@ public class TestBiTemporal extends BasicJavaClientREST {
           docMgr.advanceLsqt(temporalLsqtCollectionName);
           afterLSQTAdvance = desc.getTemporalSystemTime();
           System.out.println("LSQT on collection after update and manual advance is " + afterLSQTAdvance);
-          assertTrue("LSQT Advance incorrect", desc.getTemporalSystemTime().trim().contains("2010-01-06T00:00:01-08:00"));
+          assertTrue(desc.getTemporalSystemTime().trim().contains("2010-01-06T00:00:01-08:00"));
 
-          // Verify that the document was updated 
+          // Verify that the document was updated
           // Make sure there are 1 documents in latest collection
           QueryManager queryMgr = readerClient.newQueryManager();
           StructuredQueryBuilder sqb = queryMgr.newStructuredQueryBuilder();
@@ -1683,7 +1657,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
           long start = 1;
           DocumentPage termQueryResults = docMgr.search(termQuery, start);
           System.out.println("Number of results = " + termQueryResults.getTotalSize());
-          assertEquals("Wrong number of results", 1, termQueryResults.getTotalSize());
+          assertEquals(1, termQueryResults.getTotalSize());
 
           // Document URIs in latest collection must be the same as the one as the
           // original documents
@@ -1691,7 +1665,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
               record = termQueryResults.next();
               String uri = record.getUri();
               System.out.println("URI = " + uri);
-              assertTrue("URIs are not what is expected", uri.equals(docId));
+              assertTrue(uri.equals(docId));
           }
 
           // Make sure there are 4 documents in jsonDocId collection
@@ -1702,7 +1676,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
           start = 1;
           termQueryResults = docMgr.search(termQuery, start);
           System.out.println("Number of results = " + termQueryResults.getTotalSize());
-          assertEquals("Wrong number of results", 4, termQueryResults.getTotalSize());
+          assertEquals(4, termQueryResults.getTotalSize());
 
           // Make sure there are 4 documents in temporal collection
           queryMgr = readerClient.newQueryManager();
@@ -1712,7 +1686,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
           start = 1;
           termQueryResults = docMgr.search(termQuery, start);
           System.out.println("Number of results = " + termQueryResults.getTotalSize());
-          assertEquals("Wrong number of results", 5, termQueryResults.getTotalSize());
+          assertEquals(5, termQueryResults.getTotalSize());
 
           // Issue a period range search to make sure update went fine.
           StructuredQueryBuilder.Axis axis = sqbLSQT.axis(axisValidName);
@@ -1720,7 +1694,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
 
           periodQueryLSQT2 = sqbLSQT.temporalPeriodRange(axis, StructuredQueryBuilder.TemporalOperator.ALN_CONTAINS, period, new String[] {});
           termQueryResultsLSQT2 = docMgrQy.search(periodQueryLSQT2, startLSQT);
-          assertTrue("CTS Period range query returned incorrect results", termQueryResultsLSQT2.getTotalSize() == 1);
+          assertTrue(termQueryResultsLSQT2.getTotalSize() == 1);
 
           while (termQueryResultsLSQT2.hasNext()) {
               DocumentRecord recordContains = termQueryResultsLSQT2.next();
@@ -1731,7 +1705,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
               recordContains.getContent(recordContainsHandle);
               String docContents = recordContainsHandle.toString();
               System.out.println("Content = " + docContents);
-              assertTrue("CTS Period range query returned incorrect results",docContents.contains("\"javaValidStartERI\":\"2001-01-01T00:00:00\",\"javaValidEndERI\":\"2011-12-31T23:59:59\""));
+              assertTrue(docContents.contains("\"javaValidStartERI\":\"2001-01-01T00:00:00\",\"javaValidEndERI\":\"2011-12-31T23:59:59\""));
           }
       }
     catch (Exception ex) {
@@ -1779,12 +1753,12 @@ public class TestBiTemporal extends BasicJavaClientREST {
       System.out.println(message);
       System.out.println(statusCode);
 
-      assertTrue("Error Message", message.equals("TEMPORAL-OPNOTAFTERLSQT"));
-      assertTrue("Status code", (statusCode == 400));
+      assertTrue(message.equals("TEMPORAL-OPNOTAFTERLSQT"));
+      assertTrue((statusCode == 400));
     }
 
-    assertTrue("Exception not thrown during invalid update of system time",
-        exceptionThrown);
+    assertTrue(
+        exceptionThrown, "Exception not thrown during invalid update of system time");
 
     // Delete by passing invalid time
     Calendar deleteTime = DatatypeConverter
@@ -1803,11 +1777,11 @@ public class TestBiTemporal extends BasicJavaClientREST {
       System.out.println(message);
       System.out.println(statusCode);
 
-      assertTrue("Error Message", message.equals("TEMPORAL-SYSTEMTIME-BACKWARDS"));
-      assertTrue("Status code", (statusCode == 400));
+      assertTrue(message.equals("TEMPORAL-SYSTEMTIME-BACKWARDS"));
+      assertTrue((statusCode == 400));
     }
 
-    assertTrue("Exception not thrown for invalid extension", exceptionThrown);
+    assertTrue(exceptionThrown);
   }
 
   @Test
@@ -1832,7 +1806,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
       if (readResults.size() != 1) {
         transaction.rollback();
 
-        assertEquals("Wrong number of results", 1, readResults.size());
+        assertEquals(1, readResults.size());
       }
 
       DocumentRecord latestDoc = readResults.next();
@@ -1841,7 +1815,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
       if (!docId.equals(latestDoc.getUri())) {
         transaction.rollback();
 
-        assertEquals("Document uri wrong after insert", docId,
+        assertEquals( docId,
             latestDoc.getUri());
       }
 
@@ -1860,8 +1834,8 @@ public class TestBiTemporal extends BasicJavaClientREST {
         transaction.rollback();
 
         assertTrue(
-            "Exception not thrown during read using no transaction handle",
-            exceptionThrown);
+
+            exceptionThrown, "Exception not thrown during read using no transaction handle");
       }
 
       updateJSONSingleDocument(temporalCollectionName, docId, transaction, null);
@@ -1880,7 +1854,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
       if (termQueryResults.getTotalSize() != 1) {
         transaction.rollback();
 
-        assertEquals("Wrong number of results", 1,
+        assertEquals(1,
             termQueryResults.getTotalSize());
       }
 
@@ -1897,7 +1871,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
       if (termQueryResults.getTotalSize() != 4) {
         transaction.rollback();
 
-        assertEquals("Wrong number of results", 4,
+        assertEquals(4,
             termQueryResults.getTotalSize());
       }
 
@@ -1916,7 +1890,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
       if (termQueryResults.getTotalSize() != 0) {
         transaction.rollback();
 
-        assertEquals("Wrong number of results", 0,
+        assertEquals(0,
             termQueryResults.getTotalSize());
       }
 
@@ -1935,7 +1909,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
       if (termQueryResults.getTotalSize() != 0) {
         transaction.rollback();
 
-        assertEquals("Wrong number of results", 0,
+        assertEquals(0,
             termQueryResults.getTotalSize());
       }
 
@@ -1951,13 +1925,13 @@ public class TestBiTemporal extends BasicJavaClientREST {
       termQueryResults = docMgr.search(termQuery, start);
       System.out.println("Number of results = "
           + termQueryResults.getTotalSize());
-      assertEquals("Wrong number of results", 0,
+      assertEquals(0,
           termQueryResults.getTotalSize());
     } catch (Exception ex) {
       transaction.rollback();
       transaction = null;
 
-      assertTrue("testTransactionCommit failed", false);
+      assertTrue(false);
     } finally {
       if (transaction != null) {
         transaction.rollback();
@@ -1983,8 +1957,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
         transaction.rollback();
         transaction = null;
 
-        assertTrue("insertJSONSingleDocument failed in testTransactionRollback",
-            false);
+        fail("insertJSONSingleDocument failed in testTransactionRollback");
       }
 
       // Verify that the document was inserted
@@ -1995,7 +1968,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
       if (readResults.size() != 1) {
         transaction.rollback();
 
-        assertEquals("Wrong number of results", 1, readResults.size());
+        assertEquals(1, readResults.size());
       }
 
       DocumentRecord latestDoc = readResults.next();
@@ -2003,7 +1976,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
       if (!docId.equals(latestDoc.getUri())) {
         transaction.rollback();
 
-        assertEquals("Document uri wrong after insert", docId, latestDoc.getUri());
+        assertEquals( docId, latestDoc.getUri());
       }
 
       try {
@@ -2012,8 +1985,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
         transaction.rollback();
         transaction = null;
 
-        assertTrue("updateJSONSingleDocument failed in testTransactionRollback",
-            false);
+        fail("updateJSONSingleDocument failed in testTransactionRollback");
       }
 
       // Verify that the document is visible and count is 4
@@ -2032,7 +2004,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
       if (termQueryResults.getTotalSize() != 4) {
         transaction.rollback();
 
-        assertEquals("Wrong number of results", 4,
+        assertEquals(4,
             termQueryResults.getTotalSize());
       }
 
@@ -2052,8 +2024,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
       if (!exceptionThrown) {
         transaction.rollback();
 
-        assertTrue("Exception not thrown during read on non-existing uri",
-            exceptionThrown);
+        assertTrue(exceptionThrown, "Exception not thrown during read on non-existing uri");
       }
 
       // =======================================================================
@@ -2071,8 +2042,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
         transaction.rollback();
         transaction = null;
 
-        assertTrue("insertJSONSingleDocument failed in testTransactionRollback",
-            false);
+        fail("insertJSONSingleDocument failed in testTransactionRollback");
       }
 
       // Verify that the document was inserted
@@ -2083,7 +2053,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
       if (readResults.size() != 1) {
         transaction.rollback();
 
-        assertEquals("Wrong number of results", 1, readResults.size());
+        assertEquals(1, readResults.size());
       }
 
       latestDoc = readResults.next();
@@ -2091,7 +2061,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
       if (!docId.equals(latestDoc.getUri())) {
         transaction.rollback();
 
-        assertEquals("Document uri wrong after insert", docId, latestDoc.getUri());
+        assertEquals( docId, latestDoc.getUri());
       }
 
       try {
@@ -2100,8 +2070,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
         transaction.rollback();
         transaction = null;
 
-        assertTrue("deleteJSONSingleDocument failed in testTransactionRollback",
-            false);
+        fail("deleteJSONSingleDocument failed in testTransactionRollback");
       }
 
       // Verify that the document is visible and count is 1
@@ -2119,7 +2088,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
       if (termQueryResults.getTotalSize() != 1) {
         transaction.rollback();
 
-        assertEquals("Wrong number of results", 1,
+        assertEquals(1,
             termQueryResults.getTotalSize());
       }
 
@@ -2182,9 +2151,9 @@ public class TestBiTemporal extends BasicJavaClientREST {
     System.out.println("Query is " + periodQuery.serialize() );
     JSONDocumentManager docMgr = readerClient.newJSONDocumentManager();
     docMgr.setMetadataCategories(Metadata.ALL); // Get all metadata
-    DocumentPage termQueryResults = docMgr.search(periodQuery, start);   
+    DocumentPage termQueryResults = docMgr.search(periodQuery, start);
     Thread.sleep(2000);
-    
+
     long count = 0;
     while (termQueryResults.hasNext()) {
       ++count;
@@ -2235,14 +2204,14 @@ public class TestBiTemporal extends BasicJavaClientREST {
         System.out.println("validStartDate = " + validStartDate);
         System.out.println("validEndDate = " + validEndDate);
 
-        assertTrue("Valid start date check failed",
+        assertTrue(
             (validStartDate.equals("2001-01-01T00:00:00") && validEndDate
                 .equals("2011-12-31T23:59:59")));
       }
     }
 
     System.out.println("Number of results using SQB = " + count);
-    assertEquals("Wrong number of results", 1, count);
+    assertEquals(1, count);
   }
 
   @Test
@@ -2313,7 +2282,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
       }
 
       if (record.getFormat() != Format.JSON) {
-        assertFalse("Invalid document format: " + record.getFormat(), true);
+        fail("Invalid document format: " + record.getFormat());
       } else {
         JacksonDatabindHandle<ObjectNode> recordHandle = new JacksonDatabindHandle<>(
             ObjectNode.class);
@@ -2337,17 +2306,17 @@ public class TestBiTemporal extends BasicJavaClientREST {
         System.out.println("validStartDate = " + validStartDate);
         System.out.println("validEndDate = " + validEndDate);
 
-        assertTrue("Valid start date check failed",
+        assertTrue(
             (validStartDate.equals("2001-01-01T00:00:00") || validStartDate
                 .equals("2003-01-01T00:00:00")));
-        assertTrue("Valid end date check failed",
+        assertTrue(
             (validEndDate.equals("2011-12-31T23:59:59") || validEndDate
                 .equals("2008-12-31T23:59:59")));
       }
     }
 
     System.out.println("Number of results using SQB = " + count);
-    assertEquals("Wrong number of results", 2, count);
+    assertEquals(2, count);
   }
 
   @Test
@@ -2440,11 +2409,11 @@ public class TestBiTemporal extends BasicJavaClientREST {
         System.out.println("validStartDate = " + validStartDate);
         System.out.println("validEndDate = " + validEndDate);
 
-        assertTrue("Valid start date check failed",
+        assertTrue(
             (validStartDate.contains("2001-01-01T00:00:00") && validEndDate
                 .contains("2011-12-31T23:59:59")));
 
-        assertTrue("System start date check failed",
+        assertTrue(
             (systemStartDate.contains("2005-01-01T00:00:01") && systemEndDate
                 .contains("2010-01-01T00:00:01")));
 
@@ -2452,7 +2421,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
     }
 
     System.out.println("Number of results using SQB = " + count);
-    assertEquals("Wrong number of results", 1, count);
+    assertEquals(1, count);
   }
 
   @Test
@@ -2550,11 +2519,11 @@ public class TestBiTemporal extends BasicJavaClientREST {
       System.out.println(message);
       System.out.println(statusCode);
 
-      assertTrue("Error Message", message.equals("XDMP-DOCROOTTEXT"));
-      assertTrue("Status code", (statusCode == 400));
+      assertTrue(message.equals("XDMP-DOCROOTTEXT"));
+      assertTrue((statusCode == 400));
     }
 
-    assertTrue("Exception not thrown for invalid extension", exceptionThrown);
+    assertTrue(exceptionThrown);
   }
 
   @Test
@@ -2591,12 +2560,11 @@ public class TestBiTemporal extends BasicJavaClientREST {
       System.out.println(message);
       System.out.println(statusCode);
 
-      assertTrue("Error Message", message.equals("TEMPORAL-COLLECTIONNOTFOUND"));
-      assertTrue("Status code", (statusCode == 400));
+      assertTrue(message.equals("TEMPORAL-COLLECTIONNOTFOUND"));
+      assertTrue((statusCode == 400));
     }
 
-    assertTrue("Exception not thrown for invalid temporal collection",
-        exceptionThrown);
+    assertTrue(exceptionThrown, "Exception not thrown for invalid temporal collection");
   }
 
   @Test
@@ -2632,12 +2600,11 @@ public class TestBiTemporal extends BasicJavaClientREST {
       System.out.println(message);
       System.out.println(statusCode);
 
-      assertTrue("Error Message", message.equals("TEMPORAL-COLLECTIONLATEST"));
-      assertTrue("Status code", (statusCode == 400));
+      assertTrue(message.equals("TEMPORAL-COLLECTIONLATEST"));
+      assertTrue((statusCode == 400));
     }
 
-    assertTrue("Exception not thrown for invalid temporal collection",
-        exceptionThrown);
+    assertTrue(exceptionThrown, "Exception not thrown for invalid temporal collection");
   }
 
   @Test
@@ -2675,12 +2642,11 @@ public class TestBiTemporal extends BasicJavaClientREST {
       System.out.println(message);
       System.out.println(statusCode);
 
-      assertTrue("Error Message", message.equals("SEC-PRIV"));
-      assertTrue("Status code", (statusCode == 403));
+      assertTrue(message.equals("SEC-PRIV"));
+      assertTrue((statusCode == 403));
     }
 
-    assertTrue("Exception not thrown for invalid temporal collection",
-        exceptionThrown);
+    assertTrue(exceptionThrown, "Exception not thrown for invalid temporal collection");
   }
 
   @Test
@@ -2724,17 +2690,16 @@ public class TestBiTemporal extends BasicJavaClientREST {
       System.out.println(message);
       System.out.println(statusCode);
 
-      assertTrue("Error Message", message.equals("TEMPORAL-CANNOT-URI"));
-      assertTrue("Status code", (statusCode == 400));
+      assertTrue(message.equals("TEMPORAL-CANNOT-URI"));
+      assertTrue((statusCode == 400));
     }
 
     ConnectedRESTQA.deleteElementRangeIndexTemporalCollection("Documents",
         jsonDocId);
 
-    assertTrue("Exception not thrown for invalid temporal collection",
-        exceptionThrown);
+    assertTrue(exceptionThrown, "Exception not thrown for invalid temporal collection");
   }
-  
+
   @Test
   // Test bitemporal create, update and delete works with a JSON document while
   // passing
@@ -2765,16 +2730,16 @@ public class TestBiTemporal extends BasicJavaClientREST {
     DocumentPage readResults = docMgr.read(docId);
 
     System.out.println("Number of results = " + readResults.size());
-    assertEquals("Wrong number of results", 1, readResults.size());
+    assertEquals(1, readResults.size());
 
     DocumentRecord record = readResults.next();
     System.out.println("URI after insert = " + record.getUri());
-    assertEquals("Document uri wrong after insert", docId, record.getUri());
+    assertEquals( docId, record.getUri());
     System.out.println("Content = " + recordHandle.toString());
 
     // Make sure System start time was what was set ("2010-01-01T00:00:01")
     if (record.getFormat() != Format.JSON) {
-      assertFalse("Invalid document format: " + record.getFormat(), true);
+      fail("Invalid document format: " + record.getFormat());
     } else {
       JsonFactory factory = new JsonFactory();
       ObjectMapper mapper = new ObjectMapper(factory);
@@ -2793,9 +2758,9 @@ public class TestBiTemporal extends BasicJavaClientREST {
       System.out.println("systemStartDate = " + systemStartDate);
       System.out.println("systemEndDate = " + systemEndDate);
 
-      assertTrue("System start date check failed",
+      assertTrue(
           (systemStartDate.contains("2010-01-01T00:00:01")));
-      assertTrue("System end date check failed",
+      assertTrue(
           (systemEndDate.contains("9999-12-31T11:59:59")));
 
       // Validate collections
@@ -2809,7 +2774,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
             && !collection.equals(insertCollectionName)
             && !collection.equals(temporalLsqtCollectionName)
             && !collection.equals(latestCollectionName)) {
-          assertFalse("Collection not what is expected: " + collection, true);
+          fail("Collection not what is expected: " + collection);
         }
       }
 
@@ -2820,38 +2785,38 @@ public class TestBiTemporal extends BasicJavaClientREST {
       String actualPermissions = getDocumentPermissionsString(permissions);
       System.out.println("actualPermissions: " + actualPermissions);
 
-      assertTrue("Document permissions difference in size value",
+      assertTrue(
           actualPermissions.contains("size:7"));
 
-      assertTrue("Document permissions difference in rest-reader permission",
+      assertTrue(
           actualPermissions.contains("rest-reader:[READ]"));
-      assertTrue("Document permissions difference in harmonized-updater permission", actualPermissions.contains("harmonized-updater:[UPDATE]"));
-      assertTrue("Document permissions difference in harmonized-reader permission", actualPermissions.contains("harmonized-reader:[READ]"));
+      assertTrue(actualPermissions.contains("harmonized-updater:[UPDATE]"));
+      assertTrue(actualPermissions.contains("harmonized-reader:[READ]"));
       // Split up rest-writer:[READ, EXECUTE, UPDATE] string
       String[] writerPerms = actualPermissions.split("rest-writer:\\[")[1].split("\\]")[0].split(",");
 
-      assertTrue("Document permissions difference in rest-writer permission - first permission",
+      assertTrue(
           writerPerms[0].contains("UPDATE") || writerPerms[1].contains("UPDATE") || writerPerms[2].contains("UPDATE"));
-      assertTrue("Document permissions difference in rest-writer permission - second permission",
+      assertTrue(
           writerPerms[0].contains("EXECUTE") || writerPerms[1].contains("EXECUTE") || writerPerms[2].contains("EXECUTE"));
-      assertTrue("Document permissions difference in rest-writer permission - third permission",
+      assertTrue(
           writerPerms[0].contains("READ") || writerPerms[1].contains("READ") || writerPerms[2].contains("READ"));
       // Split up app-user app-user:[UPDATE, EXECUTE, READ] string
       String[] appUserPerms = actualPermissions.split("app\\-user:\\[")[1].split("\\]")[0].split(",");
 
-      assertTrue("Document permissions difference in App User permission - first permission",
+      assertTrue(
           appUserPerms[0].contains("UPDATE") || appUserPerms[1].contains("UPDATE") || appUserPerms[2].contains("UPDATE"));
-      assertTrue("Document permissions difference in App User permission - second permission",
+      assertTrue(
           appUserPerms[0].contains("READ") || appUserPerms[1].contains("READ") || appUserPerms[2].contains("READ"));
-      assertTrue("Document permissions difference in App User permission - third permission",
+      assertTrue(
           appUserPerms[0].contains("EXECUTE") || appUserPerms[1].contains("EXECUTE") || appUserPerms[2].contains("EXECUTE"));
 
       // Split up temporal-admin=[READ, UPDATE] string
       String[] temporalAdminPerms = actualPermissions.split("temporal-admin:\\[")[1].split("\\]")[0].split(",");
 
-      assertTrue("Document permissions difference in temporal-admin permission - first permission",
+      assertTrue(
           temporalAdminPerms[0].contains("UPDATE") || temporalAdminPerms[1].contains("UPDATE"));
-      assertTrue("Document permissions difference in rest-writer permission - second permission",
+      assertTrue(
           temporalAdminPerms[0].contains("READ") || temporalAdminPerms[1].contains("READ"));
 
       // Validate quality
@@ -2879,7 +2844,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
     DocumentPage termQueryResults = docMgr.search(termQuery, start);
     System.out
         .println("Number of results = " + termQueryResults.getTotalSize());
-    assertEquals("Wrong number of results", 1, termQueryResults.getTotalSize());
+    assertEquals(1, termQueryResults.getTotalSize());
 
     // Document URIs in latest collection must be the same as the one as the
     // original document
@@ -2890,7 +2855,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
       System.out.println("URI = " + uri);
 
       if (!uri.equals(docId)) {
-        assertFalse("URIs are not what is expected", true);
+        fail("URIs are not what is expected");
       }
     }
 
@@ -2903,7 +2868,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
     termQueryResults = docMgr.search(termQuery, start);
     System.out
         .println("Number of results = " + termQueryResults.getTotalSize());
-    assertEquals("Wrong number of results", 4, termQueryResults.getTotalSize());
+    assertEquals(4, termQueryResults.getTotalSize());
 
     // Make sure there are 4 documents in temporal collection
     queryMgr = readerClient.newQueryManager();
@@ -2914,7 +2879,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
     termQueryResults = docMgr.search(termQuery, start);
     System.out
         .println("Number of results = " + termQueryResults.getTotalSize());
-    assertEquals("Wrong number of results", 4, termQueryResults.getTotalSize());
+    assertEquals(4, termQueryResults.getTotalSize());
 
     // Make sure there are 4 documents in total. Use string search for this
     queryMgr = readerClient.newQueryManager();
@@ -2926,7 +2891,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
     termQueryResults = docMgr.search(stringQD, start);
     System.out
         .println("Number of results = " + termQueryResults.getTotalSize());
-    assertEquals("Wrong number of results", 4, termQueryResults.getTotalSize());
+    assertEquals(4, termQueryResults.getTotalSize());
 
     while (termQueryResults.hasNext()) {
       record = termQueryResults.next();
@@ -2936,7 +2901,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
       record.getMetadata(metadataHandle);
 
       if (record.getFormat() != Format.JSON) {
-        assertFalse("Format is not JSON: " + Format.JSON, true);
+        fail("Format is not JSON: " + Format.JSON);
       } else {
         // Make sure that system and valid times are what is expected
         recordHandle = new JacksonDatabindHandle<>(ObjectNode.class);
@@ -2981,9 +2946,9 @@ public class TestBiTemporal extends BasicJavaClientREST {
 
         if (validStartDate.contains("2003-01-01T00:00:00")
             && validEndDate.contains("2008-12-31T23:59:59")) {
-          assertTrue("System start date check failed",
+          assertTrue(
               (systemStartDate.contains("2011-01-01T00:00:01")));
-          assertTrue("System end date check failed",
+          assertTrue(
               (systemEndDate.contains("9999-12-31T11:59:59")));
 
           Iterator<String> resCollections = metadataHandle.getCollections()
@@ -2995,43 +2960,42 @@ public class TestBiTemporal extends BasicJavaClientREST {
             if (!collection.equals(docId)
                 && !collection.equals(updateCollectionName)
                 && !collection.equals(temporalLsqtCollectionName)) {
-              assertFalse("Collection not what is expected: " + collection,
-                  true);
+              fail("Collection not what is expected: " + collection);
             }
           }
-          assertTrue("Properties should be empty", metadataHandle
+          assertTrue(metadataHandle
               .getProperties().isEmpty());
 
-          assertTrue("Document permissions difference in size value",
+          assertTrue(
               actualPermissions.contains("size:7"));
-          
-          assertTrue("Document permissions difference in harmonized-updater permission", actualPermissions.contains("harmonized-updater:[UPDATE]"));
-          assertTrue("Document permissions difference in harmonized-reader permission", actualPermissions.contains("harmonized-reader:[READ]"));
+
+          assertTrue(actualPermissions.contains("harmonized-updater:[UPDATE]"));
+          assertTrue(actualPermissions.contains("harmonized-reader:[READ]"));
           // Split up rest-writer:[READ, EXECUTE, UPDATE] string
           String[] writerPerms = actualPermissions.split("rest-writer:\\[")[1].split("\\]")[0].split(",");
 
-          assertTrue("Document permissions difference in rest-writer permission - first permission",
+          assertTrue(
               writerPerms[0].contains("UPDATE") || writerPerms[1].contains("UPDATE") || writerPerms[2].contains("UPDATE"));
-          assertTrue("Document permissions difference in rest-writer permission - second permission",
+          assertTrue(
               writerPerms[0].contains("EXECUTE") || writerPerms[1].contains("EXECUTE") || writerPerms[2].contains("EXECUTE"));
-          assertTrue("Document permissions difference in rest-writer permission - third permission",
+          assertTrue(
               writerPerms[0].contains("READ") || writerPerms[1].contains("READ") || writerPerms[2].contains("READ"));
           // Split up app-user app-user:[UPDATE, READ] string
           String[] appUserPerms = actualPermissions.split("app-user:\\[")[1].split("\\]")[0].split(",");
 
-          assertTrue("Document permissions difference in App User permission - first permission",
+          assertTrue(
               appUserPerms[0].contains("UPDATE") || appUserPerms[1].contains("UPDATE"));
-          assertTrue("Document permissions difference in App user permission - second permission",
+          assertTrue(
               appUserPerms[0].contains("READ") || appUserPerms[1].contains("READ"));
           // Split up temporal-admin=[READ, UPDATE] string
           String[] temporalAdminPerms = actualPermissions.split("temporal-admin:\\[")[1].split("\\]")[0].split(",");
 
-          assertTrue("Document permissions difference in temporal-admin permission - first permission",
+          assertTrue(
               temporalAdminPerms[0].contains("UPDATE") || temporalAdminPerms[1].contains("UPDATE"));
-          assertTrue("Document permissions difference in rest-writer permission - second permission",
+          assertTrue(
               temporalAdminPerms[0].contains("READ") || temporalAdminPerms[1].contains("READ"));
 
-          assertFalse("Document permissions difference in app-user permission",
+          assertFalse(
               actualPermissions.split("app-user:\\[")[1].split("\\]")[0].contains("EXECUTE"));
 
           assertEquals(quality, 99);
@@ -3039,9 +3003,9 @@ public class TestBiTemporal extends BasicJavaClientREST {
 
         if (validStartDate.contains("2001-01-01T00:00:00")
             && validEndDate.contains("2003-01-01T00:00:00")) {
-          assertTrue("System start date check failed",
+          assertTrue(
               (systemStartDate.contains("2011-01-01T00:00:01")));
-          assertTrue("System end date check failed",
+          assertTrue(
               (systemEndDate.contains("9999-12-31T11:59:59")));
 
           Iterator<String> resCollections = metadataHandle.getCollections()
@@ -3053,46 +3017,44 @@ public class TestBiTemporal extends BasicJavaClientREST {
             if (!collection.equals(docId)
                 && !collection.equals(insertCollectionName)
                 && !collection.equals(temporalLsqtCollectionName)) {
-              assertFalse("Collection not what is expected: " + collection,
-                  true);
+              fail("Collection not what is expected: " + collection);
             }
           }
 
-          assertTrue("Properties should be empty", metadataHandle
+          assertTrue(metadataHandle
               .getProperties().isEmpty());
 
-          assertTrue("Document permissions difference in size value",
+          assertTrue(
               actualPermissions.contains("size:7"));
 
           assertTrue(
-              "Document permissions difference in rest-reader permission",
               actualPermissions.contains("rest-reader:[READ]"));
-          assertTrue("Document permissions difference in harmonized-updater permission", actualPermissions.contains("harmonized-updater:[UPDATE]"));
-          assertTrue("Document permissions difference in harmonized-reader permission", actualPermissions.contains("harmonized-reader:[READ]"));
+          assertTrue(actualPermissions.contains("harmonized-updater:[UPDATE]"));
+          assertTrue(actualPermissions.contains("harmonized-reader:[READ]"));
           // Split up rest-writer:[READ, EXECUTE, UPDATE] string
           String[] writerPerms = actualPermissions.split("rest-writer:\\[")[1].split("\\]")[0].split(",");
 
-          assertTrue("Document permissions difference in rest-writer permission - first permission",
+          assertTrue(
               writerPerms[0].contains("UPDATE") || writerPerms[1].contains("UPDATE") || writerPerms[2].contains("UPDATE"));
-          assertTrue("Document permissions difference in rest-writer permission - second permission",
+          assertTrue(
               writerPerms[0].contains("EXECUTE") || writerPerms[1].contains("EXECUTE") || writerPerms[2].contains("EXECUTE"));
-          assertTrue("Document permissions difference in rest-writer permission - third permission",
+          assertTrue(
               writerPerms[0].contains("READ") || writerPerms[1].contains("READ") || writerPerms[2].contains("READ"));
           // Split up app-user app-user:[READ, UPDATE, EXECUTE] string
           String[] appUserPerms = actualPermissions.split("app-user:\\[")[1].split("\\]")[0].split(",");
 
-          assertTrue("Document permissions difference in App User permission - first permission",
+          assertTrue(
               appUserPerms[0].contains("UPDATE") || appUserPerms[1].contains("UPDATE") || appUserPerms[2].contains("UPDATE"));
-          assertTrue("Document permissions difference in App user permission - second permission",
+          assertTrue(
               appUserPerms[0].contains("READ") || appUserPerms[1].contains("READ") || appUserPerms[2].contains("READ"));
-          assertTrue("Document permissions difference in App user permission - third permission",
+          assertTrue(
               appUserPerms[0].contains("EXECUTE") || appUserPerms[1].contains("EXECUTE") || appUserPerms[2].contains("EXECUTE"));
           // Split up temporal-admin=[READ, UPDATE] string
           String[] temporalAdminPerms = actualPermissions.split("temporal-admin:\\[")[1].split("\\]")[0].split(",");
 
-          assertTrue("Document permissions difference in temporal-admin permission - first permission",
+          assertTrue(
               temporalAdminPerms[0].contains("UPDATE") || temporalAdminPerms[1].contains("UPDATE"));
-          assertTrue("Document permissions difference in rest-writer permission - second permission",
+          assertTrue(
               temporalAdminPerms[0].contains("READ") || temporalAdminPerms[1].contains("READ"));
 
           assertEquals(quality, 11);
@@ -3101,11 +3063,11 @@ public class TestBiTemporal extends BasicJavaClientREST {
         if (validStartDate.contains("2008-12-31T23:59:59")
             && validEndDate.contains("2011-12-31T23:59:59")) {
           // This is the latest document
-          assertTrue("System start date check failed",
+          assertTrue(
               (systemStartDate.contains("2011-01-01T00:00:01")));
-          assertTrue("System end date check failed",
+          assertTrue(
               (systemEndDate.contains("9999-12-31T11:59:59")));
-          assertTrue("URI should be the doc uri ", record.getUri()
+          assertTrue(record.getUri()
               .equals(docId));
 
           Iterator<String> resCollections = metadataHandle.getCollections()
@@ -3118,43 +3080,41 @@ public class TestBiTemporal extends BasicJavaClientREST {
                 && !collection.equals(insertCollectionName)
                 && !collection.equals(temporalLsqtCollectionName)
                 && !collection.equals(latestCollectionName)) {
-              assertFalse("Collection not what is expected: " + collection,
-                  true);
+              fail("Collection not what is expected: " + collection);
             }
           }
 
-          assertTrue("Document permissions difference in size value",
+          assertTrue(
               actualPermissions.contains("size:7"));
-          assertTrue("Document permissions difference in harmonized-updater permission", actualPermissions.contains("harmonized-updater:[UPDATE]"));
-          assertTrue("Document permissions difference in harmonized-reader permission", actualPermissions.contains("harmonized-reader:[READ]"));
+          assertTrue(actualPermissions.contains("harmonized-updater:[UPDATE]"));
+          assertTrue(actualPermissions.contains("harmonized-reader:[READ]"));
 
           assertTrue(
-              "Document permissions difference in rest-reader permission",
               actualPermissions.contains("rest-reader:[READ]"));
           // Split up rest-writer:[READ, EXECUTE, UPDATE] string
           String[] writerPerms = actualPermissions.split("rest-writer:\\[")[1].split("\\]")[0].split(",");
 
-          assertTrue("Document permissions difference in rest-writer permission - first permission",
+          assertTrue(
               writerPerms[0].contains("UPDATE") || writerPerms[1].contains("UPDATE") || writerPerms[2].contains("UPDATE"));
-          assertTrue("Document permissions difference in rest-writer permission - second permission",
+          assertTrue(
               writerPerms[0].contains("EXECUTE") || writerPerms[1].contains("EXECUTE") || writerPerms[2].contains("EXECUTE"));
-          assertTrue("Document permissions difference in rest-writer permission - third permission",
+          assertTrue(
               writerPerms[0].contains("READ") || writerPerms[1].contains("READ") || writerPerms[2].contains("READ"));
           // Split up app-user app-user:[READ, UPDATE, EXECUTE] string
           String[] appUserPerms = actualPermissions.split("app-user:\\[")[1].split("\\]")[0].split(",");
 
-          assertTrue("Document permissions difference in App User permission - first permission",
+          assertTrue(
               appUserPerms[0].contains("UPDATE") || appUserPerms[1].contains("UPDATE") || appUserPerms[2].contains("UPDATE"));
-          assertTrue("Document permissions difference in App user permission - second permission",
+          assertTrue(
               appUserPerms[0].contains("READ") || appUserPerms[1].contains("READ") || appUserPerms[2].contains("READ"));
-          assertTrue("Document permissions difference in App user permission - third permission",
+          assertTrue(
               appUserPerms[0].contains("EXECUTE") || appUserPerms[1].contains("EXECUTE") || appUserPerms[2].contains("EXECUTE"));
           // Split up temporal-admin=[READ, UPDATE] string
           String[] temporalAdminPerms = actualPermissions.split("temporal-admin:\\[")[1].split("\\]")[0].split(",");
 
-          assertTrue("Document permissions difference in temporal-admin permission - first permission",
+          assertTrue(
               temporalAdminPerms[0].contains("UPDATE") || temporalAdminPerms[1].contains("UPDATE"));
-          assertTrue("Document permissions difference in rest-writer permission - second permission",
+          assertTrue(
               temporalAdminPerms[0].contains("READ") || temporalAdminPerms[1].contains("READ"));
 
           assertEquals(quality, 11);
@@ -3164,9 +3124,9 @@ public class TestBiTemporal extends BasicJavaClientREST {
 
         if (validStartDate.contains("2001-01-01T00:00:00")
             && validEndDate.contains("2011-12-31T23:59:59")) {
-          assertTrue("System start date check failed",
+          assertTrue(
               (systemStartDate.contains("2010-01-01T00:00:01")));
-          assertTrue("System start date check failed",
+          assertTrue(
               (systemEndDate.contains("2011-01-01T00:00:01")));
 
           Iterator<String> resCollections = metadataHandle.getCollections()
@@ -3178,45 +3138,43 @@ public class TestBiTemporal extends BasicJavaClientREST {
             if (!collection.equals(docId)
                 && !collection.equals(insertCollectionName)
                 && !collection.equals(temporalLsqtCollectionName)) {
-              assertFalse("Collection not what is expected: " + collection,
-                  true);
+              fail("Collection not what is expected: " + collection);
             }
           }
 
-          assertTrue("Properties should be empty", metadataHandle
+          assertTrue(metadataHandle
               .getProperties().isEmpty());
 
-          assertTrue("Document permissions difference in size value",
+          assertTrue(
               actualPermissions.contains("size:7"));
           assertTrue(
-              "Document permissions difference in rest-reader permission",
               actualPermissions.contains("rest-reader:[READ]"));
-          assertTrue("Document permissions difference in harmonized-updater permission", actualPermissions.contains("harmonized-updater:[UPDATE]"));
-          assertTrue("Document permissions difference in harmonized-reader permission", actualPermissions.contains("harmonized-reader:[READ]"));
+          assertTrue(actualPermissions.contains("harmonized-updater:[UPDATE]"));
+          assertTrue(actualPermissions.contains("harmonized-reader:[READ]"));
           // Split up rest-writer:[READ, EXECUTE, UPDATE] string
           String[] writerPerms = actualPermissions.split("rest-writer:\\[")[1].split("\\]")[0].split(",");
 
-          assertTrue("Document permissions difference in rest-writer permission - first permission",
+          assertTrue(
               writerPerms[0].contains("UPDATE") || writerPerms[1].contains("UPDATE") || writerPerms[2].contains("UPDATE"));
-          assertTrue("Document permissions difference in rest-writer permission - second permission",
+          assertTrue(
               writerPerms[0].contains("EXECUTE") || writerPerms[1].contains("EXECUTE") || writerPerms[2].contains("EXECUTE"));
-          assertTrue("Document permissions difference in rest-writer permission - third permission",
+          assertTrue(
               writerPerms[0].contains("READ") || writerPerms[1].contains("READ") || writerPerms[2].contains("READ"));
           // Split up app-user app-user:[READ, UPDATE, EXECUTE] string
           String[] appUserPerms = actualPermissions.split("app-user:\\[")[1].split("\\]")[0].split(",");
 
-          assertTrue("Document permissions difference in App User permission - first permission",
+          assertTrue(
               appUserPerms[0].contains("UPDATE") || appUserPerms[1].contains("UPDATE") || appUserPerms[2].contains("UPDATE"));
-          assertTrue("Document permissions difference in App user permission - second permission",
+          assertTrue(
               appUserPerms[0].contains("READ") || appUserPerms[1].contains("READ") || appUserPerms[2].contains("READ"));
-          assertTrue("Document permissions difference in App user permission - third permission",
+          assertTrue(
               appUserPerms[0].contains("EXECUTE") || appUserPerms[1].contains("EXECUTE") || appUserPerms[2].contains("EXECUTE"));
           // Split up temporal-admin=[READ, UPDATE] string
           String[] temporalAdminPerms = actualPermissions.split("temporal-admin:\\[")[1].split("\\]")[0].split(",");
 
-          assertTrue("Document permissions difference in temporal-admin permission - first permission",
+          assertTrue(
               temporalAdminPerms[0].contains("UPDATE") || temporalAdminPerms[1].contains("UPDATE"));
-          assertTrue("Document permissions difference in rest-writer permission - second permission",
+          assertTrue(
               temporalAdminPerms[0].contains("READ") || temporalAdminPerms[1].contains("READ"));
 
           assertEquals(quality, 11);
@@ -3242,14 +3200,14 @@ public class TestBiTemporal extends BasicJavaClientREST {
     termQueryResults = docMgr.search(termQuery, start);
     System.out
         .println("Number of results = " + termQueryResults.getTotalSize());
-    assertEquals("Wrong number of results", 4, termQueryResults.getTotalSize());
+    assertEquals(4, termQueryResults.getTotalSize());
 
     // Make sure there is one document with docId uri
     docMgr = readerClient.newJSONDocumentManager();
     readResults = docMgr.read(docId);
 
     System.out.println("Number of results = " + readResults.size());
-    assertEquals("Wrong number of results", 1, readResults.size());
+    assertEquals(1, readResults.size());
 
     // Make sure there are no documents in latest collection
     queryMgr = readerClient.newQueryManager();
@@ -3260,7 +3218,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
     termQueryResults = docMgr.search(termQuery, start);
     System.out
         .println("Number of results = " + termQueryResults.getTotalSize());
-    assertEquals("Wrong number of results", 0, termQueryResults.getTotalSize());
+    assertEquals(0, termQueryResults.getTotalSize());
 
     // Make sure there are 4 documents in temporal collection
     queryMgr = readerClient.newQueryManager();
@@ -3272,7 +3230,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
     termQueryResults = docMgr.search(termQuery, start);
     System.out
         .println("Number of results = " + termQueryResults.getTotalSize());
-    assertEquals("Wrong number of results", 4, termQueryResults.getTotalSize());
+    assertEquals(4, termQueryResults.getTotalSize());
 
     while (termQueryResults.hasNext()) {
       record = termQueryResults.next();
@@ -3282,7 +3240,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
       record.getMetadata(metadataHandle);
 
       if (record.getFormat() != Format.JSON) {
-        assertFalse("Format is not JSON: " + Format.JSON, true);
+        fail("Format is not JSON: " + Format.JSON);
       } else {
         // Make sure that system and valid times are what is expected
         recordHandle = new JacksonDatabindHandle<>(ObjectNode.class);
@@ -3327,9 +3285,9 @@ public class TestBiTemporal extends BasicJavaClientREST {
 
         if (validStartDate.contains("2003-01-01T00:00:00")
             && validEndDate.contains("2008-12-31T23:59:59")) {
-          assertTrue("System start date check failed",
+          assertTrue(
               (systemStartDate.contains("2011-01-01T00:00:01")));
-          assertTrue("System start date check failed",
+          assertTrue(
               (systemEndDate.contains("2012-01-01T00:00:01")));
 
           Iterator<String> resCollections = metadataHandle.getCollections()
@@ -3341,54 +3299,52 @@ public class TestBiTemporal extends BasicJavaClientREST {
             if (!collection.equals(docId)
                 && !collection.equals(updateCollectionName)
                 && !collection.equals(temporalLsqtCollectionName)) {
-              assertFalse("Collection not what is expected: " + collection,
-                  true);
+              fail("Collection not what is expected: " + collection);
             }
           }
 
-          assertTrue("Properties should be empty", metadataHandle
+          assertTrue(metadataHandle
               .getProperties().isEmpty());
 
-          assertTrue("Document permissions difference in size value",
+          assertTrue(
               actualPermissions.contains("size:7"));
-          assertTrue("Document permissions difference in harmonized-updater permission", actualPermissions.contains("harmonized-updater:[UPDATE]"));
-          assertTrue("Document permissions difference in harmonized-reader permission", actualPermissions.contains("harmonized-reader:[READ]"));
+          assertTrue(actualPermissions.contains("harmonized-updater:[UPDATE]"));
+          assertTrue(actualPermissions.contains("harmonized-reader:[READ]"));
 
           assertTrue(
-              "Document permissions difference in rest-reader permission",
               actualPermissions.contains("rest-reader:[READ]"));
 
           // Split up rest-writer:[READ, EXECUTE, UPDATE] string
           String[] writerPerms = actualPermissions.split("rest-writer:\\[")[1].split("\\]")[0].split(",");
 
-          assertTrue("Document permissions difference in rest-writer permission - first permission",
+          assertTrue(
               writerPerms[0].contains("UPDATE") || writerPerms[1].contains("UPDATE") || writerPerms[2].contains("UPDATE"));
-          assertTrue("Document permissions difference in rest-writer permission - second permission",
+          assertTrue(
               writerPerms[0].contains("EXECUTE") || writerPerms[1].contains("EXECUTE") || writerPerms[2].contains("EXECUTE"));
-          assertTrue("Document permissions difference in rest-writer permission - third permission",
+          assertTrue(
               writerPerms[0].contains("READ") || writerPerms[1].contains("READ") || writerPerms[2].contains("READ"));
           // Split up app-user app-user:[READ, UPDATE] string
           String[] appUserPerms = actualPermissions.split("app-user:\\[")[1].split("\\]")[0].split(",");
 
-          assertTrue("Document permissions difference in App User permission - first permission",
+          assertTrue(
               appUserPerms[0].contains("UPDATE") || appUserPerms[1].contains("UPDATE"));
-          assertTrue("Document permissions difference in App user permission - second permission",
+          assertTrue(
               appUserPerms[0].contains("READ") || appUserPerms[1].contains("READ"));
           // Split up temporal-admin=[READ, UPDATE] string
           String[] temporalAdminPerms = actualPermissions.split("temporal-admin:\\[")[1].split("\\]")[0].split(",");
 
-          assertTrue("Document permissions difference in temporal-admin permission - first permission",
+          assertTrue(
               temporalAdminPerms[0].contains("UPDATE") || temporalAdminPerms[1].contains("UPDATE"));
-          assertTrue("Document permissions difference in rest-writer permission - second permission",
+          assertTrue(
               temporalAdminPerms[0].contains("READ") || temporalAdminPerms[1].contains("READ"));
           assertEquals(quality, 99);
         }
 
         if (validStartDate.contains("2001-01-01T00:00:00")
             && validEndDate.contains("2003-01-01T00:00:00")) {
-          assertTrue("System start date check failed",
+          assertTrue(
               (systemStartDate.contains("2011-01-01T00:00:01")));
-          assertTrue("System start date check failed",
+          assertTrue(
               (systemEndDate.contains("2012-01-01T00:00:01")));
 
           Iterator<String> resCollections = metadataHandle.getCollections()
@@ -3400,47 +3356,45 @@ public class TestBiTemporal extends BasicJavaClientREST {
             if (!collection.equals(docId)
                 && !collection.equals(insertCollectionName)
                 && !collection.equals(temporalLsqtCollectionName)) {
-              assertFalse("Collection not what is expected: " + collection,
-                  true);
+              fail("Collection not what is expected: " + collection);
             }
           }
 
-          assertTrue("Properties should be empty", metadataHandle
+          assertTrue(metadataHandle
               .getProperties().isEmpty());
 
-          assertTrue("Document permissions difference in size value",
+          assertTrue(
               actualPermissions.contains("size:7"));
-          assertTrue("Document permissions difference in harmonized-updater permission", actualPermissions.contains("harmonized-updater:[UPDATE]"));
-          assertTrue("Document permissions difference in harmonized-reader permission", actualPermissions.contains("harmonized-reader:[READ]"));
+          assertTrue(actualPermissions.contains("harmonized-updater:[UPDATE]"));
+          assertTrue(actualPermissions.contains("harmonized-reader:[READ]"));
 
           assertTrue(
-              "Document permissions difference in rest-reader permission",
               actualPermissions.contains("rest-reader:[READ]"));
 
           // Split up rest-writer:[READ, EXECUTE, UPDATE] string
           String[] writerPerms = actualPermissions.split("rest-writer:\\[")[1].split("\\]")[0].split(",");
 
-          assertTrue("Document permissions difference in rest-writer permission - first permission",
+          assertTrue(
               writerPerms[0].contains("UPDATE") || writerPerms[1].contains("UPDATE") || writerPerms[2].contains("UPDATE"));
-          assertTrue("Document permissions difference in rest-writer permission - second permission",
+          assertTrue(
               writerPerms[0].contains("EXECUTE") || writerPerms[1].contains("EXECUTE") || writerPerms[2].contains("EXECUTE"));
-          assertTrue("Document permissions difference in rest-writer permission - third permission",
+          assertTrue(
               writerPerms[0].contains("READ") || writerPerms[1].contains("READ") || writerPerms[2].contains("READ"));
           // Split up app-user app-user:[READ, UPDATE, EXECUTE] string
           String[] appUserPerms = actualPermissions.split("app-user:\\[")[1].split("\\]")[0].split(",");
 
-          assertTrue("Document permissions difference in App User permission - first permission",
+          assertTrue(
               appUserPerms[0].contains("UPDATE") || appUserPerms[1].contains("UPDATE") || appUserPerms[2].contains("UPDATE"));
-          assertTrue("Document permissions difference in App user permission - second permission",
+          assertTrue(
               appUserPerms[0].contains("READ") || appUserPerms[1].contains("READ") || appUserPerms[2].contains("READ"));
-          assertTrue("Document permissions difference in App user permission - third permission",
+          assertTrue(
               appUserPerms[0].contains("EXECUTE") || appUserPerms[1].contains("EXECUTE") || appUserPerms[2].contains("EXECUTE"));
           // Split up temporal-admin=[READ, UPDATE] string
           String[] temporalAdminPerms = actualPermissions.split("temporal-admin:\\[")[1].split("\\]")[0].split(",");
 
-          assertTrue("Document permissions difference in temporal-admin permission - first permission",
+          assertTrue(
               temporalAdminPerms[0].contains("UPDATE") || temporalAdminPerms[1].contains("UPDATE"));
-          assertTrue("Document permissions difference in rest-writer permission - second permission",
+          assertTrue(
               temporalAdminPerms[0].contains("READ") || temporalAdminPerms[1].contains("READ"));
 
           assertEquals(quality, 11);
@@ -3448,12 +3402,12 @@ public class TestBiTemporal extends BasicJavaClientREST {
 
         if (validStartDate.contains("2008-12-31T23:59:59")
             && validEndDate.contains("2011-12-31T23:59:59")) {
-          assertTrue("System start date check failed",
+          assertTrue(
               (systemStartDate.contains("2011-01-01T00:00:01")));
-          assertTrue("System start date check failed",
+          assertTrue(
               (systemEndDate.contains("2012-01-01T00:00:01")));
 
-          assertTrue("URI should be the doc uri ", record.getUri()
+          assertTrue(record.getUri()
               .equals(docId));
 
           // Document should not be in latest collection
@@ -3466,44 +3420,42 @@ public class TestBiTemporal extends BasicJavaClientREST {
             if (!collection.equals(docId)
                 && !collection.equals(insertCollectionName)
                 && !collection.equals(temporalLsqtCollectionName)) {
-              assertFalse("Collection not what is expected: " + collection,
-                  true);
+              fail("Collection not what is expected: " + collection);
             }
           }
 
-          assertTrue("Document permissions difference in size value",
+          assertTrue(
               actualPermissions.contains("size:7"));
-          assertTrue("Document permissions difference in harmonized-updater permission", actualPermissions.contains("harmonized-updater:[UPDATE]"));
-          assertTrue("Document permissions difference in harmonized-reader permission", actualPermissions.contains("harmonized-reader:[READ]"));
+          assertTrue(actualPermissions.contains("harmonized-updater:[UPDATE]"));
+          assertTrue(actualPermissions.contains("harmonized-reader:[READ]"));
 
           assertTrue(
-              "Document permissions difference in rest-reader permission",
               actualPermissions.contains("rest-reader:[READ]"));
 
           // Split up rest-writer:[READ, EXECUTE, UPDATE] string
           String[] writerPerms = actualPermissions.split("rest-writer:\\[")[1].split("\\]")[0].split(",");
 
-          assertTrue("Document permissions difference in rest-writer permission - first permission",
+          assertTrue(
               writerPerms[0].contains("UPDATE") || writerPerms[1].contains("UPDATE") || writerPerms[2].contains("UPDATE"));
-          assertTrue("Document permissions difference in rest-writer permission - second permission",
+          assertTrue(
               writerPerms[0].contains("EXECUTE") || writerPerms[1].contains("EXECUTE") || writerPerms[2].contains("EXECUTE"));
-          assertTrue("Document permissions difference in rest-writer permission - third permission",
+          assertTrue(
               writerPerms[0].contains("READ") || writerPerms[1].contains("READ") || writerPerms[2].contains("READ"));
           // Split up app-user app-user:[READ, UPDATE, EXECUTE] string
           String[] appUserPerms = actualPermissions.split("app-user:\\[")[1].split("\\]")[0].split(",");
 
-          assertTrue("Document permissions difference in App User permission - first permission",
+          assertTrue(
               appUserPerms[0].contains("UPDATE") || appUserPerms[1].contains("UPDATE") || appUserPerms[2].contains("UPDATE"));
-          assertTrue("Document permissions difference in App user permission - second permission",
+          assertTrue(
               appUserPerms[0].contains("READ") || appUserPerms[1].contains("READ") || appUserPerms[2].contains("READ"));
-          assertTrue("Document permissions difference in App user permission - third permission",
+          assertTrue(
               appUserPerms[0].contains("EXECUTE") || appUserPerms[1].contains("EXECUTE") || appUserPerms[2].contains("EXECUTE"));
           // Split up temporal-admin=[READ, UPDATE] string
           String[] temporalAdminPerms = actualPermissions.split("temporal-admin:\\[")[1].split("\\]")[0].split(",");
 
-          assertTrue("Document permissions difference in temporal-admin permission - first permission",
+          assertTrue(
               temporalAdminPerms[0].contains("UPDATE") || temporalAdminPerms[1].contains("UPDATE"));
-          assertTrue("Document permissions difference in rest-writer permission - second permission",
+          assertTrue(
               temporalAdminPerms[0].contains("READ") || temporalAdminPerms[1].contains("READ"));
 
           assertEquals(quality, 11);
@@ -3513,9 +3465,9 @@ public class TestBiTemporal extends BasicJavaClientREST {
 
         if (validStartDate.contains("2001-01-01T00:00:00")
             && validEndDate.contains("2011-12-31T23:59:59")) {
-          assertTrue("System start date check failed",
+          assertTrue(
               (systemStartDate.contains("2010-01-01T00:00:01")));
-          assertTrue("System start date check failed",
+          assertTrue(
               (systemEndDate.contains("2011-01-01T00:00:01")));
           Iterator<String> resCollections = metadataHandle.getCollections()
               .iterator();
@@ -3526,47 +3478,45 @@ public class TestBiTemporal extends BasicJavaClientREST {
             if (!collection.equals(docId)
                 && !collection.equals(insertCollectionName)
                 && !collection.equals(temporalLsqtCollectionName)) {
-              assertFalse("Collection not what is expected: " + collection,
-                  true);
+              fail("Collection not what is expected: " + collection);
             }
           }
 
-          assertTrue("Properties should be empty", metadataHandle
+          assertTrue(metadataHandle
               .getProperties().isEmpty());
 
-          assertTrue("Document permissions difference in size value",
+          assertTrue(
               actualPermissions.contains("size:7"));
-          assertTrue("Document permissions difference in harmonized-updater permission", actualPermissions.contains("harmonized-updater:[UPDATE]"));
-          assertTrue("Document permissions difference in harmonized-reader permission", actualPermissions.contains("harmonized-reader:[READ]"));
+          assertTrue(actualPermissions.contains("harmonized-updater:[UPDATE]"));
+          assertTrue(actualPermissions.contains("harmonized-reader:[READ]"));
 
           assertTrue(
-              "Document permissions difference in rest-reader permission",
               actualPermissions.contains("rest-reader:[READ]"));
 
           // Split up rest-writer:[READ, EXECUTE, UPDATE] string
           String[] writerPerms = actualPermissions.split("rest-writer:\\[")[1].split("\\]")[0].split(",");
 
-          assertTrue("Document permissions difference in rest-writer permission - first permission",
+          assertTrue(
               writerPerms[0].contains("UPDATE") || writerPerms[1].contains("UPDATE") || writerPerms[2].contains("UPDATE"));
-          assertTrue("Document permissions difference in rest-writer permission - second permission",
+          assertTrue(
               writerPerms[0].contains("EXECUTE") || writerPerms[1].contains("EXECUTE") || writerPerms[2].contains("EXECUTE"));
-          assertTrue("Document permissions difference in rest-writer permission - third permission",
+          assertTrue(
               writerPerms[0].contains("READ") || writerPerms[1].contains("READ") || writerPerms[2].contains("READ"));
           // Split up app-user app-user:[READ, UPDATE, EXECUTE] string
           String[] appUserPerms = actualPermissions.split("app-user:\\[")[1].split("\\]")[0].split(",");
 
-          assertTrue("Document permissions difference in App User permission - first permission",
+          assertTrue(
               appUserPerms[0].contains("UPDATE") || appUserPerms[1].contains("UPDATE") || appUserPerms[2].contains("UPDATE"));
-          assertTrue("Document permissions difference in App user permission - second permission",
+          assertTrue(
               appUserPerms[0].contains("READ") || appUserPerms[1].contains("READ") || appUserPerms[2].contains("READ"));
-          assertTrue("Document permissions difference in App user permission - third permission",
+          assertTrue(
               appUserPerms[0].contains("EXECUTE") || appUserPerms[1].contains("EXECUTE") || appUserPerms[2].contains("EXECUTE"));
           // Split up temporal-admin=[READ, UPDATE] string
           String[] temporalAdminPerms = actualPermissions.split("temporal-admin:\\[")[1].split("\\]")[0].split(",");
 
-          assertTrue("Document permissions difference in temporal-admin permission - first permission",
+          assertTrue(
               temporalAdminPerms[0].contains("UPDATE") || temporalAdminPerms[1].contains("UPDATE"));
-          assertTrue("Document permissions difference in rest-writer permission - second permission",
+          assertTrue(
               temporalAdminPerms[0].contains("READ") || temporalAdminPerms[1].contains("READ"));
 
           assertEquals(quality, 11);
@@ -3581,7 +3531,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
     termQueryResults = docMgr.search(stringQD, start);
     System.out
         .println("Number of results = " + termQueryResults.getTotalSize());
-    assertEquals("Wrong number of results", 4, termQueryResults.getTotalSize());
+    assertEquals(4, termQueryResults.getTotalSize());
   }
 
   /*
@@ -3640,7 +3590,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
       docMgr = readerClient.newXMLDocumentManager();
       docMgr.setMetadataCategories(Metadata.ALL); // Get all metadata
       termQueryResults = docMgr.search(termQuery, start);
-      assertEquals("Records counts is incorrect", 4, termQueryResults.size());
+      assertEquals(4, termQueryResults.size());
       // Verify the Document Record content with map contents for each record.
       while (termQueryResults.hasNext()) {
 
@@ -3657,7 +3607,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
         DOMHandle readDOMHandle = map.get(record.getUri());
         String mapContent = readDOMHandle.evaluateXPath("/root/Address/text()", String.class);
         System.out.println("Map Content is " + mapContent);
-        assertTrue("Address value is incorrect ", recordContent.contains(mapContent));
+        assertTrue(recordContent.contains(mapContent));
 
         readDOMHandle = null;
         mapContent = null;
@@ -3705,7 +3655,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
           extMsg = ex.getMessage();
           System.out.println("Permissions exception message for LSQT advance is " + extMsg);
         }
-        assertTrue("Expected exception message incorrect for LSQT advance user permission", extMsg.contains(permnExceptMsg));
+        assertTrue(extMsg.contains(permnExceptMsg));
 
         QueryManager queryMgrLSQT = adminClient.newQueryManager();
 
@@ -3732,14 +3682,14 @@ public class TestBiTemporal extends BasicJavaClientREST {
           actualNoAdvanceMsg = ex.getMessage();
           System.out.println("Exception message for LSQT without advance set is " + actualNoAdvanceMsg);
         }
-        assertTrue("Expected exception message not available for LSQT advance user permission", actualNoAdvanceMsg.contains(WithoutAdvaceSetExceptMsg));
+        assertTrue(actualNoAdvanceMsg.contains(WithoutAdvaceSetExceptMsg));
 
         // Set the Advance manually.
         docMgr.advanceLsqt(temporalLsqtCollectionName);
         termQueryResultsLSQT = docMgrQy.search(periodQueryLSQT, startLSQT);
 
-        assertTrue("LSQT Query results (Total Pages) before advance is incorrect", termQueryResultsLSQT.getTotalPages() == 0);
-        assertTrue("LSQT Query results (Size) before advance is incorrect", termQueryResultsLSQT.size() == 0);
+        assertTrue(termQueryResultsLSQT.getTotalPages() == 0);
+        assertTrue(termQueryResultsLSQT.size() == 0);
 
         // After Advance of the LSQT, query again with new query time greater than LSQT
 
@@ -3761,7 +3711,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
         } catch (Exception ex) {
           actGrMsg = ex.getMessage();
         }
-        assertTrue("Expected exception message not available for LSQT advance user permission", actGrMsg.contains(excepMsgGrtr));
+        assertTrue(actGrMsg.contains(excepMsgGrtr));
 
         // Query again with query time less than LSQT. 10 minutes less than the LSQT
         Calendar callessTime = DatatypeConverter.parseDateTime("2009-01-01T00:00:01");
@@ -3773,8 +3723,8 @@ public class TestBiTemporal extends BasicJavaClientREST {
 
         System.out.println("LSQT Query results (Total Pages) after advance " + termQueryResultsLSQT2.getTotalPages());
         System.out.println("LSQT Query results (Size) after advance " + termQueryResultsLSQT2.size());
-        assertTrue("LSQT Query results (Total Pages) after advance is incorrect", termQueryResultsLSQT2.getTotalPages() == 0);
-        assertTrue("LSQT Query results (Size) after advance is incorrect", termQueryResultsLSQT2.size() == 0);
+        assertTrue(termQueryResultsLSQT2.getTotalPages() == 0);
+        assertTrue(termQueryResultsLSQT2.size() == 0);
       } catch (Exception ex) {
         System.out.println("Exception thrown from testAdvacingLSQT method " + ex.getMessage());
       } finally {

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBug18736.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBug18736.java
@@ -16,63 +16,49 @@
 
 package com.marklogic.client.functionaltest;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.admin.QueryOptionsManager;
+import com.marklogic.client.admin.ServerConfigurationManager;
+import com.marklogic.client.document.DocumentDescriptor;
+import com.marklogic.client.document.XMLDocumentManager;
+import com.marklogic.client.io.*;
+import com.marklogic.client.query.*;
+import com.marklogic.client.query.StructuredQueryBuilder.Operator;
+import org.custommonkey.xmlunit.exceptions.XpathException;
+import org.json.JSONException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
 
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.TransformerException;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.TransformerException;
-
-import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.json.JSONException;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.skyscreamer.jsonassert.JSONAssert;
-import org.w3c.dom.Document;
-import org.xml.sax.SAXException;
-
-import com.marklogic.client.DatabaseClient;
-import com.marklogic.client.admin.QueryOptionsManager;
-import com.marklogic.client.admin.ServerConfigurationManager;
-import com.marklogic.client.document.DocumentDescriptor;
-import com.marklogic.client.document.XMLDocumentManager;
-import com.marklogic.client.io.DOMHandle;
-import com.marklogic.client.io.Format;
-import com.marklogic.client.io.InputStreamHandle;
-import com.marklogic.client.io.SearchHandle;
-import com.marklogic.client.io.StringHandle;
-import com.marklogic.client.io.XMLStreamReaderHandle;
-import com.marklogic.client.query.MatchDocumentSummary;
-import com.marklogic.client.query.QueryManager;
-import com.marklogic.client.query.StringQueryDefinition;
-import com.marklogic.client.query.StructuredQueryBuilder;
-import com.marklogic.client.query.StructuredQueryDefinition;
-import com.marklogic.client.query.ValuesDefinition;
-import com.marklogic.client.query.StructuredQueryBuilder.Operator;
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestBug18736 extends BasicJavaClientREST {
 
   private static String dbName = "Bug18736DB";
   private static String[] fNames = { "Bug18736DB-1" };
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception
   {
     System.out.println("In setup");
     configureRESTServer(dbName, fNames);
     setupAppServicesConstraint(dbName);
   }
-  
-  @After
+
+  @AfterEach
   public void afterEach() throws Exception
   {
     System.out.println("In afterEach");
@@ -93,11 +79,11 @@ public class TestBug18736 extends BasicJavaClientREST {
      * Map<String,String> xpathNS = new HashMap<>(); xpathNS.put("",
      * "http://purl.org/dc/elements/1.1/"); SimpleNamespaceContext
      * xpathNsContext = new SimpleNamespaceContext(xpathNS);
-     * 
+     *
      * XMLUnit.setIgnoreAttributeOrder(true); XMLUnit.setIgnoreWhitespace(true);
      * XMLUnit.setNormalize(true); XMLUnit.setNormalizeWhitespace(true);
      * XMLUnit.setIgnoreDiffBetweenTextAndCDATA(true);
-     * 
+     *
      * xpathEngine = XMLUnit.newXpathEngine();
      * xpathEngine.setNamespaceContext(xpathNsContext);
      */
@@ -126,7 +112,7 @@ public class TestBug18736 extends BasicJavaClientREST {
     String out = convertXMLDocumentToString(readDoc);
     System.out.println(out);
 
-    assertTrue("Unable to read doc", out.contains("0011"));
+    assertTrue(out.contains("0011"));
 
     // get xml document for expected result
     // Document expectedDoc = expectedXMLDocument(filename);
@@ -136,7 +122,7 @@ public class TestBug18736 extends BasicJavaClientREST {
     // release client
     client.release();
   }
-  
+
   @Test
   public void testDefaultFacetValue() throws KeyManagementException, NoSuchAlgorithmException, IOException, ParserConfigurationException, SAXException, XpathException,
       TransformerException
@@ -202,7 +188,7 @@ public class TestBug18736 extends BasicJavaClientREST {
     // release client
     client.release();
   }
-  
+
 
   @Test
   public void testBug18990() throws KeyManagementException, NoSuchAlgorithmException, IOException, ParserConfigurationException, SAXException, XpathException,
@@ -260,7 +246,7 @@ public class TestBug18736 extends BasicJavaClientREST {
     // release client
     client.release();
   }
-  
+
   @Test
   public void testBug19046() throws KeyManagementException, NoSuchAlgorithmException, IOException, ParserConfigurationException, SAXException, XpathException, TransformerException
   {
@@ -288,12 +274,12 @@ public class TestBug18736 extends BasicJavaClientREST {
 
     System.out.println(exception);
 
-    assertTrue("Exception is not thrown", exception.contains(expectedException));
+    assertTrue(exception.contains(expectedException));
 
     // release client
     client.release();
   }
-  
+
   @Test
   public void testBug19092() throws KeyManagementException, NoSuchAlgorithmException, IOException, ParserConfigurationException, SAXException, XpathException, TransformerException
   {
@@ -322,10 +308,10 @@ public class TestBug18736 extends BasicJavaClientREST {
     String output = readHandle.get();
     System.out.println(output);
 
-    assertTrue("Default term is not correct",
+    assertTrue(
         output.contains("<ns2:term-option>case-sensitive</ns2:term-option>") || output.contains("<search:term-option>case-sensitive</search:term-option>"));
-    assertFalse("Weight element exists", output.contains("<ns2:weight>0.0</ns2:weight>") || output.contains("<search:weight>0.0</search:weight>"));
-    assertFalse("Default element exists", output.contains("<ns2:default/>") || output.contains("<search:default/>"));
+    assertFalse(output.contains("<ns2:weight>0.0</ns2:weight>") || output.contains("<search:weight>0.0</search:weight>"));
+    assertFalse(output.contains("<ns2:default/>") || output.contains("<search:default/>"));
 
     // release client
     client.release();
@@ -360,12 +346,12 @@ public class TestBug18736 extends BasicJavaClientREST {
     String output = readHandle.get();
     System.out.println(output);
 
-    assertTrue("Default term is not correct", output.contains("{\"options\":{\"term\":{\"term-option\":[\"case-sensitive\"]}}}"));
+    assertTrue(output.contains("{\"options\":{\"term\":{\"term-option\":[\"case-sensitive\"]}}}"));
 
     // release client
     client.release();
   }
-  
+
   @Test
   public void testBug19140() throws KeyManagementException, NoSuchAlgorithmException, IOException, ParserConfigurationException, SAXException, XpathException, TransformerException
   {
@@ -392,13 +378,13 @@ public class TestBug18736 extends BasicJavaClientREST {
     String output = readHandle.get();
     System.out.println(output);
 
-    assertTrue("transform-results is incorrect", output.contains("transform-results apply=\"raw\"/"));
-    assertFalse("preferred-elements is exist", output.contains("preferred-elements/"));
+    assertTrue(output.contains("transform-results apply=\"raw\"/"));
+    assertFalse(output.contains("preferred-elements/"));
 
     // release client
     client.release();
   }
-  
+
   @Test
   public void testBug19144WithJson() throws KeyManagementException, NoSuchAlgorithmException, IOException, ParserConfigurationException, SAXException, XpathException,
       TransformerException
@@ -478,7 +464,7 @@ public class TestBug18736 extends BasicJavaClientREST {
     // release client
     client.release();
   }
-  
+
   @Test
   public void testBug19389() throws KeyManagementException, NoSuchAlgorithmException, IOException, ParserConfigurationException, SAXException, XpathException, TransformerException
   {
@@ -512,7 +498,7 @@ public class TestBug18736 extends BasicJavaClientREST {
 
     System.out.println(exception);
 
-    assertTrue("Exception is not thrown", exception.contains(expectedException));
+    assertTrue(exception.contains(expectedException));
 
     // release client
     client.release();
@@ -564,7 +550,7 @@ public class TestBug18736 extends BasicJavaClientREST {
     System.out.println(actual);
     System.out.println("Output is :  \n");
     System.out.println(output);
-    assertTrue("Element geo-option not available", actual.contains("<search:geo-option>type=long-lat-point</search:geo-option>"));
+    assertTrue(actual.contains("<search:geo-option>type=long-lat-point</search:geo-option>"));
 
     // release client
     client.release();
@@ -605,12 +591,12 @@ public class TestBug18736 extends BasicJavaClientREST {
     String strPlan = resultsHandle.getPlan(new StringHandle()).get();
     System.out.println(strPlan);
 
-    assertTrue("string is not matched", strPlan.contains("qry:result estimate=\"3\""));
+    assertTrue(strPlan.contains("qry:result estimate=\"3\""));
 
     // release client
     client.release();
   }
-  
+
   @Test
   public void testBug21183() throws KeyManagementException, NoSuchAlgorithmException, IOException, ParserConfigurationException, SAXException, XpathException, TransformerException
   {
@@ -649,15 +635,15 @@ public class TestBug18736 extends BasicJavaClientREST {
       // Commenting as per Update from Bug 23788
       // assertTrue("Returned doc from SearchHandle has no namespace",
       // resultDoc1.contains("<test xmlns:myns=\"http://mynamespace.com\" xmlns:search=\"http://marklogic.com/appservices/search\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">"));
-      assertTrue("Returned doc from SearchHandle has no attribute", resultDoc1.contains("<txt att=\"1\">a</txt>"));
+      assertTrue(resultDoc1.contains("<txt att=\"1\">a</txt>"));
       System.out.println();
     }
 
     XMLStreamReaderHandle shandle = queryMgr.search(querydef, new XMLStreamReaderHandle());
     String resultDoc2 = shandle.toString();
     System.out.println(resultDoc2);
-    assertTrue("Returned doc from XMLStreamReaderHandle has no namespace", resultDoc2.contains("<test xmlns:myns=\"http://mynamespace.com\">"));
-    assertTrue("Returned doc from XMLStreamReaderHandle has no attribute", resultDoc2.contains("<txt att=\"1\">a</txt>"));
+    assertTrue(resultDoc2.contains("<test xmlns:myns=\"http://mynamespace.com\">"));
+    assertTrue(resultDoc2.contains("<txt att=\"1\">a</txt>"));
 
     // release client
     client.release();
@@ -699,8 +685,8 @@ public class TestBug18736 extends BasicJavaClientREST {
     // release client
     client.release();
   }
-  
-  @AfterClass
+
+  @AfterAll
   public static void tearDown() throws Exception
   {
     System.out.println("In tear down");

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBug18993.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBug18993.java
@@ -16,25 +16,22 @@
 
 package com.marklogic.client.functionaltest;
 
-import static org.junit.Assert.assertTrue;
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.document.XMLDocumentManager;
+import com.marklogic.client.io.StringHandle;
+import org.junit.jupiter.api.*;
 
 import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 
-import org.junit.*;
-
-import com.marklogic.client.DatabaseClient;
-import com.marklogic.client.document.XMLDocumentManager;
-import com.marklogic.client.io.StringHandle;
-
-@Ignore
+@Disabled
 public class TestBug18993 extends BasicJavaClientREST {
 
   private static String dbName = "Bug18993DB";
   private static String[] fNames = { "Bug18993DB-1" };
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception
   {
     System.out.println("In setup");
@@ -45,7 +42,7 @@ public class TestBug18993 extends BasicJavaClientREST {
     }
   }
 
-  @After
+  @AfterEach
   public void testCleanUp() throws Exception
   {
     clearDB();
@@ -76,7 +73,7 @@ public class TestBug18993 extends BasicJavaClientREST {
         System.out.println();
         String strXML = readHandle.toString();
         System.out.print(readHandle.toString());
-        assertTrue("Document is not returned", strXML.contains(expectedXML));
+        Assertions.assertTrue(strXML.contains(expectedXML));
         System.out.println();
       }
 
@@ -85,7 +82,7 @@ public class TestBug18993 extends BasicJavaClientREST {
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() throws Exception
   {
     System.out.println("In tear down");

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBug21159.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBug21159.java
@@ -16,26 +16,6 @@
 
 package com.marklogic.client.functionaltest;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import java.io.File;
-import java.io.IOException;
-import java.security.KeyManagementException;
-import java.security.NoSuchAlgorithmException;
-import java.util.ArrayList;
-
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.TransformerException;
-
-import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.xml.sax.SAXException;
-
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.admin.QueryOptionsManager;
 import com.marklogic.client.admin.ServerConfigurationManager;
@@ -43,20 +23,30 @@ import com.marklogic.client.io.Format;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.io.TuplesHandle;
 import com.marklogic.client.io.ValuesHandle;
-import com.marklogic.client.query.CountedDistinctValue;
-import com.marklogic.client.query.QueryManager;
-import com.marklogic.client.query.RawCombinedQueryDefinition;
-import com.marklogic.client.query.RawCtsQueryDefinition;
-import com.marklogic.client.query.Tuple;
-import com.marklogic.client.query.TypedDistinctValue;
-import com.marklogic.client.query.ValuesDefinition;
+import com.marklogic.client.query.*;
+import org.custommonkey.xmlunit.exceptions.XpathException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.TransformerException;
+import java.io.File;
+import java.io.IOException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestBug21159 extends BasicJavaClientREST {
 
   private static String dbName = "TestTuplesRawCombinedQueryDB";
   private static String[] fNames = { "TestTuplesRawCombinedQueryDB-1" };
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception
   {
     System.out.println("In setup");
@@ -165,7 +155,7 @@ public class TestBug21159 extends BasicJavaClientREST {
     // release client
     client.release();
   }
-  
+
   @Test
   public void testTuplesWithRawCtsQueryDefinition() throws KeyManagementException, NoSuchAlgorithmException, IOException, ParserConfigurationException, SAXException, XpathException,
       TransformerException
@@ -183,7 +173,7 @@ public class TestBug21159 extends BasicJavaClientREST {
     srvMgr.writeConfiguration();
     QueryOptionsManager optionsMgr = client.newServerConfigManager().newQueryOptionsManager();
     StringHandle Opthandle = new StringHandle();
-    String options = "<options xmlns=\"http://marklogic.com/appservices/search\"> " + 
+    String options = "<options xmlns=\"http://marklogic.com/appservices/search\"> " +
             "<tuples name=\"n-way\">" +
             "<range type=\"xs:double\"> " +
             "<element ns=\"\" name=\"double\"/> " +
@@ -211,8 +201,8 @@ public class TestBug21159 extends BasicJavaClientREST {
     // create a search definition
     String wordQuery = "<cts:word-query xmlns:cts=\"http://marklogic.com/cts\">" +
             "<cts:text>Alaska</cts:text>" +
-            "</cts:word-query>"; 
-           
+            "</cts:word-query>";
+
     ValuesDefinition valuesDef = queryMgr.newValuesDefinition("n-way", queryOptionName);
 
     StringHandle handle = new StringHandle().with(wordQuery).withFormat(Format.XML);
@@ -224,27 +214,27 @@ public class TestBug21159 extends BasicJavaClientREST {
     Tuple[] distinctValues = tHandle.getTuples();
 
     System.out.println("TuplesHandle length is " + distinctValues.length);
-    assertEquals("TuplesHandle length is incorrect", 2, distinctValues.length);
+    assertEquals(2, distinctValues.length);
     TypedDistinctValue[] firstdistinctValues = distinctValues[0].getValues();
     TypedDistinctValue[] seconddistinctValues = distinctValues[1].getValues();
-    
+
     // Sort the distinct values present inside as array elements in each TypedDistinctValue instance.
-    ArrayList<Double> arr = new ArrayList<Double>(); 
+    ArrayList<Double> arr = new ArrayList<Double>();
     arr.add(firstdistinctValues[0].get(Double.class));
     arr.add(seconddistinctValues[0].get(Double.class));
     arr.sort(null);
 
     System.out.println("TuplesHandle name is " + tHandle.getName().toString());
-    assertTrue("TuplesHandle name is incorrect", tHandle.getName().toString().trim().contains("n-way"));
-    
+    assertTrue(tHandle.getName().toString().trim().contains("n-way"));
+
     assertEquals(1.1, arr.get(0), 0.0);
     assertEquals(1.2, arr.get(1), 0.0);
-    assertTrue("TuplesHandle element 1 is incorrect", firstdistinctValues[2].get(String.class).trim().contains("Alaska"));
-    assertTrue("TuplesHandle element 2 is incorrect", seconddistinctValues[2].get(String.class).trim().contains("Alaska"));
+    assertTrue(firstdistinctValues[2].get(String.class).trim().contains("Alaska"));
+    assertTrue(seconddistinctValues[2].get(String.class).trim().contains("Alaska"));
     // release client
     client.release();
   }
-  
+
   @Test
   public void testTuplesWithRawCombinedCtsQuery() throws KeyManagementException, NoSuchAlgorithmException, IOException, ParserConfigurationException, SAXException, XpathException,
       TransformerException
@@ -259,7 +249,7 @@ public class TestBug21159 extends BasicJavaClientREST {
     srvMgr.setQueryOptionValidation(true);
     srvMgr.writeConfiguration();
     StringHandle Opthandle = new StringHandle();
-    String options = "<options xmlns=\"http://marklogic.com/appservices/search\"> " + 
+    String options = "<options xmlns=\"http://marklogic.com/appservices/search\"> " +
             "<tuples name=\"n-way\">" +
             "<range type=\"xs:double\"> " +
             "<element ns=\"\" name=\"double\"/> " +
@@ -289,7 +279,7 @@ public class TestBug21159 extends BasicJavaClientREST {
             "</cts:word-query>"+
             options +
             "</search:search>";
-    
+
     ValuesDefinition valuesDef = queryMgr.newValuesDefinition("n-way");
 
     StringHandle handle = new StringHandle().with(wordQuery).withFormat(Format.XML);
@@ -301,28 +291,28 @@ public class TestBug21159 extends BasicJavaClientREST {
     Tuple[] distinctValues = tHandle.getTuples();
 
     System.out.println("TuplesHandle length is " + distinctValues.length);
-    assertEquals("TuplesHandle length is incorrect", 2, distinctValues.length);
+    assertEquals(2, distinctValues.length);
     TypedDistinctValue[] firstdistinctValues = distinctValues[0].getValues();
     TypedDistinctValue[] seconddistinctValues = distinctValues[1].getValues();
-    
+
     // Sort the distinct values present inside as array elements in each TypedDistinctValue instance.
-    ArrayList<Double> arr = new ArrayList<Double>(); 
+    ArrayList<Double> arr = new ArrayList<Double>();
     arr.add(firstdistinctValues[0].get(Double.class));
     arr.add(seconddistinctValues[0].get(Double.class));
     arr.sort(null);
 
     System.out.println("TuplesHandle name is " + tHandle.getName().toString());
-    assertTrue("TuplesHandle name is incorrect", tHandle.getName().toString().trim().contains("n-way"));
-    
+    assertTrue(tHandle.getName().toString().trim().contains("n-way"));
+
     assertEquals(1.1, arr.get(0), 0.0);
     assertEquals(1.2, arr.get(1), 0.0);
-    assertTrue("TuplesHandle element 1 is incorrect", firstdistinctValues[2].get(String.class).trim().contains("Alaska"));
-    assertTrue("TuplesHandle element 2 is incorrect", seconddistinctValues[2].get(String.class).trim().contains("Alaska"));
+    assertTrue(firstdistinctValues[2].get(String.class).trim().contains("Alaska"));
+    assertTrue(seconddistinctValues[2].get(String.class).trim().contains("Alaska"));
     // release client
     client.release();
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() throws Exception
   {
     System.out.println("In tear down");

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientKerberosFromFile.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientKerberosFromFile.java
@@ -16,52 +16,6 @@
 
 package com.marklogic.client.functionaltest;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
-import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.StringReader;
-import java.security.KeyManagementException;
-import java.security.NoSuchAlgorithmException;
-import java.util.Calendar;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-
-import javax.net.ssl.SSLContext;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.stream.XMLStreamException;
-import javax.xml.stream.XMLStreamReader;
-import javax.xml.transform.TransformerException;
-
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.auth.AuthScope;
-import org.apache.http.auth.UsernamePasswordCredentials;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.DefaultHttpClient;
-import org.apache.http.util.EntityUtils;
-import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.w3c.dom.Document;
-import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marklogic.client.DatabaseClient;
@@ -76,32 +30,17 @@ import com.marklogic.client.admin.TransformExtensionsManager;
 import com.marklogic.client.alerting.RuleDefinition;
 import com.marklogic.client.alerting.RuleDefinitionList;
 import com.marklogic.client.alerting.RuleManager;
-import com.marklogic.client.document.DocumentManager;
+import com.marklogic.client.document.*;
 import com.marklogic.client.document.DocumentManager.Metadata;
-import com.marklogic.client.document.DocumentPage;
-import com.marklogic.client.document.DocumentRecord;
-import com.marklogic.client.document.DocumentWriteSet;
-import com.marklogic.client.document.JSONDocumentManager;
-import com.marklogic.client.document.ServerTransform;
-import com.marklogic.client.document.TextDocumentManager;
-import com.marklogic.client.document.XMLDocumentManager;
 import com.marklogic.client.eval.EvalResult;
 import com.marklogic.client.eval.EvalResult.Type;
 import com.marklogic.client.eval.EvalResultIterator;
 import com.marklogic.client.eval.ServerEvaluationCall;
-import com.marklogic.client.io.BytesHandle;
-import com.marklogic.client.io.DOMHandle;
-import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.client.io.*;
 import com.marklogic.client.io.DocumentMetadataHandle.Capability;
 import com.marklogic.client.io.DocumentMetadataHandle.DocumentCollections;
 import com.marklogic.client.io.DocumentMetadataHandle.DocumentPermissions;
 import com.marklogic.client.io.DocumentMetadataHandle.DocumentProperties;
-import com.marklogic.client.io.FileHandle;
-import com.marklogic.client.io.Format;
-import com.marklogic.client.io.JacksonDatabindHandle;
-import com.marklogic.client.io.JacksonHandle;
-import com.marklogic.client.io.StringHandle;
-import com.marklogic.client.io.XMLStreamReaderHandle;
 import com.marklogic.client.pojo.PojoPage;
 import com.marklogic.client.pojo.PojoQueryBuilder;
 import com.marklogic.client.pojo.PojoQueryDefinition;
@@ -112,6 +51,32 @@ import com.marklogic.client.query.StringQueryDefinition;
 import com.marklogic.client.query.StructuredQueryBuilder;
 import com.marklogic.client.query.StructuredQueryDefinition;
 import com.marklogic.client.util.RequestLogger;
+import org.custommonkey.xmlunit.exceptions.XpathException;
+import org.junit.jupiter.api.*;
+import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+import javax.net.ssl.SSLContext;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import javax.xml.transform.TransformerException;
+import java.io.File;
+import java.io.IOException;
+import java.io.StringReader;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
+import static org.junit.jupiter.api.Assertions.*;
 
 /*
  * For this test we need to have a services.keytab file that contains both service (host name) and user principal names.
@@ -122,7 +87,7 @@ import com.marklogic.client.util.RequestLogger;
  * Copy the services.keytab file to ML Server data directory.
  */
 
-@Ignore("Ignored because it was previously ignored in build.gradle though without explanation")
+@Disabled("Ignored because it was previously ignored in build.gradle though without explanation")
 public class TestDatabaseClientKerberosFromFile extends BasicJavaClientREST {
 
   private static String dbName = "TestDBClientWithKerberosFileDB";
@@ -146,18 +111,18 @@ public class TestDatabaseClientKerberosFromFile extends BasicJavaClientREST {
 
   private DatabaseClient client;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpBeforeClass() throws Exception {
     System.out.println("In setup");
     loadGradleProperties();
     appServerHostName = getRestAppServerHostName();
-    
+
     // Modify default location if needed for services.keytab file. Jenkins job passes in the services.keytab file.
  	keytabFile = System.getProperty("keytabFile");
  	principal = System.getProperty("principal");
- 	
+
      System.out.println("Location of key tab file is " + keytabFile);
-     
+
      if (keytabFile == null) {
      	fail("Key tab file value from Gradle is null / incorrect");
      }
@@ -172,14 +137,14 @@ public class TestDatabaseClientKerberosFromFile extends BasicJavaClientREST {
     // Create the External Security setting.
     createExternalSecurityForKerberos(appServerName, extSecurityName);
     associateRESTServerWithKerberosExtSecurity(appServerName, extSecurityName);
-    
+
     createUserRolesWithPrevilages("test-evalKer", "xdbc:eval", "xdbc:eval-in", "xdmp:eval-in", "any-uri", "xdbc:invoke");
-    
+
     createRESTKerberosUser("builder", "Welcome123", kdcPrincipalUser, "rest-reader", "rest-writer", "rest-admin", "rest-extension-user", "test-evalKer");
     createRESTUser("rest-admin", "x", "rest-admin");
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownAfterClass() throws Exception {
     System.out.println("In tear down");
     deleteUserRole("test-evalKer");
@@ -187,13 +152,13 @@ public class TestDatabaseClientKerberosFromFile extends BasicJavaClientREST {
     tearDownJavaRESTServer(dbName, fNames, appServerName);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws KeyManagementException, NoSuchAlgorithmException, Exception {
     SSLContext sslcontext = null;
 
     if (IsSecurityEnabled()) {
       sslcontext = getSslContext();
-      
+
       KerberosConfig krbConfig = new DatabaseClientFactory.KerberosConfig().withPrincipal(principal)
   			.withUseKeyTab(true)
   			.withDoNotPrompt(true)
@@ -204,11 +169,11 @@ public class TestDatabaseClientKerberosFromFile extends BasicJavaClientREST {
               appServerHostName, appServerHostPort,
               new DatabaseClientFactory.KerberosAuthContext(krbConfig).withSSLContext(sslcontext));
     } else {
-    	/*Pass this file's location for the gradle (thru Jenkins job) 
+    	/*Pass this file's location for the gradle (thru Jenkins job)
     	  QA functional test project's build.gradle file has << systemProperty "keytabFile", System.getProperty("keytabFile") >>
     	  On gradle command line use the following syntax to pass in the location of the keytab file:
     	  ./gradlew marklogic-client-api-functionaltests:test -DkeytabFile=$WORKSPACE/java-client-api/services.keytab -Dprincipal=builder  .....other options
-    	  */   	
+    	  */
     	KerberosConfig krbConfig = new DatabaseClientFactory.KerberosConfig().withPrincipal(principal)
     			.withUseKeyTab(true)
     			.withDoNotPrompt(true)
@@ -221,7 +186,7 @@ public class TestDatabaseClientKerberosFromFile extends BasicJavaClientREST {
     }
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     // release client
     client.release();
@@ -244,7 +209,6 @@ public class TestDatabaseClientKerberosFromFile extends BasicJavaClientREST {
         succeeded = true;
       } else {
         assertTrue(
-            "testArtifactIndexedOnString - No Json node available to insert into database",
             succeeded);
       }
 
@@ -309,9 +273,9 @@ public class TestDatabaseClientKerberosFromFile extends BasicJavaClientREST {
   }
 
   public void validateArtifact(GeoSpecialArtifact art) {
-    assertNotNull("Artifact object should never be Null", art);
-    assertNotNull("Id should never be Null", art.id);
-    assertTrue("Inventry is always greater than 1000", art.getInventory() > 1000);
+    assertNotNull( art);
+    assertNotNull( art.id);
+    assertTrue(art.getInventory() > 1000);
   }
 
   public void loadSimplePojos(PojoRepository products) {
@@ -336,28 +300,27 @@ public class TestDatabaseClientKerberosFromFile extends BasicJavaClientREST {
     // "size:5|reviewed:true|myInteger:10|myDecimal:34.56678|myCalendar:2014|myString:foo|";
     String actualProperties = getDocumentPropertiesString(properties);
     boolean result = actualProperties.contains("size:5|");
-    assertTrue("Document properties count", result);
+    assertTrue(result);
 
     // Permissions
     String actualPermissions = getDocumentPermissionsString(permissions);
     System.out.println(actualPermissions);
     // size:5|rest-writer:[EXECUTE, READ,
     // UPDATE]|rest-reader:[READ]|app-user:[READ, UPDATE]|
-    assertTrue("Document permissions difference in size value",
+    assertTrue(
         actualPermissions.contains("size:5"));
-    assertTrue("Document permissions difference in rest-reader permission",
+    assertTrue(
         actualPermissions.contains("rest-reader:[READ]"));
     // Split up rest-writer:[READ, EXECUTE, UPDATE] string
     String[] writerPerms = actualPermissions.split("rest-writer:\\[")[1].split("\\]")[0].split(",");
 
-    assertTrue("Document permissions difference in rest-writer permission - first permission",
+    assertTrue(
         writerPerms[0].contains("UPDATE") || writerPerms[1].contains("UPDATE") || writerPerms[2].contains("UPDATE"));
-    assertTrue("Document permissions difference in rest-writer permission - second permission",
+    assertTrue(
         writerPerms[0].contains("EXECUTE") || writerPerms[1].contains("EXECUTE") || writerPerms[2].contains("EXECUTE"));
-    assertTrue("Document permissions difference in rest-writer permission - third permission",
+    assertTrue(
         writerPerms[0].contains("READ") || writerPerms[1].contains("READ") || writerPerms[2].contains("READ"));
     assertTrue(
-        "Document permissions difference in app-user permissions",
         (actualPermissions.contains("app-user:[UPDATE, READ]") || actualPermissions
             .contains("app-user:[READ, UPDATE]")));
 
@@ -365,11 +328,11 @@ public class TestDatabaseClientKerberosFromFile extends BasicJavaClientREST {
     String actualCollections = getDocumentCollectionsString(collections);
     System.out.println(collections);
 
-    assertTrue("Document collections difference in size value",
+    assertTrue(
         actualCollections.contains("size:2"));
-    assertTrue("my-collection1 not found",
+    assertTrue(
         actualCollections.contains("my-collection1"));
-    assertTrue("my-collection2 not found",
+    assertTrue(
         actualCollections.contains("my-collection2"));
   }
 
@@ -401,53 +364,53 @@ public class TestDatabaseClientKerberosFromFile extends BasicJavaClientREST {
 
         if (jh.get().isArray()) {
             System.out.println("Type Array :" + jh.get().toString());
-            assertEquals("array value at index 0 ", 1, jh.get().get(0).asInt());
-            assertEquals("array value at index 1 ", 2, jh.get().get(1).asInt());
-            assertEquals("array value at index 2 ", 3, jh.get().get(2).asInt());
+            assertEquals( 1, jh.get().get(0).asInt());
+            assertEquals( 2, jh.get().get(1).asInt());
+            assertEquals( 3, jh.get().get(2).asInt());
          } else if (jh.get().isObject()) {
            System.out.println("Type Object :" + jh.get().toString());
            if (jh.get().has("foo")) {
-               assertNull("this object also has null node", jh.get().get("testNull").textValue());
+               assertNull(jh.get().get("testNull").textValue());
            } else if (jh.get().has("obj")) {
-               assertEquals("Value of the object is ", "value", jh.get().get("obj").asText());
+               assertEquals( "value", jh.get().get("obj").asText());
            } else {
-               assertFalse("getting a wrong object ", true);
+               fail("getting a wrong object ");
            }
 
            } else if (jh.get().isNumber()) {
                System.out.println("Type Number :" + jh.get().toString());
-               assertEquals("Number value", 1, jh.get().asInt());
+               assertEquals( 1, jh.get().asInt());
            } else if (jh.get().isNull()) {
                System.out.println("Type Null :" + jh.get().toString());
                assertNull("Returned Null", jh.get().textValue());
            } else if (jh.get().isBoolean()) {
                System.out.println("Type boolean :" + jh.get().toString());
-               assertTrue("Boolean value returned false", jh.get().asBoolean());
+               assertTrue(jh.get().asBoolean());
            } else {
                // System.out.println("Running into different types than expected");
-               assertFalse("Running into different types than expected", true);
+               fail("Running into different types than expected");
            }
 
       } else if (er.getType().equals(Type.TEXTNODE)) {
-          assertTrue("document contains", er.getAs(String.class).equals("test1"));
+          assertTrue(er.getAs(String.class).equals("test1"));
               // System.out.println("type txt node :"+er.getAs(String.class));
 
       } else if (er.getType().equals(Type.BINARY)) {
           FileHandle fh = new FileHandle();
           fh = er.get(fh);
           // System.out.println("type binary :"+fh.get().length());
-          assertEquals("files size", 2, fh.get().length());
+          assertEquals( 2, fh.get().length());
       } else if (er.getType().equals(Type.BOOLEAN)) {
-          assertTrue("Documents exist?", er.getBoolean());
+          assertTrue(er.getBoolean());
           // System.out.println("type boolean:"+er.getBoolean());
       } else if (er.getType().equals(Type.INTEGER)) {
           System.out.println("type Integer: "+ er.getNumber().longValue());
-          assertEquals("count of documents ", 31, er.getNumber().intValue());
+          assertEquals( 31, er.getNumber().intValue());
       } else if (er.getType().equals(Type.STRING)) {
           String str = er.getString();
           // There is git issue 152
           System.out.println("type string: " + str );
-          assertTrue("String?", str.contains("true") || str.contains("xml")
+          assertTrue(str.contains("true") || str.contains("xml")
                       || str.contains("31") || str.contains("1.0471975511966"));
 
       } else if (er.getType().equals(Type.NULL)) {
@@ -457,71 +420,69 @@ public class TestDatabaseClientKerberosFromFile extends BasicJavaClientREST {
       } else if (er.getType().equals(Type.OTHER)) {
           // There is git issue 151
           System.out.println("Testing is Others? "+ er.getAs(String.class));
-          // assertEquals("Returns OTHERs","xdmp:forest-restart#1",er.getString());
 
       } else if (er.getType().equals(Type.ANYURI)) {
           // System.out.println("Testing is AnyUri? "+er.getAs(String.class));
-          assertEquals("Returns me a uri :", "test1.xml", er.getAs(String.class));
+          assertEquals( "test1.xml", er.getAs(String.class));
 
       } else if (er.getType().equals(Type.DATE)) {
           // System.out.println("Testing is DATE? "+er.getAs(String.class));
-          assertEquals("Returns me a date :", "2002-03-07-07:00", er.getAs(String.class));
+          assertEquals( "2002-03-07-07:00", er.getAs(String.class));
       } else if (er.getType().equals(Type.DATETIME)) {
           // System.out.println("Testing is DATETIME? "+er.getAs(String.class));
-          assertEquals("Returns me a dateTime :", "2010-01-06T18:13:50.874-07:00", er.getAs(String.class));
+          assertEquals( "2010-01-06T18:13:50.874-07:00", er.getAs(String.class));
       } else if (er.getType().equals(Type.DECIMAL)) {
           // System.out.println("Testing is Decimal? "+er.getAs(String.class));
-          assertEquals("Returns me a Decimal :", "1.0471975511966", er.getAs(String.class));
+          assertEquals( "1.0471975511966", er.getAs(String.class));
 
       } else if (er.getType().equals(Type.DOUBLE)) {
           // System.out.println("Testing is Double? "+er.getAs(String.class));
           assertEquals(1.0471975511966, er.getNumber().doubleValue(), 0);
       } else if (er.getType().equals(Type.DURATION)) {
           System.out.println("Testing is Duration? "+ er.getAs(String.class));
-          // assertEquals("Returns me a Duration :",0.4903562,er.getNumber().floatValue());
       } else if (er.getType().equals(Type.FLOAT)) {
           // System.out.println("Testing is Float? "+er.getAs(String.class));
           assertEquals(20, er.getNumber().floatValue(), 0);
       } else if (er.getType().equals(Type.GDAY)) {
           // System.out.println("Testing is GDay? "+er.getAs(String.class));
-          assertEquals("Returns me a GDAY :", "---01", er.getAs(String.class));
+          assertEquals( "---01", er.getAs(String.class));
       } else if (er.getType().equals(Type.GMONTH)) {
           // System.out.println("Testing is GMonth "+er.getAs(String.class));
-          assertEquals("Returns me a GMONTH :", "--01", er.getAs(String.class));
+          assertEquals( "--01", er.getAs(String.class));
       } else if (er.getType().equals(Type.GMONTHDAY)) {
           // System.out.println("Testing is GMonthDay? "+er.getAs(String.class));
-          assertEquals("Returns me a GMONTHDAY :", "--12-25-14:00", er.getAs(String.class));
+          assertEquals( "--12-25-14:00", er.getAs(String.class));
       } else if (er.getType().equals(Type.GYEAR)) {
           // System.out.println("Testing is GYear? "+er.getAs(String.class));
-          assertEquals("Returns me a GYEAR :", "2005-12:00", er.getAs(String.class));
+          assertEquals( "2005-12:00", er.getAs(String.class));
       } else if (er.getType().equals(Type.GYEARMONTH)) {
           // System.out.println("Testing is GYearMonth?1976-02 "+er.getAs(String.class));
-          assertEquals("Returns me a GYEARMONTH :", "1976-02", er.getAs(String.class));
+          assertEquals( "1976-02", er.getAs(String.class));
       } else if (er.getType().equals(Type.HEXBINARY)) {
           // System.out.println("Testing is HEXBINARY? "+er.getAs(String.class));
-          assertEquals("Returns me a HEXBINARY :", "BEEF", er.getAs(String.class));
+          assertEquals( "BEEF", er.getAs(String.class));
       } else if (er.getType().equals(Type.QNAME)) {
           // System.out.println("Testing is QNAME integer"+er.getAs(String.class));
-          assertEquals("Returns me a QNAME :", "integer", er.getAs(String.class));
+          assertEquals( "integer", er.getAs(String.class));
       } else if (er.getType().equals(Type.TIME)) {
           // System.out.println("Testing is TIME? "+er.getAs(String.class));
-          assertEquals("Returns me a TIME :", "10:00:00", er.getAs(String.class));
+          assertEquals( "10:00:00", er.getAs(String.class));
       } else if (er.getType().equals(Type.ATTRIBUTE)) {
           // System.out.println("Testing is ATTRIBUTE? "+er.getAs(String.class));
-          assertEquals("Returns me a ATTRIBUTE :", "attribute", er.getAs(String.class));
+          assertEquals( "attribute", er.getAs(String.class));
       } else if (er.getType().equals(Type.PROCESSINGINSTRUCTION)) {
           // System.out.println("Testing is ProcessingInstructions? "+er.getAs(String.class));
-          assertEquals("Returns me a PROCESSINGINSTRUCTION :", "<?processing instruction?>", er.getAs(String.class));
+          assertEquals( "<?processing instruction?>", er.getAs(String.class));
       } else if (er.getType().equals(Type.COMMENT)) {
           // System.out.println("Testing is Comment node? "+er.getAs(String.class));
-          assertEquals("Returns me a COMMENT :", "<!--comment-->", er.getAs(String.class));
+          assertEquals( "<!--comment-->", er.getAs(String.class));
       } else if (er.getType().equals(Type.BASE64BINARY)) {
           // System.out.println("Testing is Base64Binary  "+er.getAs(String.class));
-          assertEquals("Returns me a BASE64BINARY :", "DEADBEEF", er.getAs(String.class));
+          assertEquals( "DEADBEEF", er.getAs(String.class));
       } else {
           System.out.println("Got something which is not belongs to anytype we support "
                       + er.getAs(String.class));
-          assertFalse("getting in else part, missing a type  ", true);
+          fail("getting in else part, missing a type  ");
       }
     }
   }
@@ -533,7 +494,7 @@ public class TestDatabaseClientKerberosFromFile extends BasicJavaClientREST {
   @Test
   public void testPOJOGeoQuerySearchWithGeoPair() {
     System.out.println("Running testPOJOGeoQuerySearchWithGeoPair method");
-  
+
     PojoRepository<GeoSpecialArtifact, Long> products = client.newPojoRepository(GeoSpecialArtifact.class, Long.class);
     PojoPage<GeoSpecialArtifact> p;
     this.loadSimplePojos(products);
@@ -546,7 +507,7 @@ public class TestDatabaseClientKerberosFromFile extends BasicJavaClientREST {
     products.setPageLength(5);
     p = products.search(qd, 1, jh);
     System.out.println(jh.get().toString());
-    assertEquals("total no of pages", 3, p.getTotalPages());
+    assertEquals( 3, p.getTotalPages());
     System.out.println(jh.get().toString());
 
     long pageNo = 1, count = 0;
@@ -556,17 +517,17 @@ public class TestDatabaseClientKerberosFromFile extends BasicJavaClientREST {
       while (p.hasNext()) {
         GeoSpecialArtifact a = p.next();
         validateArtifact(a);
-        assertTrue("Verifying document id is part of the search ids", a.getId() % 5 == 0);
-        assertEquals("Verifying Manufacurer is from state ", "Reno", a.getManufacturer().getState());
+        assertTrue(a.getId() % 5 == 0);
+        assertEquals( "Reno", a.getManufacturer().getState());
         count++;
       }
-      assertEquals("Page size", count, p.size());
+      assertEquals( count, p.size());
       pageNo = pageNo + p.getPageSize();
     } while (!p.isLastPage() && pageNo <= p.getTotalSize());
-    assertEquals("page number after the loop", 3, p.getPageNumber());
-    assertEquals("total no of pages", 3, p.getTotalPages());
-    assertEquals("page length from search handle", 5, jh.get().path("page-length").asInt());
-    assertEquals("Total results from search handle", 11, jh.get().path("total").asInt());
+    assertEquals( 3, p.getPageNumber());
+    assertEquals( 3, p.getTotalPages());
+    assertEquals( 5, jh.get().path("page-length").asInt());
+    assertEquals( 11, jh.get().path("total").asInt());
   }
 
   @Test
@@ -575,7 +536,7 @@ public class TestDatabaseClientKerberosFromFile extends BasicJavaClientREST {
     String docId = "/foo/test/myFoo.txt";
     TextDocumentManager docMgr = client.newTextDocumentManager();
     docMgr.write(docId, new StringHandle().with("This is so foo"));
-    assertEquals("Text document write difference", "This is so foo", docMgr.read(docId, new StringHandle()).get());
+    assertEquals( "This is so foo", docMgr.read(docId, new StringHandle()).get());
   }
 
   @Test
@@ -597,7 +558,7 @@ public class TestDatabaseClientKerberosFromFile extends BasicJavaClientREST {
     long size = getBinarySizeFromByte(fileRead);
     long expectedSize = 34543;
 
-    assertEquals("Binary size difference", expectedSize, size);
+    assertEquals( expectedSize, size);
 
     // update the doc
     // acquire the content for update
@@ -614,7 +575,7 @@ public class TestDatabaseClientKerberosFromFile extends BasicJavaClientREST {
     long sizeUpdate = getBinarySizeFromByte(fileReadUpdate);
     // long expectedSizeUpdate = 3290;
     long expectedSizeUpdate = 3322;
-    assertEquals("Binary size difference", expectedSizeUpdate, sizeUpdate);
+    assertEquals( expectedSizeUpdate, sizeUpdate);
 
     // delete the document
     deleteDocument(client, uri + filename, "Binary");
@@ -628,7 +589,7 @@ public class TestDatabaseClientKerberosFromFile extends BasicJavaClientREST {
     }
 
     String expectedException = "com.marklogic.client.ResourceNotFoundException: Local message: Could not read non-existent document. Server Message: RESTAPI-NODOCUMENT: (err:FOER0000) Resource or document does not exist:  category: content message: /write-bin-Bytehandle/Pandakarlino.jpg";
-    assertEquals("Document is not deleted", expectedException, exception);
+    assertEquals( expectedException, exception);
   }
 
   @Test
@@ -667,27 +628,27 @@ public class TestDatabaseClientKerberosFromFile extends BasicJavaClientREST {
     docMgr.read(docId[0], jacksonDBReadHandle);
     Product product1 = (Product) jacksonDBReadHandle.get();
 
-    assertTrue("Did not return a iPhone 6", product1.getName().equalsIgnoreCase("iPhone 6"));
-    assertTrue("Did not return a Mobile Phone", product1.getIndustry().equalsIgnoreCase("Mobile Phone"));
-    assertTrue("Did not return a Mobile Phone", product1.getDescription().equalsIgnoreCase("New iPhone 6"));
+    assertTrue(product1.getName().equalsIgnoreCase("iPhone 6"));
+    assertTrue(product1.getIndustry().equalsIgnoreCase("Mobile Phone"));
+    assertTrue(product1.getDescription().equalsIgnoreCase("New iPhone 6"));
 
     docMgr.readMetadata(docId[0], mhRead);
     validateMetadata(mhRead);
 
     docMgr.read(docId[1], jacksonDBReadHandle);
     Product product2 = (Product) jacksonDBReadHandle.get();
-    assertTrue("Did not return a iMac", product2.getName().equalsIgnoreCase("iMac"));
-    assertTrue("Did not return a Desktop", product2.getIndustry().equalsIgnoreCase("Desktop"));
-    assertTrue("Did not return a Air Book OS X", product2.getDescription().equalsIgnoreCase("Air Book OS X"));
+    assertTrue(product2.getName().equalsIgnoreCase("iMac"));
+    assertTrue(product2.getIndustry().equalsIgnoreCase("Desktop"));
+    assertTrue(product2.getDescription().equalsIgnoreCase("Air Book OS X"));
 
     docMgr.readMetadata(docId[1], mhRead);
     validateMetadata(mhRead);
 
     docMgr.read(docId[2], jacksonDBReadHandle);
     Product product3 = (Product) jacksonDBReadHandle.get();
-    assertTrue("Did not return a iPad", product3.getName().equalsIgnoreCase("iPad"));
-    assertTrue("Did not return a Tablet", product3.getIndustry().equalsIgnoreCase("Tablet"));
-    assertTrue("Did not return a iPad Mini", product3.getDescription().equalsIgnoreCase("iPad Mini"));
+    assertTrue(product3.getName().equalsIgnoreCase("iPad"));
+    assertTrue(product3.getIndustry().equalsIgnoreCase("Tablet"));
+    assertTrue(product3.getDescription().equalsIgnoreCase("iPad Mini"));
 
     docMgr.readMetadata(docId[2], mhRead);
     validateMetadata(mhRead);
@@ -715,7 +676,7 @@ public class TestDatabaseClientKerberosFromFile extends BasicJavaClientREST {
     Document expectedDoc = expectedXMLDocument(filename);
     String expectedContent = convertXMLDocumentToString(expectedDoc);
     expectedContent = "null" + expectedContent.substring(expectedContent.indexOf("<name>") + 6, expectedContent.indexOf("</name>"));
-    assertEquals("Write XML difference", expectedContent, readContent);
+    assertEquals( expectedContent, readContent);
 
     // delete the document
     deleteDocument(client, uri + filename, "XML");
@@ -729,7 +690,7 @@ public class TestDatabaseClientKerberosFromFile extends BasicJavaClientREST {
 
     String expectedException = "Could not read non-existent document";
     boolean documentIsDeleted = exception.contains(expectedException);
-    assertTrue("Document is not deleted", documentIsDeleted);
+    assertTrue(documentIsDeleted);
   }
 
   @Test
@@ -878,7 +839,7 @@ public class TestDatabaseClientKerberosFromFile extends BasicJavaClientREST {
       // Verify rollback on DocumentManager write method with transform.
       tRollback.rollback();
       DocumentPage pageRollback = docMgr.read(uris);
-      assertEquals("Document count is not zero. Transaction did not rollback", 0, pageRollback.size());
+      assertEquals( 0, pageRollback.size());
 
       // Perform write with a commit.
       Transaction tCommit = client.openTransaction();
@@ -905,16 +866,16 @@ public class TestDatabaseClientKerberosFromFile extends BasicJavaClientREST {
       while (page.hasNext()) {
         DocumentRecord rec = page.next();
         rec.getContent(dh);
-        assertTrue("Element has attribure ? :", dh.get().getElementsByTagName("foo").item(0).hasAttributes());
+        assertTrue(dh.get().getElementsByTagName("foo").item(0).hasAttributes());
         verifyAttrValue = dh.get().getElementsByTagName("foo").item(0).getAttributes().getNamedItem("Lang").getNodeValue();
-        assertTrue("Server Transform did not go through ", verifyAttrValue.equalsIgnoreCase("testBulkXQYTransformWithTrans"));
+        assertTrue(verifyAttrValue.equalsIgnoreCase("testBulkXQYTransformWithTrans"));
         count++;
       }
     } catch (Exception e) {
       System.out.println(e.getMessage());
       throw e;
     }
-    assertEquals("document count", 102, count);
+    assertEquals( 102, count);
   }
 
   @Test
@@ -956,7 +917,7 @@ public class TestDatabaseClientKerberosFromFile extends BasicJavaClientREST {
     docMgr.stopLogging();
 
     String expectedContentMax = "9223372036854775807";
-    assertEquals("Content log is not equal", expectedContentMax, Long.toString(logger.getContentMax()));
+    assertEquals( expectedContentMax, Long.toString(logger.getContentMax()));
   }
 
   @Test
@@ -1050,11 +1011,11 @@ public class TestDatabaseClientKerberosFromFile extends BasicJavaClientREST {
     }
 
     System.out.println(expected);
-    assertTrue("incorrect rule", expected.contains("RULE-TEST-1 - {rule-number=one} |"));
+    assertTrue(expected.contains("RULE-TEST-1 - {rule-number=one} |"));
   }
 
   // Access database on Uber port with specifying the database name.
-  @Ignore
+  @Disabled
   public void testUberClientWithDbName() throws IOException, SAXException, ParserConfigurationException {
     System.out.println("Running testUberClientWithDbName method");
 
@@ -1127,11 +1088,11 @@ public class TestDatabaseClientKerberosFromFile extends BasicJavaClientREST {
 
       docMgr.write(writeset);
 
-      assertEquals("Text document write difference", "This is so foo1",
+      assertEquals( "This is so foo1",
           docMgr.read(docId[0], new StringHandle()).get());
-      assertEquals("Text document write difference", "This is so foo2",
+      assertEquals( "This is so foo2",
           docMgr.read(docId[1], new StringHandle()).get());
-      assertEquals("Text document write difference", "This is so foo3",
+      assertEquals( "This is so foo3",
           docMgr.read(docId[2], new StringHandle()).get());
 
       // Bulk delete on TextDocumentManager
@@ -1142,18 +1103,18 @@ public class TestDatabaseClientKerberosFromFile extends BasicJavaClientREST {
       System.out.println("Exception is" + exception);
     }
     String expectedException = null;
-    if (IsSecurityEnabled()) 
+    if (IsSecurityEnabled())
         expectedException = "java.net.ProtocolException";
     else
      expectedException = "com.marklogic.client.FailedRequestException: Local message: failed to apply resource at documents: Unauthorized. Server Message: Unauthorized";
     boolean exceptionIsThrown = exception.contains(expectedException);
-    assertTrue("Exception is not thrown", exceptionIsThrown);
+    assertTrue(exceptionIsThrown);
 
     clientDigest.release();
   }
-  
+
   //Test DatabaseCLient with valid ADC user, but that user is not in the services keytab file. Should expect an Exception.
- @Ignore
+ @Disabled
  public void testValidDCUserNotInKeytabFile() {
 	 System.out.println("Running testValidDCUserNotInKeytabFile method");
 
@@ -1173,15 +1134,15 @@ public class TestDatabaseClientKerberosFromFile extends BasicJavaClientREST {
 		 msg.append(e.getMessage());
 		 e.printStackTrace();
 	 }
-	 
-	 assertTrue("Exception is not thrown for user2", msg.toString().contains("Unable to obtain password from user"));
+
+	 assertTrue(msg.toString().contains("Unable to obtain password from user"));
 	 if (client2 != null) {
 		 client2.release();
 	 }
  }
- 
+
 //Test DatabaseCLient with invalid ADC user. Should expect an Exception.
-@Ignore
+@Disabled
 public void testInValidDCUserNotInKeytabFile() {
 	 System.out.println("Running testInValidDCUserNotInKeytabFile method");
 
@@ -1201,11 +1162,11 @@ public void testInValidDCUserNotInKeytabFile() {
 		 msg.append(e.getMessage());
 		 e.printStackTrace();
 	 }
-	 
-	 assertTrue("Exception is not thrown for builder890", msg.toString().contains("Unable to obtain password from user"));
+
+	 assertTrue(msg.toString().contains("Unable to obtain password from user"));
 	 if (client890 != null) {
 		 client890.release();
 	 }
 }
-	
+
 }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientWithCertBasedAuth.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientWithCertBasedAuth.java
@@ -16,24 +16,6 @@
 
 package com.marklogic.client.functionaltest;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.net.InetAddress;
-
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.auth.AuthScope;
-import org.apache.http.auth.UsernamePasswordCredentials;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.DefaultHttpClient;
-import org.apache.http.util.EntityUtils;
-import org.junit.*;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -43,10 +25,24 @@ import com.marklogic.client.DatabaseClientFactory.CertificateAuthContext;
 import com.marklogic.client.DatabaseClientFactory.SecurityContext;
 import com.marklogic.client.document.TextDocumentManager;
 import com.marklogic.client.io.StringHandle;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.util.EntityUtils;
+import org.junit.jupiter.api.*;
 
-import junit.framework.Assert;
+import java.io.*;
+import java.net.InetAddress;
 
-@Ignore("Ignored because it was previously ignored in build.gradle though without explanation")
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Disabled("Ignored because it was previously ignored in build.gradle though without explanation")
 public class TestDatabaseClientWithCertBasedAuth extends BasicJavaClientREST {
 
   public static String newLine = System.getProperty("line.separator");
@@ -60,7 +56,7 @@ public class TestDatabaseClientWithCertBasedAuth extends BasicJavaClientREST {
   public static DatabaseClient secClient;
   public static String localHostname = getBootStrapHostFromML();
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpBeforeClass() throws Exception {
 
     createRESTServerWithDB(server, port);
@@ -83,7 +79,7 @@ public class TestDatabaseClientWithCertBasedAuth extends BasicJavaClientREST {
     associateRESTServerWithDB(server, "Documents");
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownAfterClass() throws Exception {
 
     removeTrustedCert();
@@ -92,13 +88,9 @@ public class TestDatabaseClientWithCertBasedAuth extends BasicJavaClientREST {
     associateRESTServerWithDB(setupServer, "Documents");
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     clearDB(port);
-  }
-
-  @After
-  public void tearDown() throws Exception {
   }
 
   @SuppressWarnings("deprecation")
@@ -119,7 +111,7 @@ public class TestDatabaseClientWithCertBasedAuth extends BasicJavaClientREST {
     docMgr.write(docId, handle);
     System.out.println(client.newServerEval().xquery(query1));
     System.out.println("Doc written");
-    Assert.assertEquals(count + 1, client.newServerEval().xquery(query1).eval().next().getNumber().intValue());
+    assertEquals(count + 1, client.newServerEval().xquery(query1).eval().next().getNumber().intValue());
     client.release();
   }
 
@@ -134,8 +126,8 @@ public class TestDatabaseClientWithCertBasedAuth extends BasicJavaClientREST {
     } catch (Exception e) {
       e.printStackTrace();
       System.out.println("Exception is " + e.getClass().getName());
-      Assert.assertTrue(e.getClass().getName().equals("com.marklogic.client.FailedRequestException"));
-      Assert.assertTrue(e.getMessage().equals("Local message: failed to apply resource at eval: Unauthorized. Server Message: Unauthorized"));
+      assertTrue(e.getClass().getName().equals("com.marklogic.client.FailedRequestException"));
+      assertTrue(e.getMessage().equals("Local message: failed to apply resource at eval: Unauthorized. Server Message: Unauthorized"));
 
     }
   }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientWithKerberos.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientWithKerberos.java
@@ -16,43 +16,6 @@
 
 package com.marklogic.client.functionaltest;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
-import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.StringReader;
-import java.security.KeyManagementException;
-import java.security.NoSuchAlgorithmException;
-import java.util.Calendar;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-
-import javax.net.ssl.SSLContext;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.stream.XMLStreamException;
-import javax.xml.stream.XMLStreamReader;
-import javax.xml.transform.TransformerException;
-
-import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.w3c.dom.Document;
-import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marklogic.client.DatabaseClient;
@@ -66,32 +29,17 @@ import com.marklogic.client.admin.TransformExtensionsManager;
 import com.marklogic.client.alerting.RuleDefinition;
 import com.marklogic.client.alerting.RuleDefinitionList;
 import com.marklogic.client.alerting.RuleManager;
-import com.marklogic.client.document.DocumentManager;
+import com.marklogic.client.document.*;
 import com.marklogic.client.document.DocumentManager.Metadata;
-import com.marklogic.client.document.DocumentPage;
-import com.marklogic.client.document.DocumentRecord;
-import com.marklogic.client.document.DocumentWriteSet;
-import com.marklogic.client.document.JSONDocumentManager;
-import com.marklogic.client.document.ServerTransform;
-import com.marklogic.client.document.TextDocumentManager;
-import com.marklogic.client.document.XMLDocumentManager;
 import com.marklogic.client.eval.EvalResult;
 import com.marklogic.client.eval.EvalResult.Type;
 import com.marklogic.client.eval.EvalResultIterator;
 import com.marklogic.client.eval.ServerEvaluationCall;
-import com.marklogic.client.io.BytesHandle;
-import com.marklogic.client.io.DOMHandle;
-import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.client.io.*;
 import com.marklogic.client.io.DocumentMetadataHandle.Capability;
 import com.marklogic.client.io.DocumentMetadataHandle.DocumentCollections;
 import com.marklogic.client.io.DocumentMetadataHandle.DocumentPermissions;
 import com.marklogic.client.io.DocumentMetadataHandle.DocumentProperties;
-import com.marklogic.client.io.FileHandle;
-import com.marklogic.client.io.Format;
-import com.marklogic.client.io.JacksonDatabindHandle;
-import com.marklogic.client.io.JacksonHandle;
-import com.marklogic.client.io.StringHandle;
-import com.marklogic.client.io.XMLStreamReaderHandle;
 import com.marklogic.client.pojo.PojoPage;
 import com.marklogic.client.pojo.PojoQueryBuilder;
 import com.marklogic.client.pojo.PojoQueryDefinition;
@@ -102,8 +50,34 @@ import com.marklogic.client.query.StringQueryDefinition;
 import com.marklogic.client.query.StructuredQueryBuilder;
 import com.marklogic.client.query.StructuredQueryDefinition;
 import com.marklogic.client.util.RequestLogger;
+import org.custommonkey.xmlunit.exceptions.XpathException;
+import org.junit.jupiter.api.*;
+import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
 
-@Ignore("Ignored because it was previously ignored in build.gradle though without explanation")
+import javax.net.ssl.SSLContext;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import javax.xml.transform.TransformerException;
+import java.io.File;
+import java.io.IOException;
+import java.io.StringReader;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
+import static org.junit.jupiter.api.Assertions.*;
+
+@Disabled("Ignored because it was previously ignored in build.gradle though without explanation")
 public class TestDatabaseClientWithKerberos extends BasicJavaClientREST {
 
   private static String dbName = "TestDatabaseClientWithKerberosDB";
@@ -125,7 +99,7 @@ public class TestDatabaseClientWithKerberos extends BasicJavaClientREST {
 
   private DatabaseClient client;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpBeforeClass() throws Exception {
     System.out.println("In setup");
     loadGradleProperties();
@@ -144,7 +118,7 @@ public class TestDatabaseClientWithKerberos extends BasicJavaClientREST {
     createRESTUser("rest-admin", "x", "rest-admin");
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownAfterClass() throws Exception {
     System.out.println("In tear down");
     deleteUserRole("test-evalKer");
@@ -152,7 +126,7 @@ public class TestDatabaseClientWithKerberos extends BasicJavaClientREST {
     tearDownJavaRESTServer(dbName, fNames, appServerName);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws KeyManagementException, NoSuchAlgorithmException, Exception {
     SSLContext sslcontext = null;
 
@@ -166,7 +140,7 @@ public class TestDatabaseClientWithKerberos extends BasicJavaClientREST {
           appServerHostPort, new KerberosAuthContext(kdcPrincipalUser));
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     // release client
     client.release();
@@ -189,7 +163,6 @@ public class TestDatabaseClientWithKerberos extends BasicJavaClientREST {
         succeeded = true;
       } else {
         assertTrue(
-            "testArtifactIndexedOnString - No Json node available to insert into database",
             succeeded);
       }
 
@@ -254,9 +227,9 @@ public class TestDatabaseClientWithKerberos extends BasicJavaClientREST {
   }
 
   public void validateArtifact(GeoSpecialArtifact art) {
-    assertNotNull("Artifact object should never be Null", art);
-    assertNotNull("Id should never be Null", art.id);
-    assertTrue("Inventry is always greater than 1000", art.getInventory() > 1000);
+    assertNotNull(art);
+    assertNotNull(art.id);
+    assertTrue( art.getInventory() > 1000);
   }
 
   public void loadSimplePojos(PojoRepository products) {
@@ -281,28 +254,27 @@ public class TestDatabaseClientWithKerberos extends BasicJavaClientREST {
     // "size:5|reviewed:true|myInteger:10|myDecimal:34.56678|myCalendar:2014|myString:foo|";
     String actualProperties = getDocumentPropertiesString(properties);
     boolean result = actualProperties.contains("size:5|");
-    assertTrue("Document properties count", result);
+    assertTrue( result);
 
     // Permissions
     String actualPermissions = getDocumentPermissionsString(permissions);
     System.out.println(actualPermissions);
     // size:5|rest-writer:[EXECUTE, READ,
     // UPDATE]|rest-reader:[READ]|app-user:[READ, UPDATE]|
-    assertTrue("Document permissions difference in size value",
+    assertTrue(
         actualPermissions.contains("size:5"));
-    assertTrue("Document permissions difference in rest-reader permission",
+    assertTrue(
         actualPermissions.contains("rest-reader:[READ]"));
     // Split up rest-writer:[READ, EXECUTE, UPDATE] string
     String[] writerPerms = actualPermissions.split("rest-writer:\\[")[1].split("\\]")[0].split(",");
 
-    assertTrue("Document permissions difference in rest-writer permission - first permission",
+    assertTrue(
         writerPerms[0].contains("UPDATE") || writerPerms[1].contains("UPDATE") || writerPerms[2].contains("UPDATE"));
-    assertTrue("Document permissions difference in rest-writer permission - second permission",
+    assertTrue(
         writerPerms[0].contains("EXECUTE") || writerPerms[1].contains("EXECUTE") || writerPerms[2].contains("EXECUTE"));
-    assertTrue("Document permissions difference in rest-writer permission - third permission",
+    assertTrue(
         writerPerms[0].contains("READ") || writerPerms[1].contains("READ") || writerPerms[2].contains("READ"));
     assertTrue(
-        "Document permissions difference in app-user permissions",
         (actualPermissions.contains("app-user:[UPDATE, READ]") || actualPermissions
             .contains("app-user:[READ, UPDATE]")));
 
@@ -310,11 +282,11 @@ public class TestDatabaseClientWithKerberos extends BasicJavaClientREST {
     String actualCollections = getDocumentCollectionsString(collections);
     System.out.println(collections);
 
-    assertTrue("Document collections difference in size value",
+    assertTrue(
         actualCollections.contains("size:2"));
-    assertTrue("my-collection1 not found",
+    assertTrue(
         actualCollections.contains("my-collection1"));
-    assertTrue("my-collection2 not found",
+    assertTrue(
         actualCollections.contains("my-collection2"));
   }
 
@@ -346,53 +318,53 @@ public class TestDatabaseClientWithKerberos extends BasicJavaClientREST {
 
         if (jh.get().isArray()) {
             System.out.println("Type Array :" + jh.get().toString());
-            assertEquals("array value at index 0 ", 1, jh.get().get(0).asInt());
-            assertEquals("array value at index 1 ", 2, jh.get().get(1).asInt());
-            assertEquals("array value at index 2 ", 3, jh.get().get(2).asInt());
+            assertEquals( 1, jh.get().get(0).asInt());
+            assertEquals( 2, jh.get().get(1).asInt());
+            assertEquals( 3, jh.get().get(2).asInt());
          } else if (jh.get().isObject()) {
            System.out.println("Type Object :" + jh.get().toString());
            if (jh.get().has("foo")) {
                assertNull("this object also has null node", jh.get().get("testNull").textValue());
            } else if (jh.get().has("obj")) {
-               assertEquals("Value of the object is ", "value", jh.get().get("obj").asText());
+               assertEquals("value", jh.get().get("obj").asText());
            } else {
-               assertFalse("getting a wrong object ", true);
+               fail("getting a wrong object ");
            }
 
            } else if (jh.get().isNumber()) {
                System.out.println("Type Number :" + jh.get().toString());
-               assertEquals("Number value", 1, jh.get().asInt());
+               assertEquals( 1, jh.get().asInt());
            } else if (jh.get().isNull()) {
                System.out.println("Type Null :" + jh.get().toString());
                assertNull("Returned Null", jh.get().textValue());
            } else if (jh.get().isBoolean()) {
                System.out.println("Type boolean :" + jh.get().toString());
-               assertTrue("Boolean value returned false", jh.get().asBoolean());
+               assertTrue( jh.get().asBoolean());
            } else {
                // System.out.println("Running into different types than expected");
-               assertFalse("Running into different types than expected", true);
+               fail("Running into different types than expected");
            }
 
       } else if (er.getType().equals(Type.TEXTNODE)) {
-          assertTrue("document contains", er.getAs(String.class).equals("test1"));
+          assertTrue( er.getAs(String.class).equals("test1"));
               // System.out.println("type txt node :"+er.getAs(String.class));
 
       } else if (er.getType().equals(Type.BINARY)) {
           FileHandle fh = new FileHandle();
           fh = er.get(fh);
           // System.out.println("type binary :"+fh.get().length());
-          assertEquals("files size", 2, fh.get().length());
+          assertEquals( 2, fh.get().length());
       } else if (er.getType().equals(Type.BOOLEAN)) {
-          assertTrue("Documents exist?", er.getBoolean());
+          assertTrue( er.getBoolean());
           // System.out.println("type boolean:"+er.getBoolean());
       } else if (er.getType().equals(Type.INTEGER)) {
           System.out.println("type Integer: "+ er.getNumber().longValue());
-          assertEquals("count of documents ", 31, er.getNumber().intValue());
+          assertEquals( 31, er.getNumber().intValue());
       } else if (er.getType().equals(Type.STRING)) {
           String str = er.getString();
           // There is git issue 152
           System.out.println("type string: " + str );
-          assertTrue("String?", str.contains("true") || str.contains("xml")
+          assertTrue( str.contains("true") || str.contains("xml")
                       || str.contains("31") || str.contains("1.0471975511966"));
 
       } else if (er.getType().equals(Type.NULL)) {
@@ -402,71 +374,69 @@ public class TestDatabaseClientWithKerberos extends BasicJavaClientREST {
       } else if (er.getType().equals(Type.OTHER)) {
           // There is git issue 151
           System.out.println("Testing is Others? "+ er.getAs(String.class));
-          // assertEquals("Returns OTHERs","xdmp:forest-restart#1",er.getString());
 
       } else if (er.getType().equals(Type.ANYURI)) {
           // System.out.println("Testing is AnyUri? "+er.getAs(String.class));
-          assertEquals("Returns me a uri :", "test1.xml", er.getAs(String.class));
+          assertEquals( "test1.xml", er.getAs(String.class));
 
       } else if (er.getType().equals(Type.DATE)) {
           // System.out.println("Testing is DATE? "+er.getAs(String.class));
-          assertEquals("Returns me a date :", "2002-03-07-07:00", er.getAs(String.class));
+          assertEquals( "2002-03-07-07:00", er.getAs(String.class));
       } else if (er.getType().equals(Type.DATETIME)) {
           // System.out.println("Testing is DATETIME? "+er.getAs(String.class));
-          assertEquals("Returns me a dateTime :", "2010-01-06T18:13:50.874-07:00", er.getAs(String.class));
+          assertEquals( "2010-01-06T18:13:50.874-07:00", er.getAs(String.class));
       } else if (er.getType().equals(Type.DECIMAL)) {
           // System.out.println("Testing is Decimal? "+er.getAs(String.class));
-          assertEquals("Returns me a Decimal :", "1.0471975511966", er.getAs(String.class));
+          assertEquals( "1.0471975511966", er.getAs(String.class));
 
       } else if (er.getType().equals(Type.DOUBLE)) {
           // System.out.println("Testing is Double? "+er.getAs(String.class));
           assertEquals(1.0471975511966, er.getNumber().doubleValue(), 0);
       } else if (er.getType().equals(Type.DURATION)) {
           System.out.println("Testing is Duration? "+ er.getAs(String.class));
-          // assertEquals("Returns me a Duration :",0.4903562,er.getNumber().floatValue());
       } else if (er.getType().equals(Type.FLOAT)) {
           // System.out.println("Testing is Float? "+er.getAs(String.class));
           assertEquals(20, er.getNumber().floatValue(), 0);
       } else if (er.getType().equals(Type.GDAY)) {
           // System.out.println("Testing is GDay? "+er.getAs(String.class));
-          assertEquals("Returns me a GDAY :", "---01", er.getAs(String.class));
+          assertEquals( "---01", er.getAs(String.class));
       } else if (er.getType().equals(Type.GMONTH)) {
           // System.out.println("Testing is GMonth "+er.getAs(String.class));
-          assertEquals("Returns me a GMONTH :", "--01", er.getAs(String.class));
+          assertEquals( "--01", er.getAs(String.class));
       } else if (er.getType().equals(Type.GMONTHDAY)) {
           // System.out.println("Testing is GMonthDay? "+er.getAs(String.class));
-          assertEquals("Returns me a GMONTHDAY :", "--12-25-14:00", er.getAs(String.class));
+          assertEquals( "--12-25-14:00", er.getAs(String.class));
       } else if (er.getType().equals(Type.GYEAR)) {
           // System.out.println("Testing is GYear? "+er.getAs(String.class));
-          assertEquals("Returns me a GYEAR :", "2005-12:00", er.getAs(String.class));
+          assertEquals( "2005-12:00", er.getAs(String.class));
       } else if (er.getType().equals(Type.GYEARMONTH)) {
           // System.out.println("Testing is GYearMonth?1976-02 "+er.getAs(String.class));
-          assertEquals("Returns me a GYEARMONTH :", "1976-02", er.getAs(String.class));
+          assertEquals( "1976-02", er.getAs(String.class));
       } else if (er.getType().equals(Type.HEXBINARY)) {
           // System.out.println("Testing is HEXBINARY? "+er.getAs(String.class));
-          assertEquals("Returns me a HEXBINARY :", "BEEF", er.getAs(String.class));
+          assertEquals( "BEEF", er.getAs(String.class));
       } else if (er.getType().equals(Type.QNAME)) {
           // System.out.println("Testing is QNAME integer"+er.getAs(String.class));
-          assertEquals("Returns me a QNAME :", "integer", er.getAs(String.class));
+          assertEquals( "integer", er.getAs(String.class));
       } else if (er.getType().equals(Type.TIME)) {
           // System.out.println("Testing is TIME? "+er.getAs(String.class));
-          assertEquals("Returns me a TIME :", "10:00:00", er.getAs(String.class));
+          assertEquals( "10:00:00", er.getAs(String.class));
       } else if (er.getType().equals(Type.ATTRIBUTE)) {
           // System.out.println("Testing is ATTRIBUTE? "+er.getAs(String.class));
-          assertEquals("Returns me a ATTRIBUTE :", "attribute", er.getAs(String.class));
+          assertEquals( "attribute", er.getAs(String.class));
       } else if (er.getType().equals(Type.PROCESSINGINSTRUCTION)) {
           // System.out.println("Testing is ProcessingInstructions? "+er.getAs(String.class));
-          assertEquals("Returns me a PROCESSINGINSTRUCTION :", "<?processing instruction?>", er.getAs(String.class));
+          assertEquals( "<?processing instruction?>", er.getAs(String.class));
       } else if (er.getType().equals(Type.COMMENT)) {
           // System.out.println("Testing is Comment node? "+er.getAs(String.class));
-          assertEquals("Returns me a COMMENT :", "<!--comment-->", er.getAs(String.class));
+          assertEquals( "<!--comment-->", er.getAs(String.class));
       } else if (er.getType().equals(Type.BASE64BINARY)) {
           // System.out.println("Testing is Base64Binary  "+er.getAs(String.class));
-          assertEquals("Returns me a BASE64BINARY :", "DEADBEEF", er.getAs(String.class));
+          assertEquals( "DEADBEEF", er.getAs(String.class));
       } else {
           System.out.println("Got something which is not belongs to anytype we support "
                       + er.getAs(String.class));
-          assertFalse("getting in else part, missing a type  ", true);
+          fail("getting in else part, missing a type  ");
       }
     }
   }
@@ -490,7 +460,7 @@ public class TestDatabaseClientWithKerberos extends BasicJavaClientREST {
     products.setPageLength(5);
     p = products.search(qd, 1, jh);
     System.out.println(jh.get().toString());
-    assertEquals("total no of pages", 3, p.getTotalPages());
+    assertEquals( 3, p.getTotalPages());
     System.out.println(jh.get().toString());
 
     long pageNo = 1, count = 0;
@@ -500,17 +470,17 @@ public class TestDatabaseClientWithKerberos extends BasicJavaClientREST {
       while (p.hasNext()) {
         GeoSpecialArtifact a = p.next();
         validateArtifact(a);
-        assertTrue("Verifying document id is part of the search ids", a.getId() % 5 == 0);
-        assertEquals("Verifying Manufacurer is from state ", "Reno", a.getManufacturer().getState());
+        assertTrue( a.getId() % 5 == 0);
+        assertEquals( "Reno", a.getManufacturer().getState());
         count++;
       }
-      assertEquals("Page size", count, p.size());
+      assertEquals( count, p.size());
       pageNo = pageNo + p.getPageSize();
     } while (!p.isLastPage() && pageNo <= p.getTotalSize());
-    assertEquals("page number after the loop", 3, p.getPageNumber());
-    assertEquals("total no of pages", 3, p.getTotalPages());
-    assertEquals("page length from search handle", 5, jh.get().path("page-length").asInt());
-    assertEquals("Total results from search handle", 11, jh.get().path("total").asInt());
+    assertEquals( 3, p.getPageNumber());
+    assertEquals( 3, p.getTotalPages());
+    assertEquals( 5, jh.get().path("page-length").asInt());
+    assertEquals( 11, jh.get().path("total").asInt());
   }
 
   @Test
@@ -519,7 +489,7 @@ public class TestDatabaseClientWithKerberos extends BasicJavaClientREST {
     String docId = "/foo/test/myFoo.txt";
     TextDocumentManager docMgr = client.newTextDocumentManager();
     docMgr.write(docId, new StringHandle().with("This is so foo"));
-    assertEquals("Text document write difference", "This is so foo", docMgr.read(docId, new StringHandle()).get());
+    assertEquals( "This is so foo", docMgr.read(docId, new StringHandle()).get());
   }
 
   @Test
@@ -541,7 +511,7 @@ public class TestDatabaseClientWithKerberos extends BasicJavaClientREST {
     long size = getBinarySizeFromByte(fileRead);
     long expectedSize = 34543;
 
-    assertEquals("Binary size difference", expectedSize, size);
+    assertEquals( expectedSize, size);
 
     // update the doc
     // acquire the content for update
@@ -558,7 +528,7 @@ public class TestDatabaseClientWithKerberos extends BasicJavaClientREST {
     long sizeUpdate = getBinarySizeFromByte(fileReadUpdate);
     // long expectedSizeUpdate = 3290;
     long expectedSizeUpdate = 3322;
-    assertEquals("Binary size difference", expectedSizeUpdate, sizeUpdate);
+    assertEquals( expectedSizeUpdate, sizeUpdate);
 
     // delete the document
     deleteDocument(client, uri + filename, "Binary");
@@ -572,7 +542,7 @@ public class TestDatabaseClientWithKerberos extends BasicJavaClientREST {
     }
 
     String expectedException = "com.marklogic.client.ResourceNotFoundException: Local message: Could not read non-existent document. Server Message: RESTAPI-NODOCUMENT: (err:FOER0000) Resource or document does not exist:  category: content message: /write-bin-Bytehandle/Pandakarlino.jpg";
-    assertEquals("Document is not deleted", expectedException, exception);
+    assertEquals( expectedException, exception);
   }
 
   @Test
@@ -611,27 +581,27 @@ public class TestDatabaseClientWithKerberos extends BasicJavaClientREST {
     docMgr.read(docId[0], jacksonDBReadHandle);
     Product product1 = (Product) jacksonDBReadHandle.get();
 
-    assertTrue("Did not return a iPhone 6", product1.getName().equalsIgnoreCase("iPhone 6"));
-    assertTrue("Did not return a Mobile Phone", product1.getIndustry().equalsIgnoreCase("Mobile Phone"));
-    assertTrue("Did not return a Mobile Phone", product1.getDescription().equalsIgnoreCase("New iPhone 6"));
+    assertTrue( product1.getName().equalsIgnoreCase("iPhone 6"));
+    assertTrue( product1.getIndustry().equalsIgnoreCase("Mobile Phone"));
+    assertTrue( product1.getDescription().equalsIgnoreCase("New iPhone 6"));
 
     docMgr.readMetadata(docId[0], mhRead);
     validateMetadata(mhRead);
 
     docMgr.read(docId[1], jacksonDBReadHandle);
     Product product2 = (Product) jacksonDBReadHandle.get();
-    assertTrue("Did not return a iMac", product2.getName().equalsIgnoreCase("iMac"));
-    assertTrue("Did not return a Desktop", product2.getIndustry().equalsIgnoreCase("Desktop"));
-    assertTrue("Did not return a Air Book OS X", product2.getDescription().equalsIgnoreCase("Air Book OS X"));
+    assertTrue( product2.getName().equalsIgnoreCase("iMac"));
+    assertTrue( product2.getIndustry().equalsIgnoreCase("Desktop"));
+    assertTrue( product2.getDescription().equalsIgnoreCase("Air Book OS X"));
 
     docMgr.readMetadata(docId[1], mhRead);
     validateMetadata(mhRead);
 
     docMgr.read(docId[2], jacksonDBReadHandle);
     Product product3 = (Product) jacksonDBReadHandle.get();
-    assertTrue("Did not return a iPad", product3.getName().equalsIgnoreCase("iPad"));
-    assertTrue("Did not return a Tablet", product3.getIndustry().equalsIgnoreCase("Tablet"));
-    assertTrue("Did not return a iPad Mini", product3.getDescription().equalsIgnoreCase("iPad Mini"));
+    assertTrue( product3.getName().equalsIgnoreCase("iPad"));
+    assertTrue( product3.getIndustry().equalsIgnoreCase("Tablet"));
+    assertTrue( product3.getDescription().equalsIgnoreCase("iPad Mini"));
 
     docMgr.readMetadata(docId[2], mhRead);
     validateMetadata(mhRead);
@@ -659,7 +629,7 @@ public class TestDatabaseClientWithKerberos extends BasicJavaClientREST {
     Document expectedDoc = expectedXMLDocument(filename);
     String expectedContent = convertXMLDocumentToString(expectedDoc);
     expectedContent = "null" + expectedContent.substring(expectedContent.indexOf("<name>") + 6, expectedContent.indexOf("</name>"));
-    assertEquals("Write XML difference", expectedContent, readContent);
+    assertEquals( expectedContent, readContent);
 
     // delete the document
     deleteDocument(client, uri + filename, "XML");
@@ -673,7 +643,7 @@ public class TestDatabaseClientWithKerberos extends BasicJavaClientREST {
 
     String expectedException = "Could not read non-existent document";
     boolean documentIsDeleted = exception.contains(expectedException);
-    assertTrue("Document is not deleted", documentIsDeleted);
+    assertTrue( documentIsDeleted);
   }
 
   @Test
@@ -822,7 +792,7 @@ public class TestDatabaseClientWithKerberos extends BasicJavaClientREST {
       // Verify rollback on DocumentManager write method with transform.
       tRollback.rollback();
       DocumentPage pageRollback = docMgr.read(uris);
-      assertEquals("Document count is not zero. Transaction did not rollback", 0, pageRollback.size());
+      assertEquals( 0, pageRollback.size());
 
       // Perform write with a commit.
       Transaction tCommit = client.openTransaction();
@@ -849,16 +819,16 @@ public class TestDatabaseClientWithKerberos extends BasicJavaClientREST {
       while (page.hasNext()) {
         DocumentRecord rec = page.next();
         rec.getContent(dh);
-        assertTrue("Element has attribure ? :", dh.get().getElementsByTagName("foo").item(0).hasAttributes());
+        assertTrue( dh.get().getElementsByTagName("foo").item(0).hasAttributes());
         verifyAttrValue = dh.get().getElementsByTagName("foo").item(0).getAttributes().getNamedItem("Lang").getNodeValue();
-        assertTrue("Server Transform did not go through ", verifyAttrValue.equalsIgnoreCase("testBulkXQYTransformWithTrans"));
+        assertTrue( verifyAttrValue.equalsIgnoreCase("testBulkXQYTransformWithTrans"));
         count++;
       }
     } catch (Exception e) {
       System.out.println(e.getMessage());
       throw e;
     }
-    assertEquals("document count", 102, count);
+    assertEquals( 102, count);
   }
 
   @Test
@@ -900,7 +870,7 @@ public class TestDatabaseClientWithKerberos extends BasicJavaClientREST {
     docMgr.stopLogging();
 
     String expectedContentMax = "9223372036854775807";
-    assertEquals("Content log is not equal", expectedContentMax, Long.toString(logger.getContentMax()));
+    assertEquals( expectedContentMax, Long.toString(logger.getContentMax()));
   }
 
   @Test
@@ -994,11 +964,11 @@ public class TestDatabaseClientWithKerberos extends BasicJavaClientREST {
     }
 
     System.out.println(expected);
-    assertTrue("incorrect rule", expected.contains("RULE-TEST-1 - {rule-number=one} |"));
+    assertTrue( expected.contains("RULE-TEST-1 - {rule-number=one} |"));
   }
 
   // Access database on Uber port with specifying the database name.
-  @Ignore
+  @Disabled
   public void testUberClientWithDbName() throws IOException, SAXException, ParserConfigurationException {
     System.out.println("Running testUberClientWithDbName method");
 
@@ -1072,11 +1042,11 @@ public class TestDatabaseClientWithKerberos extends BasicJavaClientREST {
 
       docMgr.write(writeset);
 
-      assertEquals("Text document write difference", "This is so foo1",
+      assertEquals( "This is so foo1",
           docMgr.read(docId[0], new StringHandle()).get());
-      assertEquals("Text document write difference", "This is so foo2",
+      assertEquals( "This is so foo2",
           docMgr.read(docId[1], new StringHandle()).get());
-      assertEquals("Text document write difference", "This is so foo3",
+      assertEquals( "This is so foo3",
           docMgr.read(docId[2], new StringHandle()).get());
 
       // Bulk delete on TextDocumentManager
@@ -1087,12 +1057,12 @@ public class TestDatabaseClientWithKerberos extends BasicJavaClientREST {
       System.out.println("Exception is" + exception);
     }
     String expectedException = null;
-    if (IsSecurityEnabled()) 
+    if (IsSecurityEnabled())
         expectedException = "java.net.ProtocolException";
     else
      expectedException = "com.marklogic.client.FailedRequestException: Local message: failed to apply resource at documents: Unauthorized. Server Message: Unauthorized";
     boolean exceptionIsThrown = exception.contains(expectedException);
-    assertTrue("Exception is not thrown", exceptionIsThrown);
+    assertTrue( exceptionIsThrown);
 
     clientDigest.release();
   }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestEvalwithRunTimeDBnTransactions.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestEvalwithRunTimeDBnTransactions.java
@@ -16,25 +16,6 @@
 
 package com.marklogic.client.functionaltest;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.security.KeyManagementException;
-import java.security.NoSuchAlgorithmException;
-import java.util.HashMap;
-import java.util.Map;
-
-import com.marklogic.client.io.*;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
-
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.Transaction;
 import com.marklogic.client.document.DocumentWriteSet;
@@ -44,20 +25,35 @@ import com.marklogic.client.eval.EvalResult;
 import com.marklogic.client.eval.EvalResult.Type;
 import com.marklogic.client.eval.EvalResultIterator;
 import com.marklogic.client.eval.ServerEvaluationCall;
+import com.marklogic.client.io.BytesHandle;
+import com.marklogic.client.io.DOMHandle;
+import com.marklogic.client.io.Format;
+import com.marklogic.client.io.InputStreamHandle;
+import org.junit.jupiter.api.*;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /*
- * This test is intended for 
+ * This test is intended for
  * looping eval query for more than 100 times
  * Eval with transactions
  */
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@TestMethodOrder(MethodOrderer.MethodName.class)
 public class TestEvalwithRunTimeDBnTransactions extends BasicJavaClientREST {
   private static String dbName = "TestEvalXqueryWithTransDB";
   private static String[] fNames = { "TestEvalXqueryWithTransDB-1" };
 
   private DatabaseClient client;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpBeforeClass() throws Exception {
     System.out.println("In setup");
     configureRESTServer(dbName, fNames);
@@ -65,7 +61,7 @@ public class TestEvalwithRunTimeDBnTransactions extends BasicJavaClientREST {
     createRESTUser("eval-user", "x", "test-eval", "rest-admin", "rest-writer", "rest-reader");
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownAfterClass() throws Exception {
     System.out.println("In tear down");
     cleanupRESTServer(dbName, fNames);
@@ -73,12 +69,12 @@ public class TestEvalwithRunTimeDBnTransactions extends BasicJavaClientREST {
     deleteUserRole("test-eval");
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws KeyManagementException, NoSuchAlgorithmException, Exception {
     client = getDatabaseClient("eval-user", "x", getConnType());
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     clearDB();
     client.release();
@@ -109,12 +105,12 @@ public class TestEvalwithRunTimeDBnTransactions extends BasicJavaClientREST {
         while (evr.hasNext()) {
           EvalResult er = evr.next();
           if (er.getType().equals(Type.INTEGER)) {
-            assertEquals("itration number", i, er.getNumber().intValue());
+            assertEquals(i, er.getNumber().intValue());
           } else if (er.getType().equals(Type.BINARY)) {
             byte[] bytes = er.get(new BytesHandle()).get();
             assertEquals(binaryLength, bytes.length);
           } else if (er.getType().equals(Type.STRING)) {
-            assertEquals("database name ", "TestEvalXqueryWithTransDB", er.getString());
+            assertEquals("TestEvalXqueryWithTransDB", er.getString());
           } else {
             fail("Getting incorrect type");
           }
@@ -153,10 +149,10 @@ public class TestEvalwithRunTimeDBnTransactions extends BasicJavaClientREST {
           + "(fn:count(fn:doc()))";
       ServerEvaluationCall evl = client.newServerEval().xquery(query);
       EvalResultIterator evr = evl.eval();
-      assertEquals("Count of documents outside of the transaction", 0, evr.next().getNumber().intValue());
+      assertEquals(0, evr.next().getNumber().intValue());
       evl = client.newServerEval().xquery(query).transaction(t1);
       evr = evl.eval();
-      assertEquals("Count of documents outside of the transaction", 102, evr.next().getNumber().intValue());
+      assertEquals(102, evr.next().getNumber().intValue());
     } catch (Exception e) {
       System.out.println(e.getMessage());
       tstatus = true;
@@ -201,10 +197,10 @@ public class TestEvalwithRunTimeDBnTransactions extends BasicJavaClientREST {
           + "(fn:count(fn:doc()))";
       ServerEvaluationCall evl = client2.newServerEval().xquery(query);
       EvalResultIterator evr = evl.eval();
-      assertEquals("Count of documents outside of the transaction", 0, evr.next().getNumber().intValue());
+      assertEquals(0, evr.next().getNumber().intValue());
       evl = client2.newServerEval().xquery(query).transaction(t1);
       evr = evl.eval();
-      assertEquals("Count of documents outside of the transaction", 102, evr.next().getNumber().intValue());
+      assertEquals(102, evr.next().getNumber().intValue());
     } catch (Exception e) {
       System.out.println(e.getMessage());
       tstatus = true;

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestSSLConnection.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestSSLConnection.java
@@ -16,30 +16,25 @@
 
 package com.marklogic.client.functionaltest;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.DatabaseClientFactory;
+import com.marklogic.client.DatabaseClientFactory.SSLHostnameVerifier;
+import com.marklogic.client.DatabaseClientFactory.SecurityContext;
+import org.junit.jupiter.api.*;
 
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
 import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509TrustManager;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
-
-import com.marklogic.client.DatabaseClient;
-import com.marklogic.client.DatabaseClientFactory;
-import com.marklogic.client.DatabaseClientFactory.SSLHostnameVerifier;
-import com.marklogic.client.DatabaseClientFactory.SecurityContext;
-
-@Ignore("Ignored because it was previously ignored in build.gradle though without explanation")
+@Disabled("Ignored because it was previously ignored in build.gradle though without explanation")
 public class TestSSLConnection extends BasicJavaClientREST {
 
   private static String dbName = "TestSSLConnectionDB";
@@ -47,7 +42,7 @@ public class TestSSLConnection extends BasicJavaClientREST {
   private static String restServerName = "REST-Java-Client-API-SSL-Server";
   private static String appServerHostname = null;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception
   {
     System.out.println("In setup");
@@ -61,47 +56,47 @@ public class TestSSLConnection extends BasicJavaClientREST {
   }
 
   /*
-   * 
-   * 
+   *
+   *
    * @SuppressWarnings("deprecation")
-   * 
+   *
    * @Test public void testSSLConnection() throws KeyManagementException,
    * NoSuchAlgorithmException, NoSuchAlgorithmException, KeyManagementException,
    * FileNotFoundException, XpathException {
    * System.out.println("Running testSSLConnection");
-   * 
+   *
    * // create a trust manager // (note: a real application should verify
    * certificates) TrustManager naiveTrustMgr = new X509TrustManager() {
-   * 
+   *
    * @Override public void checkClientTrusted(X509Certificate[] chain, String
    * authType) { }
-   * 
+   *
    * @Override public void checkServerTrusted(X509Certificate[] chain, String
    * authType) { }
-   * 
+   *
    * @Override public X509Certificate[] getAcceptedIssuers() { return new
    * X509Certificate[0]; } };
-   * 
+   *
    * // create an SSL context SSLContext sslContext =
    * SSLContext.getInstance("SSLv3"); sslContext.init(null, new TrustManager[] {
    * naiveTrustMgr }, null);
-   * 
+   *
    * String filename1 = "constraint1.xml"; String filename2 = "constraint2.xml";
    * String filename3 = "constraint3.xml"; String filename4 = "constraint4.xml";
    * String filename5 = "constraint5.xml";
-   * 
+   *
    * // create the client // (note: a real application should use a COMMON,
    * STRICT, or implemented hostname verifier) DatabaseClient client =
    * DatabaseClientFactory.newClient("appServerHostname", 8012, "rest-admin",
    * "x", getConnType(), sslContext, SSLHostnameVerifier.ANY);
-   * 
+   *
    * // create and initialize a handle on the metadata DocumentMetadataHandle
    * metadataHandle1 = new DocumentMetadataHandle(); DocumentMetadataHandle
    * metadataHandle2 = new DocumentMetadataHandle(); DocumentMetadataHandle
    * metadataHandle3 = new DocumentMetadataHandle(); DocumentMetadataHandle
    * metadataHandle4 = new DocumentMetadataHandle(); DocumentMetadataHandle
    * metadataHandle5 = new DocumentMetadataHandle();
-   * 
+   *
    * // set the metadata
    * metadataHandle1.getCollections().addAll("http://test.com/set1");
    * metadataHandle1.getCollections().addAll("http://test.com/set5");
@@ -110,7 +105,7 @@ public class TestSSLConnection extends BasicJavaClientREST {
    * metadataHandle4.getCollections().addAll("http://test.com/set3/set3-1");
    * metadataHandle5.getCollections().addAll("http://test.com/set1");
    * metadataHandle5.getCollections().addAll("http://test.com/set5");
-   * 
+   *
    * // write docs writeDocumentUsingInputStreamHandle(client, filename1,
    * "/ssl-connection/", metadataHandle1, "XML");
    * writeDocumentUsingInputStreamHandle(client, filename2, "/ssl-connection/",
@@ -119,18 +114,18 @@ public class TestSSLConnection extends BasicJavaClientREST {
    * writeDocumentUsingInputStreamHandle(client, filename4, "/ssl-connection/",
    * metadataHandle4, "XML"); writeDocumentUsingInputStreamHandle(client,
    * filename5, "/ssl-connection/", metadataHandle5, "XML");
-   * 
+   *
    * // create query options manager QueryOptionsManager optionsMgr =
    * client.newServerConfigManager().newQueryOptionsManager();
-   * 
+   *
    * // create query options builder QueryOptionsBuilder builder = new
    * QueryOptionsBuilder();
-   * 
+   *
    * // create query options handle QueryOptionsHandle handle = new
    * QueryOptionsHandle();
-   * 
+   *
    * // build query options
-   * 
+   *
    * handle.build( builder.returnMetrics(false), builder.returnQtext(false),
    * builder.debug(true), builder.transformResults("raw"),
    * builder.constraint("id", builder.value(builder.element("id"))),
@@ -148,18 +143,18 @@ public class TestSSLConnection extends BasicJavaClientREST {
    * builder.element("popularity"), builder.bucket("high", "High", "5", null),
    * builder.bucket("medium", "Medium", "3", "5"), builder.bucket("low", "Low",
    * "1", "3"))) );
-   * 
-   * 
+   *
+   *
    * // write query options
    * optionsMgr.writeOptions("AllConstraintsWithStructuredSearch", handle);
-   * 
+   *
    * // read query option StringHandle readHandle = new StringHandle();
    * readHandle.setFormat(Format.XML);
    * optionsMgr.readOptions("AllConstraintsWithStructuredSearch", readHandle);
    * String output = readHandle.get(); System.out.println(output);
-   * 
+   *
    * // create query manager QueryManager queryMgr = client.newQueryManager();
-   * 
+   *
    * // create query def StructuredQueryBuilder qb =
    * queryMgr.newStructuredQueryBuilder("AllConstraintsWithStructuredSearch");
    * StructuredQueryDefinition query1 = qb.and(qb.collectionConstraint("coll",
@@ -177,18 +172,18 @@ public class TestSSLConnection extends BasicJavaClientREST {
    * StructuredQueryBuilder.Operator.EQ, "medium")); StructuredQueryDefinition
    * queryFinal = qb.and(query1, query2, query3, query4, query5, query6,
    * query7);
-   * 
+   *
    * // create handle DOMHandle resultsHandle = new DOMHandle();
    * queryMgr.search(queryFinal, resultsHandle);
-   * 
+   *
    * // get the result Document resultDoc = resultsHandle.get();
-   * 
+   *
    * assertXpathEvaluatesTo("1",
    * "string(//*[local-name()='result'][last()]//@*[local-name()='index'])",
    * resultDoc); assertXpathEvaluatesTo("Vannevar Bush",
    * "string(//*[local-name()='result'][1]//*[local-name()='title'])",
    * resultDoc);
-   * 
+   *
    * // release client client.release(); }
    */
 
@@ -250,7 +245,7 @@ public class TestSSLConnection extends BasicJavaClientREST {
       exception = e.toString();
     }
 
-    assertTrue("Exception is not thrown", exception.contains(expectedException));
+    assertTrue(exception.contains(expectedException));
 
     // release client
     client.release();
@@ -314,7 +309,7 @@ public class TestSSLConnection extends BasicJavaClientREST {
       exception = e.toString();
     }
 
-    assertEquals("Exception is not thrown", expectedException, exception);
+    assertEquals(expectedException, exception);
 
     // release client
     client.release();
@@ -381,7 +376,7 @@ public class TestSSLConnection extends BasicJavaClientREST {
     System.out.println("Actual exception: " + exception);
     boolean isExceptionThrown = exception.contains(expectedException);
 
-    assertTrue("Exception is not thrown", isExceptionThrown);
+    assertTrue(isExceptionThrown);
 
     // release client
     client.release();
@@ -448,13 +443,13 @@ public class TestSSLConnection extends BasicJavaClientREST {
 
     boolean isExceptionThrown = exception.contains(expectedException);
 
-    assertTrue("Exception is not thrown", isExceptionThrown);
+    assertTrue(isExceptionThrown);
 
     // release client
     client.release();
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() throws Exception
   {
     System.out.println("In tear down");

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestSandBox.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestSandBox.java
@@ -16,30 +16,6 @@
 
 package com.marklogic.client.functionaltest;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import java.io.File;
-import java.io.IOException;
-import java.security.KeyManagementException;
-import java.security.NoSuchAlgorithmException;
-import java.util.Calendar;
-import java.util.HashMap;
-import java.util.Map;
-
-import javax.xml.bind.DatatypeConverter;
-import javax.xml.datatype.DatatypeFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.TransformerException;
-
-import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.junit.*;
-import org.w3c.dom.Document;
-import org.xml.sax.SAXException;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -49,39 +25,44 @@ import com.marklogic.client.DatabaseClientFactory;
 import com.marklogic.client.DatabaseClientFactory.DigestAuthContext;
 import com.marklogic.client.Transaction;
 import com.marklogic.client.bitemporal.TemporalDocumentManager.ProtectionLevel;
-import com.marklogic.client.document.DocumentManager;
+import com.marklogic.client.document.*;
 import com.marklogic.client.document.DocumentManager.Metadata;
-import com.marklogic.client.document.DocumentPage;
-import com.marklogic.client.document.DocumentRecord;
-import com.marklogic.client.document.DocumentWriteSet;
-import com.marklogic.client.document.JSONDocumentManager;
 import com.marklogic.client.expression.PlanBuilder;
 import com.marklogic.client.expression.PlanBuilder.ModifyPlan;
-import com.marklogic.client.io.DOMHandle;
-import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.client.io.*;
 import com.marklogic.client.io.DocumentMetadataHandle.Capability;
 import com.marklogic.client.io.DocumentMetadataHandle.DocumentCollections;
 import com.marklogic.client.io.DocumentMetadataHandle.DocumentPermissions;
 import com.marklogic.client.io.DocumentMetadataHandle.DocumentProperties;
-import com.marklogic.client.io.FileHandle;
-import com.marklogic.client.io.Format;
-import com.marklogic.client.io.JacksonDatabindHandle;
-import com.marklogic.client.io.JacksonHandle;
-import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.pojo.PojoPage;
 import com.marklogic.client.pojo.PojoRepository;
-import com.marklogic.client.query.QueryManager;
-import com.marklogic.client.query.RawQueryByExampleDefinition;
-import com.marklogic.client.query.StringQueryDefinition;
-import com.marklogic.client.query.StructuredQueryBuilder;
-import com.marklogic.client.query.StructuredQueryDefinition;
+import com.marklogic.client.query.*;
 import com.marklogic.client.row.RowManager;
 import com.marklogic.client.semantics.GraphManager;
 import com.marklogic.client.semantics.RDFMimeTypes;
 import com.marklogic.client.type.CtsReferenceExpr;
 import com.marklogic.client.type.XsStringSeqVal;
+import org.custommonkey.xmlunit.exceptions.XpathException;
+import org.junit.jupiter.api.*;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
 
-@Ignore("Ignored because it was previously ignored in build.gradle though without explanation")
+import javax.xml.bind.DatatypeConverter;
+import javax.xml.datatype.DatatypeFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.TransformerException;
+import java.io.File;
+import java.io.IOException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
+import static org.junit.jupiter.api.Assertions.*;
+
+@Disabled("Ignored because it was previously ignored in build.gradle though without explanation")
 public class TestSandBox extends BasicJavaClientREST {
 
   private static String dbName = "TestSandBox";
@@ -115,7 +96,7 @@ public class TestSandBox extends BasicJavaClientREST {
   private static int restPort = 0;
   private static String datasource = null;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpBeforeClass() throws Exception {
     System.out.println("In setup");
     configureRESTServer(dbName, fNames);
@@ -285,7 +266,7 @@ public class TestSandBox extends BasicJavaClientREST {
     client.release();
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownAfterClass() throws Exception {
     System.out.println("In tear down");
 
@@ -309,7 +290,7 @@ public class TestSandBox extends BasicJavaClientREST {
     deleteForest(schemafNames[0]);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     createUserRolesWithPrevilages("test-eval", "xdbc:eval", "xdbc:eval-in",
         "xdmp:eval-in", "any-uri", "xdbc:invoke",
@@ -323,7 +304,7 @@ public class TestSandBox extends BasicJavaClientREST {
         dbName, "eval-user", "x", getConnType());
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     //clearDB();
   }
@@ -365,7 +346,7 @@ public class TestSandBox extends BasicJavaClientREST {
 
     // Setup for JSON document
     /**
-     * 
+     *
      { "System": { systemStartERIName : "", systemEndERIName : "", }, "Valid":
      * { validStartERIName: "2001-01-01T00:00:00", validEndERIName:
      * "2011-12-31T23:59:59" }, "Address": "999 Skyway Park", "uri":
@@ -446,7 +427,6 @@ public class TestSandBox extends BasicJavaClientREST {
           + str.toString());
     }
     assertTrue(
-        "Doc should not be updated",
         str.toString().contains(
             "The document javaSingleJSONDoc.json is protected noUpdate"));
     try {
@@ -459,7 +439,7 @@ public class TestSandBox extends BasicJavaClientREST {
       JSONDocumentManager jsonDocMgr = writerClient.newJSONDocumentManager();
       DocumentPage readResults = jsonDocMgr.read(t1, docId);
       System.out.println("Number of results = " + readResults.size());
-      assertEquals("Wrong number of results", 1, readResults.size());
+      assertEquals( 1, readResults.size());
 
       QueryManager queryMgr = writerClient.newQueryManager();
 
@@ -473,7 +453,7 @@ public class TestSandBox extends BasicJavaClientREST {
       DocumentPage termQueryResults = docMgr.search(termQuery, start, t2);
       System.out.println("Number of results = "
           + termQueryResults.getTotalSize());
-      assertEquals("Wrong number of results", 4,
+      assertEquals( 4,
           termQueryResults.getTotalSize());
     } catch (Exception e) {
       System.out.println("Exception when update within 30 sec is "
@@ -594,7 +574,7 @@ public class TestSandBox extends BasicJavaClientREST {
     String filename3 = "property3.xml";
     String queryOptionName = "propertiesSearchWordOpt.xml";
     DatabaseClient client = null;
-    
+
     try {
 
       client = getDatabaseClient("rest-admin", "x", getConnType());
@@ -709,9 +689,8 @@ public class TestSandBox extends BasicJavaClientREST {
 
       JsonNode jsonBindingsNodes = jsonResults.path("rows");
       assertTrue(
-          "Number of Elements after plan execution is incorrect. Should be 1",
           1 == jsonBindingsNodes.size());
-      assertEquals("Row 1 myCity.city value incorrect", "new york",
+      assertEquals( "new york",
           jsonBindingsNodes.path(0).path("myCity.city").path("value").asText());
     }
     catch(Exception ex) {
@@ -721,7 +700,7 @@ public class TestSandBox extends BasicJavaClientREST {
       client.release();
     }
   }
-  
+
   @Test
   public void testWriteMultiJSONFilesDefaultMetadata() throws KeyManagementException, NoSuchAlgorithmException, Exception
   {
@@ -791,7 +770,7 @@ public class TestSandBox extends BasicJavaClientREST {
   /*
    * Write Triples of Type JSON Merge NTriples into the same graph and validate
    * mergeGraphs with transactions.
-   * 
+   *
    * Merge within same write transaction Write and merge Triples within
    * different transactions. Commit the merge transaction Write and merge
    * Triples within different transactions. Rollback the merge transaction Write
@@ -824,9 +803,9 @@ public class TestSandBox extends BasicJavaClientREST {
       FileHandle handle = gmWriter.read(uri, new FileHandle());
       File readFile = handle.get();
       String expectedContent = convertFileToString(readFile);
-      assertTrue("Did not write Quad in transaction",
+      assertTrue(
           expectedContent.contains("<http://example.com/ns/person#firstName"));
-      assertTrue("Did not merge Quad",
+      assertTrue(
           expectedContent.contains("<http://example.com/mergeQuadP"));
       trxIn = null;
       handle = null;
@@ -850,7 +829,7 @@ public class TestSandBox extends BasicJavaClientREST {
       handle = gmWriter.read(uri, new FileHandle());
       readFile = handle.get();
       expectedContent = convertFileToString(readFile);
-      assertTrue("Did not write Quad in transaction",
+      assertTrue(
           expectedContent.contains("<http://example.com/ns/person#firstName"));
       handle = null;
       readFile = null;
@@ -865,9 +844,9 @@ public class TestSandBox extends BasicJavaClientREST {
       handle = gmWriter.read(uri, new FileHandle());
       readFile = handle.get();
       expectedContent = convertFileToString(readFile);
-      assertTrue("Merge corrupted original Quad in transaction",
+      assertTrue(
           expectedContent.contains("<http://example.com/ns/person#firstName"));
-      assertTrue("Did not merge Quad in separate transaction",
+      assertTrue(
           expectedContent.contains("<http://example.com/mergeQuadP"));
 
       trxIn = null;
@@ -895,7 +874,7 @@ public class TestSandBox extends BasicJavaClientREST {
       handle = gmWriter.read(uri, new FileHandle());
       readFile = handle.get();
       expectedContent = convertFileToString(readFile);
-      assertTrue("Did not write Quad in transaction",
+      assertTrue(
           expectedContent.contains("<http://example.com/ns/person#firstName"));
       handle = null;
       readFile = null;
@@ -910,10 +889,9 @@ public class TestSandBox extends BasicJavaClientREST {
       expectedContent = convertFileToString(readFile);
 
       // Verify if original quad is available.
-      assertTrue("Merge corrupted original Quad in transaction",
+      assertTrue(
           expectedContent.contains("<http://example.com/ns/person#firstName"));
       assertFalse(
-          "Did merge Quad when it should not have, since transaction was rolled back",
           expectedContent.contains("<http://example.com/mergeQuadP"));
 
       trxIn = null;
@@ -940,7 +918,7 @@ public class TestSandBox extends BasicJavaClientREST {
       handle = gmWriter.read(uri, new FileHandle());
       readFile = handle.get();
       expectedContent = convertFileToString(readFile);
-      assertTrue("Did not write Quad in transaction",
+      assertTrue(
           expectedContent.contains("<http://example.com/ns/person#firstName"));
       handle = null;
       readFile = null;
@@ -957,10 +935,9 @@ public class TestSandBox extends BasicJavaClientREST {
       expectedContent = convertFileToString(readFile);
 
       // Verify if original quad is available.
-      assertTrue("Merge corrupted original Quad in transaction",
+      assertTrue(
           expectedContent.contains("<http://example.com/ns/person#firstName"));
       assertFalse(
-          "Did merge Quad when it should not have, since transaction was rolled back",
           expectedContent.contains("<http://example.com/mergeQuadP"));
 
       trxIn = null;
@@ -979,9 +956,9 @@ public class TestSandBox extends BasicJavaClientREST {
       readFile = handle.get();
       expectedContent = convertFileToString(readFile);
       // Verify if original quad is available.
-      assertTrue("Merge corrupted original Quad in transaction",
+      assertTrue(
           expectedContent.contains("<http://example.com/ns/person#firstName"));
-      assertTrue("Did not merge Quad in second commit transaction",
+      assertTrue(
           expectedContent.contains("<http://example.com/mergeQuadP"));
 
       // Delete Graphs inside the transaction.
@@ -1011,7 +988,7 @@ public class TestSandBox extends BasicJavaClientREST {
       }
     }
   }
-  
+
   @Test
   public void testPOJOSearchWithJacksonHandle() throws KeyManagementException, NoSuchAlgorithmException, IOException {
     DatabaseClient client = null;
@@ -1028,7 +1005,7 @@ public class TestSandBox extends BasicJavaClientREST {
       JacksonHandle results = new JacksonHandle();
       p = products.search(qd, 1, results);
       products.setPageLength(11);
-      assertEquals("total no of pages", 3, p.getTotalPages());
+      assertEquals( 3, p.getTotalPages());
       // System.out.println(p.getTotalPages()+results.get().toString());
       long pageNo = 1, count = 0;
       do {
@@ -1042,20 +1019,20 @@ public class TestSandBox extends BasicJavaClientREST {
           // System.out.println(a.getId()+" "+a.getManufacturer().getName()
           // +"  "+count);
         }
-        assertEquals("Page size", count, p.size());
+        assertEquals( count, p.size());
         pageNo = pageNo + p.getPageSize();
 
-        assertEquals("Page start from search handls vs page methods", results.get().get("start").asLong(), p.getStart());
-        assertEquals("Format in the search handle", "json", results.get().withArray("results").get(1).path("format").asText());
-        assertTrue("Uri in search handle contains Artifact", results.get().withArray("results").get(1).path("uri").asText().contains("Artifact"));
+        assertEquals( results.get().get("start").asLong(), p.getStart());
+        assertEquals( "json", results.get().withArray("results").get(1).path("format").asText());
+        assertTrue( results.get().withArray("results").get(1).path("uri").asText().contains("Artifact"));
         // System.out.println(results.get().toString());
       } while (!p.isLastPage() && pageNo < p.getTotalSize());
-      // assertTrue("search handle has metrics",results.get().has("metrics"));
-      assertEquals("Search text is", "cogs", results.get().path("qtext").asText());
-      assertEquals("Total from search handle", 110, results.get().get("total").asInt());
-      assertEquals("page number after the loop", 10, p.getPageNumber());
-      assertEquals("total no of pages", 10, p.getTotalPages());
-    }  
+      // assertTrue(results.get().has("metrics"));
+      assertEquals( "cogs", results.get().path("qtext").asText());
+      assertEquals( 110, results.get().get("total").asInt());
+      assertEquals( 10, p.getPageNumber());
+      assertEquals( 10, p.getTotalPages());
+    }
     catch(Exception ex) {
       System.out.println("Exceptions" + ex.getStackTrace());
     }
@@ -1066,7 +1043,7 @@ public class TestSandBox extends BasicJavaClientREST {
 
   /**
    * Write document using DOMHandle
-   * 
+   *
    * @param client
    * @param filename
    * @param uri
@@ -1104,7 +1081,7 @@ public class TestSandBox extends BasicJavaClientREST {
 
   /**
    * Function to select and create document manager based on the type
-   * 
+   *
    * @param client
    * @param docMgr
    * @param type
@@ -1135,7 +1112,7 @@ public class TestSandBox extends BasicJavaClientREST {
     }
     return docMgr;
   }
-  
+
   public DocumentMetadataHandle setMetadata() {
     // create and initialize a handle on the meta-data
     DocumentMetadataHandle metadataHandle = new DocumentMetadataHandle();
@@ -1149,7 +1126,7 @@ public class TestSandBox extends BasicJavaClientREST {
     metadataHandle.setQuality(23);
     return metadataHandle;
   }
-  
+
   public void validateMetadata(DocumentMetadataHandle mh) {
     // get meta-data values
     DocumentProperties properties = mh.getProperties();
@@ -1161,36 +1138,36 @@ public class TestSandBox extends BasicJavaClientREST {
     // "size:5|reviewed:true|myInteger:10|myDecimal:34.56678|myCalendar:2014|myString:foo|";
     String actualProperties = getDocumentPropertiesString(properties);
     boolean result = actualProperties.contains("size:5|");
-    assertTrue("Document properties count", result);
+    assertTrue( result);
 
     // Permissions
     String actualPermissions = getDocumentPermissionsString(permissions);
     System.out.println(actualPermissions);
 
-    assertTrue("Document permissions difference in size value", actualPermissions.contains("size:5"));
-    // assertTrue("Document permissions difference in flexrep-eval permission",
+    assertTrue( actualPermissions.contains("size:5"));
+    // assertTrue(
     // actualPermissions.contains("flexrep-eval:[READ]"));
-    assertTrue("Document permissions difference in rest-reader permission", actualPermissions.contains("rest-reader:[READ]"));
-    assertTrue("Document permissions difference in rest-writer permission", actualPermissions.contains("rest-writer:[UPDATE]"));
-    assertTrue("Document permissions difference in app-user permissions",
+    assertTrue( actualPermissions.contains("rest-reader:[READ]"));
+    assertTrue( actualPermissions.contains("rest-writer:[UPDATE]"));
+    assertTrue(
         (actualPermissions.contains("app-user:[UPDATE, READ]") || actualPermissions.contains("app-user:[READ, UPDATE]")));
 
     // Collections
     String actualCollections = getDocumentCollectionsString(collections);
     System.out.println(collections);
 
-    assertTrue("Document collections difference in size value", actualCollections.contains("size:2"));
-    assertTrue("my-collection1 not found", actualCollections.contains("my-collection1"));
-    assertTrue("my-collection2 not found", actualCollections.contains("my-collection2"));
+    assertTrue( actualCollections.contains("size:2"));
+    assertTrue( actualCollections.contains("my-collection1"));
+    assertTrue( actualCollections.contains("my-collection2"));
   }
-  
+
   public void validateArtifact(Artifact art)
   {
-    assertNotNull("Artifact object should never be Null", art);
-    assertNotNull("Id should never be Null", art.id);
-    assertTrue("Inventry is always greater than 1000", art.getInventory() > 1000);
+    assertNotNull(art);
+    assertNotNull(art.id);
+    assertTrue( art.getInventory() > 1000);
   }
-  
+
   public void loadSimplePojos(PojoRepository products)
   {
     for (int i = 1; i < 111; i++) {
@@ -1202,7 +1179,7 @@ public class TestSandBox extends BasicJavaClientREST {
       }
     }
   }
-  
+
   public Artifact getArtifact(int counter) {
 
     Artifact cogs = new Artifact();

--- a/marklogic-client-api/build.gradle
+++ b/marklogic-client-api/build.gradle
@@ -26,7 +26,10 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4.2'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.13.4'
 
-    testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.13.4'
+	testImplementation 'org.junit.jupiter:junit-jupiter:5.9.1'
+	testImplementation 'org.xmlunit:xmlunit-legacy:2.9.0'
+
+	testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.13.4'
     testImplementation "org.mockito:mockito-core:4.9.0"
     testImplementation "org.mockito:mockito-inline:4.9.0"
     testImplementation group: 'ch.qos.logback', name: 'logback-classic', version:'1.2.11'
@@ -45,6 +48,7 @@ dependencies {
 
 // Ensure that mlHost and mlPassword can override the defaults of localhost/admin if they've been modified
 test {
+	useJUnitPlatform()
 	systemProperty "TEST_HOST", mlHost
 	systemProperty "TEST_ADMIN_PASSWORD", mlPassword
 	// Needed by the tests for the example programs
@@ -224,6 +228,7 @@ task generatePomForDependencyGraph(dependsOn: "generatePomFileForMainJavaPublica
 }
 
 task testRows(type: Test) {
-    description = "Run all 'rows' tests; i.e. those exercising Optic and Optic Update functionality"
-    include "com/marklogic/client/test/rows/**"
+	useJUnitPlatform()
+	description = "Run all 'rows' tests; i.e. those exercising Optic and Optic Update functionality"
+	include "com/marklogic/client/test/rows/**"
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/impl/PlanDocDescriptorImplTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/impl/PlanDocDescriptorImplTest.java
@@ -1,8 +1,5 @@
 package com.marklogic.client.impl;
 
-import org.junit.Assert;
-import org.junit.Test;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -13,8 +10,12 @@ import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.DocumentMetadataHandle.Capability;
 import com.marklogic.client.io.Format;
 import com.marklogic.client.io.StringHandle;
+import org.junit.jupiter.api.Test;import static org.junit.jupiter.api.Assertions.*;
 
-public class PlanDocDescriptorImplTest extends Assert {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class PlanDocDescriptorImplTest {
 
     @Test
     public void minimalWriteOp() {
@@ -22,7 +23,7 @@ public class PlanDocDescriptorImplTest extends Assert {
                 "/test.json", new StringHandle("{\"hello\":1}").withFormat(Format.JSON)));
         assertEquals("/test.json", plan.get("uri").asText());
         assertEquals(1, plan.get("doc").get("hello").asInt());
-        assertEquals("Expecting only 'uri' and 'doc'", 2, plan.size());
+        assertEquals(2, plan.size(), "Expecting only 'uri' and 'doc'");
     }
 
     @Test
@@ -48,17 +49,17 @@ public class PlanDocDescriptorImplTest extends Assert {
         assertEquals("value1", plan.get("metadata").get("key1").asText());
         assertEquals("value2", plan.get("metadata").get("key2").asText());
 
-        assertEquals("Expecting uri, temporalCollection, doc, quality, collections, permissions, and metadata; "
-                + "document properties are not yet supported", 7, plan.size());
+        assertEquals(7, plan.size(),
+			"Expecting uri, temporalCollection, doc, quality, collections, permissions, and metadata; "
+				+ "document properties are not yet supported");
     }
 
     @Test
     public void nonJsonContent() {
         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> export(
                 new DocumentWriteOperationImpl("/test.xml", new StringHandle("<test/>").withFormat(Format.XML))));
-        assertEquals(
-                "Only JSON content can be used with fromDocDescriptors; non-JSON content found for document with URI: /test.xml",
-                ex.getMessage());
+        assertEquals(ex.getMessage(),
+                "Only JSON content can be used with fromDocDescriptors; non-JSON content found for document with URI: /test.xml");
     }
 
     private ObjectNode export(DocumentWriteOperation writeOp) {

--- a/marklogic-client-api/src/test/java/com/marklogic/client/impl/PlanRowColTypesImplTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/impl/PlanRowColTypesImplTest.java
@@ -2,10 +2,11 @@ package com.marklogic.client.impl;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;import static org.junit.jupiter.api.Assertions.*;
 
-public class PlanRowColTypesImplTest extends Assert {
+import static org.junit.jupiter.api.Assertions.*;
+
+public class PlanRowColTypesImplTest {
 
     @Test
     public void columnOnly() {

--- a/marklogic-client-api/src/test/java/com/marklogic/client/impl/PlanRowColTypesSeqImplTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/impl/PlanRowColTypesSeqImplTest.java
@@ -2,10 +2,12 @@ package com.marklogic.client.impl;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class PlanRowColTypesSeqImplTest extends Assert {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class PlanRowColTypesSeqImplTest {
 
     @Test
     public void twoColumns() throws Exception {

--- a/marklogic-client-api/src/test/java/com/marklogic/client/impl/TransformDefImplTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/impl/TransformDefImplTest.java
@@ -4,10 +4,11 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.client.expression.TransformDef;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class TransformDefImplTest extends Assert {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TransformDefImplTest {
 
     @Test
     public void paramsWithPlanColumn() throws Exception {

--- a/marklogic-client-api/src/test/java/com/marklogic/client/impl/okhttp/NewBaseUrlTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/impl/okhttp/NewBaseUrlTest.java
@@ -1,20 +1,20 @@
 package com.marklogic.client.impl.okhttp;
 
 import okhttp3.HttpUrl;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.net.ssl.SSLContext;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class NewBaseUrlTest {
 
 	@Test
 	public void nullBasePath() {
 		HttpUrl url = HttpUrlBuilder.newBaseUrl("anyhost", 8123, null, null);
-		assertEquals("OkHttpServices has always defaulted to including /v1/ping on the base URL; other " +
-				"parts of it expect that to be present, including the code for checkConnection",
-			"http://anyhost:8123/v1/ping", url.toString());
+		assertEquals("http://anyhost:8123/v1/ping", url.toString(),
+			"OkHttpServices has always defaulted to including /v1/ping on the base URL; other " +
+				"parts of it expect that to be present, including the code for checkConnection");
 		assertEquals("http://anyhost:8123/v1/documents", url.resolve("documents").toString());
 	}
 

--- a/marklogic-client-api/src/test/java/com/marklogic/client/impl/okhttp/NewDataServicesBaseUrlTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/impl/okhttp/NewDataServicesBaseUrlTest.java
@@ -1,9 +1,9 @@
 package com.marklogic.client.impl.okhttp;
 
 import okhttp3.HttpUrl;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class NewDataServicesBaseUrlTest {
 
@@ -12,10 +12,11 @@ public class NewDataServicesBaseUrlTest {
 		HttpUrl url = HttpUrlBuilder.newDataServicesBaseUri(
 			HttpUrlBuilder.newBaseUrl("anyhost", 8000, null, null)
 		);
-		assertEquals("For DS, the expectation is that the v1 stuff doesn't exist, as endpoints are expected " +
-				"to be resolved from the root of the app server",
-			"http://anyhost:8000/", url.toString());
-		assertEquals("http://anyhost:8000/my/service/endpoint.sjs", url.resolve("my/service/endpoint.sjs").toString());
+		assertEquals("http://anyhost:8000/", url.toString(),
+			"For DS, the expectation is that the v1 stuff doesn't exist, as endpoints are expected " +
+				"to be resolved from the root of the app server");
+		assertEquals("http://anyhost:8000/my/service/endpoint.sjs",
+			url.resolve("my/service/endpoint.sjs").toString());
 	}
 
 	@Test

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/BinaryDocumentTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/BinaryDocumentTest.java
@@ -15,40 +15,30 @@
  */
 package com.marklogic.client.test;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
-import static org.junit.Assert.*;
+import com.marklogic.client.document.*;
+import com.marklogic.client.document.BinaryDocumentManager.MetadataExtraction;
+import com.marklogic.client.document.DocumentManager.Metadata;
+import com.marklogic.client.io.*;
+import org.custommonkey.xmlunit.exceptions.XpathException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
 
+import javax.xml.bind.DatatypeConverter;
 import java.io.File;
 import java.io.IOException;
 import java.util.Random;
 
-import javax.xml.bind.DatatypeConverter;
-
-import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.w3c.dom.Document;
-
-import com.marklogic.client.document.DocumentDescriptor;
-import com.marklogic.client.document.DocumentPage;
-import com.marklogic.client.document.DocumentRecord;
-import com.marklogic.client.document.DocumentWriteSet;
-import com.marklogic.client.document.DocumentManager.Metadata;
-import com.marklogic.client.document.BinaryDocumentManager;
-import com.marklogic.client.document.BinaryDocumentManager.MetadataExtraction;
-import com.marklogic.client.io.BytesHandle;
-import com.marklogic.client.io.DOMHandle;
-import com.marklogic.client.io.FileHandle;
-import com.marklogic.client.io.Format;
-import com.marklogic.client.io.InputStreamHandle;
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class BinaryDocumentTest {
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     Common.connect();
   }
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
   }
 
@@ -79,22 +69,21 @@ public class BinaryDocumentTest {
         }
 
         DocumentDescriptor desc = docMgr.exists(docId);
-        assertTrue("Binary exists did not get number of bytes",
-                desc.getByteLength() != DocumentDescriptor.UNKNOWN_LENGTH);
-        assertEquals("Binary exists got wrong number of bytes", BYTES_BINARY.length, desc.getByteLength());
+        assertTrue(desc.getByteLength() != DocumentDescriptor.UNKNOWN_LENGTH);
+        assertEquals(BYTES_BINARY.length, desc.getByteLength());
 
         byte[] buf = docMgr.read(docId, new BytesHandle()).get();
-        assertEquals("Binary document read wrong number of bytes", BYTES_BINARY.length, buf.length);
+        assertEquals(BYTES_BINARY.length, buf.length);
 
         buf = Common.streamToBytes(docMgr.read(docId, new InputStreamHandle()).get());
-        assertTrue("Binary document read binary empty input stream",buf.length > 0);
+        assertTrue(buf.length > 0);
 
         switch (i) {
             case 0:
                 handle = new BytesHandle();
                 buf = docMgr.read(docId, handle, 9, 10).get();
-                assertEquals("Binary range read wrong number of bytes", 10, buf.length);
-                assertEquals("Binary range did not set length in handle", 10, handle.getByteLength());
+                assertEquals(10, buf.length);
+                assertEquals(10, handle.getByteLength());
                 break;
             case 1:
                 break;
@@ -113,7 +102,7 @@ public class BinaryDocumentTest {
   }
 
   @Test
-  public void test_issue_758() throws Exception {
+  public void test_issue_758() {
    BinaryDocumentManager docMgr = Common.client.newBinaryDocumentManager();
    DocumentWriteSet writeset = docMgr.newWriteSet();
    FileHandle h1 = new FileHandle(new File(
@@ -126,7 +115,7 @@ public class BinaryDocumentTest {
    docMgr.write(writeset);
    DocumentPage page = docMgr.read(uri);
    DocumentRecord rec = page.next();
-   assertNotNull("DocumentRecord should never be null", rec);
+   assertNotNull(rec);
    assertEquals(rec.getFormat(),Format.BINARY);
   }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/BitemporalFeaturesTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/BitemporalFeaturesTest.java
@@ -15,29 +15,12 @@
  */
 package com.marklogic.client.test;
 
-import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.w3c.dom.Document;
-import org.xml.sax.SAXException;
-
-import static org.junit.Assert.assertEquals;
-
-import java.io.IOException;
-
-import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
-
-import javax.xml.datatype.DatatypeConfigurationException;
-import javax.xml.datatype.DatatypeFactory;
-
 import com.marklogic.client.bitemporal.TemporalDocumentManager.ProtectionLevel;
+import com.marklogic.client.document.DocumentMetadataPatchBuilder;
 import com.marklogic.client.document.DocumentPatchBuilder;
+import com.marklogic.client.document.DocumentPatchBuilder.Position;
 import com.marklogic.client.document.DocumentWriteSet;
 import com.marklogic.client.document.XMLDocumentManager;
-import com.marklogic.client.document.DocumentMetadataPatchBuilder;
-import com.marklogic.client.document.DocumentMetadataPatchBuilder.Cardinality;
-import com.marklogic.client.document.DocumentPatchBuilder.Position;
 import com.marklogic.client.io.Format;
 import com.marklogic.client.io.SearchHandle;
 import com.marklogic.client.io.StringHandle;
@@ -45,6 +28,19 @@ import com.marklogic.client.io.marker.DocumentPatchHandle;
 import com.marklogic.client.query.MatchDocumentSummary;
 import com.marklogic.client.query.QueryDefinition;
 import com.marklogic.client.query.QueryManager;
+import org.custommonkey.xmlunit.exceptions.XpathException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.xml.sax.SAXException;
+
+import javax.xml.datatype.DatatypeConfigurationException;
+import javax.xml.datatype.DatatypeFactory;
+import java.io.IOException;
+
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class BitemporalFeaturesTest {
 
@@ -65,14 +61,14 @@ public class BitemporalFeaturesTest {
   static String docId2 = "test-" + uniqueTerm2 + ".xml";
   static String docId3 = "test-" + uniqueTerm3 + ".xml";
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     Common.connectAdmin();
     docMgr = Common.adminClient.newXMLDocumentManager();
     queryMgr = Common.adminClient.newQueryManager();
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() throws DatatypeConfigurationException {
     cleanUp();
   }
@@ -112,7 +108,7 @@ public class BitemporalFeaturesTest {
     query.setCollections(temporalDocument1);
     SearchHandle handle = queryMgr.search(query, new SearchHandle());
     MatchDocumentSummary[] docs = handle.getMatchResults();
-    assertEquals("Incorrect number of docs",2, docs.length);
+    assertEquals(2, docs.length);
   }
 
   @Test
@@ -159,12 +155,12 @@ public class BitemporalFeaturesTest {
     query.setCollections(temporalDocument1);
     SearchHandle handle = queryMgr.search(query, new SearchHandle());
     MatchDocumentSummary[] docs = handle.getMatchResults();
-    assertEquals("Incorrect number of docs",3, docs.length);
+    assertEquals(3, docs.length);
     query = queryMgr.newStringDefinition();
     query.setCollections(temporalDocument2);
     handle = queryMgr.search(query, new SearchHandle());
     docs = handle.getMatchResults();
-    assertEquals("Incorrect number of docs",2, docs.length);
+    assertEquals(2, docs.length);
   }
 
   @Test
@@ -244,7 +240,7 @@ public class BitemporalFeaturesTest {
     query.setCollections(logicalID);
     SearchHandle handle = queryMgr.search(query, new SearchHandle());
     MatchDocumentSummary[] docs = handle.getMatchResults();
-    assertEquals("Incorrect number of docs",0, docs.length);
+    assertEquals(0, docs.length);
   }
 
   static public void cleanUp() throws DatatypeConfigurationException {

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/BufferableHandleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/BufferableHandleTest.java
@@ -15,49 +15,35 @@
  */
 package com.marklogic.client.test;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import java.io.IOException;
-import java.util.HashMap;
-
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-
+import com.marklogic.client.io.*;
+import com.marklogic.client.test.util.Referred;
+import com.marklogic.client.test.util.Refers;
 import org.custommonkey.xmlunit.SimpleNamespaceContext;
 import org.custommonkey.xmlunit.XMLUnit;
 import org.custommonkey.xmlunit.XpathEngine;
 import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.xml.sax.SAXException;
 
-import com.marklogic.client.io.BytesHandle;
-import com.marklogic.client.io.DOMHandle;
-import com.marklogic.client.io.DocumentMetadataHandle;
-import com.marklogic.client.io.InputSourceHandle;
-import com.marklogic.client.io.InputStreamHandle;
-import com.marklogic.client.io.JAXBHandle;
-import com.marklogic.client.io.ReaderHandle;
-import com.marklogic.client.io.SourceHandle;
-import com.marklogic.client.io.StringHandle;
-import com.marklogic.client.io.XMLEventReaderHandle;
-import com.marklogic.client.io.XMLStreamReaderHandle;
-import com.marklogic.client.test.util.Referred;
-import com.marklogic.client.test.util.Refers;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
+
+import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class BufferableHandleTest {
   static private XpathEngine xpather;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     Common.connect();
 
@@ -78,7 +64,7 @@ public class BufferableHandleTest {
     xpather = XMLUnit.newXpathEngine();
     xpather.setNamespaceContext(namespaceContext);
   }
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
   }
 
@@ -110,54 +96,54 @@ public class BufferableHandleTest {
     BytesHandle bytesH = new BytesHandle();
     bytesH.fromBuffer(before);
     after = bytesH.toBuffer();
-    assertNotNull("Bytes after",after);
+    assertNotNull(after);
     assertXMLEqual("Bytes buffering",beforeStr,new String(after));
 
     domH.fromBuffer(before);
     after = domH.toBuffer();
-    assertNotNull("DOM  after",after);
+    assertNotNull(after);
     assertXMLEqual("DOM buffering",beforeStr,new String(after));
 
     InputSourceHandle inputSourceH = new InputSourceHandle();
     inputSourceH.fromBuffer(before);
     after = inputSourceH.toBuffer();
-    assertNotNull("InputSource after",after);
+    assertNotNull(after);
     assertXMLEqual("InputSource buffering",beforeStr,new String(after));
 
     InputStreamHandle inputStreamH = new InputStreamHandle();
     inputStreamH.fromBuffer(before);
     after = inputStreamH.toBuffer();
-    assertNotNull("InputStream after",after);
+    assertNotNull(after);
     assertXMLEqual("InputStream buffering",beforeStr,new String(after));
 
     ReaderHandle readerH = new ReaderHandle();
     readerH.fromBuffer(before);
     after = readerH.toBuffer();
-    assertNotNull("Reader after",after);
+    assertNotNull(after);
     assertXMLEqual("Reader buffering",beforeStr,new String(after));
 
     SourceHandle sourceH = new SourceHandle();
     sourceH.fromBuffer(before);
     after = sourceH.toBuffer();
-    assertNotNull("Source after",after);
+    assertNotNull(after);
     assertXMLEqual("Source buffering",beforeStr,new String(after));
 
     StringHandle stringH = new StringHandle();
     stringH.fromBuffer(before);
     after = stringH.toBuffer();
-    assertNotNull("String after",after);
+    assertNotNull(after);
     assertXMLEqual("String buffering",beforeStr,new String(after));
 
     XMLEventReaderHandle eventReaderH = new XMLEventReaderHandle();
     eventReaderH.fromBuffer(before);
     after = eventReaderH.toBuffer();
-    assertNotNull("EventReader after",after);
+    assertNotNull(after);
     assertXMLEqual("EventReader buffering",beforeStr,new String(after));
 
     XMLStreamReaderHandle streamReaderH = new XMLStreamReaderHandle();
     streamReaderH.fromBuffer(before);
     after = streamReaderH.toBuffer();
-    assertNotNull("StreamReader after",after);
+    assertNotNull(after);
     assertXMLEqual("StreamReader buffering",beforeStr,new String(after));
 
     Refers refers = new Refers();
@@ -171,7 +157,7 @@ public class BufferableHandleTest {
     beforeStr = new String(before);
     jaxbH.fromBuffer(before);
     after = jaxbH.toBuffer();
-    assertNotNull("JAXB after",after);
+    assertNotNull(after);
     assertXMLEqual("JAXB buffering",beforeStr,new String(after));
 
     String metadataText = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"+
@@ -208,54 +194,54 @@ public class BufferableHandleTest {
 
     metadataH.fromBuffer(before);
     after = metadataH.toBuffer();
-    assertNotNull("DocumentMetadata after",after);
+    assertNotNull(after);
     String afterStr = new String(after);
-    assertTrue("", xpather.getMatchingNodes(
+    assertTrue( xpather.getMatchingNodes(
       "/rapi:metadata/rapi:collections/rapi:collection[string(.) = '/document/collection1']",
       XMLUnit.buildControlDocument(afterStr)
     ).getLength() == 1);
 
-    assertTrue("", xpather.getMatchingNodes(
+    assertTrue( xpather.getMatchingNodes(
       "/rapi:metadata/rapi:collections/rapi:collection[string(.) = '/document/collection2']",
       XMLUnit.buildControlDocument(afterStr)
     ).getLength() == 1);
-    assertTrue("", xpather.getMatchingNodes(
+    assertTrue( xpather.getMatchingNodes(
       "/rapi:metadata/rapi:permissions/rapi:permission/rapi:role-name[string(.) = 'app-user']",
       XMLUnit.buildControlDocument(afterStr)
     ).getLength() == 1);
-    assertTrue("", xpather.getMatchingNodes(
+    assertTrue( xpather.getMatchingNodes(
       "/rapi:metadata/rapi:permissions/rapi:permission/rapi:capability[string(.) = 'read']",
       XMLUnit.buildControlDocument(afterStr)
     ).getLength() == 1);
-    assertTrue("", xpather.getMatchingNodes(
+    assertTrue( xpather.getMatchingNodes(
       "/rapi:metadata/rapi:permissions/rapi:permission/rapi:capability[string(.) = 'update']",
       XMLUnit.buildControlDocument(afterStr)
     ).getLength() == 1);
-    assertTrue("", xpather.getMatchingNodes(
+    assertTrue( xpather.getMatchingNodes(
       "/rapi:metadata/prop:properties/first[string(.) = 'value one']",
       XMLUnit.buildControlDocument(afterStr)
     ).getLength() == 1);
-    assertTrue("", xpather.getMatchingNodes(
+    assertTrue( xpather.getMatchingNodes(
       "/rapi:metadata/prop:properties/second[string(.) = '2']",
       XMLUnit.buildControlDocument(afterStr)
     ).getLength() == 1);
-    assertTrue("", xpather.getMatchingNodes(
+    assertTrue( xpather.getMatchingNodes(
       "/rapi:metadata/prop:properties/third/third.first[string(.) = 'value third one']",
       XMLUnit.buildControlDocument(afterStr)
     ).getLength() == 1);
-    assertTrue("", xpather.getMatchingNodes(
+    assertTrue( xpather.getMatchingNodes(
       "/rapi:metadata/prop:properties/third/third.second[string(.) = '3.2']",
       XMLUnit.buildControlDocument(afterStr)
     ).getLength() == 1);
-    assertTrue("", xpather.getMatchingNodes(
+    assertTrue( xpather.getMatchingNodes(
       "/rapi:metadata/rapi:metadata-values/rapi:metadata-value[@key = 'key1'][string(.) = 'value1']",
       XMLUnit.buildControlDocument(afterStr)
     ).getLength() == 1);
-    assertTrue("", xpather.getMatchingNodes(
+    assertTrue( xpather.getMatchingNodes(
       "/rapi:metadata/rapi:metadata-values/rapi:metadata-value[@key = 'number1'][string(.) = '10']",
       XMLUnit.buildControlDocument(afterStr)
     ).getLength() == 1);
-    assertTrue("", xpather.getMatchingNodes(
+    assertTrue( xpather.getMatchingNodes(
       "/rapi:metadata/rapi:quality[string(.) = '3']",
       XMLUnit.buildControlDocument(afterStr)
     ).getLength() == 1);

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/City.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/City.java
@@ -15,14 +15,10 @@
  */
 package com.marklogic.client.test;
 
-import javax.xml.bind.annotation.XmlRootElement;
-
-import com.marklogic.client.pojo.annotation.Id;
-import com.marklogic.client.pojo.annotation.PathIndexProperty;
+import com.marklogic.client.pojo.annotation.*;
 import com.marklogic.client.pojo.annotation.PathIndexProperty.ScalarType;
-import com.marklogic.client.pojo.annotation.GeospatialPathIndexProperty;
-import com.marklogic.client.pojo.annotation.GeospatialLatitude;
-import com.marklogic.client.pojo.annotation.GeospatialLongitude;
+
+import javax.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement
 public class City {

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/ClosingHandlesTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/ClosingHandlesTest.java
@@ -15,38 +15,20 @@
  */
 package com.marklogic.client.test;
 
-import static org.junit.Assert.assertTrue;
-
-import java.io.ByteArrayInputStream;
-import java.io.Closeable;
-import java.io.IOException;
-
-import javax.xml.bind.JAXBContext;
-
-import org.junit.Test;
-
 import com.marklogic.client.extra.dom4j.DOM4JHandle;
 import com.marklogic.client.extra.gson.GSONHandle;
 import com.marklogic.client.extra.jdom.JDOMHandle;
 import com.marklogic.client.impl.HandleAccessor;
-import com.marklogic.client.io.DOMHandle;
-import com.marklogic.client.io.DocumentMetadataHandle;
-import com.marklogic.client.io.InputSourceHandle;
-import com.marklogic.client.io.InputStreamHandle;
-import com.marklogic.client.io.JAXBHandle;
-import com.marklogic.client.io.JacksonDatabindHandle;
-import com.marklogic.client.io.JacksonHandle;
-import com.marklogic.client.io.JacksonParserHandle;
-import com.marklogic.client.io.QueryOptionsListHandle;
-import com.marklogic.client.io.ReaderHandle;
-import com.marklogic.client.io.SearchHandle;
-import com.marklogic.client.io.SourceHandle;
-import com.marklogic.client.io.TuplesHandle;
-import com.marklogic.client.io.ValuesHandle;
-import com.marklogic.client.io.ValuesListHandle;
-import com.marklogic.client.io.XMLEventReaderHandle;
-import com.marklogic.client.io.XMLStreamReaderHandle;
+import com.marklogic.client.io.*;
 import com.marklogic.client.io.marker.AbstractReadHandle;
+import org.junit.jupiter.api.Test;
+
+import javax.xml.bind.JAXBContext;
+import java.io.ByteArrayInputStream;
+import java.io.Closeable;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ClosingHandlesTest {
   private static class MockInputStream extends ByteArrayInputStream {
@@ -107,7 +89,7 @@ public class ClosingHandlesTest {
     if ( handle instanceof Closeable ) {
       ((Closeable) handle).close();
     }
-    assertTrue("Handle " + handle.getClass().getName() + " did not close underlying InputStream", stream.isClosed());
+    assertTrue(stream.isClosed(), "Handle " + handle.getClass().getName() + " did not close underlying InputStream");
 
   }
 

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/CombinedQueryBuilderTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/CombinedQueryBuilderTest.java
@@ -15,22 +15,6 @@
  */
 package com.marklogic.client.test;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
-
-import java.io.ByteArrayOutputStream;
-import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
-
-import javax.xml.stream.XMLOutputFactory;
-import javax.xml.stream.XMLStreamException;
-import javax.xml.stream.XMLStreamWriter;
-
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
-
 import com.marklogic.client.impl.CombinedQueryBuilderImpl;
 import com.marklogic.client.impl.CombinedQueryDefinition;
 import com.marklogic.client.impl.XmlFactories;
@@ -41,15 +25,25 @@ import com.marklogic.client.pojo.PojoQueryBuilder;
 import com.marklogic.client.pojo.PojoRepository;
 import com.marklogic.client.query.StructuredQueryBuilder;
 import com.marklogic.client.query.StructuredQueryDefinition;
+import org.junit.jupiter.api.*;
 
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+
+import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+
+@TestMethodOrder(MethodOrderer.MethodName.class)
 public class CombinedQueryBuilderTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     Common.connect();
   }
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
   }
 

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/Common.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/Common.java
@@ -15,20 +15,8 @@
  */
 package com.marklogic.client.test;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.io.StringReader;
-import java.io.StringWriter;
-import java.io.UnsupportedEncodingException;
-import java.net.URI;
-import java.net.URISyntaxException;
-
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.DatabaseClientFactory;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
 import org.w3c.dom.ls.DOMImplementationLS;
@@ -36,8 +24,11 @@ import org.w3c.dom.ls.LSException;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
-import com.marklogic.client.DatabaseClient;
-import com.marklogic.client.DatabaseClientFactory;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.*;
+import java.net.URI;
+import java.net.URISyntaxException;
 
 public class Common {
   final public static String USER= "rest-writer";

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/ConditionalDocumentTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/ConditionalDocumentTest.java
@@ -15,40 +15,34 @@
  */
 package com.marklogic.client.test;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import com.marklogic.client.*;
+import com.marklogic.client.admin.ServerConfigurationManager;
+import com.marklogic.client.admin.ServerConfigurationManager.UpdatePolicy;
+import com.marklogic.client.document.DocumentDescriptor;
+import com.marklogic.client.document.DocumentPage;
+import com.marklogic.client.document.DocumentRecord;
+import com.marklogic.client.document.XMLDocumentManager;
+import com.marklogic.client.impl.FailedRequest;
+import com.marklogic.client.io.Format;
+import com.marklogic.client.io.StringHandle;
+import com.marklogic.client.query.StructuredQueryBuilder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.xml.sax.SAXException;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import com.marklogic.client.document.DocumentPage;
-import com.marklogic.client.document.DocumentRecord;
-import com.marklogic.client.query.StructuredQueryBuilder;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.xml.sax.SAXException;
-
-import com.marklogic.client.DatabaseClient;
-import com.marklogic.client.FailedRequestException;
-import com.marklogic.client.ForbiddenUserException;
-import com.marklogic.client.ResourceNotFoundException;
-import com.marklogic.client.ResourceNotResendableException;
-import com.marklogic.client.admin.ServerConfigurationManager;
-import com.marklogic.client.admin.ServerConfigurationManager.UpdatePolicy;
-import com.marklogic.client.document.DocumentDescriptor;
-import com.marklogic.client.document.XMLDocumentManager;
-import com.marklogic.client.impl.FailedRequest;
-import com.marklogic.client.io.Format;
-import com.marklogic.client.io.StringHandle;
+import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ConditionalDocumentTest {
   static DatabaseClient adminClient = Common.connectAdmin();
   static ServerConfigurationManager serverConfig;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass()
     throws FailedRequestException, ForbiddenUserException, ResourceNotFoundException, ResourceNotResendableException
   {
@@ -61,7 +55,7 @@ public class ConditionalDocumentTest {
 
     Common.connect();
   }
-  @AfterClass
+  @AfterAll
   public static void afterClass()
     throws FailedRequestException, ResourceNotFoundException, ResourceNotResendableException, ForbiddenUserException
   {
@@ -101,9 +95,9 @@ public class ConditionalDocumentTest {
         statusCode = failreq.getStatusCode();
       ex = e;
     }
-    assertTrue("Write with bad version succeeded", ex != null);
-    assertTrue("Write with bad version had wrong error", statusCode == 412);
-    assertTrue("Write with no version had misleading message",
+    assertTrue( ex != null);
+    assertTrue( statusCode == 412);
+    assertTrue(
       ex.getMessage().contains("Local message: Content version must match to write document. Server Message: RESTAPI-CONTENTWRONGVERSION: (err:FOER0000) Content version mismatch:  uri /test/conditional1.xml doesn't match if-match: 11111"));
 
 
@@ -112,15 +106,15 @@ public class ConditionalDocumentTest {
 
     String result = docMgr.read(desc, new StringHandle()).get();
     long goodVersion = desc.getVersion();
-    assertTrue("Failed to read version", goodVersion != DocumentDescriptor.UNKNOWN_VERSION);
+    assertTrue( goodVersion != DocumentDescriptor.UNKNOWN_VERSION);
     assertXMLEqual("Failed to read document content",result,GenericDocumentTest.content);
 
     desc.setVersion(badVersion);
-    assertTrue("Read with bad version did not get content",
+    assertTrue(
       docMgr.read(desc, new StringHandle()).get() != null);
 
     desc.setVersion(goodVersion);
-    assertTrue("Read with good version did not skip content",
+    assertTrue(
       docMgr.read(desc, new StringHandle()) == null);
 
     ex = null;
@@ -135,9 +129,9 @@ public class ConditionalDocumentTest {
         statusCode = failreq.getStatusCode();
       ex = e;
     }
-    assertTrue("Overwrite without version succeeded", ex != null);
-    assertEquals("Write with no version had wrong error", 428, statusCode);
-    assertEquals("Write with no version had misleading message",
+    assertTrue( ex != null);
+    assertEquals( 428, statusCode);
+    assertEquals(
       "Local message: Content version required to write document. Server Message: RESTAPI-CONTENTNOVERSION: (err:FOER0000) No content version supplied:  uri /test/conditional1.xml",
       ex.getMessage());
 
@@ -152,17 +146,17 @@ public class ConditionalDocumentTest {
         statusCode = failreq.getStatusCode();
       ex = e;
     }
-    assertTrue("Overwrite with bad version succeeded", ex != null);
-    assertEquals("Write with bad version had wrong error", 412, statusCode);
-    assertTrue("Write with no version had misleading message",
+    assertTrue( ex != null);
+    assertEquals( 412, statusCode);
+    assertTrue(
       ex.getMessage().contains("Local message: Content version must match to write document. Server Message: RESTAPI-CONTENTWRONGVERSION: (err:FOER0000) Content version mismatch:  uri /test/conditional1.xml has current version"));
 
     desc.setVersion(goodVersion);
     docMgr.write(desc, contentHandle);
 
     desc = docMgr.exists(docId);
-    assertTrue("Exists did not get version", desc.getVersion() != DocumentDescriptor.UNKNOWN_VERSION);
-    assertTrue("Overwrite did not change version", goodVersion != desc.getVersion());
+    assertTrue( desc.getVersion() != DocumentDescriptor.UNKNOWN_VERSION);
+    assertTrue( goodVersion != desc.getVersion());
     goodVersion = desc.getVersion();
 
     ex = null;
@@ -176,8 +170,8 @@ public class ConditionalDocumentTest {
         statusCode = failreq.getStatusCode();
       ex = e;
     }
-    assertTrue("Delete without version succeeded", ex != null);
-    assertEquals("Delete without version had wrong error", 428, statusCode);
+    assertTrue( ex != null);
+    assertEquals( 428, statusCode);
 
     ex = null;
     // TODO: statusCode
@@ -187,15 +181,15 @@ public class ConditionalDocumentTest {
     } catch (FailedRequestException e) {
       ex = e;
     }
-    assertTrue("Delete with bad version succeeded", ex != null);
+    assertTrue( ex != null);
 
     try {
       docMgr.delete(documentUri); // internal documentdescriptor
     } catch (FailedRequestException e) {
       ex = e;
     }
-    assertTrue("Delete with no version succeeded", ex != null);
-    assertEquals("Delete with no version had misleading message",
+    assertTrue( ex != null);
+    assertEquals(
       "Local message: Content version required to delete document. Server Message: RESTAPI-CONTENTNOVERSION: (err:FOER0000) No content version supplied:  uri /test/conditional1.xml",
       ex.getMessage());
 
@@ -221,11 +215,11 @@ public class ConditionalDocumentTest {
   void verifyDescriptors(List<String> docList, DocumentPage page) {
     for (DocumentRecord record: page) {
       DocumentDescriptor desc = record.getDescriptor();
-      assertTrue("bad document URI when reading multiple descriptors", docList.contains(desc.getUri()));
-      assertEquals("bad content format when reading multiple descriptors", Format.XML, desc.getFormat());
-      assertTrue("bad content mime type when reading multiple descriptors", desc.getMimetype().startsWith("application/xml"));
-      assertTrue("bad content length when reading multiple descriptors", desc.getByteLength() >= 0);
-      assertTrue("bad content version when reading multiple descriptors", desc.getVersion() >= -1);
+      assertTrue( docList.contains(desc.getUri()));
+      assertEquals( Format.XML, desc.getFormat());
+      assertTrue( desc.getMimetype().startsWith("application/xml"));
+      assertTrue( desc.getByteLength() >= 0);
+      assertTrue( desc.getVersion() >= -1);
     }
   }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/CtsQueryDefinitionTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/CtsQueryDefinitionTest.java
@@ -24,25 +24,25 @@ import com.marklogic.client.query.MatchLocation;
 import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.type.CtsQueryExpr;
 import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 
 import java.io.File;
 
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CtsQueryDefinitionTest {
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         Common.connect();
         queryMgr = Common.client.newQueryManager();
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         Common.client.newDocumentManager().delete("CtsQueryDefinitionTest.xml");
         Common.client.newDocumentManager().delete("CtsQueryDefinitionTest.json");

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/DOMSearchResultTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/DOMSearchResultTest.java
@@ -15,34 +15,32 @@
  */
 package com.marklogic.client.test;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertEquals;
-
-import java.io.IOException;
-
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.xpath.XPathExpression;
-import javax.xml.xpath.XPathExpressionException;
-
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import com.marklogic.client.io.DOMHandle;
+import com.marklogic.client.query.QueryManager;
+import com.marklogic.client.query.StringQueryDefinition;
+import com.marklogic.client.util.EditableNamespaceContext;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
-import com.marklogic.client.query.QueryManager;
-import com.marklogic.client.query.StringQueryDefinition;
-import com.marklogic.client.util.EditableNamespaceContext;
-import com.marklogic.client.io.DOMHandle;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathExpressionException;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class DOMSearchResultTest {
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     Common.connect();
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
   }
 
@@ -56,7 +54,7 @@ public class DOMSearchResultTest {
 
     DOMHandle responseHandle = queryMgr.search(qdef, new DOMHandle());
     Document doc = responseHandle.get();
-    assertNotNull("null response document", doc);
+    assertNotNull( doc);
 
     // configure namespace bindings for the XPath processor
     EditableNamespaceContext namespaces = new EditableNamespaceContext();
@@ -65,20 +63,20 @@ public class DOMSearchResultTest {
 
     // string expression against the document
     String total = responseHandle.evaluateXPath("string(/search:response/@total)", String.class);
-    assertNotNull("null total", total);
+    assertNotNull( total);
 
     // compiled expression against the document
     XPathExpression resultsExpression = responseHandle.compileXPath("/search:response/search:result");
     NodeList resultList = responseHandle.evaluateXPath(resultsExpression, NodeList.class);
-    assertNotNull("null result list", resultList);
-    assertEquals("result count mismatch", resultList.getLength(), Integer.parseInt(total));
+    assertNotNull( resultList);
+    assertEquals( resultList.getLength(), Integer.parseInt(total));
 
     // string expression against an element
     Element firstResult = responseHandle.evaluateXPath("/search:response/search:result[1]", Element.class);
-    assertNotNull("null first result", firstResult);
+    assertNotNull( firstResult);
 
     String firstResultUri = responseHandle.evaluateXPath("string(@uri)", firstResult, String.class);
     String firstItemUri   = ((Element) resultList.item(0)).getAttribute("uri");
-    assertEquals("first uri mismatch", firstResultUri, firstItemUri);
+    assertEquals( firstResultUri, firstItemUri);
   }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/DatabaseClientFactoryTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/DatabaseClientFactoryTest.java
@@ -15,29 +15,10 @@
  */
 package com.marklogic.client.test;
 
-import static org.junit.Assert.*;
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
-
-import java.io.IOException;
-import java.util.concurrent.TimeUnit;
-
-import okhttp3.OkHttpClient;
-import okhttp3.OkHttpClient.Builder;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.xml.sax.SAXException;
-
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.DatabaseClientFactory;
-import com.marklogic.client.DatabaseClientFactory.ClientConfigurator;
-import com.marklogic.client.DatabaseClientFactory.DigestAuthContext;
 import com.marklogic.client.ResourceNotFoundException;
-import com.marklogic.client.document.DocumentDescriptor;
-import com.marklogic.client.document.DocumentPage;
-import com.marklogic.client.document.DocumentPatchBuilder;
-import com.marklogic.client.document.DocumentUriTemplate;
-import com.marklogic.client.document.XMLDocumentManager;
+import com.marklogic.client.document.*;
 import com.marklogic.client.eval.ServerEvaluationCall;
 import com.marklogic.client.extra.okhttpclient.OkHttpClientConfigurator;
 import com.marklogic.client.io.Format;
@@ -46,19 +27,30 @@ import com.marklogic.client.io.marker.DocumentPatchHandle;
 import com.marklogic.client.query.MatchDocumentSummary;
 import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.query.StringQueryDefinition;
+import okhttp3.OkHttpClient;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class DatabaseClientFactoryTest {
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     Common.connectEval();
   }
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
   }
 
   @Test
   public void testConnectStringIntStringStringDigest() {
-    assertNotNull("Factory could not create client with digest connection", Common.evalClient);
+    assertNotNull( Common.evalClient);
   }
 
   @Test
@@ -69,24 +61,24 @@ public class DatabaseClientFactoryTest {
     final String SECOND_DB_NAME = "Documents";
     DatabaseClient tmpClient = Common.newEvalClient(FIRST_DB_NAME);
     try {
-      assertNotNull("Factory could not create client", tmpClient);
+      assertNotNull( tmpClient);
       String database =
         tmpClient.newServerEval()
           .xquery("xdmp:database-name(xdmp:database())")
           .evalAs(String.class);
-      assertEquals("Runtime database is wrong", FIRST_DB_NAME, database);
+      assertEquals( FIRST_DB_NAME, database);
     } finally {
       tmpClient.release();
     }
 
     tmpClient = Common.newEvalClient(SECOND_DB_NAME);
     try {
-      assertNotNull("Factory could not create client", tmpClient);
+      assertNotNull( tmpClient);
       String database =
         tmpClient.newServerEval()
           .xquery("xdmp:database-name(xdmp:database())")
           .evalAs(String.class);
-      assertEquals("Runtime database is wrong", SECOND_DB_NAME, database);
+      assertEquals( SECOND_DB_NAME, database);
 /*
       QueryManager fixupQueryMgr = tmpClient.newQueryManager();
       DeleteQueryDefinition delQuery = fixupQueryMgr.newDeleteDefinition();
@@ -111,7 +103,7 @@ public class DatabaseClientFactoryTest {
 
       // test that the doc exists via the DocumentManager api
       DocumentDescriptor existsDesc = runtimeDbDocMgr.exists(docUri);
-      assertNotNull("Doc " + docUri + " should exist in the Documents db", existsDesc);
+      assertNotNull(existsDesc);
 
       // test overwriting the contents of the doc
       String docContents2 = "<a>hello2</a>";
@@ -127,8 +119,8 @@ public class DatabaseClientFactoryTest {
       query.setCriteria("hello2");
       query.setDirectory("/test/");
       MatchDocumentSummary match = runtimeDbQueryMgr.findOne(query);
-      assertNotNull("Should get a doc back", match);
-      assertEquals("URL doesn't match", docUri, match.getUri());
+      assertNotNull( match);
+      assertEquals( docUri, match.getUri());
 
       // test patching
       String newValue = "new value";
@@ -140,8 +132,8 @@ public class DatabaseClientFactoryTest {
 
       // use bulk read to make sure the doc got the update
       DocumentPage docs = runtimeDbDocMgr.read(docUri);
-      assertNotNull("Should get a doc back", docs);
-      assertTrue("Should get a doc back", docs.hasNext());
+      assertNotNull( docs);
+      assertTrue( docs.hasNext());
       String value3 = docs.next().getContent(new StringHandle()).get();
       assertXMLEqual("Doc contents incorrect", docContents3, value3);
 
@@ -153,9 +145,9 @@ public class DatabaseClientFactoryTest {
       } catch (ResourceNotFoundException e) {
         deleted = true;
       }
-      assertTrue("Doc still exists", deleted);
+      assertTrue( deleted);
       String value4 = getHello.evalAs(String.class);
-      assertEquals("Eval response wrong", null, value4);
+      assertEquals( null, value4);
 
     } finally {
       tmpClient.release();
@@ -172,7 +164,7 @@ public class DatabaseClientFactoryTest {
     DatabaseClient client = Common.makeNewClient(
       Common.HOST, Common.PORT, Common.newSecurityContext(Common.USER, Common.PASS));
     try {
-      assertTrue("Factory did not apply custom configurator", configurator.isConfigured);
+      assertTrue( configurator.isConfigured);
       OkHttpClient okClient = (OkHttpClient) client.getClientImplementation();
       assertEquals(testConnectTimeoutMillis, okClient.connectTimeoutMillis());
     } finally {

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/DatabaseClientTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/DatabaseClientTest.java
@@ -24,115 +24,115 @@ import com.marklogic.client.eval.ServerEvaluationCall;
 import com.marklogic.client.pojo.PojoRepository;
 import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.util.RequestLogger;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class DatabaseClientTest {
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     Common.connect();
     Common.connectAdmin();
   }
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
   }
 
   @Test
   public void testNewDocument() {
     GenericDocumentManager doc = Common.client.newDocumentManager();
-    assertNotNull("Client could not create generic document", doc);
+    assertNotNull( doc);
   }
 
   @Test
   public void testNewBinaryDocument() {
     BinaryDocumentManager doc = Common.client.newBinaryDocumentManager();
-    assertNotNull("Client could not create binary document", doc);
+    assertNotNull( doc);
   }
 
   @Test
   public void testNewJSONDocument() {
     JSONDocumentManager doc = Common.client.newJSONDocumentManager();
-    assertNotNull("Client could not create JSON document", doc);
+    assertNotNull( doc);
   }
 
   @Test
   public void testNewTextDocument() {
     TextDocumentManager doc = Common.client.newTextDocumentManager();
-    assertNotNull("Client could not create text document", doc);
+    assertNotNull( doc);
   }
 
   @Test
   public void testNewXMLDocument() {
     XMLDocumentManager doc = Common.client.newXMLDocumentManager();
-    assertNotNull("Client could not create XML document", doc);
+    assertNotNull( doc);
   }
 
   @Test
   public void testNewLogger() {
     RequestLogger logger = Common.client.newLogger(System.out);
-    assertNotNull("Client could not create request logger", logger);
+    assertNotNull( logger);
   }
 
   @Test
   public void testNewQueryManager() {
     QueryManager mgr = Common.client.newQueryManager();
-    assertNotNull("Client could not create query manager", mgr);
+    assertNotNull( mgr);
   }
 
   @Test
   public void testNewRuleManager() {
     RuleManager mgr = Common.client.newRuleManager();
-    assertNotNull("Client could not create rule manager", mgr);
+    assertNotNull( mgr);
   }
 
   @Test
   public void testNewPojoRepository() {
     PojoRepository<City, Integer> mgr = Common.client.newPojoRepository(City.class, Integer.class);
-    assertNotNull("Client could not create pojo repository", mgr);
+    assertNotNull( mgr);
   }
 
   @Test
   public void testNewServerEvaluationCall() {
     ServerEvaluationCall mgr = Common.client.newServerEval();
-    assertNotNull("Client could not create ServerEvaluationCall", mgr);
+    assertNotNull( mgr);
   }
 
   @Test
   public void testNewQueryOptionsManager() {
     QueryOptionsManager mgr = Common.adminClient.newServerConfigManager().newQueryOptionsManager();
-    assertNotNull("Client could not create query options manager", mgr);
+    assertNotNull( mgr);
   }
 
   @Test
   public void testGetClientImplementationObject() {
     Object impl = Common.client.getClientImplementation();
-    assertNotNull("Client could not get client implementation", impl);
-    assertTrue("", impl instanceof okhttp3.OkHttpClient);
+    assertNotNull( impl);
+    assertTrue( impl instanceof okhttp3.OkHttpClient);
   }
-  
+
   @Test
   public void testCheckConnectionWithValidUser() {
-		
+
 	DatabaseClient marklogic = Common.makeNewClient(Common.HOST,
 		        Common.PORT, Common.newSecurityContext(
 				        Common.SERVER_ADMIN_USER, Common.SERVER_ADMIN_PASS));
-  
+
     ConnectionResult connResult = marklogic.checkConnection();
     assertTrue(connResult.isConnected());
   }
-  
+
   @Test
   public void testCheckConnectionWithInvalidUser() {
 	DatabaseClient marklogic = Common.makeNewClient(Common.HOST,
 		        Common.PORT, Common.newSecurityContext("invalid", "invalid"));
-  
+
     ConnectionResult connResult = marklogic.checkConnection();
     assertFalse(connResult.isConnected());
     assertTrue(connResult.getStatusCode() == 401);
     assertTrue(connResult.getErrorMessage().equalsIgnoreCase("Unauthorized"));
   }
-  
+
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/DeleteSearchTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/DeleteSearchTest.java
@@ -15,23 +15,6 @@
  */
 package com.marklogic.client.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-
-import java.io.IOException;
-
-import javax.xml.parsers.DocumentBuilderFactory;
-
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.ls.DOMImplementationLS;
-
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.document.DocumentDescriptor;
 import com.marklogic.client.document.GenericDocumentManager;
@@ -39,15 +22,23 @@ import com.marklogic.client.document.XMLDocumentManager;
 import com.marklogic.client.io.DOMHandle;
 import com.marklogic.client.query.DeleteQueryDefinition;
 import com.marklogic.client.query.QueryManager;
+import org.junit.jupiter.api.*;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.ls.DOMImplementationLS;
 
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@TestMethodOrder(MethodOrderer.MethodName.class)
 public class DeleteSearchTest {
   private static final String directory = "/delete/test/";
   private static final String filename = "testWrite1.xml";
   private static final String docId = directory + filename;
   private static DatabaseClient client = Common.connect();
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() throws Exception {
     writeDoc();
   }
@@ -73,15 +64,15 @@ public class DeleteSearchTest {
     docMgr.write(docId, new DOMHandle().with(domDocument));
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
   }
 
   @Test
-  public void test_A_Delete() throws IOException {
+  public void test_A_Delete() {
     GenericDocumentManager docMgr = client.newDocumentManager();
     DocumentDescriptor desc = docMgr.exists(docId);
-    assertNotNull("Should find document before delete", desc);
+    assertNotNull(desc);
     assertEquals(desc.getUri(), docId);
 
     QueryManager queryMgr = client.newQueryManager();
@@ -91,7 +82,7 @@ public class DeleteSearchTest {
     queryMgr.delete(qdef);
 
     desc = docMgr.exists(docId);
-    assertNull("Should not find document after delete", desc);
+    assertNull(desc);
   }
 
   @Test

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/DocumentMetadataHandleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/DocumentMetadataHandleTest.java
@@ -15,51 +15,45 @@
  */
 package com.marklogic.client.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.util.ArrayList;
-
-import javax.xml.namespace.QName;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-
+import com.marklogic.client.Transaction;
+import com.marklogic.client.document.BinaryDocumentManager;
+import com.marklogic.client.document.DocumentManager.Metadata;
+import com.marklogic.client.document.XMLDocumentManager;
+import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.client.io.DocumentMetadataHandle.*;
+import com.marklogic.client.io.FileHandle;
+import com.marklogic.client.io.InputStreamHandle;
+import com.marklogic.client.io.StringHandle;
 import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
-import com.marklogic.client.Transaction;
-import com.marklogic.client.document.DocumentManager.Metadata;
-import com.marklogic.client.document.BinaryDocumentManager;
-import com.marklogic.client.document.XMLDocumentManager;
-import com.marklogic.client.io.DocumentMetadataHandle;
-import com.marklogic.client.io.DocumentMetadataHandle.Capability;
-import com.marklogic.client.io.DocumentMetadataHandle.DocumentCollections;
-import com.marklogic.client.io.DocumentMetadataHandle.DocumentMetadataValues;
-import com.marklogic.client.io.DocumentMetadataHandle.DocumentPermissions;
-import com.marklogic.client.io.DocumentMetadataHandle.DocumentProperties;
-import com.marklogic.client.io.FileHandle;
-import com.marklogic.client.io.InputStreamHandle;
-import com.marklogic.client.io.StringHandle;
+import javax.xml.namespace.QName;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class DocumentMetadataHandleTest {
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     Common.connect();
   }
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
   }
 
@@ -135,34 +129,34 @@ public class DocumentMetadataHandleTest {
         docMgr.writeMetadata(docId, metaWriteHandle);
         StringHandle xmlStringHandle = new StringHandle();
         String stringMetadata = docMgr.readMetadata(docId, xmlStringHandle).get();
-        assertTrue("Could not get document metadata as an XML String", stringMetadata != null && stringMetadata.length() > 0);
+        assertTrue( stringMetadata != null && stringMetadata.length() > 0);
       } else {
-        assertTrue("Test case error", false);
+        assertTrue( false);
       }
 
       DocumentMetadataHandle metaReadHandle = docMgr.readMetadata(docId, new DocumentMetadataHandle());
-      assertTrue("Could not get document metadata as a structure", metaReadHandle != null);
+      assertTrue( metaReadHandle != null);
       DocumentCollections collections = metaReadHandle.getCollections();
-      assertEquals("Collection with wrong size", 2, collections.size());
-      assertTrue("Collection with wrong values", collections.contains("/document/collection1") && collections.contains("/document/collection2"));
+      assertEquals( 2, collections.size());
+      assertTrue( collections.contains("/document/collection1") && collections.contains("/document/collection2"));
       DocumentPermissions permissions = metaReadHandle.getPermissions();
       // rest-reader and rest-writer expected
-      assertEquals("Permissions with wrong size", 5, permissions.size());
-      assertTrue("Permissions without key", permissions.containsKey("app-user"));
-      assertEquals("Permission key with wrong value size", 2, permissions.get("app-user").size());
-      assertTrue("Permission key with wrong values", permissions.get("app-user").contains(Capability.READ) && permissions.get("app-user").contains(Capability.UPDATE));
+      assertEquals( 5, permissions.size());
+      assertTrue( permissions.containsKey("app-user"));
+      assertEquals( 2, permissions.get("app-user").size());
+      assertTrue( permissions.get("app-user").contains(Capability.READ) && permissions.get("app-user").contains(Capability.UPDATE));
       DocumentProperties properties = metaReadHandle.getProperties();
-      assertTrue("Properties without first property", properties.containsKey("first"));
-      assertTrue("Properties without second property", properties.containsKey("second"));
-      assertTrue("Properties without third property", properties.containsKey("third"));
-      assertEquals("First property with wrong value", "value one", properties.get("first"));
+      assertTrue( properties.containsKey("first"));
+      assertTrue( properties.containsKey("second"));
+      assertTrue( properties.containsKey("third"));
+      assertEquals( "value one", properties.get("first"));
       if (pass==0) {
-        assertEquals("Second property with wrong value", String.valueOf(2), properties.get("second"));
+        assertEquals( String.valueOf(2), properties.get("second"));
       } else if (pass==1) {
-        assertEquals("Second property with wrong value", 2, properties.get("second"));
+        assertEquals( 2, properties.get("second"));
       }
       Object thirdValue = properties.get("third");
-      assertTrue("Third property with wrong class for value", thirdValue instanceof NodeList);
+      assertTrue( thirdValue instanceof NodeList);
       NodeList thirdNodes = (NodeList) thirdValue;
       List<Element> thirdElements = new ArrayList<>();
       for (int i=0; i < thirdNodes.getLength(); i++) {
@@ -171,17 +165,17 @@ public class DocumentMetadataHandleTest {
           continue;
         thirdElements.add((Element) thirdNode);
       }
-      assertEquals("Third property with wrong number of child nodes", thirdChildren.getLength(), thirdElements.size());
+      assertEquals( thirdChildren.getLength(), thirdElements.size());
       for (int i=0; i < thirdChildren.getLength(); i++) {
         Node    expectedNode = thirdChildren.item(i);
         Element actualNode   = thirdElements.get(i);
-        assertEquals("Third property with wrong child name "+i,  expectedNode.getNodeName(),  actualNode.getNodeName());
-        assertEquals("Third property with wrong child value "+i, expectedNode.getNodeValue(), actualNode.getNodeValue());
+        assertEquals(expectedNode.getNodeName(),  actualNode.getNodeName(), "Third property with wrong child name "+i);
+        assertEquals(expectedNode.getNodeValue(), actualNode.getNodeValue(), "Third property with wrong child value "+i);
       }
-      assertEquals("Wrong quality", 3, metaReadHandle.getQuality());
+      assertEquals( 3, metaReadHandle.getQuality());
       DocumentMetadataValues metadataValues = metaReadHandle.getMetadataValues();
-      assertEquals("Wrong value for key in the values metadata", "value1", metadataValues.get("key1"));
-      assertEquals("Wrong value for key in the values metadata", "value2", metadataValues.get("key2"));
+      assertEquals( "value1", metadataValues.get("key1"));
+      assertEquals( "value2", metadataValues.get("key2"));
     }
   }
 
@@ -194,11 +188,11 @@ public class DocumentMetadataHandleTest {
     assertEquals(Capability.NODE_UPDATE, Capability.getValueOf("node-Update"));
     assertEquals(Capability.NODE_UPDATE, Capability.getValueOf("NODE_UPDATE"));
   }
-  
+
   @Test
   public void testMetadataPropertiesExtraction() {
 	String docId = "/test.bin";
-	// Make a document manager to work with binary files 
+	// Make a document manager to work with binary files
     BinaryDocumentManager docMgr = Common.client.newBinaryDocumentManager();
     DocumentMetadataHandle metadataHandle = new DocumentMetadataHandle();
     docMgr.setMetadataExtraction(BinaryDocumentManager.MetadataExtraction.PROPERTIES);
@@ -216,16 +210,16 @@ public class DocumentMetadataHandleTest {
     // Create a handle to hold string content.
     InputStreamHandle handle = new InputStreamHandle(docStream);
     docMgr.write(docId, metadataHandle, handle);
-    
+
     DocumentMetadataHandle readMetadataHandle = new DocumentMetadataHandle();
     //read only the metadata into a handle
     docMgr.readMetadata(docId, readMetadataHandle);
     QName qn = new QName("", "testId");
     readMetadataHandle.getProperties().put(qn, "123456");
     docMgr.writeMetadata(docId, readMetadataHandle);
-    
+
     readMetadataHandle = new DocumentMetadataHandle();
-    
+
     docMgr.readMetadata(docId, readMetadataHandle);
     assertEquals("123456", readMetadataHandle.getProperties().get(qn));
   }
@@ -233,7 +227,7 @@ public class DocumentMetadataHandleTest {
 
   // testing https://github.com/marklogic/java-client-api/issues/783
 //  @Test
-  @Ignore
+  @Disabled
   public void testStack20170725() throws IOException {
     XMLDocumentManager documentManager = Common.client.newXMLDocumentManager();
     Transaction transaction = Common.client.openTransaction();

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/EvalTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/EvalTest.java
@@ -15,40 +15,11 @@
  */
 package com.marklogic.client.test;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.Reader;
-import java.math.BigInteger;
-import java.util.Calendar;
-import java.util.GregorianCalendar;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.TimeZone;
-
-import javax.xml.bind.DatatypeConverter;
-import javax.xml.datatype.DatatypeConfigurationException;
-import javax.xml.datatype.DatatypeFactory;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.w3c.dom.Document;
-import org.xml.sax.SAXException;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.marklogic.client.DatabaseClient;
-import com.marklogic.client.DatabaseClientFactory;
-import com.marklogic.client.DatabaseClientFactory.Authentication;
 import com.marklogic.client.FailedRequestException;
 import com.marklogic.client.Transaction;
 import com.marklogic.client.admin.ExtensionLibrariesManager;
@@ -58,17 +29,30 @@ import com.marklogic.client.eval.EvalResult;
 import com.marklogic.client.eval.EvalResultIterator;
 import com.marklogic.client.eval.ServerEvaluationCall;
 import com.marklogic.client.impl.HandleAccessor;
-import com.marklogic.client.io.BytesHandle;
-import com.marklogic.client.io.DOMHandle;
-import com.marklogic.client.io.Format;
-import com.marklogic.client.io.InputStreamHandle;
-import com.marklogic.client.io.JacksonHandle;
-import com.marklogic.client.io.ReaderHandle;
-import com.marklogic.client.io.StringHandle;
+import com.marklogic.client.io.*;
 import com.marklogic.client.query.DeleteQueryDefinition;
 import com.marklogic.client.query.QueryManager;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
 
-import static org.junit.Assert.*;
+import javax.xml.bind.DatatypeConverter;
+import javax.xml.datatype.DatatypeConfigurationException;
+import javax.xml.datatype.DatatypeFactory;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.math.BigInteger;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.HashMap;
+import java.util.TimeZone;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 
 public class EvalTest {
@@ -76,7 +60,7 @@ public class EvalTest {
   private static ExtensionLibrariesManager libMgr;
   private static DatabaseClient adminClient = Common.connectAdmin();
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     libMgr = adminClient.newServerConfigManager().newExtensionLibrariesManager();
     Common.connectEval();
@@ -84,7 +68,7 @@ public class EvalTest {
     septFirst.set(2014, Calendar.SEPTEMBER, 1, 0, 0, 0);
     septFirst.set(Calendar.MILLISECOND, 0);
   }
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
   }
 
@@ -93,7 +77,7 @@ public class EvalTest {
     // javascript hello world and response determined by implicit StringHandle which registered with String.class
     ServerEvaluationCall query = Common.evalClient.newServerEval().javascript("'hello world'");
     String response = query.evalAs(String.class);
-    assertEquals("Return should be 'hello world'", "hello world", response);
+    assertEquals( "hello world", response);
 
     // xquery hello world with a variable and response explicit set to StringHandle
     query = Common.evalClient.newServerEval()
@@ -101,7 +85,7 @@ public class EvalTest {
         "'hello world from ' || $planet")
       .addVariable("planet", "Mars");
     StringHandle strResponse = query.eval(new StringHandle());
-    assertEquals("Return should be 'hello world from Mars'", "hello world from Mars", strResponse.get());
+    assertEquals( "hello world from Mars", strResponse.get());
   }
 
   @Test
@@ -177,22 +161,22 @@ public class EvalTest {
       .addVariable("myNull", (String) null);
 
     try (EvalResultIterator results = call.eval()) {
-      assertEquals("myString looks wrong", "Mars", results.next().getAs(String.class));
-      assertEquals("myArray looks wrong",
+      assertEquals( "Mars", results.next().getAs(String.class));
+      assertEquals(
         new ObjectMapper().readTree("[\"item1\",\"item2\"]"),
         results.next().getAs(JsonNode.class));
-      assertEquals("myObject looks wrong",
+      assertEquals(
         new ObjectMapper().readTree("{\"item1\":\"value1\"}"),
         results.next().getAs(JsonNode.class));
-      assertEquals("myBool looks wrong", true, results.next().getBoolean());
-      assertEquals("myInteger looks wrong", 123,
+      assertEquals( true, results.next().getBoolean());
+      assertEquals( 123,
         results.next().getNumber().intValue());
-      assertEquals("myDouble looks wrong", 1.1,
+      assertEquals( 1.1,
         results.next().getNumber().doubleValue(), .001);
       // the same format we sent in (from javax.xml.datatype.XMLGregorianCalendar.toString())
-      assertEquals("myDate looks wrong", "2014-09-01T00:00:00.000+02:00",
+      assertEquals( "2014-09-01T00:00:00.000+02:00",
         results.next().getString());
-      assertEquals("myNull looks wrong", null, results.next().getString());
+      assertEquals( null, results.next().getString());
     }
 
   }
@@ -204,26 +188,26 @@ public class EvalTest {
       .addVariable("myNull", (String) null);
 
     try (EvalResultIterator results = call.eval()) {
-       assertEquals("myNull looks wrong", null, results.next().getString());
+       assertEquals( null, results.next().getString());
     }
 
     try (EvalResultIterator results = call.eval()) {
-      assertEquals("myNull looks wrong", null, results.next().get(new StringHandle()).get());
+      assertEquals( null, results.next().get(new StringHandle()).get());
     }
 
     try (EvalResultIterator results = call.eval()) {
-      assertEquals("myNull looks wrong", null, results.next().get(new BytesHandle()).get());
+      assertEquals( null, results.next().get(new BytesHandle()).get());
     }
 
     try (EvalResultIterator results = call.eval()) {
       NullNode jsonNullNode = new ObjectMapper().createObjectNode().nullNode();
-      assertEquals("myNull looks wrong", jsonNullNode, results.next().get(new JacksonHandle()).get());
+      assertEquals( jsonNullNode, results.next().get(new JacksonHandle()).get());
     }
 
     try (EvalResultIterator results = call.eval()) {
       ReaderHandle valueReader = results.next().get(new ReaderHandle());
       String value = HandleAccessor.contentAsString(valueReader);
-      assertEquals("myNull looks wrong", "null", value);
+      assertEquals( "null", value);
     }
   }
 
@@ -272,144 +256,143 @@ public class EvalTest {
 
     try (EvalResultIterator results = call.eval()) {
       EvalResult result = results.next();
-      assertEquals("myString should = 'Mars'", "Mars", result.getAs(String.class));
-      assertEquals("myString should be Type.STRING", EvalResult.Type.STRING, result.getType());
-      assertEquals("myString should be Format.TEXT", Format.TEXT, result.getFormat());
+      assertEquals("Mars", result.getAs(String.class));
+      assertEquals( EvalResult.Type.STRING, result.getType());
+      assertEquals( Format.TEXT, result.getFormat());
       result = results.next();
-      assertEquals("myArray should = [\"item1\",\"item2\"]",
+      assertEquals(
         new ObjectMapper().readTree("[\"item1\",\"item2\"]"),
         result.getAs(JsonNode.class));
-      assertEquals("myArray should be Type.JSON", EvalResult.Type.JSON, result.getType());
-      assertEquals("myArray should be Format.JSON", Format.JSON, result.getFormat());
+      assertEquals( EvalResult.Type.JSON, result.getType());
+      assertEquals( Format.JSON, result.getFormat());
       result = results.next();
-      assertEquals("myObject should = {\"item1\":\"value1\"}",
+      assertEquals(
         new ObjectMapper().readTree("{\"item1\":\"value1\"}"),
         result.getAs(JsonNode.class));
-      assertEquals("myObject should be Type.JSON", EvalResult.Type.JSON, result.getType());
-      assertEquals("myObject should be Format.JSON", Format.JSON, result.getFormat());
+      assertEquals( EvalResult.Type.JSON, result.getType());
+      assertEquals( Format.JSON, result.getFormat());
       result = results.next();
-      assertEquals("myAnyUri looks wrong", "http://marklogic.com/a", result.getString());
-      assertEquals("myAnyUri should be Type.ANYURI", EvalResult.Type.ANYURI, result.getType());
-      assertEquals("myAnyUri should be Format.TEXT", Format.TEXT, result.getFormat());
+      assertEquals( "http://marklogic.com/a", result.getString());
+      assertEquals( EvalResult.Type.ANYURI, result.getType());
+      assertEquals( Format.TEXT, result.getFormat());
       result = results.next();
-      assertEquals("myBinary looks wrong", ",", result.getString());
-      assertEquals("myBinary should be Type.BINARY", EvalResult.Type.BINARY, result.getType());
-      assertEquals("myBinary should be Format.BINARY", Format.BINARY, result.getFormat());
+      assertEquals( ",", result.getString());
+      assertEquals( EvalResult.Type.BINARY, result.getType());
+      assertEquals( Format.BINARY, result.getFormat());
       result = results.next();
-      assertArrayEquals("myBase64Binary should = 1, 2, 3", new byte[] {1, 2, 3},
+      assertArrayEquals(new byte[] {1, 2, 3},
         DatatypeConverter.parseBase64Binary(result.getString()));
-      assertEquals("myBase64Binary should be Type.BASE64BINARY", EvalResult.Type.BASE64BINARY, result.getType());
-      assertEquals("myBase64Binary should be Format.TEXT", Format.TEXT, result.getFormat());
+      assertEquals( EvalResult.Type.BASE64BINARY, result.getType());
+      assertEquals( Format.TEXT, result.getFormat());
       result = results.next();
-      assertArrayEquals("myHexBinary should = 1, 2, 3", new byte[] {1, 2, 3},
+      assertArrayEquals(new byte[] {1, 2, 3},
         DatatypeConverter.parseHexBinary(result.getString()));
-      assertEquals("myHexBinary should be Type.HEXBINARY", EvalResult.Type.HEXBINARY, result.getType());
-      assertEquals("myHexBinary should be Format.TEXT", Format.TEXT, result.getFormat());
+      assertEquals( EvalResult.Type.HEXBINARY, result.getType());
+      assertEquals( Format.TEXT, result.getFormat());
       result = results.next();
-      assertEquals("myDuration should = P100D", "P100D", result.getString());
-      assertEquals("myDuration should be Type.DURATION", EvalResult.Type.DURATION, result.getType());
-      assertEquals("myDuration should be Format.TEXT", Format.TEXT, result.getFormat());
+      assertEquals("P100D", result.getString());
+      assertEquals( EvalResult.Type.DURATION, result.getType());
+      assertEquals( Format.TEXT, result.getFormat());
       result = results.next();
-      assertEquals("myQName doesn't look right", "myPrefix:a", result.getString());
-      assertEquals("myQName should be Type.QNAME", EvalResult.Type.QNAME, result.getType());
-      assertEquals("myQName should be Format.TEXT", Format.TEXT, result.getFormat());
+      assertEquals( "myPrefix:a", result.getString());
+      assertEquals( EvalResult.Type.QNAME, result.getType());
+      assertEquals( Format.TEXT, result.getFormat());
       result = results.next();
-      assertEquals("myDocument doesn't look right",
+      assertEquals(
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
           "<search:options xmlns:search=\"http://marklogic.com/appservices/search\"/>",
         result.getString());
-      assertEquals("myDocument should be Type.XML", EvalResult.Type.XML, result.getType());
-      assertEquals("myDocument should be Format.XML", Format.XML, result.getFormat());
+      assertEquals( EvalResult.Type.XML, result.getType());
+      assertEquals( Format.XML, result.getFormat());
       result = results.next();
-      assertEquals("myAttribute looks wrong", "a", result.getString());
-      assertEquals("myAttribute should be Type.ATTRIBUTE", EvalResult.Type.ATTRIBUTE, result.getType());
-      assertEquals("myAttribute should be Format.TEXT", Format.TEXT, result.getFormat());
+      assertEquals( "a", result.getString());
+      assertEquals( EvalResult.Type.ATTRIBUTE, result.getType());
+      assertEquals( Format.TEXT, result.getFormat());
       result = results.next();
-      assertEquals("myComment should = <!--a-->", "<!--a-->", result.getString());
-      assertEquals("myComment should be Type.COMMENT", EvalResult.Type.COMMENT, result.getType());
-      assertEquals("myComment should be Format.TEXT", Format.TEXT, result.getFormat());
+      assertEquals("<!--a-->", result.getString());
+      assertEquals( EvalResult.Type.COMMENT, result.getType());
+      assertEquals( Format.TEXT, result.getFormat());
       result = results.next();
-      assertEquals("myElement looks wrong", "<a a=\"a\"/>", result.getString());
-      assertEquals("myElement should be Type.XML", EvalResult.Type.XML, result.getType());
-      assertEquals("myElement should be Format.XML", Format.XML, result.getFormat());
+      assertEquals( "<a a=\"a\"/>", result.getString());
+      assertEquals( EvalResult.Type.XML, result.getType());
+      assertEquals( Format.XML, result.getFormat());
       result = results.next();
-      assertEquals("myProcessingInstruction should = <?a?>", "<?a?>", result.getString());
-      assertEquals("myProcessingInstruction should be Type.PROCESSINGINSTRUCTION",
+      assertEquals("<?a?>", result.getString());
+      assertEquals(
         EvalResult.Type.PROCESSINGINSTRUCTION, result.getType());
-      assertEquals("myProcessingInstruction should be Format.TEXT", Format.TEXT, result.getFormat());
+      assertEquals( Format.TEXT, result.getFormat());
       result = results.next();
-      assertEquals("myText should = a", "a", result.getString());
-      assertEquals("myText should be Type.TEXTNODE", EvalResult.Type.TEXTNODE, result.getType());
-      assertEquals("myText should be Format.TEXT", Format.TEXT, result.getFormat());
+      assertEquals("a", result.getString());
+      assertEquals( EvalResult.Type.TEXTNODE, result.getType());
+      assertEquals( Format.TEXT, result.getFormat());
       result = results.next();
-      assertEquals("myBool should = true", true, result.getBoolean());
-      assertEquals("myBool should be Type.BOOLEAN", EvalResult.Type.BOOLEAN, result.getType());
-      assertEquals("myBool should be Format.TEXT", Format.TEXT, result.getFormat());
+      assertEquals(true, result.getBoolean());
+      assertEquals( EvalResult.Type.BOOLEAN, result.getType());
+      assertEquals( Format.TEXT, result.getFormat());
       result = results.next();
-      assertEquals("myInteger should = 1234567890123456789l", 1234567890123456789l,
+      assertEquals(1234567890123456789l,
         result.getNumber().longValue());
-      assertEquals("myInteger should be Type.INTEGER", EvalResult.Type.INTEGER, result.getType());
-      assertEquals("myInteger should be Format.TEXT", Format.TEXT, result.getFormat());
+      assertEquals( EvalResult.Type.INTEGER, result.getType());
+      assertEquals( Format.TEXT, result.getFormat());
       result = results.next();
-      assertEquals("myBigInteger looks wrong", new BigInteger("123456789012345678901234567890"),
+      assertEquals( new BigInteger("123456789012345678901234567890"),
         new BigInteger(result.getString()));
-      assertEquals("myBigInteger should be Type.STRING", EvalResult.Type.STRING, result.getType());
-      assertEquals("myBigInteger should be Format.TEXT", Format.TEXT, result.getFormat());
+      assertEquals( EvalResult.Type.STRING, result.getType());
+      assertEquals( Format.TEXT, result.getFormat());
       result = results.next();
-      assertEquals("myDecimal looks wrong", 1111111111111111111.9,
+      assertEquals( 1111111111111111111.9,
         result.getNumber().doubleValue(), .001);
-      assertEquals("myDecimal should be Type.DECIMAL", EvalResult.Type.DECIMAL, result.getType());
-      assertEquals("myDecimal should be Format.TEXT", Format.TEXT, result.getFormat());
+      assertEquals( EvalResult.Type.DECIMAL, result.getType());
+      assertEquals( Format.TEXT, result.getFormat());
       result = results.next();
-      assertEquals("myDouble looks wrong", 1.11111111111111E19,
+      assertEquals( 1.11111111111111E19,
         result.getNumber().doubleValue(), .001);
-      assertEquals("myDouble should be Type.DOUBLE", EvalResult.Type.DOUBLE, result.getType());
-      assertEquals("myDouble should be Format.TEXT", Format.TEXT, result.getFormat());
+      assertEquals( EvalResult.Type.DOUBLE, result.getType());
+      assertEquals( Format.TEXT, result.getFormat());
       result = results.next();
-      assertEquals("myFloat looks wrong", 1.1, result.getNumber().floatValue(), .001);
-      assertEquals("myFloat should be Type.FLOAT", EvalResult.Type.FLOAT, result.getType());
-      assertEquals("myFloat should be Format.TEXT", Format.TEXT, result.getFormat());
+      assertEquals( 1.1, result.getNumber().floatValue(), .001);
+      assertEquals( EvalResult.Type.FLOAT, result.getType());
+      assertEquals( Format.TEXT, result.getFormat());
       result = results.next();
-      assertEquals("myGDay looks wrong", "---01", result.getString());
-      assertEquals("myGDay should be Type.GDAY", EvalResult.Type.GDAY, result.getType());
-      assertEquals("myGDay should be Format.TEXT", Format.TEXT, result.getFormat());
+      assertEquals( "---01", result.getString());
+      assertEquals( EvalResult.Type.GDAY, result.getType());
+      assertEquals( Format.TEXT, result.getFormat());
       result = results.next();
-      assertEquals("myGMonth looks wrong", "--01", result.getString());
-      assertEquals("myGMonth should be Type.GMONTH", EvalResult.Type.GMONTH, result.getType());
-      assertEquals("myGMonth should be Format.TEXT", Format.TEXT, result.getFormat());
+      assertEquals( "--01", result.getString());
+      assertEquals( EvalResult.Type.GMONTH, result.getType());
+      assertEquals( Format.TEXT, result.getFormat());
       result = results.next();
-      assertEquals("myGMonthDay looks wrong", "--01-01", result.getString());
-      assertEquals("myGMonthDay should be Type.GMONTHDAY", EvalResult.Type.GMONTHDAY, result.getType());
-      assertEquals("myGMonthDay should be Format.TEXT", Format.TEXT, result.getFormat());
+      assertEquals( "--01-01", result.getString());
+      assertEquals( EvalResult.Type.GMONTHDAY, result.getType());
+      assertEquals( Format.TEXT, result.getFormat());
       result = results.next();
-      assertEquals("myGYear looks wrong", "1901", result.getString());
-      assertEquals("myGYear should be Type.GYEAR", EvalResult.Type.GYEAR, result.getType());
-      assertEquals("myGYear should be Format.TEXT", Format.TEXT, result.getFormat());
+      assertEquals( "1901", result.getString());
+      assertEquals( EvalResult.Type.GYEAR, result.getType());
+      assertEquals( Format.TEXT, result.getFormat());
       result = results.next();
-      assertEquals("myGYearMonth looks wrong", "1901-01", result.getString());
-      assertEquals("myGYearMonth should be Type.GYEARMONTH", EvalResult.Type.GYEARMONTH, result.getType());
-      assertEquals("myGYearMonth should be Format.TEXT", Format.TEXT, result.getFormat());
+      assertEquals( "1901-01", result.getString());
+      assertEquals( EvalResult.Type.GYEARMONTH, result.getType());
+      assertEquals( Format.TEXT, result.getFormat());
       result = results.next();
       // the lexical format MarkLogic uses to serialize a date
-      assertEquals("myDate should = '2014-09-01", "2014-09-01", result.getString());
-      assertEquals("myDate should be Type.DATE", EvalResult.Type.DATE, result.getType());
-      assertEquals("myDate should be Format.TEXT", Format.TEXT, result.getFormat());
+      assertEquals("2014-09-01", result.getString());
+      assertEquals( EvalResult.Type.DATE, result.getType());
+      assertEquals( Format.TEXT, result.getFormat());
       result = results.next();
       // the lexical format MarkLogic uses to serialize a dateTime
-      assertEquals("myDateTime should = '2014-09-01T00:00:00+02:00'", "2014-09-01T00:00:00+02:00",
-        result.getString());
-      assertEquals("myDateTime should be Type.DATETIME", EvalResult.Type.DATETIME, result.getType());
-      assertEquals("myDateTime should be Format.TEXT", Format.TEXT, result.getFormat());
+      assertEquals("2014-09-01T00:00:00+02:00", result.getString());
+      assertEquals( EvalResult.Type.DATETIME, result.getType());
+      assertEquals( Format.TEXT, result.getFormat());
       result = results.next();
-      assertEquals("myTime looks wrong", "00:01:01", result.getString());
-      assertEquals("myTime should be Type.TIME", EvalResult.Type.TIME, result.getType());
-      assertEquals("myTime should be Format.TEXT", Format.TEXT, result.getFormat());
+      assertEquals( "00:01:01", result.getString());
+      assertEquals( EvalResult.Type.TIME, result.getType());
+      assertEquals( Format.TEXT, result.getFormat());
       result = results.next();
-      assertEquals("myCtsQuery should be Type.OTHER", EvalResult.Type.OTHER, result.getType());
-      assertEquals("myCtsQuery should be Format.TEXT", Format.TEXT, result.getFormat());
+      assertEquals( EvalResult.Type.OTHER, result.getType());
+      assertEquals( Format.TEXT, result.getFormat());
       result = results.next();
-      assertEquals("myFunction should be Type.OTHER", EvalResult.Type.OTHER, result.getType());
-      assertEquals("myFunction should be Format.TEXT", Format.TEXT, result.getFormat());
+      assertEquals( EvalResult.Type.OTHER, result.getType());
+      assertEquals( Format.TEXT, result.getFormat());
     }
   }
 
@@ -447,11 +430,11 @@ public class EvalTest {
       String query = "(fn:count(xdmp:directory('" + directory + "')))";
       ServerEvaluationCall evl= client.newServerEval().xquery(query);
       try (EvalResultIterator evr = evl.eval()) {
-        assertEquals("Count of documents outside of the transaction", 0, evr.next().getNumber().intValue());
+        assertEquals( 0, evr.next().getNumber().intValue());
       }
       evl = client.newServerEval().xquery(query).transaction(t1);
       try (EvalResultIterator evr = evl.eval()) {
-        assertEquals("Count of documents outside of the transaction", 2, evr.next().getNumber().intValue());
+        assertEquals( 2, evr.next().getNumber().intValue());
       }
     } catch(Exception e) {
       System.out.println(e.getMessage());
@@ -498,34 +481,32 @@ public class EvalTest {
     assertEquals(expectedOutput.toString(), strVal);
   }
 
-  @Test(expected = RuntimeException.class)
-  public void test_issue874() {
-    try (EvalResultIterator iterator =
-             new EvalResultIterator() {
+	@Test
+	public void test_issue874() {
+		assertThrows(RuntimeException.class, () -> {
+			try (EvalResultIterator iterator = new EvalResultIterator() {
+				@Override
+				public void close() throws RuntimeException {
+					throw new RuntimeException("test close() from try-with-resources");
+				}
 
-              @Override
-              public void close() throws RuntimeException {
-                throw new RuntimeException("test close() from try-with-resources");
-              }
+				public java.util.Iterator<com.marklogic.client.eval.EvalResult> iterator() {
+					return this;
+				}
 
-              public java.util.Iterator<com.marklogic.client.eval.EvalResult> iterator() {
-                return this;
-              }
+				@Override
+				public boolean hasNext() {
+					return false;
+				}
 
-              @Override
-              public boolean hasNext() {
-                return false;
-              }
-
-              @Override
-              public EvalResult next() {
-                throw new UnsupportedOperationException();
-              }
-            }
-    ) {
-      assertFalse(iterator.hasNext());
-    }
-    fail("Should not get here. Close method should have been invoked, throwing an exception");
-  }
+				@Override
+				public EvalResult next() {
+					throw new UnsupportedOperationException();
+				}
+			}) {
+				iterator.hasNext();
+			}
+		});
+	}
 
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/ExtensionLibrariesTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/ExtensionLibrariesTest.java
@@ -15,14 +15,6 @@
  */
 package com.marklogic.client.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.io.File;
-
-import org.junit.Test;
-
 import com.marklogic.client.FailedRequestException;
 import com.marklogic.client.ForbiddenUserException;
 import com.marklogic.client.ResourceNotFoundException;
@@ -32,6 +24,11 @@ import com.marklogic.client.admin.ExtensionLibraryDescriptor;
 import com.marklogic.client.io.FileHandle;
 import com.marklogic.client.io.Format;
 import com.marklogic.client.io.StringHandle;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ExtensionLibrariesTest {
 
@@ -52,7 +49,7 @@ public class ExtensionLibrariesTest {
     String xqueryModuleAsString = libsMgr.read(
       "/ext/my/path/to/my/module.xqy", new StringHandle()).get();
 
-    assertTrue("module read and read back", xqueryModuleAsString.startsWith("xquery version \"1.0-ml\";"));
+    assertTrue( xqueryModuleAsString.startsWith("xquery version \"1.0-ml\";"));
 
     // rewrite XQuery file to the modules database with permissions
     ExtensionLibraryDescriptor moduleDescriptor = new ExtensionLibraryDescriptor();
@@ -64,7 +61,7 @@ public class ExtensionLibrariesTest {
 
     // get the list of descriptors
     ExtensionLibraryDescriptor[] descriptors = libsMgr.list("/ext/my/path/to/my/");
-    assertEquals("number of modules installed", 1, descriptors.length);
+    assertEquals( 1, descriptors.length);
 
     for (ExtensionLibraryDescriptor descriptor : descriptors) {
       assertEquals(descriptor.getPath(), "/ext/my/path/to/my/module.xqy");
@@ -82,7 +79,7 @@ public class ExtensionLibrariesTest {
     }
 
     descriptors = libsMgr.list("/ext/my/path/to/my/");
-    assertEquals("number of modules installed", 0, descriptors.length);
+    assertEquals( 0, descriptors.length);
 
   }
 

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/FailedRequestTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/FailedRequestTest.java
@@ -16,25 +16,20 @@
 package com.marklogic.client.test;
 
 import com.marklogic.client.*;
+import com.marklogic.client.admin.QueryOptionsManager;
 import com.marklogic.client.document.XMLDocumentManager;
 import com.marklogic.client.io.Format;
-import org.junit.Test;
-import org.junit.Ignore;
+import com.marklogic.client.io.StringHandle;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.marklogic.client.DatabaseClientFactory.DigestAuthContext;
-import com.marklogic.client.admin.QueryOptionsManager;
-import com.marklogic.client.admin.ServerConfigurationManager;
-import com.marklogic.client.io.StringHandle;
-
-import java.io.StringWriter;
 
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
+import java.io.StringWriter;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class FailedRequestTest {
   private static final Logger logger = LoggerFactory.getLogger(FailedRequestTest.class);
@@ -49,7 +44,7 @@ public class FailedRequestTest {
 
     try {
       mgr.writeOptions("testempty", new StringHandle("<options xmlns=\"http://marklogic.com/appservices/search\"/>"));
-//      assertFalse("expected options write to fail because forbidden", true);
+//      assertFalse( true);
     } catch (ForbiddenUserException e) {
       assertEquals(
           "Local message: User is not allowed to write /config/query. Server Message: You do not have permission to this method and URL.",
@@ -88,7 +83,7 @@ public class FailedRequestTest {
     logger.debug(xml.toString());
     try {
       mgr.writeOptions("testempty", new StringHandle(xml.toString()));
-//      assertFalse("expected options write to fail because empty", true);
+//      assertFalse( true);
     } catch (FailedRequestException e) {
       assertEquals(
         "Local message: /config/query write failed: Bad Request. Server Message: RESTAPI-INVALIDCONTENT: (err:FOER0000) Invalid content: Operation results in invalid Options: Operator or constraint name \"blah\" is used more than once (must be unique).",

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/GeospatialRegionQueriesTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/GeospatialRegionQueriesTest.java
@@ -15,36 +15,30 @@
  */
 package com.marklogic.client.test;
 
-import static org.junit.Assert.assertEquals;
-
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-
 import com.marklogic.client.admin.QueryOptionsManager;
 import com.marklogic.client.document.DocumentWriteSet;
 import com.marklogic.client.document.XMLDocumentManager;
 import com.marklogic.client.io.DOMHandle;
 import com.marklogic.client.io.SearchHandle;
 import com.marklogic.client.io.StringHandle;
-import com.marklogic.client.query.MatchDocumentSummary;
-import com.marklogic.client.query.QueryManager;
-import com.marklogic.client.query.RawCombinedQueryDefinition;
-import com.marklogic.client.query.StructuredQueryBuilder;
+import com.marklogic.client.query.*;
 import com.marklogic.client.query.StructuredQueryBuilder.CoordinateSystem;
 import com.marklogic.client.query.StructuredQueryBuilder.GeospatialOperator;
-import com.marklogic.client.query.StructuredQueryDefinition;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class GeospatialRegionQueriesTest {
 
-  @AfterClass
+  @AfterAll
   public static void teardown() {
     deleteEnvironment();
   }
@@ -57,7 +51,7 @@ public class GeospatialRegionQueriesTest {
     Common.propertyWait();
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() {
     Common.connect();
     Common.connectAdmin();
@@ -153,7 +147,7 @@ public class GeospatialRegionQueriesTest {
     Common.propertyWait();
   }
 
-  @Ignore
+  @Disabled
   public void testGeospatialRegionQuery() {
     QueryManager queryMgr = Common.client.newQueryManager();
     StructuredQueryBuilder qb = new StructuredQueryBuilder();
@@ -169,7 +163,7 @@ public class GeospatialRegionQueriesTest {
     }
   }
 
-  @Ignore
+  @Disabled
   public void testFloatPrecision() {
     QueryManager queryMgr = Common.client.newQueryManager();
     StructuredQueryBuilder qb = new StructuredQueryBuilder();
@@ -184,7 +178,7 @@ public class GeospatialRegionQueriesTest {
     assertEquals(2, summaries.length);
   }
 
-  @Ignore
+  @Disabled
   public void testDoublePrecision() {
     QueryManager queryMgr = Common.client.newQueryManager();
     StructuredQueryBuilder qb = new StructuredQueryBuilder();
@@ -199,7 +193,7 @@ public class GeospatialRegionQueriesTest {
     assertEquals(1, summaries.length);
   }
 
-  @Ignore
+  @Disabled
   public void testGeospatialRegionDoubleQuery() {
     String options = "<options xmlns=\"http://marklogic.com/appservices/search\">"
                    + "    <search-option>filtered</search-option>"
@@ -240,7 +234,7 @@ public class GeospatialRegionQueriesTest {
     optionsMgr.deleteOptions("geodoubleoptions");
   }
 
-  @Ignore
+  @Disabled
   public void testFloatPrecisionCoordinateSystem() {
     QueryManager queryMgr = Common.client.newQueryManager();
     StructuredQueryBuilder qb = new StructuredQueryBuilder();
@@ -255,7 +249,7 @@ public class GeospatialRegionQueriesTest {
     assertEquals(2, summaries.length);
   }
 
-  @Ignore
+  @Disabled
   public void testDoublePrecisionCoordinateSystem() {
     QueryManager queryMgr = Common.client.newQueryManager();
     StructuredQueryBuilder qb = new StructuredQueryBuilder();
@@ -270,7 +264,7 @@ public class GeospatialRegionQueriesTest {
     assertEquals(1, summaries.length);
   }
 
-  @Ignore
+  @Disabled
   public void testGeospatialRegionQueryConstraint() {
     QueryManager queryMgr = Common.client.newQueryManager();
     StructuredQueryBuilder qb = queryMgr.newStructuredQueryBuilder();
@@ -300,7 +294,7 @@ public class GeospatialRegionQueriesTest {
     }
   }
 
-  @Ignore
+  @Disabled
   public void testGeospatialRegionQueryOptionsConstraint() {
     String options = "<options xmlns=\"http://marklogic.com/appservices/search\">"
                    + "  <constraint name='geoo'>"

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/GraphsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/GraphsTest.java
@@ -15,37 +15,27 @@
  */
 package com.marklogic.client.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.util.Iterator;
-
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
-import com.marklogic.client.DatabaseClient;
-import com.marklogic.client.DatabaseClientFactory;
-import com.marklogic.client.DatabaseClientFactory.DigestAuthContext;
-import com.marklogic.client.ForbiddenUserException;
-import com.marklogic.client.ResourceNotFoundException;
-import com.marklogic.client.Transaction;
+import com.marklogic.client.*;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.semantics.GraphManager;
 import com.marklogic.client.semantics.RDFMimeTypes;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Iterator;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class GraphsTest {
   private static GraphManager gmgr;
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     Common.connect();
     gmgr = Common.client.newGraphManager();
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     DatabaseClientFactory.getHandleRegistry().register(StringHandle.newFactory());
   }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/HandleAccessorTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/HandleAccessorTest.java
@@ -15,26 +15,17 @@
  */
 package com.marklogic.client.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import com.marklogic.client.impl.HandleAccessor;
+import com.marklogic.client.io.*;
+import org.junit.jupiter.api.Test;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.StringReader;
+import java.io.*;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.Charset;
 
-import org.junit.Test;
-
-import com.marklogic.client.impl.HandleAccessor;
-import com.marklogic.client.io.BytesHandle;
-import com.marklogic.client.io.FileHandle;
-import com.marklogic.client.io.InputStreamHandle;
-import com.marklogic.client.io.ReaderHandle;
-import com.marklogic.client.io.StringHandle;
-import java.io.InputStream;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 public class HandleAccessorTest {
   public static boolean fileInputStreamWasClosed;
 
@@ -44,16 +35,16 @@ public class HandleAccessorTest {
     // charset issues
     String hola = "¡Hola!";
     System.out.println("Default Java Charset: " + Charset.defaultCharset());
-    assertEquals("String content mismatch", hola,
+    assertEquals( hola,
       HandleAccessor.contentAsString(new StringHandle(hola)));
-    assertEquals("byte[] content mismatch", hola,
+    assertEquals(hola,
       HandleAccessor.contentAsString(new BytesHandle(hola.getBytes("UTF-8"))));
     URL filePath = this.getClass().getClassLoader().getResource("hola.txt");
-    assertEquals("Reader content mismatch", hola,
+    assertEquals( hola,
       HandleAccessor.contentAsString(new ReaderHandle(new StringReader(hola))));
-    assertEquals("File content mismatch", hola,
+    assertEquals( hola,
       HandleAccessor.contentAsString(new FileHandle(new File(filePath.toURI()))));
-    assertEquals("InputStream content mismatch", hola,
+    assertEquals( hola,
       HandleAccessor.contentAsString(new InputStreamHandle(filePath.openStream())));
 
     InputStream fileInputStream = new FileInputStream(new File(filePath.toURI())) {
@@ -63,7 +54,7 @@ public class HandleAccessorTest {
           HandleAccessorTest.fileInputStreamWasClosed = true;
       }
     };
-    assertEquals("InputStream content mismatch", hola,
+    assertEquals( hola,
       HandleAccessor.contentAsString(new InputStreamHandle(fileInputStream)));
     assertTrue(this.fileInputStreamWasClosed);
   }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/InvalidUserTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/InvalidUserTest.java
@@ -15,16 +15,13 @@
  */
 package com.marklogic.client.test;
 
-import static org.junit.Assert.assertEquals;
-
-import org.junit.Test;
-
 import com.marklogic.client.DatabaseClient;
-import com.marklogic.client.DatabaseClientFactory;
 import com.marklogic.client.FailedRequestException;
-import com.marklogic.client.DatabaseClientFactory.DigestAuthContext;
 import com.marklogic.client.document.TextDocumentManager;
 import com.marklogic.client.io.StringHandle;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class InvalidUserTest {
   @Test

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/JAXBHandleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/JAXBHandleTest.java
@@ -15,32 +15,29 @@
  */
 package com.marklogic.client.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
 import com.marklogic.client.document.XMLDocumentManager;
 import com.marklogic.client.io.JAXBHandle;
 import com.marklogic.client.test.util.Referred;
 import com.marklogic.client.test.util.Refers;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 public class JAXBHandleTest {
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     Common.connect();
   }
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
   }
 
@@ -73,14 +70,14 @@ public class JAXBHandleTest {
     docMgr.write(docId, objectHandle.with(refers));
 
     Refers refers2 = (Refers) docMgr.read(docId, objectHandle).get();
-    assertTrue("Failed to read JAXB root", refers2 != null);
-    assertEquals("JAXB document with different root", refers.name, refers2.name);
-    assertTrue("Failed to read JAXB child", refers2.child != null);
-    assertEquals("JAXB document with different child", refers.child.name, refers2.child.name);
-    assertTrue("Failed to read JAXB map", refers2.map != null);
-    assertEquals("JAXB document with different map", refers.map.size(), refers2.map.size());
-    assertTrue("Failed to read JAXB list", refers2.list != null);
-    assertEquals("JAXB document with different list", refers.list.size(), refers2.list.size());
+    assertTrue( refers2 != null);
+    assertEquals( refers.name, refers2.name);
+    assertTrue( refers2.child != null);
+    assertEquals( refers.child.name, refers2.child.name);
+    assertTrue( refers2.map != null);
+    assertEquals( refers.map.size(), refers2.map.size());
+    assertTrue( refers2.list != null);
+    assertEquals( refers.list.size(), refers2.list.size());
 
     // Again with a type token -- useful for convenience and strong typing
     JAXBHandle<Refers> objectHandle2 = new JAXBHandle<>(context, Refers.class);
@@ -88,13 +85,13 @@ public class JAXBHandleTest {
     docMgr.write(docId, objectHandle2.with(refers));
 
     refers2 = docMgr.read(docId, objectHandle2).get();
-    assertTrue("Failed to read JAXB root", refers2 != null);
-    assertEquals("JAXB document with different root", refers.name, refers2.name);
-    assertTrue("Failed to read JAXB child", refers2.child != null);
-    assertEquals("JAXB document with different child", refers.child.name, refers2.child.name);
-    assertTrue("Failed to read JAXB map", refers2.map != null);
-    assertEquals("JAXB document with different map", refers.map.size(), refers2.map.size());
-    assertTrue("Failed to read JAXB list", refers2.list != null);
-    assertEquals("JAXB document with different list", refers.list.size(), refers2.list.size());
+    assertTrue( refers2 != null);
+    assertEquals( refers.name, refers2.name);
+    assertTrue( refers2.child != null);
+    assertEquals( refers.child.name, refers2.child.name);
+    assertTrue( refers2.map != null);
+    assertEquals( refers.map.size(), refers2.map.size());
+    assertTrue( refers2.list != null);
+    assertEquals( refers.list.size(), refers2.list.size());
   }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/JSONDocumentTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/JSONDocumentTest.java
@@ -15,42 +15,35 @@
  */
 package com.marklogic.client.test;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.Reader;
-import java.nio.charset.Charset;
-
-import com.marklogic.client.admin.ExtensionLibrariesManager;
-import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.xml.sax.SAXException;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.marklogic.client.admin.ExtensionLibrariesManager;
 import com.marklogic.client.document.DocumentManager.Metadata;
 import com.marklogic.client.document.DocumentMetadataPatchBuilder.Cardinality;
 import com.marklogic.client.document.DocumentPatchBuilder;
 import com.marklogic.client.document.DocumentPatchBuilder.PathLanguage;
 import com.marklogic.client.document.DocumentPatchBuilder.Position;
 import com.marklogic.client.document.JSONDocumentManager;
-import com.marklogic.client.io.BytesHandle;
+import com.marklogic.client.io.*;
 import com.marklogic.client.io.DocumentMetadataHandle.Capability;
-import com.marklogic.client.io.FileHandle;
-import com.marklogic.client.io.Format;
-import com.marklogic.client.io.InputStreamHandle;
-import com.marklogic.client.io.ReaderHandle;
-import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.io.marker.DocumentPatchHandle;
+import org.custommonkey.xmlunit.exceptions.XpathException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xml.sax.SAXException;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.charset.Charset;
+
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class JSONDocumentTest {
 
@@ -73,7 +66,7 @@ public class JSONDocumentTest {
   static final private Logger logger = LoggerFactory
     .getLogger(JSONDocumentTest.class);
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     Common.connectAdmin();
     // get a manager
@@ -87,7 +80,7 @@ public class JSONDocumentTest {
     Common.connect();
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     libsMgr.delete("/ext/my-lib.xqy");
   }
@@ -103,31 +96,31 @@ public class JSONDocumentTest {
     docMgr.write(docId, new StringHandle().with(content));
 
     String docText = docMgr.read(docId, new StringHandle()).get();
-    assertNotNull("Read null string for JSON content", docText);
+    assertNotNull( docText);
     JsonNode readNode = mapper.readTree(docText);
-    assertTrue("Failed to read JSON document as String",
+    assertTrue(
       sourceNode.equals(readNode));
 
     BytesHandle bytesHandle = new BytesHandle();
     docMgr.read(docId, bytesHandle);
     readNode = mapper.readTree(bytesHandle.get());
-    assertTrue("JSON document mismatch reading bytes",
+    assertTrue(
       sourceNode.equals(readNode));
 
     InputStreamHandle inputStreamHandle = new InputStreamHandle();
     docMgr.read(docId, inputStreamHandle);
     readNode = mapper.readTree(inputStreamHandle.get());
-    assertTrue("JSON document mismatch reading input stream",
+    assertTrue(
       sourceNode.equals(readNode));
 
     Reader reader = docMgr.read(docId, new ReaderHandle()).get();
     readNode = mapper.readTree(reader);
-    assertTrue("JSON document mismatch with reader",
+    assertTrue(
       sourceNode.equals(readNode));
 
     File file = docMgr.read(docId, new FileHandle()).get();
     readNode = mapper.readTree(file);
-    assertTrue("JSON document mismatch with file",
+    assertTrue(
       sourceNode.equals(readNode));
   }
 
@@ -205,14 +198,14 @@ public class JSONDocumentTest {
     expectedNode.put("numberKey3" , 18);
 
     String docText = docMgr.read(docId, new StringHandle()).get();
-    assertNotNull("Read null string for patched JSON content", docText);
+    assertNotNull( docText);
 
     logger.debug("Before1:" + content);
     logger.debug("After1:"+docText);
     logger.debug("Expected1:" + mapper.writeValueAsString(expectedNode));
 
     JsonNode readNode = mapper.readTree(docText);
-    assertTrue("Patched JSON document without expected result",
+    assertTrue(
       expectedNode.equals(readNode));
 
   }
@@ -261,10 +254,10 @@ public class JSONDocumentTest {
       new StringHandle().withFormat(Format.XML)).get();
 
     logger.debug("After2:" + metadata);
-    assertTrue("Could not read document metadata after write default",
+    assertTrue(
       metadata != null);
 
-    assertTrue("Could not read document metadata after write default", metadata != null);
+    assertTrue( metadata != null);
     assertXpathEvaluatesTo("3","count(/*[local-name()='metadata']/*[local-name()='collections']/*[local-name()='collection'])",metadata);
     assertXpathEvaluatesTo("1","count(/*[local-name()='metadata']/*[local-name()='collections']/*[local-name()='collection' and string(.)='collection4after'])",metadata);
     assertXpathEvaluatesTo("1","count(/*[local-name()='metadata']/*[local-name()='permissions']/*[local-name()='permission' and string(*[local-name()='role-name'])='app-user']/*[local-name()='capability'])",metadata);
@@ -354,14 +347,14 @@ public class JSONDocumentTest {
 
     String docText = docMgr.read(docId, new StringHandle()).get();
 
-    assertNotNull("Read null string for patched JSON content", docText);
+    assertNotNull( docText);
     JsonNode readNode = mapper.readTree(docText);
 
     logger.debug("Before3:" + content);
     logger.debug("After3:"+docText);
     logger.debug("Expected3:" + mapper.writeValueAsString(expectedNode));
 
-    assertTrue("Patched JSON document without expected result",
+    assertTrue(
       expectedNode.equals(readNode));
 
     docMgr.delete(docId);
@@ -418,10 +411,10 @@ public class JSONDocumentTest {
     logger.debug("After4: "+ jsonMetadata);
 
 
-    assertTrue("Could not read document metadata after write default",
+    assertTrue(
       metadata != null);
 
-    assertTrue("Could not read document metadata after write default", metadata != null);
+    assertTrue( metadata != null);
     assertXpathEvaluatesTo("4","count(/*[local-name()='metadata']/*[local-name()='collections']/*[local-name()='collection'])",metadata);
     assertXpathEvaluatesTo("1","count(/*[local-name()='metadata']/*[local-name()='collections']/*[local-name()='collection' and string(.)='collection4after'])",metadata);
     assertXpathEvaluatesTo("1","count(/*[local-name()='metadata']/*[local-name()='permissions']/*[local-name()='permission' and string(*[local-name()='role-name'])='app-user']/*[local-name()='capability'])",metadata);

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/JacksonDatabindTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/JacksonDatabindTest.java
@@ -16,23 +16,15 @@
 package com.marklogic.client.test;
 
 
-import java.io.BufferedReader;
-import java.io.IOException;
-
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.geonames.Toponym;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
-import com.fasterxml.jackson.dataformat.csv.CsvSchema;
 import com.fasterxml.jackson.dataformat.csv.CsvMapper;
+import com.fasterxml.jackson.dataformat.csv.CsvSchema;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.DatabaseClientFactory;
@@ -45,6 +37,13 @@ import com.marklogic.client.io.JacksonDatabindHandle;
 import com.marklogic.client.query.DeleteQueryDefinition;
 import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.test.BulkReadWriteTest.CityWriter;
+import org.geonames.Toponym;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
 
 public class JacksonDatabindTest {
   private static final String CITIES_FILE = "cities_above_300K.txt";
@@ -52,7 +51,7 @@ public class JacksonDatabindTest {
   private static final String DIRECTORY = "/databindTest/";
   private static DatabaseClient client;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     // demonstrate our ability to set advanced configuration on a mapper
     ObjectMapper mapper = new ObjectMapper();
@@ -68,7 +67,7 @@ public class JacksonDatabindTest {
     client = Common.newClient();
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     cleanUp();
   }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/JacksonHandleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/JacksonHandleTest.java
@@ -15,15 +15,6 @@
  */
 package com.marklogic.client.test;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import java.io.IOException;
-
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -33,13 +24,21 @@ import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.query.QueryDefinition;
 import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.query.StructuredQueryBuilder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class JacksonHandleTest {
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     Common.connect();
   }
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
   }
 
@@ -76,9 +75,8 @@ public class JacksonHandleTest {
 
     // access the document content
     JsonNode readRoot = readHandle.get();
-    assertNotNull("Wrote null Jackson JSON structure", readRoot);
-    assertTrue("Jackson JSON structures not equal",
-      readRoot.equals(writeRoot));
+    assertNotNull(readRoot);
+    assertTrue(readRoot.equals(writeRoot));
 
     // delete the document
     docMgr.delete(docId);

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/JacksonStreamTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/JacksonStreamTest.java
@@ -15,19 +15,6 @@
  */
 package com.marklogic.client.test;
 
-import static org.junit.Assert.*;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.Reader;
-import java.io.StringWriter;
-import java.util.ArrayList;
-
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
@@ -38,27 +25,38 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marklogic.client.document.JSONDocumentManager;
 import com.marklogic.client.io.JacksonParserHandle;
 import com.marklogic.client.io.ReaderHandle;
-import com.marklogic.client.test.Common;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.io.StringWriter;
+import java.util.ArrayList;
 import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class JacksonStreamTest {
   private static final String ORDER_FILE = "sampleOrder.json";
   private static final String ORDER_URI = "sampleOrder.json";
   private static JSONDocumentManager docMgr;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     Common.connect();
     docMgr = Common.client.newJSONDocumentManager();
 
   }
 
-  @Before
+  @BeforeEach
   public void beforeTest() {
     docMgr.write(ORDER_URI, new ReaderHandle(Common.testFileToReader(ORDER_FILE)));
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     cleanUp();
   }
@@ -107,19 +105,19 @@ public class JacksonStreamTest {
       throw new IOException("Expected data to start with an Object");
     }
     List<OrderItem> orderItems = getOrderItems(jp);
-    assertEquals("orderItems array length is wrong", 4, orderItems.size());
-    assertEquals("OrderItem 1 productId is wrong", "widget",   orderItems.get(0).getProductId());
-    assertEquals("OrderItem 2 productId is wrong", "cog",      orderItems.get(1).getProductId());
-    assertEquals("OrderItem 3 productId is wrong", "spring",   orderItems.get(2).getProductId());
-    assertEquals("OrderItem 4 productId is wrong", "bearings", orderItems.get(3).getProductId());
-    assertEquals("OrderItem 1 quantity is wrong", 1, orderItems.get(0).getQuantity());
-    assertEquals("OrderItem 2 quantity is wrong", 5, orderItems.get(1).getQuantity());
-    assertEquals("OrderItem 3 quantity is wrong", 1, orderItems.get(2).getQuantity());
-    assertEquals("OrderItem 4 quantity is wrong", 3, orderItems.get(3).getQuantity());
-    assertEquals("OrderItem 1 itemCostUSD is wrong", 31.99, orderItems.get(0).getItemCostUSD(), 0.001);
-    assertEquals("OrderItem 2 itemCostUSD is wrong", 23.99, orderItems.get(1).getItemCostUSD(), 0.001);
-    assertEquals("OrderItem 3 itemCostUSD is wrong", 12.99, orderItems.get(2).getItemCostUSD(), 0.001);
-    assertEquals("OrderItem 4 itemCostUSD is wrong", 1.99,  orderItems.get(3).getItemCostUSD(), 0.001);
+    assertEquals( 4, orderItems.size());
+    assertEquals( "widget",   orderItems.get(0).getProductId());
+    assertEquals( "cog",      orderItems.get(1).getProductId());
+    assertEquals( "spring",   orderItems.get(2).getProductId());
+    assertEquals( "bearings", orderItems.get(3).getProductId());
+    assertEquals( 1, orderItems.get(0).getQuantity());
+    assertEquals( 5, orderItems.get(1).getQuantity());
+    assertEquals( 1, orderItems.get(2).getQuantity());
+    assertEquals( 3, orderItems.get(3).getQuantity());
+    assertEquals( 31.99, orderItems.get(0).getItemCostUSD(), 0.001);
+    assertEquals( 23.99, orderItems.get(1).getItemCostUSD(), 0.001);
+    assertEquals( 12.99, orderItems.get(2).getItemCostUSD(), 0.001);
+    assertEquals( 1.99,  orderItems.get(3).getItemCostUSD(), 0.001);
   }
 
   private List<OrderItem> getOrderItems(JsonParser parser) throws IOException {
@@ -183,11 +181,11 @@ public class JacksonStreamTest {
 
     JsonNode originalTree = docMgr.readAs(ORDER_URI, JsonNode.class);
     JsonNode streamedTree = docMgr.readAs("testWriteStream.json", JsonNode.class);
-    assertEquals("customerName fields don't match",
+    assertEquals(
       originalTree.get("customerName"), streamedTree.get("customerName"));
-    assertEquals("shipToAddress fields don't match",
+    assertEquals(
       originalTree.get("shipToAddress"), streamedTree.get("shipToAddress"));
-    assertEquals("billingAddressRequired fields don't match",
+    assertEquals(
       originalTree.get("billingAddressRequired"), streamedTree.get("billingAddressRequired"));
   }
 
@@ -224,9 +222,9 @@ public class JacksonStreamTest {
     JsonNode readTree1 = docMgr.readAs("/testWriteParser1.json", JsonNode.class);
     JsonNode readTree2 = docMgr.readAs("/testWriteParser2.json", JsonNode.class);
     JsonNode readTree3 = docMgr.readAs("/testWriteParser3.json", JsonNode.class);
-    assertEquals("readTree1 does not match writeTree", writeTree, readTree1);
-    assertEquals("readTree2 does not match writeTree", writeTree, readTree2);
-    assertEquals("readTree3 does not match writeTree", writeTree, readTree3);
+    assertEquals( writeTree, readTree1);
+    assertEquals( writeTree, readTree2);
+    assertEquals( writeTree, readTree3);
   }
 
   private static void cleanUp() {

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/MarkLogicVersionTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/MarkLogicVersionTest.java
@@ -1,9 +1,10 @@
 package com.marklogic.client.test;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class MarkLogicVersionTest extends Assert {
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MarkLogicVersionTest {
 
     private MarkLogicVersion version;
 

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/NamespacesManagerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/NamespacesManagerTest.java
@@ -15,25 +15,23 @@
  */
 package com.marklogic.client.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
 import com.marklogic.client.FailedRequestException;
 import com.marklogic.client.ForbiddenUserException;
 import com.marklogic.client.ResourceNotFoundException;
-import com.marklogic.client.util.EditableNamespaceContext;
 import com.marklogic.client.admin.NamespacesManager;
+import com.marklogic.client.util.EditableNamespaceContext;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class NamespacesManagerTest {
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     Common.connectAdmin();
   }
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
   }
 
@@ -47,7 +45,7 @@ public class NamespacesManagerTest {
     nsMgr.updatePrefix("dc", "http://purl.org/dc/terms/");
 
     String nsUri = nsMgr.readPrefix("dc");
-    assertEquals("Could not read namespace", nsUri, "http://purl.org/dc/terms/");
+    assertEquals( nsUri, "http://purl.org/dc/terms/");
 
     nsMgr.updatePrefix("rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns#");
     nsMgr.updatePrefix("skos", "http://www.w3.org/2004/02/skos/core#");
@@ -55,30 +53,30 @@ public class NamespacesManagerTest {
     EditableNamespaceContext context = (EditableNamespaceContext) nsMgr.readAll();
 
     int initialSize = context.size();
-    assertTrue("Failed to retrieve three namespaces", initialSize >= 3);
-    assertEquals("Did not retrieve RDF namespace",
+    assertTrue( initialSize >= 3);
+    assertEquals(
       "http://purl.org/dc/terms/",
       context.get("dc"));
-    assertEquals("Did not retrieve RDF namespace",
+    assertEquals(
       "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
       context.get("rdf"));
-    assertEquals("Did not retrieve SKOS namespace",
+    assertEquals(
       "http://www.w3.org/2004/02/skos/core#",
       context.get("skos"));
 
     nsMgr.updatePrefix("dc", "http://diverted/category/");
 
     nsUri = nsMgr.readPrefix("dc");
-    assertEquals("Could not read namespace", nsUri, "http://diverted/category/");
+    assertEquals( nsUri, "http://diverted/category/");
 
     nsMgr.deletePrefix("dc");
     context = (EditableNamespaceContext) nsMgr.readAll();
     // assumes no concurrent deletes
-    assertEquals("Failed to delete namespace", initialSize - 1, context.size());
+    assertEquals( initialSize - 1, context.size());
 
     nsMgr.deleteAll();
     context = (EditableNamespaceContext) nsMgr.readAll();
-    assertTrue("Failed to delete all namespaces",
+    assertTrue(
       context == null || context.size() == 0);
   }
 
@@ -95,7 +93,7 @@ public class NamespacesManagerTest {
     } catch (IllegalArgumentException e) {
       illegalArgument = true;
     }
-    assertTrue("Updating default prefix did not throw illegal argument exception", illegalArgument);
+    assertTrue( illegalArgument);
 
     illegalArgument = false;
     try {
@@ -103,6 +101,6 @@ public class NamespacesManagerTest {
     } catch (IllegalArgumentException e) {
       illegalArgument = true;
     }
-    assertTrue("Adding default prefix did not throw illegal argument exception", illegalArgument);
+    assertTrue( illegalArgument);
   }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/PageTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/PageTest.java
@@ -15,15 +15,14 @@
  */
 package com.marklogic.client.test;
 
+import com.marklogic.client.Page;
+import com.marklogic.client.impl.BasicPage;
+import org.junit.jupiter.api.Test;
+
 import java.util.HashSet;
 import java.util.Iterator;
 
-import static org.junit.Assert.assertEquals;
-
-import org.junit.Test;
-
-import com.marklogic.client.Page;
-import com.marklogic.client.impl.BasicPage;
+import static org.junit.jupiter.api.Assertions.*;
 
 /** Implements com.marklogic.client.Page to test the default methods.
  **/
@@ -38,94 +37,94 @@ public class PageTest {
     Iterator<Object> iterator = new HashSet<>().iterator();
 
     Page<Object> page = new TestPage(iterator, 1, 10, 100);
-    assertEquals("Unexpected size", 10, page.size());
-    assertEquals("Unexpected totalPages", 10, page.getTotalPages());
-    assertEquals("Unexpected hasContent", true, page.hasContent());
-    assertEquals("Unexpected hasNextPage", true, page.hasNextPage());
-    assertEquals("Unexpected pageNumber", 1, page.getPageNumber());
-    assertEquals("Unexpected isFirstPage", true, page.isFirstPage());
-    assertEquals("Unexpected isLastPage", false, page.isLastPage());
+    assertEquals( 10, page.size());
+    assertEquals( 10, page.getTotalPages());
+    assertEquals( true, page.hasContent());
+    assertEquals( true, page.hasNextPage());
+    assertEquals( 1, page.getPageNumber());
+    assertEquals( true, page.isFirstPage());
+    assertEquals( false, page.isLastPage());
 
     page = new TestPage(iterator, 1, 1, 100);
-    assertEquals("Unexpected size", 1, page.size());
-    assertEquals("Unexpected totalPages", 100, page.getTotalPages());
-    assertEquals("Unexpected hasContent", true, page.hasContent());
-    assertEquals("Unexpected hasNextPage", true, page.hasNextPage());
-    assertEquals("Unexpected pageNumber", 1, page.getPageNumber());
-    assertEquals("Unexpected isFirstPage", true, page.isFirstPage());
-    assertEquals("Unexpected isLastPage", false, page.isLastPage());
+    assertEquals( 1, page.size());
+    assertEquals( 100, page.getTotalPages());
+    assertEquals( true, page.hasContent());
+    assertEquals( true, page.hasNextPage());
+    assertEquals( 1, page.getPageNumber());
+    assertEquals( true, page.isFirstPage());
+    assertEquals( false, page.isLastPage());
 
     page = new TestPage(iterator, 10, 0, 101);
-    assertEquals("Unexpected size", 0, page.size());
-    assertEquals("Unexpected totalSize", 101, page.getTotalSize());
-    assertEquals("Unexpected totalPages", 0, page.getTotalPages());
-    assertEquals("Unexpected hasContent", false, page.hasContent());
-    assertEquals("Unexpected hasNextPage", false, page.hasNextPage());
-    assertEquals("Unexpected pageNumber", 0, page.getPageNumber());
-    assertEquals("Unexpected isFirstPage", true, page.isFirstPage());
-    assertEquals("Unexpected isLastPage", true, page.isLastPage());
+    assertEquals( 0, page.size());
+    assertEquals( 101, page.getTotalSize());
+    assertEquals( 0, page.getTotalPages());
+    assertEquals( false, page.hasContent());
+    assertEquals( false, page.hasNextPage());
+    assertEquals( 0, page.getPageNumber());
+    assertEquals( true, page.isFirstPage());
+    assertEquals( true, page.isLastPage());
 
     page = new TestPage(iterator, 2, 10, 100);
-    assertEquals("Unexpected size", 10, page.size());
-    assertEquals("Unexpected totalPages", 10, page.getTotalPages());
-    assertEquals("Unexpected hasContent", true, page.hasContent());
-    assertEquals("Unexpected hasNextPage", true, page.hasNextPage());
-    assertEquals("Unexpected pageNumber", 1, page.getPageNumber());
-    assertEquals("Unexpected isFirstPage", true, page.isFirstPage());
-    assertEquals("Unexpected isLastPage", false, page.isLastPage());
+    assertEquals( 10, page.size());
+    assertEquals( 10, page.getTotalPages());
+    assertEquals( true, page.hasContent());
+    assertEquals( true, page.hasNextPage());
+    assertEquals( 1, page.getPageNumber());
+    assertEquals( true, page.isFirstPage());
+    assertEquals( false, page.isLastPage());
 
     page = new TestPage(iterator, 10, 10, 100);
-    assertEquals("Unexpected size", 10, page.size());
-    assertEquals("Unexpected totalPages", 10, page.getTotalPages());
-    assertEquals("Unexpected hasContent", true, page.hasContent());
-    assertEquals("Unexpected hasNextPage", true, page.hasNextPage());
-    assertEquals("Unexpected pageNumber", 1, page.getPageNumber());
-    assertEquals("Unexpected isFirstPage", true, page.isFirstPage());
-    assertEquals("Unexpected isLastPage", false, page.isLastPage());
+    assertEquals( 10, page.size());
+    assertEquals( 10, page.getTotalPages());
+    assertEquals( true, page.hasContent());
+    assertEquals( true, page.hasNextPage());
+    assertEquals( 1, page.getPageNumber());
+    assertEquals( true, page.isFirstPage());
+    assertEquals( false, page.isLastPage());
 
     page = new TestPage(iterator, 12, 10, 100);
-    assertEquals("Unexpected size", 10, page.size());
-    assertEquals("Unexpected totalPages", 10, page.getTotalPages());
-    assertEquals("Unexpected hasContent", true, page.hasContent());
-    assertEquals("Unexpected hasNextPage", true, page.hasNextPage());
-    assertEquals("Unexpected pageNumber", 2, page.getPageNumber());
-    assertEquals("Unexpected isFirstPage", false, page.isFirstPage());
-    assertEquals("Unexpected isLastPage", false, page.isLastPage());
+    assertEquals( 10, page.size());
+    assertEquals( 10, page.getTotalPages());
+    assertEquals( true, page.hasContent());
+    assertEquals( true, page.hasNextPage());
+    assertEquals( 2, page.getPageNumber());
+    assertEquals( false, page.isFirstPage());
+    assertEquals( false, page.isLastPage());
 
     page = new TestPage(iterator, 20, 20, 100);
-    assertEquals("Unexpected size", 20, page.size());
-    assertEquals("Unexpected totalPages", 5, page.getTotalPages());
-    assertEquals("Unexpected hasContent", true, page.hasContent());
-    assertEquals("Unexpected hasNextPage", true, page.hasNextPage());
-    assertEquals("Unexpected pageNumber", 1, page.getPageNumber());
-    assertEquals("Unexpected isFirstPage", true, page.isFirstPage());
-    assertEquals("Unexpected isLastPage", false, page.isLastPage());
+    assertEquals( 20, page.size());
+    assertEquals( 5, page.getTotalPages());
+    assertEquals( true, page.hasContent());
+    assertEquals( true, page.hasNextPage());
+    assertEquals( 1, page.getPageNumber());
+    assertEquals( true, page.isFirstPage());
+    assertEquals( false, page.isLastPage());
 
     page = new TestPage(iterator, 22, 20, 100);
-    assertEquals("Unexpected size", 20, page.size());
-    assertEquals("Unexpected totalPages", 5, page.getTotalPages());
-    assertEquals("Unexpected hasContent", true, page.hasContent());
-    assertEquals("Unexpected hasNextPage", true, page.hasNextPage());
-    assertEquals("Unexpected pageNumber", 2, page.getPageNumber());
-    assertEquals("Unexpected isFirstPage", false, page.isFirstPage());
-    assertEquals("Unexpected isLastPage", false, page.isLastPage());
+    assertEquals( 20, page.size());
+    assertEquals( 5, page.getTotalPages());
+    assertEquals( true, page.hasContent());
+    assertEquals( true, page.hasNextPage());
+    assertEquals( 2, page.getPageNumber());
+    assertEquals( false, page.isFirstPage());
+    assertEquals( false, page.isLastPage());
 
     page = new TestPage(iterator, 18, 20, 20);
-    assertEquals("Unexpected size", 20, page.size());
-    assertEquals("Unexpected totalPages", 1, page.getTotalPages());
-    assertEquals("Unexpected hasContent", true, page.hasContent());
-    assertEquals("Unexpected hasNextPage", false, page.hasNextPage());
-    assertEquals("Unexpected pageNumber", 1, page.getPageNumber());
-    assertEquals("Unexpected isFirstPage", true, page.isFirstPage());
-    assertEquals("Unexpected isLastPage", true, page.isLastPage());
+    assertEquals( 20, page.size());
+    assertEquals( 1, page.getTotalPages());
+    assertEquals( true, page.hasContent());
+    assertEquals( false, page.hasNextPage());
+    assertEquals( 1, page.getPageNumber());
+    assertEquals( true, page.isFirstPage());
+    assertEquals( true, page.isLastPage());
 
     page = new TestPage(iterator, 905, 100, 990);
-    assertEquals("Unexpected size", 90, page.size());
-    assertEquals("Unexpected totalPages", 10, page.getTotalPages());
-    assertEquals("Unexpected hasContent", true, page.hasContent());
-    assertEquals("Unexpected hasNextPage", false, page.hasNextPage());
-    assertEquals("Unexpected pageNumber", 10, page.getPageNumber());
-    assertEquals("Unexpected isFirstPage", false, page.isFirstPage());
-    assertEquals("Unexpected isLastPage", true, page.isLastPage());
+    assertEquals( 90, page.size());
+    assertEquals( 10, page.getTotalPages());
+    assertEquals( true, page.hasContent());
+    assertEquals( false, page.hasNextPage());
+    assertEquals( 10, page.getPageNumber());
+    assertEquals( false, page.isFirstPage());
+    assertEquals( true, page.isLastPage());
   }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/PlanExpressionTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/PlanExpressionTest.java
@@ -20,27 +20,27 @@ import com.marklogic.client.row.RowManager;
 import com.marklogic.client.row.RowRecord;
 import com.marklogic.client.row.RowSet;
 import com.marklogic.client.type.PlanExprCol;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class PlanExpressionTest {
     protected static RowManager rowMgr = null;
     protected static PlanBuilder p = null;
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         Common.connect();
         rowMgr = Common.client.newRowManager();
         p      = rowMgr.newPlanBuilder();
     }
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         p      = null;
         rowMgr = null;
@@ -53,7 +53,7 @@ public class PlanExpressionTest {
 
        RowSet<RowRecord> rowSet = rowMgr.resultRows(plan);
        Iterator<RowRecord> rowItr = rowSet.iterator();
-       assertTrue("no row to test for "+testName, rowItr.hasNext());
+       assertTrue(rowItr.hasNext());
 
        return rowItr.next();
    }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/PlanGeneratedBase.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/PlanGeneratedBase.java
@@ -15,26 +15,6 @@
  */
 package com.marklogic.client.test;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.w3c.dom.Document;
-import org.xml.sax.SAXException;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marklogic.client.MarkLogicIOException;
@@ -43,8 +23,24 @@ import com.marklogic.client.io.Format;
 import com.marklogic.client.row.RowManager;
 import com.marklogic.client.row.RowRecord;
 import com.marklogic.client.row.RowSet;
-import com.marklogic.client.type.ServerExpression;
 import com.marklogic.client.type.PlanExprCol;
+import com.marklogic.client.type.ServerExpression;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class PlanGeneratedBase {
   protected static RowManager             rowMgr = null;
@@ -52,7 +48,7 @@ public class PlanGeneratedBase {
   protected static PlanBuilder.AccessPlan lit    = null;
 
   @SuppressWarnings("unchecked")
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     Common.connect();
     rowMgr = Common.client.newRowManager();
@@ -65,7 +61,7 @@ public class PlanGeneratedBase {
     lit = p.fromLiterals(new Map[]{row});
 
   }
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     lit    = null;
     p      = null;
@@ -93,14 +89,14 @@ public class PlanGeneratedBase {
 
     RowSet<RowRecord>   rowSet = rowMgr.resultRows(plan);
     Iterator<RowRecord> rowItr = rowSet.iterator();
-    assertTrue("no row to test for: "+testName, rowItr.hasNext());
+    assertTrue(rowItr.hasNext());
 
     RowRecord row = rowItr.next();
 
     if (expected == null) {
-      assertEquals(testName, RowRecord.ColumnKind.NULL, row.getKind("t"));
+      assertEquals(RowRecord.ColumnKind.NULL, row.getKind("t"));
     } else if (isVolatile) {
-      assertFalse(testName, row.getKind("t") == RowRecord.ColumnKind.NULL);
+      assertFalse(row.getKind("t") == RowRecord.ColumnKind.NULL);
     } else if (format != null) {
       switch (format) {
         case JSON:
@@ -114,11 +110,11 @@ public class PlanGeneratedBase {
       }
     } else {
       String actualVal = row.getString("t");
-      assertEquals(testName, expected.trim(), actualVal.trim());
+      assertEquals(expected.trim(), actualVal.trim());
 // TODO: assertions on type if set, allowing for fallback to base type
     }
 
-    assertFalse("too many results for: "+testName, rowItr.hasNext());
+    assertFalse(rowItr.hasNext());
     try {
       rowSet.close();
     } catch(IOException e) {
@@ -128,15 +124,15 @@ public class PlanGeneratedBase {
   private void checkJSON(String testName, String kind, String expectedRaw, RowRecord row) {
     try {
 // TODO: assertions on kind if set
-      assertEquals(testName, Format.JSON, row.getContentFormat("t"));
-      assertEquals(testName, "application/json", row.getContentMimetype("t"));
+      assertEquals(Format.JSON, row.getContentFormat("t"));
+      assertEquals("application/json", row.getContentMimetype("t"));
       if (expectedRaw.length() > 2) {
         ObjectMapper mapper = new ObjectMapper();
         JsonNode expected = mapper.readTree(expectedRaw);
         JsonNode actual   = row.getContentAs("t", JsonNode.class);
-        assertEquals(testName, expected, actual);
+        assertEquals(expected, actual);
       } else {
-        assertEquals(testName, expectedRaw, row.getContentAs("t", String.class).trim());
+        assertEquals(expectedRaw, row.getContentAs("t", String.class).trim());
       }
     } catch (IOException e) {
       throw new RuntimeException(e);
@@ -145,8 +141,8 @@ public class PlanGeneratedBase {
   private void checkXML(String testName, String kind, String expectedRaw, RowRecord row) {
     try {
 // TODO: assertions on kind if set
-      assertEquals(testName, Format.XML, row.getContentFormat("t"));
-      assertEquals(testName, "application/xml", row.getContentMimetype("t"));
+      assertEquals(Format.XML, row.getContentFormat("t"));
+      assertEquals("application/xml", row.getContentMimetype("t"));
       DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
       factory.setCoalescing(true);
       factory.setNamespaceAware(true);

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/PlanGeneratedTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/PlanGeneratedTest.java
@@ -16,10 +16,9 @@
 
 package com.marklogic.client.test;
 
-import org.junit.Test;
-
 import com.marklogic.client.io.Format;
 import com.marklogic.client.type.ServerExpression;
+import org.junit.jupiter.api.Test;
 
 // IMPORTANT: Do not edit. This file is generated.
 // Exception - some of these tests cannot pass on ML <= 10. Those have been modified to not run unless ML is >= 11.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/PojoFacadeTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/PojoFacadeTest.java
@@ -15,24 +15,6 @@
  */
 package com.marklogic.client.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import java.text.SimpleDateFormat;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.GregorianCalendar;
-import java.util.TimeZone;
-
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
@@ -50,18 +32,26 @@ import com.marklogic.client.pojo.annotation.Id;
 import com.marklogic.client.query.StringQueryDefinition;
 import com.marklogic.client.query.StructuredQueryBuilder;
 import com.marklogic.client.test.BulkReadWriteTest.CityWriter;
+import org.junit.jupiter.api.*;
 
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@TestMethodOrder(MethodOrderer.MethodName.class)
 public class PojoFacadeTest {
   private static final int MAX_TO_WRITE = 100;
   private static PojoRepository<City, Integer> cities;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     Common.connect();
     cities = Common.client.newPojoRepository(City.class, Integer.class);
   }
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     cleanUp();
   }
@@ -80,7 +70,7 @@ public class PojoFacadeTest {
     }
     @Override
     public void setNumRecords(int numRecords) {
-      assertEquals("Number of records not expected", numRecords, BulkReadWriteTest.RECORDS_EXPECTED);
+      assertEquals( numRecords, BulkReadWriteTest.RECORDS_EXPECTED);
     }
   }
 
@@ -186,15 +176,15 @@ public class PojoFacadeTest {
     students.write(stud, "students");
 
     Student student1 = students.read(id);
-    assertEquals("Student id", student1.getStudId(), stud.getStudId());
-    assertEquals("Zip code", student1.getAddress().zip, stud.getAddress().zip);
-    assertEquals("class status", student1.getclassStatus(), stud.getclassStatus());
+    assertEquals( student1.getStudId(), stud.getStudId());
+    assertEquals( student1.getAddress().zip, stud.getAddress().zip);
+    assertEquals( student1.getclassStatus(), stud.getclassStatus());
   }
 
   @Test
   public void testA_LoadPojos() throws Exception {
     BulkReadWriteTest.loadCities(new PojoCityWriter());
-    assertEquals("total docs = MAX_TO_WRITE + Chittigong", MAX_TO_WRITE + 1, cities.count());
+    assertEquals(MAX_TO_WRITE + 1, cities.count());
   }
 
   @Test
@@ -205,15 +195,15 @@ public class PojoFacadeTest {
         validateCity(city);
         numRead++;
       }
-      assertEquals("Failed to read number of records expected", 3, numRead);
-      assertEquals("PojoPage failed to report number of records expected", numRead, page.size());
+      assertEquals( 3, numRead);
+      assertEquals( numRead, page.size());
     }
 
     // test reading a valid plus a non-existent document
     try ( PojoPage<City> page = cities.read(new Integer[]{1185098, -1}) ) {
-      assertEquals("Should have results", true, page.hasContent());
-      assertEquals("Failed to report number of records expected", 1, page.size());
-      assertEquals("Wrong only doc", 1185098, page.next().getGeoNameId());
+      assertEquals( true, page.hasContent());
+      assertEquals( 1, page.size());
+      assertEquals( 1185098, page.next().getGeoNameId());
     }
 
     // test reading only a non-existent document
@@ -225,7 +215,7 @@ public class PojoFacadeTest {
     } catch (ResourceNotFoundException e) {
       exceptionThrown = true;
     }
-    assertTrue("ResourceNotFoundException should have been thrown", exceptionThrown);
+    assertTrue( exceptionThrown);
 
     // test reading multiple non-existent documents, https://github.com/marklogic/java-client-api/issues/185
     // since this is a bulk API, we are consistent with search and no errors are thrown
@@ -237,7 +227,7 @@ public class PojoFacadeTest {
       exceptionThrown = true;
       e.printStackTrace();
     }
-    assertFalse("ResourceNotFoundException should not have been thrown", exceptionThrown);
+    assertFalse( exceptionThrown);
   }
 
   @SuppressWarnings("unused")
@@ -250,9 +240,9 @@ public class PojoFacadeTest {
     try ( PojoPage<City> page = cities.search(stringQuery, 1) ) {
       int numRead = 0;
       for ( City city : page ) numRead++;
-      assertEquals("Failed to find number of records expected", 0, numRead);
-      assertEquals("PojoPage failed to report number of records expected", numRead, page.size());
-      assertEquals("PojoRepository.count failed to find number of records expected",
+      assertEquals( 0, numRead);
+      assertEquals( numRead, page.size());
+      assertEquals(
         numRead, cities.count(stringQuery));
     }
 
@@ -261,9 +251,9 @@ public class PojoFacadeTest {
     try ( PojoPage<City> page = cities.search(stringQuery, 1) ) {
       int numRead = 0;
       for ( City city : page ) numRead++;
-      assertEquals("Failed to find number of records expected", 3, numRead);
-      assertEquals("PojoPage failed to report number of records expected", numRead, page.size());
-      assertEquals("PojoRepository.count failed to find number of records expected",
+      assertEquals( 3, numRead);
+      assertEquals( numRead, page.size());
+      assertEquals(
         numRead, cities.count(stringQuery));
     }
 
@@ -273,9 +263,9 @@ public class PojoFacadeTest {
     try ( PojoPage<City> page = cities.search(query, 1) ) {
       int numRead = 0;
       for ( City city : page ) numRead++;
-      assertEquals("Failed to find number of records expected", 3, numRead);
-      assertEquals("PojoPage failed to report number of records expected", numRead, page.size());
-      assertEquals("PojoRepository.count failed to find number of records expected",
+      assertEquals( 3, numRead);
+      assertEquals( numRead, page.size());
+      assertEquals(
         numRead, cities.count(query));
     }
 
@@ -286,9 +276,9 @@ public class PojoFacadeTest {
     try ( PojoPage<City> page = cities.search(query, 1) ) {
       int numRead = 0;
       for ( City city : page ) numRead++;
-      assertEquals("Failed to find number of records expected", 1, numRead);
-      assertEquals("PojoPage failed to report number of records expected", numRead, page.size());
-      assertEquals("PojoRepository.count failed to find number of records expected",
+      assertEquals( 1, numRead);
+      assertEquals( numRead, page.size());
+      assertEquals(
         numRead, cities.count(query));
     }
 
@@ -298,8 +288,8 @@ public class PojoFacadeTest {
     //  - first lets's see it produce inaccurate results
     query = qb.word("asciiName", new String[] {"wildcarded"}, 1, "Chittagong*");
     try ( PojoPage<City> page = cities.search(query, 1) ) {
-      assertEquals("The estimate number should match everything", 101, page.getTotalSize());
-      assertEquals("PojoRepository.count should match everything",
+      assertEquals( 101, page.getTotalSize());
+      assertEquals(
         101, cities.count(query));
     }
 
@@ -312,18 +302,18 @@ public class PojoFacadeTest {
     try ( PojoPage<City> page = cities.search(query, 1) ) {
       int numRead = 0;
       for ( City city : page ) numRead++;
-      assertEquals("Failed to find number of records expected", 1, numRead);
-      assertEquals("PojoPage failed to report number of records expected", numRead, page.size());
-      assertEquals("The estimate number is no longer an estimate, it knows there's only 1 match",
+      assertEquals( 1, numRead);
+      assertEquals( numRead, page.size());
+      assertEquals(
         1, page.getTotalSize());
-      assertEquals("PojoRepository.count should still match everything",
+      assertEquals(
         101, cities.count(query));
     }
 
     long defaultPageLength = cities.getPageLength();
     cities.setPageLength(0);
     try ( PojoPage<City> page = cities.search(query, 1) ) {
-      assertEquals("With pageLength 0, the estimate number should again match everything",
+      assertEquals(
         101, page.getTotalSize());
     }
     cities.setPageLength(defaultPageLength);
@@ -339,9 +329,9 @@ public class PojoFacadeTest {
     try ( PojoPage<City> page = cities.search(query, 1) ) {
       int numRead = 0;
       for ( City city : page ) numRead++;
-      assertEquals("Failed to find number of records expected", 1, numRead);
-      assertEquals("PojoPage failed to report number of records expected", numRead, page.size());
-      assertEquals("PojoRepository.count should still match everything",
+      assertEquals( 1, numRead);
+      assertEquals( numRead, page.size());
+      assertEquals(
         101, cities.count(query));
     }
 
@@ -349,11 +339,11 @@ public class PojoFacadeTest {
     try ( PojoPage<City> page = cities.search(query, 1) ) {
       int numRead = 0;
       for ( City city : page ) {
-        assertEquals("Wrong continent", "AF", city.getContinent());
+        assertEquals( "AF", city.getContinent());
         numRead++;
       }
-      assertEquals("Failed to find number of records expected", 7, numRead);
-      assertEquals("PojoPage failed to report number of records expected", numRead, page.size());
+      assertEquals( 7, numRead);
+      assertEquals( numRead, page.size());
     }
 
     query = qb.containerQuery("alternateNames", qb.term("San", "Santo"));
@@ -361,12 +351,12 @@ public class PojoFacadeTest {
       int numRead = 0;
       for ( City city : page ) {
         String alternateNames = Arrays.asList(city.getAlternateNames()).toString();
-        assertTrue("Should contain San", alternateNames.contains("San"));
+        assertTrue( alternateNames.contains("San"));
         numRead++;
       }
-      assertEquals("Failed to find number of records expected", 11, numRead);
-      assertEquals("PojoPage failed to report number of records expected", numRead, page.size());
-      assertEquals("PojoRepository.count failed to find number of records expected",
+      assertEquals( 11, numRead);
+      assertEquals( numRead, page.size());
+      assertEquals(
         numRead, cities.count(query));
     }
 
@@ -376,11 +366,11 @@ public class PojoFacadeTest {
     try ( PojoPage<City> page = cities.search(query, 1) ) {
       int numRead = 0;
       for ( City city : page ) {
-        assertEquals("Wrong City", "Tirana", city.getName());
+        assertEquals( "Tirana", city.getName());
         numRead++;
       }
-      assertEquals("Failed to find number of records expected", 1, numRead);
-      assertEquals("PojoPage failed to report number of records expected", numRead, page.size());
+      assertEquals( 1, numRead);
+      assertEquals( numRead, page.size());
     }
 
     // test numeric (fractional) values
@@ -388,11 +378,11 @@ public class PojoFacadeTest {
     try ( PojoPage<City> page = cities.search(query, 1) ) {
       int numRead = 0;
       for ( City city : page ) {
-        assertEquals("Wrong City", "Quilmes", city.getName());
+        assertEquals( "Quilmes", city.getName());
         numRead++;
       }
-      assertEquals("Failed to find number of records expected", 1, numRead);
-      assertEquals("PojoPage failed to report number of records expected", numRead, page.size());
+      assertEquals( 1, numRead);
+      assertEquals( numRead, page.size());
     }
 
     // test null values
@@ -400,16 +390,16 @@ public class PojoFacadeTest {
     try ( PojoPage<City> page = cities.search(query, 1) ) {
       int numRead = 0;
       for ( City city : page ) numRead++;
-      assertEquals("Failed to find number of records expected", 50, numRead);
-      assertEquals("PojoPage failed to report number of records expected", numRead, page.size());
+      assertEquals( 50, numRead);
+      assertEquals( numRead, page.size());
     }
 
     query = qb.range("population", Operator.LT, 350000);
     try ( PojoPage<City> page = cities.search(query, 1) ) {
       int numRead = 0;
       for ( City city : page ) numRead++;
-      assertEquals("Failed to find number of records expected", 21, numRead);
-      assertEquals("PojoPage failed to report number of records expected", numRead, page.size());
+      assertEquals( 21, numRead);
+      assertEquals( numRead, page.size());
     }
 
     query = qb.geospatial(
@@ -419,8 +409,8 @@ public class PojoFacadeTest {
     try ( PojoPage<City> page = cities.search(query, 1) ) {
       int numRead = 0;
       for ( City city : page ) numRead++;
-      assertEquals("Failed to find number of records expected", 4, numRead);
-      assertEquals("PojoPage failed to report number of records expected", numRead, page.size());
+      assertEquals( 4, numRead);
+      assertEquals( numRead, page.size());
     }
 
     query = qb.geospatial(
@@ -430,8 +420,8 @@ public class PojoFacadeTest {
     try ( PojoPage<City> page = cities.search(query, 1) ) {
       int numRead = 0;
       for ( City city : page ) numRead++;
-      assertEquals("Failed to find number of records expected", 4, numRead);
-      assertEquals("PojoPage failed to report number of records expected", numRead, page.size());
+      assertEquals( 4, numRead);
+      assertEquals( numRead, page.size());
     }
   }
 
@@ -470,35 +460,35 @@ public class PojoFacadeTest {
     PojoQueryBuilder<Country> countriesQb = qb.containerQueryBuilder("country", Country.class);
     PojoQueryDefinition query = countriesQb.value("continent", "EU");
     try ( PojoPage<City> page = cities.search(query, 1) ) {
-      assertEquals("Should not find any countries", 0, page.getTotalSize());
+      assertEquals( 0, page.getTotalSize());
     }
 
     query = countriesQb.value("continent", "AS");
     try ( PojoPage<City> page = cities.search(query, 1) ) {
-      assertEquals("Should find two cities", 2, page.getTotalSize());
+      assertEquals( 2, page.getTotalSize());
     }
 
     query = countriesQb.range("continent", Operator.EQ, "AS");
     try ( PojoPage<City> page = cities.search(query, 1) ) {
-      assertEquals("Should find two cities", 2, page.getTotalSize());
+      assertEquals( 2, page.getTotalSize());
     }
 
     // all countries containing the term SA
     query = countriesQb.term("SA");
     try ( PojoPage<City> page = cities.search(query, 1) ) {
-      assertEquals("Should find one city", 1, page.getTotalSize());
+      assertEquals( 1, page.getTotalSize());
     }
 
     // all cities containing the term SA
     query = qb.term("SA");
     try ( PojoPage<City> page = cities.search(query, 1) ) {
-      assertEquals("Should find sixty one cities", 61, page.getTotalSize());
+      assertEquals( 61, page.getTotalSize());
     }
 
     // all countries containing the property "currencyName" with the term "peso"
     query = countriesQb.word("currencyName", "peso");
     try ( PojoPage<City> page = cities.search(query, 1) ) {
-      assertEquals("Should find one city", 1, page.getTotalSize());
+      assertEquals( 1, page.getTotalSize());
     }
   }
 
@@ -533,23 +523,23 @@ public class PojoFacadeTest {
     StringQueryDefinition query = Common.client.newQueryManager().newStringDefinition();
     query.setCriteria("1001");
     try ( PojoPage<Product1> page = products1.search(query, 1) ) {
-      assertEquals("Should not find the product by id", 0, page.getTotalSize());
+      assertEquals( 0, page.getTotalSize());
     }
 
     // though, of course, we can search on string field
     query = Common.client.newQueryManager().newStringDefinition();
     query.setCriteria("widget1");
     try ( PojoPage<Product1> page = products1.search(query, 1) ) {
-      assertEquals("Should find the product by name", 1, page.getTotalSize());
-      assertEquals("Should find the right product id", 1001, page.next().id);
+      assertEquals( 1, page.getTotalSize());
+      assertEquals( 1001, page.next().id);
     }
 
     // with the JsonSerialize annotation, the id is indexed as a string and therefore searchable
     query = Common.client.newQueryManager().newStringDefinition();
     query.setCriteria("2001");
     try ( PojoPage<Product2> page = products2.search(query, 1) ) {
-      assertEquals("Should find the product by id", 1, page.getTotalSize());
-      assertEquals("Should find the right product id", 2001, page.next().id);
+      assertEquals( 1, page.getTotalSize());
+      assertEquals( 2001, page.next().id);
     }
   }
 
@@ -564,11 +554,11 @@ public class PojoFacadeTest {
     times.write(timeTest1);
 
     TimeTest timeTest1FromDb = times.read("1");
-    assertEquals("Calendar objs should be equal", timeTest1.calendarTest,
+    assertEquals( timeTest1.calendarTest,
       timeTest1FromDb.calendarTest);
-    assertEquals("Date objs should be equal", timeTest1.dateTest,
+    assertEquals( timeTest1.dateTest,
       timeTest1FromDb.dateTest);
-    assertEquals("Epoch time should be equal", timeTest1.dateTest.getTime(),
+    assertEquals( timeTest1.dateTest.getTime(),
       timeTest1FromDb.dateTest.getTime());
 
     GregorianCalendar septThirdCET = new GregorianCalendar(TimeZone.getTimeZone("CET"));
@@ -579,14 +569,14 @@ public class PojoFacadeTest {
 
     TimeTest timeTest2FromDb = times.read("2");
         /* Jackson 2.8.3 converts all Date/Calendar to UTC, so we can't get the object in the correct timezone
-        assertEquals("Calendar objs should be equal", timeTest2.calendarTest,
+        assertEquals( timeTest2.calendarTest,
             timeTest2FromDb.calendarTestCet);
         */
-    assertEquals("Calendar objs timestamps should be equal", timeTest2.calendarTest.getTime().getTime(),
+    assertEquals( timeTest2.calendarTest.getTime().getTime(),
       timeTest2FromDb.calendarTestCet.getTime().getTime());
-    assertEquals("Date objs should be equal", timeTest2.dateTest,
+    assertEquals( timeTest2.dateTest,
       timeTest2FromDb.dateTest);
-    assertEquals("Epoch time should be equal", timeTest2.calendarTest.getTime().getTime(),
+    assertEquals( timeTest2.calendarTest.getTime().getTime(),
       timeTest2FromDb.calendarTest.getTime().getTime());
 
     // let's try to test serializing back to CET time zone
@@ -600,7 +590,7 @@ public class PojoFacadeTest {
         // re-read the object with the modified objectMapper
         timeTest2FromDb = times.read("2");
         // now validate that the object has everything including the time zone equal
-        assertEquals("Calendar objs should be equal", timeTest2.calendarTest,
+        assertEquals( timeTest2.calendarTest,
             timeTest2FromDb.calendarTest);
         */
 
@@ -615,10 +605,10 @@ public class PojoFacadeTest {
         int numRead = 0;
         for ( TimeTest time : page ) {
           numRead++;
-          assertEquals("Should find the right TimeTest id", "2", time.id);
+          assertEquals( "2", time.id);
         }
-        assertEquals("Failed to find number of records expected", 1, numRead);
-        assertEquals("PojoPage failed to report number of records expected", numRead, page.size());
+        assertEquals( 1, numRead);
+        assertEquals( numRead, page.size());
       }
     }
 
@@ -632,8 +622,8 @@ public class PojoFacadeTest {
         try ( PojoPage<City> page = cities.search(query, 1) ) {
             int numRead = 0;
             for ( City city : page ) numRead++;
-            assertEquals("Failed to find number of records expected", 11, numRead);
-            assertEquals("PojoPage failed to report number of records expected", numRead, page.size());
+            assertEquals( 11, numRead);
+            assertEquals( numRead, page.size());
         }
 
     }
@@ -645,20 +635,20 @@ public class PojoFacadeTest {
     StringQueryDefinition query = Common.client.newQueryManager().newStringDefinition();
     query.setCriteria("Tungi OR Dalatando OR Chittagong");
     try ( PojoPage<City> page = cities.search(query, 1) ) {
-      assertEquals("Failed to read number of records expected", 1, page.getTotalSize());
+      assertEquals( 1, page.getTotalSize());
     }
 
     // now delete them all
     cities.deleteAll();
     long count = cities.count();
-    assertEquals("Failed to read number of records expected", 0, count);
+    assertEquals( 0, count);
   }
 
   private void validateCity(City city) {
-    assertNotNull("City should never be null", city);
-    assertNotNull("GeoNameId should never be null", city.getGeoNameId());
+    assertNotNull( city);
+    assertNotNull( city.getGeoNameId());
     if ( "Chittagong".equals(city.getName()) ) {
-      assertEquals("Chittagong should have id 1205733", 1205733, cities.getId(city).intValue());
+      assertEquals( 1205733, cities.getId(city).intValue());
       BulkReadWriteTest.validateChittagong(city);
     }
   }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/QueryByExampleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/QueryByExampleTest.java
@@ -15,33 +15,28 @@
  */
 package com.marklogic.client.test;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
-
 import com.marklogic.client.document.DocumentPage;
-import com.marklogic.client.document.JSONDocumentManager;
 import com.marklogic.client.document.DocumentWriteSet;
+import com.marklogic.client.document.JSONDocumentManager;
 import com.marklogic.client.document.XMLDocumentManager;
-import com.marklogic.client.io.DOMHandle;
-import com.marklogic.client.io.JacksonHandle;
-import com.marklogic.client.io.SearchHandle;
-import com.marklogic.client.io.StringHandle;
-import com.marklogic.client.io.Format;
+import com.marklogic.client.io.*;
 import com.marklogic.client.query.DeleteQueryDefinition;
 import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.query.RawQueryByExampleDefinition;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class QueryByExampleTest {
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     Common.connect();
     setupData();
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     cleanUpData();
   }
@@ -60,16 +55,16 @@ public class QueryByExampleTest {
     System.out.println(report.toString());
 
     SearchHandle results = qm.search(query, new SearchHandle());
-    assertEquals("6 json results should have matched", results.getTotalResults(), 6);
+    assertEquals(results.getTotalResults(), 6);
 
     DocumentPage documents = jdm.search(query, 1);
-    assertEquals("6 json documents should have matched", documents.getTotalSize(), 6);
+    assertEquals(documents.getTotalSize(), 6);
 
     documents = jdm.search(query, 1, new JacksonHandle());
-    assertEquals("6 json documents should have matched", documents.getTotalSize(), 6);
+    assertEquals(documents.getTotalSize(), 6);
 
     documents = jdm.search(query, 1, new SearchHandle());
-    assertEquals("6 json documents should have matched", documents.getTotalSize(), 6);
+    assertEquals(documents.getTotalSize(), 6);
   }
 
   @Test
@@ -89,13 +84,13 @@ public class QueryByExampleTest {
     System.out.println(report.toString());
 
     SearchHandle results = qm.search(query, new SearchHandle());
-    assertEquals("No XML results should have matched", results.getTotalResults(), 0);
+    assertEquals(results.getTotalResults(), 0);
 
     DocumentPage documents = xdm.search(query, 1);
-    assertEquals("No XML documents should have matched", documents.getTotalSize(), 0);
+    assertEquals(documents.getTotalSize(), 0);
 
     documents = xdm.search(query, 1, new DOMHandle());
-    assertEquals("No XML documents should have matched", documents.getTotalSize(), 0);
+    assertEquals(documents.getTotalSize(), 0);
   }
 
   public static void setupData() {

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/QueryOptionsListHandleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/QueryOptionsListHandleTest.java
@@ -15,44 +15,41 @@
  */
 package com.marklogic.client.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.HashMap;
-
-import javax.xml.parsers.ParserConfigurationException;
-
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.xml.sax.SAXException;
-
 import com.marklogic.client.FailedRequestException;
 import com.marklogic.client.ForbiddenUserException;
 import com.marklogic.client.admin.QueryOptionsManager;
 import com.marklogic.client.io.QueryOptionsListHandle;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.query.QueryManager;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class QueryOptionsListHandleTest {
   @SuppressWarnings("unused")
   private static final Logger logger = (Logger) LoggerFactory
     .getLogger(QueryOptionsListHandleTest.class);
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     Common.connect();
     Common.connectAdmin();
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
   }
 
@@ -65,8 +62,8 @@ public class QueryOptionsListHandleTest {
       v.parseTestData(is);
     }
     Map<String,String> map = v.getValuesMap();
-    assertEquals("Map should contain two keys", map.size(), 2);
-    assertEquals("photos should have this uri", map.get("photos"), "/v1/config/query/photos");
+    assertEquals( map.size(), 2);
+    assertEquals( map.get("photos"), "/v1/config/query/photos");
   }
 
   // This only works if you've loaded the 5min guide @Test
@@ -76,8 +73,8 @@ public class QueryOptionsListHandleTest {
     QueryOptionsListHandle results = queryMgr.optionsList(new QueryOptionsListHandle());
     assertNotNull(results);
     Map<String,String> map = results.getValuesMap();
-    assertEquals("Map should contain two keys", map.size(), 2);
-    assertEquals("photos should have this uri", map.get("photos"), "/v1/config/query/photos");
+    assertEquals( map.size(), 2);
+    assertEquals( map.get("photos"), "/v1/config/query/photos");
   }
 
   @Test

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/QueryOptionsManagerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/QueryOptionsManagerTest.java
@@ -15,48 +15,40 @@
  */
 package com.marklogic.client.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import java.io.File;
-import java.io.IOException;
-
-import javax.xml.bind.JAXBException;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.marklogic.client.FailedRequestException;
+import com.marklogic.client.ForbiddenUserException;
+import com.marklogic.client.ResourceNotFoundException;
+import com.marklogic.client.ResourceNotResendableException;
+import com.marklogic.client.admin.QueryOptionsManager;
+import com.marklogic.client.io.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.ls.DOMImplementationLS;
 import org.xml.sax.SAXException;
-import com.fasterxml.jackson.databind.JsonNode;
 
-import com.marklogic.client.FailedRequestException;
-import com.marklogic.client.ForbiddenUserException;
-import com.marklogic.client.ResourceNotFoundException;
-import com.marklogic.client.ResourceNotResendableException;
-import com.marklogic.client.io.Format;
-import com.marklogic.client.admin.QueryOptionsManager;
-import com.marklogic.client.io.DOMHandle;
-import com.marklogic.client.io.FileHandle;
-import com.marklogic.client.io.JacksonHandle;
-import com.marklogic.client.io.StringHandle;
+import javax.xml.bind.JAXBException;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 @SuppressWarnings("deprecation")
 public class QueryOptionsManagerTest {
   private static final org.slf4j.Logger logger = LoggerFactory.getLogger(QueryOptionsManagerTest.class);
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     Common.connectAdmin();
   }
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
   }
 
@@ -66,14 +58,14 @@ public class QueryOptionsManagerTest {
   {
     QueryOptionsManager mgr =
       Common.adminClient.newServerConfigManager().newQueryOptionsManager();
-    assertNotNull("Client could not create query options manager", mgr);
+    assertNotNull( mgr);
 
     mgr.writeOptions("testempty", new StringHandle("{\"options\":{}}").withFormat(Format.JSON));
 
     String optionsResult = mgr.readOptions("testempty", new StringHandle()).get();
     logger.debug("Empty options from server {}", optionsResult);
-    assertTrue("Empty options result not empty",optionsResult.contains("options"));
-    assertTrue("Empty options result not empty",optionsResult.contains("\"http://marklogic.com/appservices/search\"/>"));
+    assertTrue(optionsResult.contains("options"));
+    assertTrue(optionsResult.contains("\"http://marklogic.com/appservices/search\"/>"));
 
     mgr.deleteOptions("testempty");
   };
@@ -106,11 +98,11 @@ public class QueryOptionsManagerTest {
             ((DOMImplementationLS) documentBldr.getDOMImplementation()).createLSSerializer().writeToString(domDocument);
 
     String optionsString = queryOptionsMgr.readOptions(optionsName, new StringHandle()).get();
-    assertNotNull("Read null string for XML content",optionsString);
+    assertNotNull(optionsString);
     logger.debug("Two XML Strings {} and {}", domString, optionsString);
 
     Document readDoc = queryOptionsMgr.readOptions(optionsName, new DOMHandle()).get();
-    assertNotNull("Read null document for XML content",readDoc);
+    assertNotNull(readDoc);
 
   }
 
@@ -120,7 +112,7 @@ public class QueryOptionsManagerTest {
   {
     QueryOptionsManager mgr =
       Common.adminClient.newServerConfigManager().newQueryOptionsManager();
-    assertNotNull("Client could not create query options manager", mgr);
+    assertNotNull( mgr);
 
     FileHandle jsonHandle = new FileHandle(new File("src/test/resources/json-config.json"));
     jsonHandle.setFormat(Format.JSON);
@@ -128,13 +120,13 @@ public class QueryOptionsManagerTest {
 
     JsonNode options = mgr.readOptions("jsonoptions", new JacksonHandle()).get();
 
-    assertEquals("JSON options came back incorrectly", options.findPath("constraint").get(0).get("name").textValue(), "decade");
+    assertEquals( options.findPath("constraint").get(0).get("name").textValue(), "decade");
 
 
     StringHandle jsonStringHandle = new StringHandle();
     jsonStringHandle.setFormat(Format.JSON);
     mgr.readOptions("jsonoptions", jsonStringHandle);
-    assertTrue("JSON String from QueryManager must start with json options", jsonStringHandle.get().startsWith("{\"options\":"));
+    assertTrue( jsonStringHandle.get().startsWith("{\"options\":"));
 
     mgr.deleteOptions("jsonoptions");
   };

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/RawCtsQueryDefinitionTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/RawCtsQueryDefinitionTest.java
@@ -15,35 +15,6 @@
  */
 package com.marklogic.client.test;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
-import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.StringReader;
-
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-
-import com.marklogic.client.impl.HandleAccessor;
-import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.w3c.dom.Document;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
-
-import com.fasterxml.jackson.databind.JsonNode;
 import com.marklogic.client.FailedRequestException;
 import com.marklogic.client.ForbiddenUserException;
 import com.marklogic.client.ResourceNotFoundException;
@@ -51,41 +22,36 @@ import com.marklogic.client.ResourceNotResendableException;
 import com.marklogic.client.admin.QueryOptionsManager;
 import com.marklogic.client.document.JSONDocumentManager;
 import com.marklogic.client.document.XMLDocumentManager;
-import com.marklogic.client.io.DOMHandle;
-import com.marklogic.client.io.FileHandle;
-import com.marklogic.client.io.Format;
-import com.marklogic.client.io.InputStreamHandle;
-import com.marklogic.client.io.JacksonHandle;
-import com.marklogic.client.io.SearchHandle;
-import com.marklogic.client.io.StringHandle;
-import com.marklogic.client.io.XMLStreamReaderHandle;
+import com.marklogic.client.io.*;
 import com.marklogic.client.io.marker.CtsQueryWriteHandle;
 import com.marklogic.client.io.marker.StructureWriteHandle;
-import com.marklogic.client.query.CountedDistinctValue;
-import com.marklogic.client.query.ExtractedItem;
-import com.marklogic.client.query.ExtractedResult;
-import com.marklogic.client.query.MatchDocumentSummary;
-import com.marklogic.client.query.MatchLocation;
-import com.marklogic.client.query.QueryDefinition;
-import com.marklogic.client.query.QueryManager;
-import com.marklogic.client.query.RawCombinedQueryDefinition;
-import com.marklogic.client.query.RawCtsQueryDefinition;
-import com.marklogic.client.query.StructuredQueryBuilder;
-import com.marklogic.client.query.StructuredQueryDefinition;
+import com.marklogic.client.query.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class RawCtsQueryDefinitionTest {
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     Common.connect();
     queryMgr = Common.client.newQueryManager();
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     Common.client.newDocumentManager().delete("testRawCtsQueryFromFileHandle.xml");
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setupTestOptions()
     throws FileNotFoundException, ResourceNotFoundException, ForbiddenUserException, FailedRequestException,
            ResourceNotResendableException
@@ -153,9 +119,8 @@ public class RawCtsQueryDefinitionTest {
     assertNotNull(summaries);
     assertTrue(summaries.length > 0);
     for (MatchDocumentSummary summary : summaries) {
-      assertTrue("Mime type of document",
-        summary.getMimeType().matches("(application|text)/xml"));
-      assertEquals("Format of document", Format.XML, summary.getFormat());
+      assertTrue(summary.getMimeType().matches("(application|text)/xml"));
+      assertEquals(Format.XML, summary.getFormat());
       MatchLocation[] locations = summary.getMatchLocations();
       for (MatchLocation location : locations) {
         assertNotNull(location.getAllSnippetText());

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/RawQueryDefinitionTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/RawQueryDefinitionTest.java
@@ -15,32 +15,6 @@
  */
 package com.marklogic.client.test;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
-import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.StringReader;
-
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-
-import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.w3c.dom.Document;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.marklogic.client.FailedRequestException;
 import com.marklogic.client.ForbiddenUserException;
@@ -49,42 +23,43 @@ import com.marklogic.client.ResourceNotResendableException;
 import com.marklogic.client.admin.QueryOptionsManager;
 import com.marklogic.client.document.JSONDocumentManager;
 import com.marklogic.client.document.XMLDocumentManager;
-import com.marklogic.client.io.DOMHandle;
-import com.marklogic.client.io.FileHandle;
-import com.marklogic.client.io.Format;
-import com.marklogic.client.io.JacksonHandle;
-import com.marklogic.client.io.SearchHandle;
-import com.marklogic.client.io.StringHandle;
-import com.marklogic.client.io.TuplesHandle;
-import com.marklogic.client.io.ValuesHandle;
+import com.marklogic.client.io.*;
 import com.marklogic.client.io.marker.StructureWriteHandle;
-import com.marklogic.client.query.CountedDistinctValue;
-import com.marklogic.client.query.ExtractedItem;
-import com.marklogic.client.query.ExtractedResult;
-import com.marklogic.client.query.MatchDocumentSummary;
-import com.marklogic.client.query.MatchLocation;
-import com.marklogic.client.query.QueryManager;
-import com.marklogic.client.query.RawCombinedQueryDefinition;
-import com.marklogic.client.query.RawQueryByExampleDefinition;
-import com.marklogic.client.query.RawStructuredQueryDefinition;
-import com.marklogic.client.query.StructuredQueryBuilder;
-import com.marklogic.client.query.StructuredQueryDefinition;
-import com.marklogic.client.query.Tuple;
-import com.marklogic.client.query.ValuesDefinition;
+import com.marklogic.client.query.*;
+import org.custommonkey.xmlunit.exceptions.XpathException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.StringReader;
+
+import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class RawQueryDefinitionTest {
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     Common.connect();
     queryMgr = Common.client.newQueryManager();
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     Common.client.newDocumentManager().delete("test_issue581_RawStructuredQueryFromFileHandle.xml");
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setupTestOptions()
     throws FileNotFoundException, ResourceNotFoundException, ForbiddenUserException, FailedRequestException, ResourceNotResendableException
   {
@@ -184,9 +159,9 @@ public class RawQueryDefinitionTest {
     assertNotNull(summaries);
     assertTrue(summaries.length > 0);
     for (MatchDocumentSummary summary : summaries) {
-      assertTrue("Mime type of document",
+      assertTrue(
         summary.getMimeType().matches("(application|text)/xml"));
-      assertEquals("Format of document", Format.XML, summary.getFormat());
+      assertEquals( Format.XML, summary.getFormat());
       Document relevanceTrace = summary.getRelevanceInfo();
       if (relevanceTrace != null) {
         assertEquals(relevanceTrace.getDocumentElement().getLocalName(),"relevance-info");
@@ -275,12 +250,12 @@ public class RawQueryDefinitionTest {
     checkResults(results);
 
     String output = queryMgr.validate(qbe, new StringHandle()).get();
-    assertNotNull("Empty XML validation", output);
+    assertNotNull( output);
     assertXMLEqual("Failed to validate QBE", output,
       "<q:valid-query xmlns:q=\"http://marklogic.com/appservices/querybyexample\"/>");
 
     output = queryMgr.convert(qbe, new StringHandle()).get();
-    assertNotNull("Empty XML conversion", output);
+    assertNotNull( output);
     assertXpathEvaluatesTo(
       "favorited",
       "string(/*[local-name()='search']/*[local-name()='query']/*[local-name()='value-query']/*[local-name()='element']/@name)",
@@ -297,8 +272,8 @@ public class RawQueryDefinitionTest {
         "}"
     );
     output = queryMgr.search(qbe, new StringHandle().withFormat(Format.JSON)).get();
-    assertNotNull("Empty JSON output", output);
-    assertTrue("Output without a match",
+    assertNotNull( output);
+    assertTrue(
       output.contains("\"results\":[{\"index\":1,"));
   }
 

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/RequestLoggerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/RequestLoggerTest.java
@@ -15,28 +15,6 @@
  */
 package com.marklogic.client.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.Reader;
-import java.io.StringReader;
-
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.ls.DOMImplementationLS;
-
 import com.marklogic.client.document.XMLDocumentManager;
 import com.marklogic.client.impl.OutputStreamTee;
 import com.marklogic.client.io.DOMHandle;
@@ -46,13 +24,26 @@ import com.marklogic.client.query.DeleteQueryDefinition;
 import com.marklogic.client.query.QueryDefinition;
 import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.util.RequestLogger;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.ls.DOMImplementationLS;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.*;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class RequestLoggerTest {
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     Common.connect();
   }
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
   }
 
@@ -71,9 +62,9 @@ public class RequestLoggerTest {
     StringReader mainReader = new StringReader(expectedString);
     Reader copyReader = logger.copyContent(mainReader);
     String copyString = Common.readerToString(copyReader);
-    assertEquals("Copy reader failed to read", expectedString, copyString);
+    assertEquals( expectedString, copyString);
     outString = new String(out.toByteArray());
-    assertEquals("Out failed to read", expectedString, outString);
+    assertEquals( expectedString, outString);
 
     out = new ByteArrayOutputStream();
     logger = Common.client.newLogger(out);
@@ -83,9 +74,9 @@ public class RequestLoggerTest {
       new ByteArrayInputStream(expectedString.getBytes());
     InputStream copyInputStream = logger.copyContent(mainInputStream);
     byte[] copyBytes = Common.streamToBytes(copyInputStream);
-    assertEquals("Copy input stream failed to read", expectedString, new String(copyBytes));
+    assertEquals( expectedString, new String(copyBytes));
     outString = new String(out.toByteArray());
-    assertEquals("Out failed to read", expectedString, outString);
+    assertEquals( expectedString, outString);
 
     out = new ByteArrayOutputStream();
     logger = Common.client.newLogger(out);
@@ -95,9 +86,9 @@ public class RequestLoggerTest {
     OutputStream tee = new OutputStreamTee(mainOutputStream, out, Long.MAX_VALUE);
     tee.write(expectedString.getBytes());
     byte[] mainBytes = mainOutputStream.toByteArray();
-    assertEquals("Main output stream failed to read", expectedString, new String(mainBytes));
+    assertEquals( expectedString, new String(mainBytes));
     outString = new String(out.toByteArray());
-    assertEquals("Out failed to read", expectedString, outString);
+    assertEquals( expectedString, outString);
     tee.close();
   }
 
@@ -134,7 +125,7 @@ public class RequestLoggerTest {
 
     docMgr.write(docId, new DOMHandle().with(domDocument));
     outString = new String(out.toByteArray());
-    assertTrue("Write failed to log output", outString.contains(domString));
+    assertTrue( outString.contains(domString));
 
     out = new ByteArrayOutputStream();
     logger = Common.client.newLogger(out);
@@ -143,7 +134,7 @@ public class RequestLoggerTest {
 
     String docText = docMgr.read(docId, new StringHandle()).get();
     outString = new String(out.toByteArray());
-    assertTrue("Read failed to log output", outString.contains(docText));
+    assertTrue( outString.contains(docText));
 
     out = new ByteArrayOutputStream();
     logger = Common.client.newLogger(out);
@@ -152,9 +143,9 @@ public class RequestLoggerTest {
 
     docMgr.exists(docId);
     outString = new String(out.toByteArray());
-    assertTrue("Exists logged null output",  outString != null);
+    assertTrue(  outString != null);
     if (outString != null)
-      assertTrue("Exists logged empty output", outString.length() > 0);
+      assertTrue( outString.length() > 0);
 
     out = new ByteArrayOutputStream();
     logger = Common.client.newLogger(out);
@@ -163,7 +154,7 @@ public class RequestLoggerTest {
 
     docMgr.delete(docId);
     outString = new String(out.toByteArray());
-    assertTrue("Delete failed to log output", outString != null && outString.length() > 0);
+    assertTrue( outString != null && outString.length() > 0);
 
   }
 
@@ -183,7 +174,7 @@ public class RequestLoggerTest {
 
     qMgr.search(querydef, new SearchHandle());
     outString = new String(out.toByteArray());
-    assertTrue("Search failed to log output", outString != null && outString.length() > 0);
+    assertTrue( outString != null && outString.length() > 0);
 
     out = new ByteArrayOutputStream();
     logger = Common.client.newLogger(out);
@@ -195,7 +186,7 @@ public class RequestLoggerTest {
 
     qMgr.delete(deleteDef);
     outString = new String(out.toByteArray());
-    assertTrue("SearchDelete failed to log output", outString != null && outString.length() > 0);
+    assertTrue( outString != null && outString.length() > 0);
 
 
   }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/ResourceExtensionsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/ResourceExtensionsTest.java
@@ -15,29 +15,26 @@
  */
 package com.marklogic.client.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import java.io.IOException;
-import java.util.HashMap;
-
-import org.custommonkey.xmlunit.SimpleNamespaceContext;
-import org.custommonkey.xmlunit.XMLUnit;
-import org.custommonkey.xmlunit.XpathEngine;
-import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.xml.sax.SAXException;
-
 import com.marklogic.client.admin.ExtensionMetadata;
 import com.marklogic.client.admin.MethodType;
 import com.marklogic.client.admin.ResourceExtensionsManager;
 import com.marklogic.client.admin.ResourceExtensionsManager.MethodParameters;
 import com.marklogic.client.io.Format;
 import com.marklogic.client.io.StringHandle;
+import org.custommonkey.xmlunit.SimpleNamespaceContext;
+import org.custommonkey.xmlunit.XMLUnit;
+import org.custommonkey.xmlunit.XpathEngine;
+import org.custommonkey.xmlunit.exceptions.XpathException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ResourceExtensionsTest {
   final static String RESOURCE_NAME = "testresource";
@@ -46,7 +43,7 @@ public class ResourceExtensionsTest {
   static private String      resourceServices;
   static private XpathEngine xpather;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() throws IOException {
     Common.connectAdmin();
     resourceServices = Common.testFileToString(XQUERY_FILE);
@@ -65,7 +62,7 @@ public class ResourceExtensionsTest {
     xpather = XMLUnit.newXpathEngine();
     xpather.setNamespaceContext(namespaceContext);
   }
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     resourceServices = null;
   }
@@ -103,11 +100,11 @@ public class ResourceExtensionsTest {
     extensionMgr.writeServices(RESOURCE_NAME, handle, metadata, params);
 
     extensionMgr.readServices(RESOURCE_NAME, handle);
-    assertEquals("Failed to retrieve resource services", resourceServices, handle.get());
+    assertEquals( resourceServices, handle.get());
 
     String result = extensionMgr.listServices(new StringHandle().withFormat(Format.XML), true).get();
-    assertNotNull("Failed to retrieve resource services list", result);
-    assertTrue("List without resource", xpather.getMatchingNodes(
+    assertNotNull( result);
+    assertTrue( xpather.getMatchingNodes(
       "/rapi:resources/rapi:resource/rapi:name[string(.) = 'testresource']",
       XMLUnit.buildControlDocument(result)
     ).getLength() == 1);
@@ -115,6 +112,6 @@ public class ResourceExtensionsTest {
     extensionMgr.deleteServices(RESOURCE_NAME);
 
     result = extensionMgr.readServices(RESOURCE_NAME, handle).get();
-    assertTrue("Failed to delete resource services", result == null);
+    assertTrue( result == null);
   }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/ResourceServicesTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/ResourceServicesTest.java
@@ -15,38 +15,37 @@
  */
 package com.marklogic.client.test;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
-import static org.junit.Assert.*;
-
-import java.io.IOException;
-import java.util.ArrayList;
-
-import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.w3c.dom.Document;
-
 import com.marklogic.client.DatabaseClient;
-import com.marklogic.client.io.Format;
-import com.marklogic.client.util.RequestParameters;
 import com.marklogic.client.admin.ResourceExtensionsManager;
 import com.marklogic.client.extensions.ResourceManager;
 import com.marklogic.client.extensions.ResourceServices;
 import com.marklogic.client.extensions.ResourceServices.ServiceResultIterator;
 import com.marklogic.client.io.DOMHandle;
+import com.marklogic.client.io.Format;
 import com.marklogic.client.io.StringHandle;
+import com.marklogic.client.util.RequestParameters;
+import org.custommonkey.xmlunit.exceptions.XpathException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
+
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ResourceServicesTest {
   static private String resourceServices;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() throws IOException {
     Common.connectAdmin();
     resourceServices = Common.testFileToString(ResourceExtensionsTest.XQUERY_FILE, "UTF-8");
   }
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     resourceServices = null;
   }
@@ -70,7 +69,7 @@ public class ResourceServicesTest {
     params.put("value", "true");
 
     Document result = resourceMgr.getResourceServices().get(params, new DOMHandle()).get();
-    assertNotNull("Failed to get resource service with single document", result);
+    assertNotNull( result);
     assertXpathEvaluatesTo("true", "/read-doc/param", result);
 
     ServiceResultIterator resultItr = resourceMgr.getResourceServices().get(params);
@@ -86,19 +85,19 @@ public class ResourceServicesTest {
     resultItr.close();
 
     int size = resultDocuments.size();
-    assertTrue("Failed to get resource service with two documents", size == 2);
+    assertTrue( size == 2);
     result = resultDocuments.get(0);
-    assertNotNull("Failed to get resource service with first document", result);
+    assertNotNull( result);
     assertXpathEvaluatesTo("true", "/read-doc/param", result);
     result = resultDocuments.get(1);
-    assertNotNull("Failed to get resource service with second document", result);
+    assertNotNull( result);
     assertXpathEvaluatesTo("true", "/read-multi-doc/multi-param", result);
 
     StringHandle writeHandle =
       new StringHandle().withFormat(Format.XML).with("<input-doc>true</input-doc>");
 
     result = resourceMgr.getResourceServices().put(params, writeHandle, new DOMHandle()).get();
-    assertNotNull("Failed to put resource service with a single document", result);
+    assertNotNull( result);
     assertXpathEvaluatesTo("true", "/wrote-doc/param", result);
     assertXpathEvaluatesTo("true", "/wrote-doc/input-doc", result);
 
@@ -107,13 +106,13 @@ public class ResourceServicesTest {
     writeHandles[1] = new StringHandle().withFormat(Format.XML).with("<multi-input-doc>true</multi-input-doc>");
 
     result = resourceMgr.getResourceServices().put(params, writeHandles, new DOMHandle()).get();
-    assertNotNull("Failed to put resource service with multiple documents", result);
+    assertNotNull( result);
     assertXpathEvaluatesTo("true", "/wrote-doc/param", result);
     assertXpathEvaluatesTo("true", "/wrote-doc/input-doc", result);
     assertXpathEvaluatesTo("true", "/wrote-doc/multi-input-doc", result);
 
     result = resourceMgr.getResourceServices().post(params, writeHandle, new DOMHandle()).get();
-    assertNotNull("Failed to post resource service with a single document", result);
+    assertNotNull( result);
     assertXpathEvaluatesTo("true", "/applied-doc/param", result);
     assertXpathEvaluatesTo("true", "/applied-doc/input-doc", result);
 
@@ -130,16 +129,16 @@ public class ResourceServicesTest {
     resultItr.close();
 
     size = resultDocuments.size();
-    assertTrue("Failed to post resource service with two documents", size == 2);
+    assertTrue( size == 2);
     result = resultDocuments.get(0);
-    assertNotNull("Failed to post resource service with first document", result);
+    assertNotNull( result);
     assertXpathEvaluatesTo("true", "/applied-doc/param", result);
     result = resultDocuments.get(1);
-    assertNotNull("Failed to post resource service with second document", result);
+    assertNotNull( result);
     assertXpathEvaluatesTo("true", "/applied-multi-doc/multi-param", result);
 
     result = resourceMgr.getResourceServices().delete(params, new DOMHandle()).get();
-    assertNotNull("Failed to delete resource service with a single document", result);
+    assertNotNull( result);
     assertXpathEvaluatesTo("true", "/deleted-doc/param", result);
 
     extensionMgr.deleteServices(ResourceExtensionsTest.RESOURCE_NAME);
@@ -155,13 +154,13 @@ public class ResourceServicesTest {
     Common.adminClient = null;
     String expectedMessage = "You cannot use this connected object anymore--connection has already been released";
     try { extensionMgr.writeServices(ResourceExtensionsTest.RESOURCE_NAME, null, null);
-    } catch (IllegalStateException e) { assertEquals("Wrong error", expectedMessage, e.getMessage()); }
+    } catch (IllegalStateException e) { assertEquals( expectedMessage, e.getMessage()); }
     try { extensionMgr.readServices(ResourceExtensionsTest.RESOURCE_NAME, new StringHandle());
-    } catch (IllegalStateException e) { assertEquals("Wrong error", expectedMessage, e.getMessage()); }
+    } catch (IllegalStateException e) { assertEquals( expectedMessage, e.getMessage()); }
     try { extensionMgr.listServices(new DOMHandle());
-    } catch (IllegalStateException e) { assertEquals("Wrong error", expectedMessage, e.getMessage()); }
+    } catch (IllegalStateException e) { assertEquals( expectedMessage, e.getMessage()); }
     try { extensionMgr.deleteServices(ResourceExtensionsTest.RESOURCE_NAME);
-    } catch (IllegalStateException e) { assertEquals("Wrong error", expectedMessage, e.getMessage()); }
+    } catch (IllegalStateException e) { assertEquals( expectedMessage, e.getMessage()); }
   }
 
   @Test

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/SPARQLManagerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/SPARQLManagerTest.java
@@ -15,25 +15,6 @@
  */
 package com.marklogic.client.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.io.IOException;
-import java.net.URLEncoder;
-import java.util.Map;
-
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.w3c.dom.Document;
-import org.w3c.dom.NamedNodeMap;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
 import com.fasterxml.jackson.core.JsonParser.Feature;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -42,27 +23,24 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.fasterxml.jackson.dataformat.csv.CsvSchema;
 import com.marklogic.client.DatabaseClient;
-import com.marklogic.client.DatabaseClientFactory;
-import com.marklogic.client.DatabaseClientFactory.DigestAuthContext;
 import com.marklogic.client.Transaction;
 import com.marklogic.client.document.XMLDocumentManager;
-import com.marklogic.client.io.DOMHandle;
-import com.marklogic.client.io.DocumentMetadataHandle;
-import com.marklogic.client.io.Format;
-import com.marklogic.client.io.JacksonHandle;
-import com.marklogic.client.io.StringHandle;
-import com.marklogic.client.query.QueryManager;
-import com.marklogic.client.query.RawCombinedQueryDefinition;
-import com.marklogic.client.query.RawStructuredQueryDefinition;
-import com.marklogic.client.query.StructuredQueryBuilder;
-import com.marklogic.client.query.StructuredQueryDefinition;
-import com.marklogic.client.semantics.GraphManager;
-import com.marklogic.client.semantics.RDFMimeTypes;
-import com.marklogic.client.semantics.SPARQLBindings;
-import com.marklogic.client.semantics.SPARQLMimeTypes;
-import com.marklogic.client.semantics.SPARQLQueryDefinition;
-import com.marklogic.client.semantics.SPARQLQueryManager;
-import com.marklogic.client.semantics.SPARQLRuleset;
+import com.marklogic.client.io.*;
+import com.marklogic.client.query.*;
+import com.marklogic.client.semantics.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class SPARQLManagerTest {
   private static String graphUri = "http://marklogic.com/java/SPARQLManagerTest";
@@ -81,7 +59,7 @@ public class SPARQLManagerTest {
   private static SPARQLQueryManager smgr;
   private static GraphManager gmgr;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     Common.connect();
     gmgr = Common.client.newGraphManager();
@@ -91,7 +69,7 @@ public class SPARQLManagerTest {
     smgr = Common.client.newSPARQLQueryManager();
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     gmgr.delete(graphUri);
   }
@@ -143,18 +121,14 @@ public class SPARQLManagerTest {
 
     Node description = rdf.getFirstChild().getFirstChild();
     assertNotNull(description.getAttributes());
-    assertEquals("subject",
-      "http://example.org/s1", description.getAttributes().item(0).getTextContent());
+    assertEquals("http://example.org/s1", description.getAttributes().item(0).getTextContent());
     assertNotNull(description.getFirstChild());
-    assertEquals("predicate",
-      "p1", description.getFirstChild().getNodeName());
-    assertEquals("predicate namespace",
-      "http://example.org/", description.getFirstChild().getNamespaceURI());
+    assertEquals("p1", description.getFirstChild().getNodeName());
+    assertEquals("http://example.org/", description.getFirstChild().getNamespaceURI());
     NamedNodeMap attrs = description.getFirstChild().getAttributes();
     assertNotNull(attrs);
     assertNotNull(attrs.getNamedItemNS("http://www.w3.org/1999/02/22-rdf-syntax-ns#", "resource"));
-    assertEquals("object", "http://example.org/o1",
-      attrs.getNamedItemNS("http://www.w3.org/1999/02/22-rdf-syntax-ns#", "resource").getTextContent());
+    assertEquals("http://example.org/o1", attrs.getNamedItemNS("http://www.w3.org/1999/02/22-rdf-syntax-ns#", "resource").getTextContent());
   }
 
   @Test
@@ -493,7 +467,7 @@ public class SPARQLManagerTest {
           sparqlManagerReader
             .newQueryDefinition("select ?o where { <s1> <p1> ?o }"),
           new StringHandle());
-      assertEquals("Empty result outside transaction", "{\"head\":{\"vars\":[]},\"results\":{\"bindings\":[]}}", handle.get());
+      assertEquals( "{\"head\":{\"vars\":[]},\"results\":{\"bindings\":[]}}", handle.get());
 
       // and can inside (with writer user)
       handle = smgr
@@ -501,7 +475,7 @@ public class SPARQLManagerTest {
           sparqlManagerReader
             .newQueryDefinition("select ?o where { <s1> <p1> ?o }"),
           new StringHandle(), tx);
-      assertEquals("writer must see effects within transaction.", "{\"head\":{\"vars\":[\"o\"]},\"results\":{\"bindings\":[{\"o\":{\"type\":\"uri\",\"value\":\"o1\"}}]}}", handle.get());
+      assertEquals( "{\"head\":{\"vars\":[\"o\"]},\"results\":{\"bindings\":[{\"o\":{\"type\":\"uri\",\"value\":\"o1\"}}]}}", handle.get());
 
       tx.rollback();
       tx = null;
@@ -511,7 +485,7 @@ public class SPARQLManagerTest {
           sparqlManagerReader
             .newQueryDefinition("select ?o where { <s1> <p1> ?o }"),
           new StringHandle());
-      assertEquals("Empty result after rollback", "{\"head\":{\"vars\":[]},\"results\":{\"bindings\":[]}}", handle.get());
+      assertEquals( "{\"head\":{\"vars\":[]},\"results\":{\"bindings\":[]}}", handle.get());
 
       // new tx
       tx = Common.client.openTransaction();
@@ -527,7 +501,7 @@ public class SPARQLManagerTest {
           sparqlManagerReader
             .newQueryDefinition("select ?o where { <s1> <p1> ?o }"),
           new StringHandle());
-      assertEquals("update has been committed", "{\"head\":{\"vars\":[\"o\"]},\"results\":{\"bindings\":[{\"o\":{\"type\":\"uri\",\"value\":\"o1\"}}]}}", handle.get());
+      assertEquals( "{\"head\":{\"vars\":[\"o\"]},\"results\":{\"bindings\":[{\"o\":{\"type\":\"uri\",\"value\":\"o1\"}}]}}", handle.get());
 
       // new transaction
       tx = Common.client.openTransaction();
@@ -539,7 +513,7 @@ public class SPARQLManagerTest {
         .executeSelect(
           smgr.newQueryDefinition("select ?o where { <s1> <p1> ?o }"),
           new StringHandle(), tx);
-      assertEquals("Empty result after delete, within tx", "{\"head\":{\"vars\":[]},\"results\":{\"bindings\":[]}}", handle.get());
+      assertEquals( "{\"head\":{\"vars\":[]},\"results\":{\"bindings\":[]}}", handle.get());
 
       tx.commit();
       tx = null;

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/SPARQLQueryDefinitionTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/SPARQLQueryDefinitionTest.java
@@ -15,23 +15,16 @@
  */
 package com.marklogic.client.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.StringHandle;
-import com.marklogic.client.semantics.GraphManager;
-import com.marklogic.client.semantics.RDFTypes;
-import com.marklogic.client.semantics.SPARQLBindings;
-import com.marklogic.client.semantics.SPARQLQueryDefinition;
-import com.marklogic.client.semantics.SPARQLQueryManager;
+import com.marklogic.client.semantics.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class SPARQLQueryDefinitionTest {
 
@@ -92,7 +85,7 @@ public class SPARQLQueryDefinitionTest {
     + ":o3 { :p4 rdfs:subPropertyOf :p1 .  } "
     + ":o4 { :p5 rdfs:range :c2 .  } ";
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     Common.connect();
     gmgr = Common.client.newGraphManager();
@@ -101,7 +94,7 @@ public class SPARQLQueryDefinitionTest {
     smgr = Common.client.newSPARQLQueryManager();
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     Common.connect();
     gmgr = Common.client.newGraphManager();
@@ -355,7 +348,7 @@ public class SPARQLQueryDefinitionTest {
     askQuery.withBinding("o", "2", RDFTypes.ANYURI);
     assertFalse(smgr.executeAsk(askQuery));
     bindings.clear();
-    
+
     askQuery.withBinding("o", "en", RDFTypes.LANGUAGE);
     assertTrue(smgr.executeAsk(askQuery));
     bindings.clear();
@@ -408,16 +401,16 @@ public class SPARQLQueryDefinitionTest {
     JsonNode rdf = smgr.executeConstruct(qdef, new JacksonHandle()).get();
 
     String subject = rdf.fieldNames().next();
-    assertEquals("base uri plus relative subject uri",
+    assertEquals(
       "http://marklogic.com/SPARQLQDefTest/relative1", subject);
 
     String predicate = rdf.get(subject).fieldNames().next();
-    assertEquals("base uri plus relative predicate uri",
+    assertEquals(
       "http://marklogic.com/SPARQLQDefTest/relative2", predicate);
 
     JsonNode objects = rdf.get(subject).get(predicate);
     assertEquals(1, objects.size());
-    assertEquals("base uri plus relative uri",
+    assertEquals(
       "http://marklogic.com/SPARQLQDefTest/relative3", objects.path(0).path("value").asText());
   }
 
@@ -435,12 +428,12 @@ public class SPARQLQueryDefinitionTest {
 
     qdef.setDefaultGraphUris("http://marklogic.com/SPARQLQDefTest/g4");
     bindings = executeAndExtractBindings(qdef);
-    assertEquals("Single graphs has one assertion", 1, bindings.size());
+    assertEquals( 1, bindings.size());
 
     qdef.setDefaultGraphUris("http://marklogic.com/SPARQLQDefTest/g4",
       "http://marklogic.com/SPARQLQDefTest/g2");
     bindings = executeAndExtractBindings(qdef);
-    assertEquals("Union two default graphs has two assertions", 2,
+    assertEquals( 2,
       bindings.size());
   }
 
@@ -451,15 +444,15 @@ public class SPARQLQueryDefinitionTest {
     qdef.setIncludeDefaultRulesets(false);
     qdef.setNamedGraphUris("http://marklogic.com/SPARQLQDefTest/g3");
     ArrayNode bindings = executeAndExtractBindings(qdef);
-    assertEquals("From named 0 result assertions", 0, bindings.size());
+    assertEquals( 0, bindings.size());
 
     qdef.setNamedGraphUris("http://marklogic.com/SPARQLQDefTest/g4");
     bindings = executeAndExtractBindings(qdef);
-    assertEquals("From named 1 result assertions", 1, bindings.size());
+    assertEquals( 1, bindings.size());
 
     qdef.setNamedGraphUris("http://marklogic.com/SPARQLQDefTest/g4", "http://marklogic.com/SPARQLQDefTest/g2");
     bindings = executeAndExtractBindings(qdef);
-    assertEquals("From named 1 result assertions", 2, bindings.size());
+    assertEquals( 2, bindings.size());
   }
 
   @Test
@@ -525,13 +518,13 @@ public class SPARQLQueryDefinitionTest {
     assertFalse(qdef.getIncludeDefaultRulesets());
     JacksonHandle handle = smgr.executeSelect(qdef, new JacksonHandle());
     JsonNode results = handle.get();
-    assertEquals("Size of results with no inference", 1,
+    assertEquals( 1,
       results.get("results").get("bindings").size());
 
     qdef.setIncludeDefaultRulesets(true);
     handle = smgr.executeSelect(qdef, new JacksonHandle());
     results = handle.get();
-    assertEquals("Size of results with default inference", 3,
+    assertEquals( 3,
       results.get("results").get("bindings").size());
 
     qdef = smgr

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/SPARQLQueryManagerImplTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/SPARQLQueryManagerImplTest.java
@@ -15,17 +15,18 @@
  */
 package com.marklogic.client.test;
 
+import com.marklogic.client.impl.HandleImplementation;
+import com.marklogic.client.impl.RESTServices;
+import com.marklogic.client.impl.SPARQLQueryDefinitionImpl;
+import com.marklogic.client.impl.SPARQLQueryManagerImpl;
 import com.marklogic.client.io.Format;
 import com.marklogic.client.io.marker.TriplesReadHandle;
 import com.marklogic.client.semantics.RDFMimeTypes;
 import com.marklogic.client.semantics.SPARQLQueryDefinition;
-import com.marklogic.client.impl.HandleImplementation;
-import com.marklogic.client.impl.RESTServices;
-import com.marklogic.client.impl.SPARQLQueryManagerImpl;
-import com.marklogic.client.impl.SPARQLQueryDefinitionImpl;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 /**

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/SSLTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/SSLTest.java
@@ -15,9 +15,12 @@
  */
 package com.marklogic.client.test;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.DatabaseClientFactory.SSLHostnameVerifier;
+import com.marklogic.client.MarkLogicIOException;
+import com.marklogic.client.document.TextDocumentManager;
+import com.marklogic.client.io.StringHandle;
+import org.junit.jupiter.api.Test;
 
 import javax.net.ssl.*;
 import javax.security.auth.x500.X500Principal;
@@ -33,15 +36,9 @@ import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
-import com.marklogic.client.MarkLogicIOException;
-import org.junit.Test;
-
-import com.marklogic.client.DatabaseClient;
-import com.marklogic.client.DatabaseClientFactory;
-import com.marklogic.client.DatabaseClientFactory.DigestAuthContext;
-import com.marklogic.client.DatabaseClientFactory.SSLHostnameVerifier;
-import com.marklogic.client.document.TextDocumentManager;
-import com.marklogic.client.io.StringHandle;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class SSLTest {
   @Test

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/SearchFacetTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/SearchFacetTest.java
@@ -15,32 +15,30 @@
  */
 package com.marklogic.client.test;
 
-import static org.junit.Assert.assertNotNull;
-
-import java.io.IOException;
-import java.io.StringReader;
-
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-
 import com.marklogic.client.FailedRequestException;
 import com.marklogic.client.ForbiddenUserException;
 import com.marklogic.client.ResourceNotFoundException;
 import com.marklogic.client.ResourceNotResendableException;
+import com.marklogic.client.admin.QueryOptionsManager;
+import com.marklogic.client.io.DOMHandle;
+import com.marklogic.client.io.SearchHandle;
+import com.marklogic.client.query.FacetResult;
 import com.marklogic.client.query.QueryManager;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import com.marklogic.client.query.StringQueryDefinition;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
-import com.marklogic.client.admin.QueryOptionsManager;
-import com.marklogic.client.query.FacetResult;
-import com.marklogic.client.query.StringQueryDefinition;
-import com.marklogic.client.io.DOMHandle;
-import com.marklogic.client.io.SearchHandle;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.IOException;
+import java.io.StringReader;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class SearchFacetTest {
   private static String options =
@@ -123,13 +121,13 @@ public class SearchFacetTest {
 
   private QueryOptionsManager mgr;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     Common.connectAdmin();
     Common.connect();
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
   }
 

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/SemanticsPermissionsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/SemanticsPermissionsTest.java
@@ -15,31 +15,16 @@
  */
 package com.marklogic.client.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
-
-import org.junit.FixMethodOrder;
-import org.junit.runners.MethodSorters;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
 import com.marklogic.client.DatabaseClient;
-import com.marklogic.client.DatabaseClientFactory;
-import com.marklogic.client.DatabaseClientFactory.DigestAuthContext;
 import com.marklogic.client.ForbiddenUserException;
 import com.marklogic.client.ResourceNotFoundException;
 import com.marklogic.client.io.StringHandle;
-import com.marklogic.client.semantics.Capability;
-import com.marklogic.client.semantics.GraphManager;
-import com.marklogic.client.semantics.GraphPermissions;
-import com.marklogic.client.semantics.RDFMimeTypes;
-import com.marklogic.client.semantics.SPARQLQueryDefinition;
-import com.marklogic.client.semantics.SPARQLQueryManager;
+import com.marklogic.client.semantics.*;
+import org.junit.jupiter.api.*;
 
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+import static org.junit.jupiter.api.Assertions.*;
+
+@TestMethodOrder(MethodOrderer.MethodName.class)
 public class SemanticsPermissionsTest {
   private static GraphManager gmgr;
   private static String graphUri = "SemanticsPermissionsTest";
@@ -48,7 +33,7 @@ public class SemanticsPermissionsTest {
   private static DatabaseClient writePrivilegedClient = Common.makeNewClient(
     Common.HOST, Common.PORT, Common.newSecurityContext(Common.WRITE_PRIVILIGED_USER, Common.WRITE_PRIVILIGED_PASS));
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     Common.connect();
     gmgr = Common.client.newGraphManager();
@@ -58,7 +43,7 @@ public class SemanticsPermissionsTest {
     gmgr.write(graphUri, new StringHandle(triple).withMimetype(RDFMimeTypes.NTRIPLES), perms);
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     GraphManager gmgr = Common.client.newGraphManager();
     gmgr.delete(graphUri);

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/ServerConfigurationManagerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/ServerConfigurationManagerTest.java
@@ -15,28 +15,26 @@
  */
 package com.marklogic.client.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-
-import java.io.IOException;
-
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
 import com.marklogic.client.FailedRequestException;
 import com.marklogic.client.ForbiddenUserException;
 import com.marklogic.client.ResourceNotFoundException;
 import com.marklogic.client.ResourceNotResendableException;
 import com.marklogic.client.admin.ServerConfigurationManager;
 import com.marklogic.client.admin.ServerConfigurationManager.UpdatePolicy;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ServerConfigurationManagerTest {
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     Common.connectAdmin();
   }
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
   }
 
@@ -46,7 +44,7 @@ public class ServerConfigurationManagerTest {
   {
     ServerConfigurationManager initialServerConfig  = Common.adminClient.newServerConfigManager();
 
-    assertNull("Initial query option validation not null", initialServerConfig.getQueryOptionValidation());
+    assertNull( initialServerConfig.getQueryOptionValidation());
 
     initialServerConfig.readConfiguration();
 
@@ -95,12 +93,12 @@ public class ServerConfigurationManagerTest {
     initialServerConfig.setUpdatePolicy(initialVersionReq);
     initialServerConfig.writeConfiguration();
 
-    assertEquals("Failed to change query validation",            modQueryValid,   refreshQueryValid);
-    assertEquals("Failed to change query options validation",    modOptionValid,  refreshOptionValid);
-    assertEquals("Failed to change document read transform",     modReadTrans,    refreshReadTrans);
-    assertEquals("Failed to change document read transform all", modReadTransAll, refreshReadTransAll);
-    assertEquals("Failed to change server request logging",      modRequestLog,   refreshRequestLog);
-    assertEquals("Failed to change update policy ",              modVersionReq,   refreshVersionReq);
+    assertEquals(            modQueryValid,   refreshQueryValid);
+    assertEquals(    modOptionValid,  refreshOptionValid);
+    assertEquals(     modReadTrans,    refreshReadTrans);
+    assertEquals( modReadTransAll, refreshReadTransAll);
+    assertEquals(      modRequestLog,   refreshRequestLog);
+    assertEquals(              modVersionReq,   refreshVersionReq);
 
     Common.propertyWait();
   }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/StringSearchTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/StringSearchTest.java
@@ -15,24 +15,6 @@
  */
 package com.marklogic.client.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-
-import javax.xml.namespace.QName;
-import javax.xml.parsers.ParserConfigurationException;
-
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.xml.sax.SAXException;
-
 import com.marklogic.client.FailedRequestException;
 import com.marklogic.client.ForbiddenUserException;
 import com.marklogic.client.ResourceNotFoundException;
@@ -42,28 +24,33 @@ import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.Format;
 import com.marklogic.client.io.SearchHandle;
 import com.marklogic.client.io.StringHandle;
-import com.marklogic.client.query.FacetResult;
-import com.marklogic.client.query.FacetValue;
-import com.marklogic.client.query.MatchDocumentSummary;
-import com.marklogic.client.query.MatchLocation;
-import com.marklogic.client.query.QueryManager;
+import com.marklogic.client.query.*;
 import com.marklogic.client.query.QueryManager.QueryView;
-import com.marklogic.client.query.RawCombinedQueryDefinition;
-import com.marklogic.client.query.SearchMetrics;
-import com.marklogic.client.query.StringQueryDefinition;
 import com.marklogic.client.util.RequestLogger;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class StringSearchTest {
   @SuppressWarnings("unused")
   private static final Logger logger = (Logger) LoggerFactory.getLogger(StringSearchTest.class);
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     Common.connect();
     Common.connectAdmin();
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
   }
 
@@ -86,13 +73,13 @@ public class StringSearchTest {
 
     FacetResult[] facets = results.getFacetResults();
     assertNotNull(facets);
-    assertEquals("expected 1 facet", 1, facets.length);
+    assertEquals( 1, facets.length);
     FacetValue[] facetVals = facets[0].getFacetValues();
-    assertEquals("expected 6 facet values", 6, facetVals.length);
+    assertEquals( 6, facetVals.length);
 
     MatchDocumentSummary[] summaries = results.getMatchResults();
     assertNotNull(summaries);
-    assertEquals("expected 2 results", 2, summaries.length);
+    assertEquals( 2, summaries.length);
   }
 
   @Test
@@ -109,11 +96,11 @@ public class StringSearchTest {
 
     MatchDocumentSummary[] summaries = handle.getMatchResults();
     assertNotNull(summaries);
-    assertEquals("expected 2 results", 2, summaries.length);
+    assertEquals( 2, summaries.length);
 
     for ( MatchDocumentSummary summary : summaries ) {
       MatchLocation[] locations = summary.getMatchLocations();
-      assertEquals("expected 1 match location", 1, locations.length);
+      assertEquals( 1, locations.length);
       for ( MatchLocation location : locations ) {
         assertNotNull(location.getAllSnippetText());
       }
@@ -139,9 +126,9 @@ public class StringSearchTest {
 
     FacetResult[] facets = results.getFacetResults();
     assertNotNull(facets);
-    assertEquals("expected 1 facet", 1, facets.length);
+    assertEquals( 1, facets.length);
     FacetValue[] facetVals = facets[0].getFacetValues();
-    assertEquals("expected 6 facet values", 6, facetVals.length);
+    assertEquals( 6, facetVals.length);
 
     MatchDocumentSummary[] summaries = results.getMatchResults();
     assertTrue(summaries == null || summaries.length == 0);
@@ -155,8 +142,8 @@ public class StringSearchTest {
 
     summaries = results.getMatchResults();
     assertNotNull(summaries);
-    assertEquals("expected 2 results", 2, summaries.length);
-    assertEquals("empty-snippet", results.getSnippetTransformType());
+    assertEquals( 2, summaries.length);
+	  assertEquals("empty-snippet", results.getSnippetTransformType());
   }
 
   @Test
@@ -177,7 +164,7 @@ public class StringSearchTest {
     assertTrue(results.getConstraintIterator(new StringHandle()).next().get().startsWith("<search:constraint"));
     assertTrue(results.getConstraintNames()[0].equals("myFacet"));
     assertTrue(results.getConstraint("myFacet", new StringHandle()).get().startsWith("<search:constraint"));
-    assertEquals("myFacet", results.getFacetNames()[0]);
+    assertEquals( "myFacet", results.getFacetNames()[0]);
     SearchMetrics metrics = results.getMetrics();
     assertTrue(metrics.getFacetResolutionTime() >= 0);
     assertTrue(metrics.getQueryResolutionTime() >= 0);

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/StructuredQueryBuilderTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/StructuredQueryBuilderTest.java
@@ -15,41 +15,36 @@
  */
 package com.marklogic.client.test;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
-
-import org.custommonkey.xmlunit.XpathEngine;
-import org.custommonkey.xmlunit.SimpleNamespaceContext;
-import org.custommonkey.xmlunit.XMLUnit;
-
-import java.io.*;
-import java.util.HashMap;
-
-import javax.xml.XMLConstants;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.parsers.SAXParser;
-import javax.xml.parsers.SAXParserFactory;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.stream.StreamSource;
-import javax.xml.validation.Schema;
-import javax.xml.validation.SchemaFactory;
-
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.xml.sax.SAXException;
-import org.xml.sax.SAXParseException;
-import org.xml.sax.helpers.DefaultHandler;
-
 import com.marklogic.client.query.StructuredQueryBuilder;
 import com.marklogic.client.query.StructuredQueryBuilder.FragmentScope;
 import com.marklogic.client.query.StructuredQueryBuilder.Operator;
 import com.marklogic.client.query.StructuredQueryDefinition;
 import com.marklogic.client.util.EditableNamespaceContext;
+import org.custommonkey.xmlunit.SimpleNamespaceContext;
+import org.custommonkey.xmlunit.XMLUnit;
+import org.custommonkey.xmlunit.XpathEngine;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+import org.xml.sax.helpers.DefaultHandler;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+import java.io.*;
+import java.util.HashMap;
 import java.util.Map;
+
+import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
 
 public class StructuredQueryBuilderTest {
   static private XpathEngine xpather;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     XMLUnit.setIgnoreAttributeOrder(true);
     XMLUnit.setIgnoreWhitespace(true);

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/StructuredSearchTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/StructuredSearchTest.java
@@ -15,41 +15,31 @@
  */
 package com.marklogic.client.test;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import java.io.IOException;
-
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.xml.sax.SAXException;
-
 import com.marklogic.client.document.GenericDocumentManager;
 import com.marklogic.client.io.Format;
 import com.marklogic.client.io.SearchHandle;
 import com.marklogic.client.io.StringHandle;
-import com.marklogic.client.query.MatchDocumentSummary;
-import com.marklogic.client.query.MatchLocation;
-import com.marklogic.client.query.QueryDefinition;
-import com.marklogic.client.query.QueryManager;
-import com.marklogic.client.query.RawCombinedQueryDefinition;
-import com.marklogic.client.query.StructuredQueryBuilder;
-import com.marklogic.client.query.StructuredQueryDefinition;
+import com.marklogic.client.query.*;
 import com.marklogic.client.util.EditableNamespaceContext;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+
+import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class StructuredSearchTest {
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     Common.connect();
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
   }
 
@@ -67,10 +57,10 @@ public class StructuredSearchTest {
 
       MatchDocumentSummary[] summaries = results.getMatchResults();
       assertNotNull(summaries);
-      assertEquals("expected 1 result", 1, summaries.length);
+      assertEquals( 1, summaries.length);
       for (MatchDocumentSummary summary : summaries) {
         MatchLocation[] locations = summary.getMatchLocations();
-        assertEquals("expected 1 match location", 1, locations.length);
+        assertEquals( 1, locations.length);
         for (MatchLocation location : locations) {
           assertNotNull(location.getAllSnippetText());
         }
@@ -91,7 +81,7 @@ public class StructuredSearchTest {
       assertNotNull(summary);
 
       GenericDocumentManager docMgr = Common.client.newDocumentManager();
-      assertNotNull("Document exists", docMgr.exists(summary.getUri()));
+      assertNotNull( docMgr.exists(summary.getUri()));
     }
   }
 
@@ -171,7 +161,7 @@ public class StructuredSearchTest {
 
     MatchDocumentSummary[] summaries = sh.getMatchResults();
     assertNotNull(summaries);
-    assertEquals("expected 1 result", 1, summaries.length);
+    assertEquals( 1, summaries.length);
 
     MatchDocumentSummary matchResult = summaries[0];
     Document metadata = matchResult.getMetadata();

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/SuggestTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/SuggestTest.java
@@ -15,27 +15,22 @@
  */
 package com.marklogic.client.test;
 
-import static org.junit.Assert.assertEquals;
-
-import java.io.FileNotFoundException;
-
-import org.custommonkey.xmlunit.XMLUnit;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.marklogic.client.DatabaseClient;
-import com.marklogic.client.FailedRequestException;
-import com.marklogic.client.ForbiddenUserException;
-import com.marklogic.client.ResourceNotFoundException;
-import com.marklogic.client.ResourceNotResendableException;
+import com.marklogic.client.*;
 import com.marklogic.client.admin.QueryOptionsManager;
 import com.marklogic.client.document.XMLDocumentManager;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.query.SuggestDefinition;
+import org.custommonkey.xmlunit.XMLUnit;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileNotFoundException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SuggestTest {
 
@@ -45,7 +40,7 @@ public class SuggestTest {
   private static final Logger logger = (Logger) LoggerFactory
     .getLogger(SuggestTest.class);
 
-  @AfterClass
+  @AfterAll
   public static void teardown()
     throws ResourceNotFoundException, ForbiddenUserException, FailedRequestException {
     XMLDocumentManager docMgr = Common.client.newXMLDocumentManager();
@@ -54,7 +49,7 @@ public class SuggestTest {
 
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setup()
     throws FileNotFoundException, ResourceNotFoundException, ForbiddenUserException, FailedRequestException, ResourceNotResendableException {
     XMLUnit.setIgnoreWhitespace(true);

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/TextDocumentTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/TextDocumentTest.java
@@ -15,29 +15,24 @@
  */
 package com.marklogic.client.test;
 
-import static org.junit.Assert.assertEquals;
+import com.marklogic.client.document.TextDocumentManager;
+import com.marklogic.client.io.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
-import com.marklogic.client.document.TextDocumentManager;
-import com.marklogic.client.io.BytesHandle;
-import com.marklogic.client.io.FileHandle;
-import com.marklogic.client.io.InputStreamHandle;
-import com.marklogic.client.io.ReaderHandle;
-import com.marklogic.client.io.StringHandle;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TextDocumentTest {
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     Common.connect();
   }
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
   }
 
@@ -48,23 +43,23 @@ public class TextDocumentTest {
 
     TextDocumentManager docMgr = Common.client.newTextDocumentManager();
     docMgr.write(docId, new StringHandle().with(text));
-    assertEquals("Text document write difference",text,docMgr.read(docId, new StringHandle()).get());
+    assertEquals(text,docMgr.read(docId, new StringHandle()).get());
 
     BytesHandle bytesHandle = new BytesHandle();
     docMgr.read(docId, bytesHandle);
-    assertEquals("Text document mismatch reading bytes", bytesHandle.get().length,text.length());
+    assertEquals( bytesHandle.get().length,text.length());
 
     InputStreamHandle inputStreamHandle = new InputStreamHandle();
     docMgr.read(docId, inputStreamHandle);
     byte[] b = Common.streamToBytes(inputStreamHandle.get());
-    assertEquals("Text document mismatch reading input stream",new String(b),text);
+    assertEquals(new String(b),text);
 
     Reader reader = docMgr.read(docId, new ReaderHandle()).get();
     String s = Common.readerToString(reader);
-    assertEquals("Text document mismatch with reader",s,text);
+    assertEquals(s,text);
 
     File file = docMgr.read(docId, new FileHandle()).get();
-    assertEquals("Text document mismatch with file",text.length(),file.length());
+    assertEquals(text.length(),file.length());
   }
 
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/TimeTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/TimeTest.java
@@ -15,13 +15,12 @@
  */
 package com.marklogic.client.test;
 
-import java.util.Calendar;
-import java.util.Date;
-
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-
 import com.marklogic.client.pojo.annotation.Id;
+
+import java.util.Calendar;
+import java.util.Date;
 
 public class TimeTest {
   @Id public String id;

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/TransformExtensionsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/TransformExtensionsTest.java
@@ -15,31 +15,28 @@
  */
 package com.marklogic.client.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import java.io.IOException;
-import java.util.HashMap;
-
-import org.custommonkey.xmlunit.SimpleNamespaceContext;
-import org.custommonkey.xmlunit.XMLUnit;
-import org.custommonkey.xmlunit.XpathEngine;
-import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.xml.sax.SAXException;
-
-import com.marklogic.client.admin.ExtensionMetadata;
 import com.marklogic.client.FailedRequestException;
 import com.marklogic.client.ForbiddenUserException;
 import com.marklogic.client.ResourceNotFoundException;
 import com.marklogic.client.ResourceNotResendableException;
-import com.marklogic.client.io.Format;
+import com.marklogic.client.admin.ExtensionMetadata;
 import com.marklogic.client.admin.TransformExtensionsManager;
+import com.marklogic.client.io.Format;
 import com.marklogic.client.io.StringHandle;
+import org.custommonkey.xmlunit.SimpleNamespaceContext;
+import org.custommonkey.xmlunit.XMLUnit;
+import org.custommonkey.xmlunit.XpathEngine;
+import org.custommonkey.xmlunit.exceptions.XpathException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TransformExtensionsTest {
   final static String XQUERY_NAME = "testxqy";
@@ -51,7 +48,7 @@ public class TransformExtensionsTest {
   static private String      xslTransform;
   static private XpathEngine xpather;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() throws IOException {
     Common.connect();
     Common.connectAdmin();
@@ -74,7 +71,7 @@ public class TransformExtensionsTest {
     xqueryTransform = Common.testFileToString(XQUERY_FILE, "UTF-8");
     xslTransform    = Common.testFileToString(XSLT_FILE, "UTF-8");
   }
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     xqueryTransform = null;
     xslTransform    = null;
@@ -113,22 +110,22 @@ public class TransformExtensionsTest {
     writeXSLTransform(extensionMgr);
 
     extensionMgr.readXQueryTransform(XQUERY_NAME, handle);
-    assertEquals("Failed to retrieve XQuery transform", xqueryTransform, handle.get());
+    assertEquals( xqueryTransform, handle.get());
 
     String result = extensionMgr.readXSLTransform(XSLT_NAME, new StringHandle()).get();
-    assertNotNull("Failed to retrieve XSLT transform", result);
-    assertTrue("Did not recognize XSLT transform", xpather.getMatchingNodes(
+    assertNotNull( result);
+    assertTrue( xpather.getMatchingNodes(
       "/xsl:stylesheet",
       XMLUnit.buildControlDocument(result)
     ).getLength() == 1);
 
     result = extensionMgr.listTransforms(new StringHandle().withFormat(Format.XML), true).get();
-    assertNotNull("Failed to retrieve transforms list", result);
-    assertTrue("List without XQuery transform", xpather.getMatchingNodes(
+    assertNotNull( result);
+    assertTrue( xpather.getMatchingNodes(
       "/rapi:transforms/rapi:transform/rapi:name[string(.) = 'testxqy']",
       XMLUnit.buildControlDocument(result)
     ).getLength() == 1);
-    assertTrue("List without XSLT transform", xpather.getMatchingNodes(
+    assertTrue( xpather.getMatchingNodes(
       "/rapi:transforms/rapi:transform/rapi:name[string(.) = 'testxsl']",
       XMLUnit.buildControlDocument(result)
     ).getLength() == 1);
@@ -143,7 +140,7 @@ public class TransformExtensionsTest {
       transformDeleted = (result == null);
     } catch(FailedRequestException ex) {
     }
-    assertTrue("Failed to delete XQuery transform", transformDeleted);
+    assertTrue( transformDeleted);
 
     extensionMgr.deleteTransform(XSLT_NAME);
 
@@ -156,7 +153,7 @@ public class TransformExtensionsTest {
     } catch(FailedRequestException ex) {
     }
 
-    assertTrue("Failed to delete XSLT transform", transformDeleted);
+    assertTrue( transformDeleted);
   }
   public void writeXQueryTransform(TransformExtensionsManager extensionMgr)
     throws ResourceNotFoundException, ResourceNotResendableException, ForbiddenUserException, FailedRequestException

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/TransformTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/TransformTest.java
@@ -15,17 +15,6 @@
  */
 package com.marklogic.client.test;
 
-import static org.junit.Assert.assertEquals;
-
-import java.io.IOException;
-
-import javax.xml.namespace.QName;
-
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.w3c.dom.Document;
-
 import com.marklogic.client.FailedRequestException;
 import com.marklogic.client.ForbiddenUserException;
 import com.marklogic.client.ResourceNotFoundException;
@@ -37,12 +26,19 @@ import com.marklogic.client.document.ServerTransform;
 import com.marklogic.client.document.XMLDocumentManager;
 import com.marklogic.client.io.DOMHandle;
 import com.marklogic.client.io.Format;
-import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.SearchHandle;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.query.StringQueryDefinition;
 import com.marklogic.client.query.ValuesDefinition;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TransformTest {
   final static public String JS_NAME = "testsjs";
@@ -57,7 +53,7 @@ public class TransformTest {
   static private ExtensionLibrariesManager libMgr;
 
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass()
     throws IOException, FailedRequestException, ForbiddenUserException, ResourceNotFoundException, ResourceNotResendableException {
     Common.connect();
@@ -102,7 +98,7 @@ public class TransformTest {
     );
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass()
     throws ResourceNotFoundException, ForbiddenUserException, FailedRequestException {
     confMgr.newQueryOptionsManager().deleteOptions(optionsName);
@@ -193,7 +189,7 @@ public class TransformTest {
     docMgr.write(docId, new StringHandle().with("<document/>"));
     Document result = docMgr.read(docId, new DOMHandle(), transform).get();
     String value = result.getDocumentElement().getAttributeNS(TEST_NS, "transformed");
-    assertEquals("Document read transform failed","true",value);
+    assertEquals("true",value);
 
     //docMgr.delete(docId);
 
@@ -201,7 +197,7 @@ public class TransformTest {
     docMgr.write(docId, new StringHandle().with("<document/>"), transform);
     result = docMgr.read(docId, new DOMHandle()).get();
     value = result.getDocumentElement().getAttributeNS(TEST_NS, "transformed");
-    assertEquals("Document write transform failed",value,"true");
+    assertEquals(value,"true");
 
     //docMgr.delete(docId);
 
@@ -213,7 +209,7 @@ public class TransformTest {
 
     result = queryMgr.search(stringQuery, new DOMHandle()).get();
     value = result.getDocumentElement().getAttributeNS(TEST_NS, "transformed");
-    assertEquals("String query read transform failed","true",value);
+    assertEquals("true",value);
 
     ValuesDefinition vdef =
       queryMgr.newValuesDefinition("double", optionsName);
@@ -224,7 +220,7 @@ public class TransformTest {
     vdef.setQueryDefinition(stringQuery);
     result = queryMgr.values(vdef, new DOMHandle()).get();
     value = result.getDocumentElement().getAttributeNS(TEST_NS, "transformed");
-    assertEquals("Values query read transform failed",value,"true");
+    assertEquals(value,"true");
 
 // TODO: QBE tests with XQuery and XSLT
   }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/TuplesHandleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/TuplesHandleTest.java
@@ -15,20 +15,6 @@
  */
 package com.marklogic.client.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import java.io.IOException;
-
-import javax.xml.parsers.ParserConfigurationException;
-
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.xml.sax.SAXException;
-
 import com.marklogic.client.FailedRequestException;
 import com.marklogic.client.ForbiddenUserException;
 import com.marklogic.client.ResourceNotFoundException;
@@ -36,12 +22,18 @@ import com.marklogic.client.ResourceNotResendableException;
 import com.marklogic.client.admin.QueryOptionsManager;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.io.TuplesHandle;
-import com.marklogic.client.query.AggregateResult;
-import com.marklogic.client.query.QueryManager;
-import com.marklogic.client.query.Tuple;
-import com.marklogic.client.query.TypedDistinctValue;
-import com.marklogic.client.query.ValuesDefinition;
-import com.marklogic.client.query.ValuesMetrics;
+import com.marklogic.client.query.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TuplesHandleTest {
 
@@ -82,13 +74,13 @@ public class TuplesHandleTest {
       "<return-values>true</return-values>" +
     "</options>";
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     Common.connect();
     Common.connectAdmin();
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
   }
 
@@ -109,19 +101,19 @@ public class TuplesHandleTest {
     TuplesHandle t = queryMgr.tuples(vdef, new TuplesHandle());
 
     AggregateResult[] agg = t.getAggregates();
-    assertEquals("Two aggregates are expected", 2, agg.length);
+    assertEquals( 2, agg.length);
 
     double cov = t.getAggregate("covariance").get("xs:double", Double.class);
-    assertTrue("The covariance is between 1.551 and 1.552",
+    assertTrue(
       cov > 1.551 && cov < 1.552);
 
     Tuple[] tuples = t.getTuples();
-    assertEquals("Twelve tuples are expected", 12, tuples.length);
-    assertEquals("The tuples are named 'co'", "co", t.getName());
+    assertEquals( 12, tuples.length);
+    assertEquals( "co", t.getName());
 
     ValuesMetrics metrics = t.getMetrics();
-    assertTrue("The values resolution time is >= 0", metrics.getValuesResolutionTime() >= 0);
-    assertTrue("The aggregate resolution time is >= 0", metrics.getAggregateResolutionTime() >= 0);
+    assertTrue(metrics.getValuesResolutionTime() >= 0);
+    assertTrue(metrics.getAggregateResolutionTime() >= 0);
 
     optionsMgr.deleteOptions("valuesoptions2");
   }
@@ -140,11 +132,11 @@ public class TuplesHandleTest {
     TuplesHandle t = queryMgr.tuples(vdef, new TuplesHandle());
 
     Tuple[] tuples = t.getTuples();
-    assertEquals("Twelve tuples are expected", 12, tuples.length);
-    assertEquals("The tuples are named 'co'", "co", t.getName());
+    assertEquals( 12, tuples.length);
+    assertEquals( "co", t.getName());
 
     ValuesMetrics metrics = t.getMetrics();
-    assertTrue("The values resolution time is >= 0", metrics.getValuesResolutionTime() >= 0);
+    assertTrue(metrics.getValuesResolutionTime() >= 0);
     // Restore after bug:18747 is fixed
     // assertEquals("The aggregate resolution time is -1 (absent)", metrics.getAggregateResolutionTime(), -1);
 
@@ -165,17 +157,17 @@ public class TuplesHandleTest {
     TuplesHandle t = queryMgr.tuples(vdef, new TuplesHandle());
 
     Tuple[] tuples = t.getTuples();
-    assertEquals("Twelve tuples are expected", 12, tuples.length);
-    assertEquals("The tuples are named 'co'", "co", t.getName());
+    assertEquals( 12, tuples.length);
+    assertEquals( "co", t.getName());
 
     TypedDistinctValue[] dv = tuples[0].getValues();
 
-    assertEquals("Two values per tuple expected", 2, dv.length);
-    assertEquals("First is long", "xs:double",  dv[0].getType());
-    assertEquals("Second is int", "xs:int", dv[1].getType());
-    assertEquals("Frequency is 1", 1, tuples[0].getCount());
-    assertEquals("First value",  1.1, (double) dv[0].get(Double.class), 0.01);
-    assertEquals("Second value", (int) 1, (int) dv[1].get(Integer.class));
+    assertEquals( 2, dv.length);
+    assertEquals( "xs:double",  dv[0].getType());
+    assertEquals( "xs:int", dv[1].getType());
+    assertEquals( 1, tuples[0].getCount());
+    assertEquals(  1.1, (double) dv[0].get(Double.class), 0.01);
+    assertEquals( (int) 1, (int) dv[1].get(Integer.class));
 
     optionsMgr.deleteOptions("valuesoptions");
   }
@@ -194,19 +186,19 @@ public class TuplesHandleTest {
     TuplesHandle t = queryMgr.tuples(vdef, new TuplesHandle());
 
     Tuple[] tuples = t.getTuples();
-    assertEquals("Four tuples are expected", 4, tuples.length);
-    assertEquals("The tuples are named 'n-way'", "n-way", t.getName());
+    assertEquals( 4, tuples.length);
+    assertEquals( "n-way", t.getName());
 
     TypedDistinctValue[] dv = tuples[0].getValues();
 
-    assertEquals("Three values per tuple expected", 3, dv.length);
-    assertEquals("First is long", "xs:double",  dv[0].getType());
-    assertEquals("Second is int", "xs:int", dv[1].getType());
-    assertEquals("Third is string", "xs:string", dv[2].getType());
-    assertEquals("Frequency is 1", 1, tuples[0].getCount());
-    assertEquals("First value",  1.1, (double) dv[0].get(Double.class), 0.01);
-    assertEquals("Second value", (int) 1, (int) dv[1].get(Integer.class));
-    assertEquals("Third value", "Alaska", (String) dv[2].get(String.class));
+    assertEquals( 3, dv.length);
+    assertEquals( "xs:double",  dv[0].getType());
+    assertEquals( "xs:int", dv[1].getType());
+    assertEquals( "xs:string", dv[2].getType());
+    assertEquals( 1, tuples[0].getCount());
+    assertEquals(  1.1, (double) dv[0].get(Double.class), 0.01);
+    assertEquals( (int) 1, (int) dv[1].get(Integer.class));
+    assertEquals( "Alaska", (String) dv[2].get(String.class));
     optionsMgr.deleteOptions("valuesoptions");
   }
 
@@ -225,18 +217,18 @@ public class TuplesHandleTest {
     TuplesHandle t = queryMgr.tuples(vdef, new TuplesHandle(), 3);
 
     Tuple[] tuples = t.getTuples();
-    assertEquals("Six tuples are expected", 6, tuples.length);
+    assertEquals( 6, tuples.length);
 
     TypedDistinctValue[] values = tuples[0].getValues();
     String value = values[0].get(Double.class)+" | "+values[1].get(Integer.class);
-    assertEquals("The first tuple is '1.2 | 3'", "1.2 | 3", value);
+    assertEquals("1.2 | 3", value);
 
     values = tuples[5].getValues();
     value =
       values[0].get(Double.class).toString()
         + " | "
         + values[1].get(Integer.class).toString();
-    assertEquals("The last tuple is '2.2 | 4'", "2.2 | 4", value);
+    assertEquals("2.2 | 4", value);
 
     optionsMgr.deleteOptions("valuesoptions");
   }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/ValueConverterTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/ValueConverterTest.java
@@ -15,31 +15,28 @@
  */
 package com.marklogic.client.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.util.Calendar;
+import com.marklogic.client.impl.ValueConverter;
+import com.marklogic.client.impl.ValueConverter.ValueProcessor;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.Duration;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Calendar;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
-import com.marklogic.client.impl.ValueConverter;
-import com.marklogic.client.impl.ValueConverter.ValueProcessor;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ValueConverterTest {
   static TestProcessor processor;
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     processor = new TestProcessor();
   }
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     processor = null;
   }
@@ -87,7 +84,7 @@ public class ValueConverterTest {
   public void testConvertFromJavaByteArray() {
     byte[] b = {'a', 'b', 'c'};
     ValueConverter.convertFromJava(b, processor);
-    assertEquals("byte array type",  "xs:base64Binary", processor.type);
+    assertEquals(  "xs:base64Binary", processor.type);
     byte[] c = (byte[]) ValueConverter.convertToJava(
       processor.type, processor.value
     );
@@ -100,7 +97,7 @@ public class ValueConverterTest {
           isSame = false;
       }
     }
-    assertTrue("byte array value", isSame);
+    assertTrue( isSame);
   }
   @Test
   public void testConvertFromJavaCalendar() {
@@ -109,8 +106,8 @@ public class ValueConverterTest {
     Calendar d = (Calendar) ValueConverter.convertToJava(
       processor.type, processor.value
     );
-    assertEquals("datetime type", "xs:dateTime", processor.type);
-    assertEquals("datetime value", c.getTimeInMillis(), d.getTimeInMillis());
+    assertEquals( "xs:dateTime", processor.type);
+    assertEquals( c.getTimeInMillis(), d.getTimeInMillis());
 
     Calendar e = Calendar.getInstance();
     e.clear();
@@ -121,8 +118,8 @@ public class ValueConverterTest {
     d = (Calendar) ValueConverter.convertToJava(
       processor.type, processor.value
     );
-    assertEquals("date type", "xs:date", processor.type);
-    assertEquals("date value", e.getTimeInMillis(), d.getTimeInMillis());
+    assertEquals( "xs:date", processor.type);
+    assertEquals( e.getTimeInMillis(), d.getTimeInMillis());
 
     e = Calendar.getInstance();
     e.clear();
@@ -134,17 +131,17 @@ public class ValueConverterTest {
     d = (Calendar) ValueConverter.convertToJava(
       processor.type, processor.value
     );
-    assertEquals("time type", "xs:time", processor.type);
-    assertEquals("time hour value",
+    assertEquals( "xs:time", processor.type);
+    assertEquals(
       e.get(Calendar.HOUR_OF_DAY),
       d.get(Calendar.HOUR_OF_DAY));
-    assertEquals("time minute value",
+    assertEquals(
       e.get(Calendar.MINUTE),
       d.get(Calendar.MINUTE));
-    assertEquals("time second value",
+    assertEquals(
       e.get(Calendar.SECOND),
       d.get(Calendar.SECOND));
-    assertEquals("time millisecond value",
+    assertEquals(
       e.get(Calendar.MILLISECOND),
       d.get(Calendar.MILLISECOND));
   }
@@ -209,11 +206,8 @@ public class ValueConverterTest {
   }
 
   void checkProcessor(String type, String xsType, Object value) {
-    assertEquals(type+" type",  xsType, processor.type);
-    assertEquals(type+" value",
-      value,
-      ValueConverter.convertToJava(processor.type, processor.value)
-    );
+    assertEquals(xsType, processor.type);
+    assertEquals(value, ValueConverter.convertToJava(processor.type, processor.value));
   }
 
   static class TestProcessor implements ValueProcessor {

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/ValuesHandleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/ValuesHandleTest.java
@@ -15,25 +15,6 @@
  */
 package com.marklogic.client.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.HashMap;
-
-import javax.xml.parsers.ParserConfigurationException;
-
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.xml.sax.SAXException;
-
 import com.marklogic.client.FailedRequestException;
 import com.marklogic.client.ForbiddenUserException;
 import com.marklogic.client.ResourceNotFoundException;
@@ -43,17 +24,22 @@ import com.marklogic.client.io.Format;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.io.ValuesHandle;
 import com.marklogic.client.io.ValuesListHandle;
-import com.marklogic.client.query.AggregateResult;
-import com.marklogic.client.query.CountedDistinctValue;
-import com.marklogic.client.query.QueryManager;
-import com.marklogic.client.query.RawCtsQueryDefinition;
-import com.marklogic.client.query.StringQueryDefinition;
-import com.marklogic.client.query.StructuredQueryBuilder;
-import com.marklogic.client.query.StructuredQueryDefinition;
-import com.marklogic.client.query.ValueQueryDefinition;
-import com.marklogic.client.query.ValuesDefinition;
-import com.marklogic.client.query.ValuesListDefinition;
+import com.marklogic.client.query.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ValuesHandleTest {
 
@@ -61,13 +47,13 @@ public class ValuesHandleTest {
   private static final Logger logger = (Logger) LoggerFactory
     .getLogger(ValuesHandleTest.class);
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     Common.connect();
     Common.connectAdmin();
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
   }
 
@@ -90,15 +76,15 @@ public class ValuesHandleTest {
     ValuesHandle v = queryMgr.values(vdef, new ValuesHandle());
 
     AggregateResult[] agg = v.getAggregates();
-    assertEquals("There should be 2 aggregates", 2, agg.length);
+    assertEquals( 2, agg.length);
     double first  = agg[0].get("xs:double", Double.class);
-    assertTrue("Aggregate 1 should be between 11.4 and 12",
+    assertTrue(
       11.4 < first && first < 12.0);
 
     double second = agg[1].get("xs:double", Double.class);
 
     logger.debug("" + second);
-    assertTrue("Aggregate 2 should be between 1.43 and 1.44",
+    assertTrue(
       1.43 < second && second < 1.44);
 
     Common.adminClient.newServerConfigManager().newQueryOptionsManager().deleteOptions(optionsName);
@@ -139,14 +125,14 @@ public class ValuesHandleTest {
           vQuery = rawCtsQuery;
           break;
         default:
-          assertTrue("test case error", false);
+          assertTrue( false);
       }
       vdef.setQueryDefinition(vQuery);
 
       ValuesHandle v = queryMgr.values(vdef, new ValuesHandle());
       CountedDistinctValue dv[] = v.getValues();
-      assertNotNull("There should be values", dv);
-      assertEquals("There should be 3 values", 3, dv.length);
+      assertNotNull( dv);
+      assertEquals( 3, dv.length);
     }
 
     Common.adminClient.newServerConfigManager().newQueryOptionsManager().deleteOptions(optionsName);
@@ -160,14 +146,14 @@ public class ValuesHandleTest {
       v = new MyValuesHandle();
       v.parseTestData(is);
     }
-    assertTrue("Name should be 'size'", "size".equals(v.getName()));
-    assertEquals("Type should be 'xs:unsignedLong'", "xs:unsignedLong", v.getType());
+    assertTrue("size".equals(v.getName()));
+    assertEquals( "xs:unsignedLong", v.getType());
 
     CountedDistinctValue dv[] = v.getValues();
 
-    assertEquals("There should be 8 values", 8, dv.length);
-    assertEquals("Frequency should be 1", 1, dv[0].getCount());
-    assertEquals("Value should be 815", (long) 815, (long) dv[0].get(v.getType(), Long.class));
+    assertEquals( 8, dv.length);
+    assertEquals( 1, dv[0].getCount());
+    assertEquals( (long) 815, (long) dv[0].get(v.getType(), Long.class));
   }
 
   @Test
@@ -179,8 +165,8 @@ public class ValuesHandleTest {
 
     v.parseTestData(is);
     Map<String,String> map = v.getValuesMap();
-    assertEquals("Map should contain two keys", map.size(), 2);
-    assertEquals("Size should have this uri", map.get("size"), "/v1/values/size?options=photos");
+    assertEquals( map.size(), 2);
+    assertEquals( map.get("size"), "/v1/values/size?options=photos");
   }
 
 
@@ -195,12 +181,12 @@ public class ValuesHandleTest {
 
     ValuesHandle v = queryMgr.values(vdef, new ValuesHandle(), 2);
     CountedDistinctValue dv[] = v.getValues();
-    assertNotNull("There should be values", dv);
-    assertEquals("There should be 2 values", 2, dv.length);
+    assertNotNull( dv);
+    assertEquals( 2, dv.length);
 
-    assertEquals("The first value should be '1.2'",
+    assertEquals(
       dv[0].get("xs:double", Double.class).toString(), "1.2");
-    assertEquals("The second value should be '2.2'",
+    assertEquals(
       dv[1].get("xs:double", Double.class).toString(), "2.2");
 
     Common.adminClient.newServerConfigManager().newQueryOptionsManager().deleteOptions(optionsName);
@@ -216,15 +202,15 @@ public class ValuesHandleTest {
     ValuesListHandle results = queryMgr.valuesList(vdef, new ValuesListHandle());
     assertNotNull(results);
     Map<String,String> map = results.getValuesMap();
-    assertEquals("Map should contain two keys", map.size(), 2);
-    assertEquals("Size should have this uri", map.get("size"), "/v1/values/size?options=photos");
+    assertEquals( map.size(), 2);
+    assertEquals( map.get("size"), "/v1/values/size?options=photos");
 
     // test pagelength
     queryMgr.setPageLength(1L);
     results = queryMgr.valuesList(vdef, new ValuesListHandle());
     assertNotNull(results);
     map = results.getValuesMap();
-    assertEquals("Map should contain one keys", map.size(), 1);
+    assertEquals( map.size(), 1);
 
   }
 

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/ApplyTransformTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/ApplyTransformTest.java
@@ -15,31 +15,31 @@
  */
 package com.marklogic.client.test.datamovement;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.datamovement.*;
+import com.marklogic.client.datamovement.ApplyTransformListener.ApplyResult;
 import com.marklogic.client.document.GenericDocumentManager;
 import com.marklogic.client.document.ServerTransform;
 import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.FileHandle;
 import com.marklogic.client.query.DeleteQueryDefinition;
-import com.marklogic.client.query.StructuredQueryDefinition;
 import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.query.StructuredQueryBuilder;
-import com.marklogic.client.datamovement.ApplyTransformListener.ApplyResult;
+import com.marklogic.client.query.StructuredQueryDefinition;
 import com.marklogic.client.test.Common;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ApplyTransformTest {
   private static DatabaseClient client = Common.connect();
@@ -53,12 +53,12 @@ public class ApplyTransformTest {
   private static String transformName1 = "WriteBatcherTest_transform.sjs";
   private static String transformName2 = "ApplyTransformTest_result_ignore_transform.sjs";
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     installModule();
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     DeleteQueryDefinition deleteQuery = queryMgr.newDeleteDefinition();
     deleteQuery.setCollections(collection);
@@ -92,8 +92,7 @@ public class ApplyTransformTest {
     moveMgr.stopJob(ticket);
 
     JsonNode docContents = docMgr.readAs(collection + "/test1.json", JsonNode.class);
-    assertEquals( "the transform should have changed testProperty to 'test1a'",
-      "test1a", docContents.get("testProperty").textValue() );
+    assertEquals("test1a", docContents.get("testProperty").textValue() );
   }
 
   @Test
@@ -115,8 +114,7 @@ public class ApplyTransformTest {
     moveMgr.stopJob(ticket);
 
     JsonNode docContents = docMgr.readAs(collection + "/test2.json", JsonNode.class);
-    assertEquals( "the transform should have changed testProperty to 'test2a'",
-      "test2a", docContents.get("testProperty").textValue() );
+    assertEquals("test2a", docContents.get("testProperty").textValue() );
   }
 
   @Test
@@ -152,7 +150,7 @@ public class ApplyTransformTest {
     batcher.awaitCompletion();
     moveMgr.stopJob(ticket2);
     System.out.println("DEBUG: count2=[" + count2 + "]");
-    assertEquals( "exactly " + numDocs + " docs should have been transformed", numDocs, count2.get());
+    assertEquals(numDocs, count2.get());
 
     StructuredQueryDefinition query3 = sqb.value(sqb.jsonProperty("testProperty"), "test3a");
     query3.setCollections(collection);
@@ -166,7 +164,7 @@ public class ApplyTransformTest {
     moveMgr.stopJob(ticket3);
 
     System.out.println("DEBUG: count3=[" + count3 + "]");
-    assertEquals( "exactly " + numDocs + " docs should match the new value test3a", numDocs, count3.get());
+    assertEquals(numDocs, count3.get());
   }
 
   @Test

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/ConcurrencyTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/ConcurrencyTest.java
@@ -1,37 +1,30 @@
 package com.marklogic.client.test.datamovement;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.client.DatabaseClient;
-import com.marklogic.client.datamovement.*;
+import com.marklogic.client.datamovement.DataMovementManager;
+import com.marklogic.client.datamovement.QueryBatchException;
+import com.marklogic.client.datamovement.QueryBatcher;
+import com.marklogic.client.datamovement.WriteBatcher;
 import com.marklogic.client.datamovement.impl.QueryBatcherImpl;
 import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.StringHandle;
-import com.marklogic.client.query.*;
+import com.marklogic.client.query.DeleteQueryDefinition;
+import com.marklogic.client.query.QueryManager;
+import com.marklogic.client.query.StructuredQueryBuilder;
 import com.marklogic.client.test.Common;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.auth.AuthScope;
-import org.apache.http.auth.UsernamePasswordCredentials;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.DefaultHttpClient;
-import org.apache.http.util.EntityUtils;
-import org.junit.AfterClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ConcurrencyTest {
 
@@ -40,7 +33,7 @@ public class ConcurrencyTest {
     private static DataMovementManager moveMgr = client.newDataMovementManager();
 
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         QueryManager queryMgr = client.newQueryManager();
         DeleteQueryDefinition deleteQuery = queryMgr.newDeleteDefinition();
@@ -90,7 +83,7 @@ public class ConcurrencyTest {
         queryBatcher.awaitCompletion();
         dmManager.stopJob(queryBatcher);
 
-        assertTrue("Output list does not contain all number of outputs", outputUris.size() == totalCount);
+        assertTrue( outputUris.size() == totalCount);
 
 /*        QueryBatcher queryBatcherAfter = dmManager.newQueryBatcher(new StructuredQueryBuilder().collection("ConcurrencyTest"));
         AtomicInteger minAfter = new AtomicInteger(Integer.MAX_VALUE);

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/DeleteListenerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/DeleteListenerTest.java
@@ -15,18 +15,16 @@
  */
 package com.marklogic.client.test.datamovement;
 
-import static org.junit.Assert.assertEquals;
-
-import com.marklogic.client.datamovement.*;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
 import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.datamovement.*;
 import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.query.StructuredQueryBuilder;
-
 import com.marklogic.client.test.Common;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class DeleteListenerTest {
   private static DatabaseClient client = Common.connect();
@@ -34,11 +32,11 @@ public class DeleteListenerTest {
   private static String collection = "DeleteListenerTest";
   private static String docContents = "doc contents";
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
   }
 
@@ -57,8 +55,7 @@ public class DeleteListenerTest {
     writeBatcher.flushAndWait();
 
     // verify that the files made it to the db
-    assertEquals( "There should be 100 documents in the db",
-      100, client.newDocumentManager().read(uris).size() );
+    assertEquals(100, client.newDocumentManager().read(uris).size() );
 
     QueryBatcher queryBatcher = moveMgr.newQueryBatcher(
         new StructuredQueryBuilder().collection(collection)
@@ -71,7 +68,6 @@ public class DeleteListenerTest {
     moveMgr.stopJob(ticket);
 
     // validate that the docs were deleted
-    assertEquals( "There should be 0 documents in the db",
-      0, client.newDocumentManager().read(uris).size() );
+    assertEquals(0, client.newDocumentManager().read(uris).size() );
   }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/ExportToWriterListenerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/ExportToWriterListenerTest.java
@@ -15,31 +15,31 @@
  */
 package com.marklogic.client.test.datamovement;
 
-import static org.junit.Assert.assertEquals;
-
-import java.io.BufferedReader;
-import java.io.FileReader;
-import java.io.File;
-import java.io.FileWriter;
-import java.nio.file.Files;
-import java.util.concurrent.TimeUnit;
-import java.util.Random;
-
-import com.marklogic.client.datamovement.*;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.datamovement.DataMovementManager;
+import com.marklogic.client.datamovement.ExportToWriterListener;
+import com.marklogic.client.datamovement.QueryBatcher;
+import com.marklogic.client.datamovement.WriteBatcher;
+import com.marklogic.client.document.DocumentManager;
+import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.client.query.StructuredQueryBuilder;
+import com.marklogic.client.query.StructuredQueryDefinition;
+import com.marklogic.client.test.Common;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.marklogic.client.DatabaseClient;
-import com.marklogic.client.io.DocumentMetadataHandle;
-import com.marklogic.client.document.DocumentManager;
-import com.marklogic.client.query.StructuredQueryDefinition;
-import com.marklogic.client.query.StructuredQueryBuilder;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.nio.file.Files;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
-import com.marklogic.client.test.Common;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ExportToWriterListenerTest {
   private Logger logger = LoggerFactory.getLogger(ExportToWriterListenerTest.class);
@@ -49,11 +49,11 @@ public class ExportToWriterListenerTest {
     new Random().nextInt(10000);
   private static String docContents = "doc contents";
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
   }
 
@@ -74,7 +74,7 @@ public class ExportToWriterListenerTest {
     batcher.flushAndWait();
 
     // verify that the files made it to the db
-    assertEquals( "There should be 100 documents in the db",
+    assertEquals(
       100, client.newDocumentManager().read(uris).size() );
 
     // export to a csv with uri, collection, and contents columns
@@ -111,7 +111,7 @@ public class ExportToWriterListenerTest {
     try (FileReader fileReader = new FileReader(outputFile); BufferedReader reader = new BufferedReader(fileReader)) {
       int lines = 0;
       while ( reader.readLine() != null ) lines++;
-      assertEquals( "There should be 100 lines in the output file", 100, lines );
+      assertEquals(100, lines );
     }
     if(outputFile.exists()) outputFile.delete();
   }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/FilteredForestConfigTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/FilteredForestConfigTest.java
@@ -15,37 +15,23 @@
  */
 package com.marklogic.client.test.datamovement;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import org.junit.Test;
-
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.datamovement.*;
+import com.marklogic.client.datamovement.impl.ForestImpl;
+import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.client.query.StructuredQueryBuilder;
+import com.marklogic.client.query.StructuredQueryDefinition;
+import com.marklogic.client.test.Common;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.marklogic.client.DatabaseClient;
-import com.marklogic.client.io.DocumentMetadataHandle;
-import com.marklogic.client.query.StructuredQueryDefinition;
-import com.marklogic.client.query.StructuredQueryBuilder;
-import com.marklogic.client.datamovement.DataMovementManager;
-import com.marklogic.client.datamovement.FilteredForestConfiguration;
-import com.marklogic.client.datamovement.Forest;
-import com.marklogic.client.datamovement.ForestConfiguration;
-import com.marklogic.client.datamovement.QueryBatcher;
-import com.marklogic.client.datamovement.WriteBatcher;
-import com.marklogic.client.datamovement.WriteEvent;
-import com.marklogic.client.datamovement.impl.ForestImpl;
-import com.marklogic.client.test.Common;
-
 import java.net.Inet4Address;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Random;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class FilteredForestConfigTest {
   private Logger logger = LoggerFactory.getLogger(FilteredForestConfigTest.class);
@@ -59,7 +45,7 @@ public class FilteredForestConfigTest {
       "forestName2", "forestId2", true, false),
     new ForestImpl("host3", null, null, "alternateHost3", "databaseName3",
       "forestName3", "forestId3", true, false),
-    new ForestImpl("host4", null, "requestHost4", null, "databaseName4", 
+    new ForestImpl("host4", null, "requestHost4", null, "databaseName4",
       "forestName4", "forestId4", true, false)
   };
 

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/ForestConfigTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/ForestConfigTest.java
@@ -15,32 +15,27 @@
  */
 package com.marklogic.client.test.datamovement;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.datamovement.DataMovementManager;
-import com.marklogic.client.datamovement.impl.DataMovementManagerImpl;
 import com.marklogic.client.datamovement.Forest;
 import com.marklogic.client.datamovement.ForestConfiguration;
-
+import com.marklogic.client.datamovement.impl.DataMovementManagerImpl;
 import com.marklogic.client.test.Common;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ForestConfigTest {
   private static DatabaseClient client = Common.connect();
   private DataMovementManager moveMgr = client.newDataMovementManager();
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
   }
 

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/JSONSplitterTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/JSONSplitterTest.java
@@ -20,16 +20,15 @@ import com.marklogic.client.datamovement.JSONSplitter;
 import com.marklogic.client.datamovement.NodeOperation;
 import com.marklogic.client.document.DocumentWriteOperation;
 import com.marklogic.client.io.StringHandle;
+import com.marklogic.client.io.marker.JSONWriteHandle;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.util.Iterator;
 import java.util.stream.Stream;
 
-import com.marklogic.client.io.marker.JSONWriteHandle;
-import org.junit.Test;
-
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class JSONSplitterTest {
     static final private String jsonObjectFile = "src/test/resources/data" + File.separator + "pathSplitter/JsonSplitterObject.json";

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/LegalHoldsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/LegalHoldsTest.java
@@ -15,37 +15,28 @@
  */
 package com.marklogic.client.test.datamovement;
 
-import com.marklogic.client.datamovement.FilteredForestConfiguration;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
-import static org.junit.Assert.fail;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.marklogic.client.datamovement.DataMovementManager;
-import com.marklogic.client.datamovement.QueryBatcher;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.marklogic.client.DatabaseClient;
-
 import com.marklogic.client.ResourceNotFoundException;
 import com.marklogic.client.admin.ExtensionLibrariesManager;
+import com.marklogic.client.datamovement.DataMovementManager;
+import com.marklogic.client.datamovement.QueryBatcher;
 import com.marklogic.client.document.JSONDocumentManager;
 import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.FileHandle;
 import com.marklogic.client.io.Format;
 import com.marklogic.client.io.JacksonHandle;
-import com.marklogic.client.query.StructuredQueryDefinition;
 import com.marklogic.client.query.StructuredQueryBuilder;
-
-import static com.marklogic.client.query.StructuredQueryBuilder.Operator;
-
+import com.marklogic.client.query.StructuredQueryDefinition;
 import com.marklogic.client.test.Common;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
+import javax.xml.bind.DatatypeConverter;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -55,7 +46,8 @@ import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import javax.xml.bind.DatatypeConverter;
+import static com.marklogic.client.query.StructuredQueryBuilder.Operator;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class LegalHoldsTest {
   private Logger logger = LoggerFactory.getLogger(LegalHoldsTest.class);
@@ -66,7 +58,7 @@ public class LegalHoldsTest {
   private static DatabaseClient evalClient = Common.connectEval();
   private static DatabaseClient adminClient = Common.connectAdmin();
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() throws Exception {
     // install the filterUrisReferencedByHolds module
     installModule();
@@ -75,7 +67,7 @@ public class LegalHoldsTest {
     // upload sample json docs.  Only file5.json matches all criteria.
     uploadData();
   }
-  @AfterClass
+  @AfterAll
   public static void afterClass() throws Exception {
     cleanup(adminClient);
   }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/LineSplitterTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/LineSplitterTest.java
@@ -4,7 +4,7 @@ import com.marklogic.client.datamovement.LineSplitter;
 import com.marklogic.client.document.DocumentWriteOperation;
 import com.marklogic.client.io.Format;
 import com.marklogic.client.io.StringHandle;
-import org.junit.*;
+import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -16,7 +16,7 @@ import java.util.Iterator;
 import java.util.stream.Stream;
 import java.util.zip.GZIPInputStream;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class LineSplitterTest {
     static final private String jsonlFile = "src/test/resources/data" + File.separator + "pathSplitter/line-delimited.jsonl";

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/PathSplitterTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/PathSplitterTest.java
@@ -22,7 +22,7 @@ import com.marklogic.client.datamovement.PathSplitter;
 import com.marklogic.client.datamovement.XMLSplitter;
 import com.marklogic.client.document.DocumentWriteOperation;
 import com.marklogic.client.io.Format;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -30,8 +30,8 @@ import java.nio.file.Paths;
 import java.util.Iterator;
 import java.util.stream.Stream;
 
-import static org.junit.Assert.*;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class PathSplitterTest {
 

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/PointInTimeQueryTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/PointInTimeQueryTest.java
@@ -15,31 +15,24 @@
  */
 package com.marklogic.client.test.datamovement;
 
-import java.util.Random;
-import java.util.concurrent.atomic.AtomicInteger;
-
+import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.datamovement.*;
-import org.junit.FixMethodOrder;
-import org.junit.runners.MethodSorters;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
+import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.client.query.DeleteQueryDefinition;
+import com.marklogic.client.query.QueryManager;
+import com.marklogic.client.query.StructuredQueryBuilder;
+import com.marklogic.client.query.StructuredQueryDefinition;
+import com.marklogic.client.test.Common;
+import org.junit.jupiter.api.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.marklogic.client.DatabaseClient;
-import com.marklogic.client.io.DocumentMetadataHandle;
-import com.marklogic.client.query.DeleteQueryDefinition;
-import com.marklogic.client.query.StructuredQueryDefinition;
-import com.marklogic.client.query.QueryManager;
-import com.marklogic.client.query.StructuredQueryBuilder;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
 
-import com.marklogic.client.test.Common;
+import static org.junit.jupiter.api.Assertions.*;
 
-import static org.junit.Assert.*;
-
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@TestMethodOrder(MethodOrderer.MethodName.class)
 public class PointInTimeQueryTest {
   private static Logger logger = LoggerFactory.getLogger(PointInTimeQueryTest.class);
   private static int numDocs = 50;
@@ -48,12 +41,12 @@ public class PointInTimeQueryTest {
   private static String collection = "PointInTimeQueryTest_" +
     new Random().nextInt(10000);
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() throws Exception {
     setup();
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     QueryManager queryMgr = client.newQueryManager();
     DeleteQueryDefinition deleteQuery = queryMgr.newDeleteDefinition();
@@ -138,8 +131,8 @@ public class PointInTimeQueryTest {
     // now that we're done deleting, wait for the exportBatcher to finish
     exportBatcher.awaitCompletion();
 
-    assertNotNull("withConsistentSnapshot was used, so the server timestamp should be available to the client",
-            exportBatcher.getServerTimestamp());
+    assertNotNull(exportBatcher.getServerTimestamp(),
+		"withConsistentSnapshot was used, so the server timestamp should be available to the client");
 
     // if we still got all the docs, that means our delete was ignored during the run
     assertEquals(numDocs, successDocs.get());

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/ProgressListenerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/ProgressListenerTest.java
@@ -17,18 +17,19 @@ package com.marklogic.client.test.datamovement;
 
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.datamovement.*;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
 import java.util.function.Consumer;
 
-public class ProgressListenerTest extends Assert {
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ProgressListenerTest {
 
 	private ProgressListener listener;
-	private TestConsumer consumer = new TestConsumer();
+	private final TestConsumer consumer = new TestConsumer();
 
 	@Test
 	public void batchesInOrder() throws Exception {
@@ -79,8 +80,8 @@ public class ProgressListenerTest extends Assert {
 		listener.processEvent(new FakeQueryBatch(2));
 
 		assertTrue(consumer.texts.get(0).startsWith("Progress: 4 of 4"));
-		assertEquals("The second batch is ignored because its jobResultsSoFar value is less than what the listener has seen so far",
-			1, consumer.texts.size());
+		assertEquals(1, consumer.texts.size(),
+			"The second batch is ignored because its jobResultsSoFar value is less than what the listener has seen so far");
 	}
 
 	@Test
@@ -103,8 +104,8 @@ public class ProgressListenerTest extends Assert {
 		listener.processEvent(new FakeQueryBatch(2));
 		listener.processEvent(new FakeQueryBatch(4));
 
-		assertEquals("Verifying that the TestConsumer still got updates, even though the first consumer kept throwing exceptions",
-			2, consumer.texts.size());
+		assertEquals(2, consumer.texts.size(),
+			"Verifying that the TestConsumer still got updates, even though the first consumer kept throwing exceptions");
 	}
 
 	@Test
@@ -115,10 +116,10 @@ public class ProgressListenerTest extends Assert {
 		listener.processEvent(new FakeQueryBatch(4));
 
 		assertEquals(2, consumer.texts.size());
-		assertTrue("On the first batch, the listener doesn't yet know that the total results is too low",
-			consumer.texts.get(0).startsWith("Progress: 2 of 3; time "));
-		assertTrue("But on the second batch, the listener should realize that the initial total results value was incorrect and adjust it",
-			consumer.texts.get(1).startsWith("Progress: 4 of 4; time "));
+		assertTrue(consumer.texts.get(0).startsWith("Progress: 2 of 3; time "),
+			"On the first batch, the listener doesn't yet know that the total results is too low");
+		assertTrue(consumer.texts.get(1).startsWith("Progress: 4 of 4; time "),
+			"But on the second batch, the listener should realize that the initial total results value was incorrect and adjust it");
 	}
 }
 
@@ -144,7 +145,7 @@ class ExceptionThrowingConsumer implements Consumer<ProgressListener.ProgressUpd
 
 class FakeQueryBatch implements QueryBatch {
 
-	private long jobResultsSoFar;
+	private final long jobResultsSoFar;
 
 	public FakeQueryBatch(long jobResultsSoFar) {
 		this.jobResultsSoFar = jobResultsSoFar;

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/QueryBatcherFailureTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/QueryBatcherFailureTest.java
@@ -5,13 +5,13 @@ import com.marklogic.client.FailedRequestException;
 import com.marklogic.client.datamovement.DataMovementManager;
 import com.marklogic.client.datamovement.QueryBatcher;
 import com.marklogic.client.test.Common;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Captures what may be surprising behavior of onQueryFailure on QueryBatcher - i.e. it does not capture exceptions
@@ -44,16 +44,14 @@ public class QueryBatcherFailureTest {
             ).onQueryFailure(failure -> failureMessages.add(failure.getMessage()))
         );
 
-        assertTrue(
-            "Unexpected message: " + ex.getMessage(),
-            ex.getMessage().contains("Directory URI path must end with '/'")
+        assertTrue(ex.getMessage().contains("Directory URI path must end with '/'"),
+			"Unexpected message: " + ex.getMessage()
         );
 
-        assertEquals(
-            "Despite the name, 'onQueryFailure' does not capture exceptions based on the query failing. If the original " +
-                "query fails, then an exception will be immediately thrown by 'newQueryBatcher' - which is good! " +
-                "A user can try/catch that and act accordingly. But an onQueryFailure listener is not invoked. ",
-            0, failureMessages.size());
+        assertEquals(0, failureMessages.size(),
+			"Despite the name, 'onQueryFailure' does not capture exceptions based on the query failing. If the original " +
+				"query fails, then an exception will be immediately thrown by 'newQueryBatcher' - which is good! " +
+				"A user can try/catch that and act accordingly. But an onQueryFailure listener is not invoked. ");
     }
 
     @Test
@@ -81,10 +79,9 @@ public class QueryBatcherFailureTest {
         assertEquals(1, processedItems.size());
         assertEquals("item1", processedItems.get(0));
 
-        assertEquals(
-            "An onQueryFailure listener does not receive errors from an onUrisReady listener. Instead, " +
-                "QueryBatcherImpl simply logs these, such that they are effectively swallowed. It's up to the user " +
-                "implementing a QueryBatchListener to provide a better error-handling mechanism.",
-            0, failureMessages.size());
+        assertEquals(0, failureMessages.size(),
+			"An onQueryFailure listener does not receive errors from an onUrisReady listener. Instead, " +
+				"QueryBatcherImpl simply logs these, such that they are effectively swallowed. It's up to the user " +
+				"implementing a QueryBatchListener to provide a better error-handling mechanism.");
     }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/QueryBatcherImplTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/QueryBatcherImplTest.java
@@ -16,13 +16,12 @@
 package com.marklogic.client.test.datamovement;
 
 import com.marklogic.client.datamovement.DataMovementManager;
-import com.marklogic.client.datamovement.FilteredForestConfiguration;
 import com.marklogic.client.datamovement.QueryBatcher;
 import com.marklogic.client.query.StructuredQueryBuilder;
 import com.marklogic.client.query.StructuredQueryDefinition;
 import com.marklogic.client.test.Common;
-import org.junit.AfterClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,7 +46,7 @@ public class QueryBatcherImplTest {
   public void testPrematureStopIteratorJob() {
     // this test can't actually validate that the message is printed, so a human
     // must check the logging output
-    // Expected something like: 
+    // Expected something like:
     //   18:14:58.420 [main] WARN  c.m.c.d.impl.QueryBatcherImpl - QueryBatcher instance "unnamed" stopped before all results were processed
     List<String> list = new ArrayList<>();
     list.add("firstUri.txt");
@@ -59,14 +58,14 @@ public class QueryBatcherImplTest {
   public void testPrematureStopQueryJob() {
     // this test can't actually validate that the message is printed, so a human
     // must check the logging output
-    // Expected something like: 
+    // Expected something like:
     //   18:20:33.607 [main] WARN  c.m.c.d.impl.QueryBatcherImpl - QueryBatcher instance "unnamed" stopped before all results were retrieved
     StructuredQueryDefinition query = new StructuredQueryBuilder().and();
     QueryBatcher batcher = moveMgr.newQueryBatcher(query);
     moveMgr.stopJob(batcher);
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     System.gc();
     System.runFinalization();

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/QueryBatcherIteratorTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/QueryBatcherIteratorTest.java
@@ -15,43 +15,32 @@
  */
 package com.marklogic.client.test.datamovement;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.datamovement.*;
+import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.client.io.SearchHandle;
+import com.marklogic.client.io.StringHandle;
+import com.marklogic.client.query.DeleteQueryDefinition;
+import com.marklogic.client.query.QueryManager;
+import com.marklogic.client.query.StructuredQueryBuilder;
+import com.marklogic.client.query.StructuredQueryDefinition;
+import com.marklogic.client.test.Common;
+import org.junit.jupiter.api.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Random;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import com.marklogic.client.datamovement.*;
-import com.marklogic.client.io.SearchHandle;
-import org.junit.FixMethodOrder;
-import org.junit.runners.MethodSorters;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
-import com.marklogic.client.DatabaseClient;
-import com.marklogic.client.io.DocumentMetadataHandle;
-import com.marklogic.client.io.StringHandle;
 import static com.marklogic.client.io.Format.JSON;
-import com.marklogic.client.query.DeleteQueryDefinition;
-import com.marklogic.client.query.StructuredQueryDefinition;
-import com.marklogic.client.query.QueryManager;
-import com.marklogic.client.query.StructuredQueryBuilder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import com.marklogic.client.test.Common;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@TestMethodOrder(MethodOrderer.MethodName.class)
 public class QueryBatcherIteratorTest {
   Logger logger = LoggerFactory.getLogger(QueryBatcherIteratorTest.class);
   private static int numDocs = 500;
@@ -61,12 +50,12 @@ public class QueryBatcherIteratorTest {
   private static String qhbTestCollection = "QueryBatcherIteratorTest_" +
     new Random().nextInt(10000);
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() throws Exception {
     setup();
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     QueryManager queryMgr = client.newQueryManager();
     DeleteQueryDefinition deleteQuery = queryMgr.newDeleteDefinition();
@@ -76,7 +65,7 @@ public class QueryBatcherIteratorTest {
 
   public static void setup() throws Exception {
 
-    assertEquals( "Since the doc doesn't exist, documentManager.exists() should return null",
+    assertEquals(
       null, client.newDocumentManager().exists(collection + "/doc_1.json") );
 
     WriteBatcher writeBatcher = moveMgr.newWriteBatcher()

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/RowBatcherTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/RowBatcherTest.java
@@ -34,9 +34,9 @@ import com.marklogic.client.row.RowManager;
 import com.marklogic.client.test.Common;
 import com.marklogic.client.type.PlanColumn;
 import com.marklogic.client.type.PlanSystemColumn;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -52,7 +52,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class RowBatcherTest {
     private final static String TEST_DIR = "/test/rowbatch/unit/";
@@ -70,7 +70,7 @@ public class RowBatcherTest {
     private static Set<String>   expectedFull = new HashSet<>();
     private static Set<JsonNode> expectedDoc  = new HashSet<>();
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() throws Exception {
         setupIndex();
         setupDocuments();
@@ -169,7 +169,7 @@ public class RowBatcherTest {
         docMetaHndl.getCollections().add(TEST_COLLECTION);
         return docMetaHndl;
     }
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         QueryManager queryMgr = db.newQueryManager();
         DeleteQueryDefinition deleteQuery = queryMgr.newDeleteDefinition();
@@ -349,22 +349,23 @@ public class RowBatcherTest {
         // System.out.println("stopped="+rowBatcher.isStopped());
 
         if (consistentSnapshot) {
-            assertNotNull("The RowBatcher should make the timestamp available so that the client can perform " +
-                            "additional operations using that timestamp after the job has completed. For example, " +
-                            "the client may wish to lookup the highest dateTime value in an index at the timestamp " +
-                            "so that a future job can constrain to documents with a dateTime greater than the " +
-                            "looked-up value, thus allowing for a 'Only process new records' feature.",
-                    rowBatcher.getServerTimestamp());
+            assertNotNull(rowBatcher.getServerTimestamp(),
+				"The RowBatcher should make the timestamp available so that the client can perform " +
+					"additional operations using that timestamp after the job has completed. For example, " +
+					"the client may wish to lookup the highest dateTime value in an index at the timestamp " +
+					"so that a future job can constrain to documents with a dateTime greater than the " +
+					"looked-up value, thus allowing for a 'Only process new records' feature.");
             docMgr.delete(addedDocUri);
         } else {
-            assertNull("If withConsistentSnapshot is not used, getServerTimestamp() should return null since no " +
-                    "server timestamp would have been captured", rowBatcher.getServerTimestamp());
+            assertNull(rowBatcher.getServerTimestamp(),
+				"If withConsistentSnapshot is not used, getServerTimestamp() should return null since no " +
+					"server timestamp would have been captured");
         }
 
-        assertEquals("test execution failed", false, failed.get());
-        assertEquals("mismatch on row estimate", expectedFull.size(), rowBatcher.getRowEstimate());
-        assertEquals("mismatch on actual rows size", expectedFull.size(), actual.size());
-        assertEquals("mismatch on actual rows", expectedFull, actual);
+        assertEquals( false, failed.get());
+        assertEquals( expectedFull.size(), rowBatcher.getRowEstimate());
+        assertEquals( expectedFull.size(), actual.size());
+        assertEquals( expectedFull, actual);
     }
     private void runDocsTest(RowBatcher<JsonNode> rowBatcher) throws Exception {
         RowManager rowMgr = rowBatcher.getRowManager();
@@ -423,10 +424,10 @@ public class RowBatcherTest {
         rowBatcher.awaitCompletion();
         // System.out.println("stopped="+rowBatcher.isStopped());
 
-        assertEquals("test failed with exception", false, failed.get());
-        assertEquals("mismatch on row estimate", expectedDoc.size(), rowBatcher.getRowEstimate());
-        assertEquals("mismatch on actual rows size", expectedDoc.size(), actual.size());
-        assertEquals("mismatch on actual docs", expectedDoc, actual);
+        assertEquals( false, failed.get());
+        assertEquals( expectedDoc.size(), rowBatcher.getRowEstimate());
+        assertEquals( expectedDoc.size(), actual.size());
+        assertEquals( expectedDoc, actual);
     }
     private void runXmlRowsTest(RowBatcher<Document> rowBatcher) throws Exception {
         RowManager rowMgr = rowBatcher.getRowManager();
@@ -530,10 +531,10 @@ public class RowBatcherTest {
         rowBatcher.awaitCompletion();
         // System.out.println("stopped="+rowBatcher.isStopped());
 
-        assertEquals("test execution failed", false, failed.get());
-        assertEquals("mismatch on row estimate", expectedFull.size(), rowBatcher.getRowEstimate());
-        assertEquals("mismatch on actual rows size", expectedFull.size(), actual.size());
-        assertEquals("mismatch on actual rows", expectedFull, actual);
+        assertEquals( false, failed.get());
+        assertEquals( expectedFull.size(), rowBatcher.getRowEstimate());
+        assertEquals( expectedFull.size(), actual.size());
+        assertEquals( expectedFull, actual);
     }
     private void runCsvRowsTest(RowBatcher<String> rowBatcher) throws Exception {
         RowManager rowMgr = rowBatcher.getRowManager();
@@ -620,9 +621,9 @@ public class RowBatcherTest {
         rowBatcher.awaitCompletion();
         // System.out.println("stopped="+rowBatcher.isStopped());
 
-        assertEquals("test execution failed", false, failed.get());
-        assertEquals("mismatch on row estimate", expectedFull.size(), rowBatcher.getRowEstimate());
-        assertEquals("mismatch on actual rows size", expectedFull.size(), actual.size());
-        assertEquals("mismatch on actual rows", expectedFull, actual);
+        assertEquals( false, failed.get());
+        assertEquals( expectedFull.size(), rowBatcher.getRowEstimate());
+        assertEquals( expectedFull.size(), actual.size());
+        assertEquals( expectedFull, actual);
     }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/ScenariosTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/ScenariosTest.java
@@ -15,22 +15,18 @@
  */
 package com.marklogic.client.test.datamovement;
 
+import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.datamovement.*;
+import com.marklogic.client.io.DOMHandle;
+import com.marklogic.client.test.Common;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.xml.parsers.DocumentBuilderFactory;
-
-import org.junit.Test;
-import org.junit.AfterClass;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
-import com.marklogic.client.DatabaseClient;
-import com.marklogic.client.io.DOMHandle;
-
-import com.marklogic.client.test.Common;
-
+import javax.xml.parsers.DocumentBuilderFactory;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -40,7 +36,7 @@ public class ScenariosTest {
   Logger logger = LoggerFactory.getLogger(ScenariosTest.class);
   DatabaseClient client = Common.connect();
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
   }
 

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/UnarySplitterTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/UnarySplitterTest.java
@@ -16,12 +16,10 @@
 
 package com.marklogic.client.test.datamovement;
 
-import com.marklogic.client.datamovement.Splitter;
 import com.marklogic.client.datamovement.UnarySplitter;
 import com.marklogic.client.document.DocumentWriteOperation;
 import com.marklogic.client.io.InputStreamHandle;
-import com.marklogic.client.io.JacksonHandle;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -30,7 +28,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class UnarySplitterTest {
     static final private String xmlFile = "src/test/resources/data" + File.separator + "/pathSplitter/people.xml";

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/XMLSplitterTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/XMLSplitterTest.java
@@ -22,7 +22,7 @@ import com.marklogic.client.document.DocumentWriteOperation;
 import com.marklogic.client.io.Format;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.io.marker.XMLWriteHandle;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.stream.XMLStreamReader;
 import java.io.File;
@@ -30,7 +30,7 @@ import java.io.FileInputStream;
 import java.util.Iterator;
 import java.util.stream.Stream;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class XMLSplitterTest {
     static final private String xmlFile = "src/test/resources/data" + File.separator + "pathSplitter/people.xml";

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/ZipSplitterTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/ZipSplitterTest.java
@@ -3,7 +3,7 @@ package com.marklogic.client.test.datamovement;
 import com.marklogic.client.datamovement.ZipSplitter;
 import com.marklogic.client.document.DocumentWriteOperation;
 import com.marklogic.client.io.BytesHandle;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -15,7 +15,7 @@ import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ZipSplitterTest {
     private static final String zipFile = "src/test/resources/data" + File.separator + "pathSplitter/files.zip";

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/javadocExamples/PackageExamplesTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/javadocExamples/PackageExamplesTest.java
@@ -16,30 +16,28 @@
 package com.marklogic.client.test.datamovement.javadocExamples;
 
 import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.datamovement.DataMovementManager;
+import com.marklogic.client.datamovement.JobTicket;
+import com.marklogic.client.datamovement.QueryBatcher;
+import com.marklogic.client.datamovement.WriteBatcher;
 import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.SearchHandle;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.query.DeleteQueryDefinition;
 import com.marklogic.client.query.MatchDocumentSummary;
-import com.marklogic.client.query.StructuredQueryDefinition;
 import com.marklogic.client.query.StructuredQueryBuilder;
-
-import com.marklogic.client.datamovement.DataMovementManager;
-import com.marklogic.client.datamovement.JobTicket;
-import com.marklogic.client.datamovement.QueryBatcher;
-import com.marklogic.client.datamovement.WriteBatcher;
+import com.marklogic.client.query.StructuredQueryDefinition;
 import com.marklogic.client.test.Common;
-
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
 import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PackageExamplesTest {
   private static Logger logger = LoggerFactory.getLogger(PackageExamplesTest.class);
@@ -50,11 +48,11 @@ public class PackageExamplesTest {
   private static DocumentMetadataHandle meta = new DocumentMetadataHandle().withCollections(collection);
   private static StructuredQueryDefinition collectionQuery = new StructuredQueryBuilder().collection(collection);
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     DeleteQueryDefinition deleteQuery = client.newQueryManager().newDeleteDefinition();
     deleteQuery.setCollections(collection);

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/javadocExamples/UrisToWriterListenerExamplesTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/javadocExamples/UrisToWriterListenerExamplesTest.java
@@ -16,32 +16,25 @@
 package com.marklogic.client.test.datamovement.javadocExamples;
 
 import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.datamovement.*;
 import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.SearchHandle;
 import com.marklogic.client.query.DeleteQueryDefinition;
-import com.marklogic.client.query.StructuredQueryDefinition;
 import com.marklogic.client.query.StructuredQueryBuilder;
-
-import com.marklogic.client.datamovement.DataMovementManager;
-import com.marklogic.client.datamovement.DeleteListener;
-import com.marklogic.client.datamovement.JobTicket;
-import com.marklogic.client.datamovement.QueryBatcher;
-import com.marklogic.client.datamovement.UrisToWriterListener;
+import com.marklogic.client.query.StructuredQueryDefinition;
 import com.marklogic.client.test.Common;
-
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
-import java.util.Random;
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.FileWriter;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class UrisToWriterListenerExamplesTest {
   private static Logger logger = LoggerFactory.getLogger(UrisToWriterListenerExamplesTest.class);
@@ -52,11 +45,11 @@ public class UrisToWriterListenerExamplesTest {
   private static DocumentMetadataHandle meta = new DocumentMetadataHandle().withCollections(collection);
   private static StructuredQueryDefinition collectionQuery = new StructuredQueryBuilder().collection(collection);
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     DeleteQueryDefinition deleteQuery = client.newQueryManager().newDeleteDefinition();
     deleteQuery.setCollections(collection);

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/BulkIOEndpointTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/BulkIOEndpointTest.java
@@ -27,7 +27,7 @@ import com.marklogic.client.io.Format;
 import com.marklogic.client.io.InputStreamHandle;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.StringHandle;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -35,7 +35,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class BulkIOEndpointTest {
     private ObjectMapper mapper = new ObjectMapper();
@@ -67,23 +67,23 @@ public class BulkIOEndpointTest {
         JSONDocumentManager docMgr = IOTestUtil.db.newJSONDocumentManager();
 
         JsonNode finalState = docMgr.read(finalStateUri, new JacksonHandle()).get();
-        assertNotNull("null final state", finalState);
-        assertTrue("final state not object", finalState.isObject());
+        assertNotNull( finalState);
+        assertTrue( finalState.isObject());
 
         JsonNode finalNext = finalState.get("next");
-        assertNotNull("null final next", finalNext);
-        assertTrue("final next not number", finalNext.isNumber());
-        assertEquals("mismatch on final next", workMax, finalNext.asInt());
+        assertNotNull( finalNext);
+        assertTrue( finalNext.isNumber());
+        assertEquals( workMax, finalNext.asInt());
 
         JsonNode finalMax = finalState.get("workMax");
-        assertNotNull("null final max", finalMax);
-        assertTrue("final max not number", finalMax.isNumber());
-        assertEquals("mismatch on final max", workMax, finalMax.asInt());
+        assertNotNull( finalMax);
+        assertTrue( finalMax.isNumber());
+        assertEquals( workMax, finalMax.asInt());
 
         JsonNode sessionCounter = finalState.get("sessionCounter");
-        assertNotNull("null final sessionCounter", sessionCounter);
-        assertTrue("final sessionCounter not number", sessionCounter.isNumber());
-        assertEquals("mismatch on final sessionCounter", (workMax - nextStart) - 1, sessionCounter.asInt());
+        assertNotNull( sessionCounter);
+        assertTrue( sessionCounter.isNumber());
+        assertEquals( (workMax - nextStart) - 1, sessionCounter.asInt());
 
         docMgr.delete(finalStateUri);
 
@@ -137,26 +137,26 @@ public class BulkIOEndpointTest {
 
         ObjectNode finalState = mapper.readValue(callContext.getEndpointState().get(), ObjectNode.class);
 
-        assertEquals("mismatch between input and output size", input.size(), output.size());
-        assertEquals("mismatch between input and output elements", input, output);
+        assertEquals( input.size(), output.size());
+        assertEquals( input, output);
 
-        assertNotNull("null final state", finalState);
-        assertTrue("final state not object", finalState.isObject());
+        assertNotNull( finalState);
+        assertTrue( finalState.isObject());
 
         JsonNode finalNext = finalState.get("next");
-        assertNotNull("null final next", finalNext);
-        assertTrue("final next not number", finalNext.isNumber());
-        assertEquals("mismatch on final next", workMax, finalNext.asInt());
+        assertNotNull( finalNext);
+        assertTrue( finalNext.isNumber());
+        assertEquals( workMax, finalNext.asInt());
 
         JsonNode finalMax = finalState.get("workMax");
-        assertNotNull("null final max", finalMax);
-        assertTrue("final max not number", finalMax.isNumber());
-        assertEquals("mismatch on final max", workMax, finalMax.asInt());
+        assertNotNull( finalMax);
+        assertTrue( finalMax.isNumber());
+        assertEquals( workMax, finalMax.asInt());
 
         JsonNode sessionCounter = finalState.get("sessionCounter");
-        assertNotNull("null final sessionCounter", sessionCounter);
-        assertTrue("final sessionCounter not number", sessionCounter.isNumber());
-        assertEquals("mismatch on final sessionCounter", callCount - 1, sessionCounter.asInt());
+        assertNotNull( sessionCounter);
+        assertTrue( sessionCounter.isNumber());
+        assertEquals( callCount - 1, sessionCounter.asInt());
 
         IOTestUtil.modMgr.delete(scriptPath, apiPath);
     }
@@ -208,26 +208,26 @@ public class BulkIOEndpointTest {
 
         ObjectNode finalState = mapper.readValue(callContext.getEndpointState().get(), ObjectNode.class);
 
-        assertEquals("mismatch between input and output size", input.size(), output.size());
-        assertEquals("mismatch between input and output elements", input, output);
+        assertEquals( input.size(), output.size());
+        assertEquals( input, output);
 
-        assertNotNull("null final state", finalState);
-        assertTrue("final state not object", finalState.isObject());
+        assertNotNull( finalState);
+        assertTrue( finalState.isObject());
 
         JsonNode finalNext = finalState.get("next");
-        assertNotNull("null final next", finalNext);
-        assertTrue("final next not number", finalNext.isNumber());
-        assertEquals("mismatch on final next", workMax, finalNext.asInt());
+        assertNotNull( finalNext);
+        assertTrue( finalNext.isNumber());
+        assertEquals( workMax, finalNext.asInt());
 
         JsonNode finalMax = finalState.get("workMax");
-        assertNotNull("null final max", finalMax);
-        assertTrue("final max not number", finalMax.isNumber());
-        assertEquals("mismatch on final max", workMax, finalMax.asInt());
+        assertNotNull( finalMax);
+        assertTrue( finalMax.isNumber());
+        assertEquals( workMax, finalMax.asInt());
 
         JsonNode sessionCounter = finalState.get("sessionCounter");
-        assertNotNull("null final sessionCounter", sessionCounter);
-        assertTrue("final sessionCounter not number", sessionCounter.isNumber());
-        assertEquals("mismatch on final sessionCounter", callCount - 1, sessionCounter.asInt());
+        assertNotNull( sessionCounter);
+        assertTrue( sessionCounter.isNumber());
+        assertEquals( callCount - 1, sessionCounter.asInt());
 
         IOTestUtil.modMgr.delete(scriptPath, apiPath);
     }
@@ -282,8 +282,8 @@ public class BulkIOEndpointTest {
         });
         bulkCaller.awaitCompletion();
 
-        assertEquals("mismatch between input and output size"+input+":"+output, input.size(), output.size());
-        assertEquals("mismatch between input and output elements", input, output);
+        assertEquals(input.size(), output.size());
+        assertEquals( input, output);
 
         IOTestUtil.modMgr.delete(scriptPath, apiPath);
     }
@@ -322,8 +322,8 @@ public class BulkIOEndpointTest {
         JSONDocumentManager docMgr = IOTestUtil.db.newJSONDocumentManager();
 
         JsonNode finalState = docMgr.read(finalStateUri, new JacksonHandle()).get();
-        assertNotNull("null final state", finalState);
-        assertTrue("final state not object", finalState.isObject());
+        assertNotNull( finalState);
+        assertTrue( finalState.isObject());
 
         docMgr.delete(finalStateUri);
 

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/BulkIOInputCallerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/BulkIOInputCallerTest.java
@@ -20,22 +20,20 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.client.dataservices.IOEndpoint;
 import com.marklogic.client.dataservices.InputCaller;
 import com.marklogic.client.document.JSONDocumentManager;
-import com.marklogic.client.impl.NodeConverter;
 import com.marklogic.client.io.Format;
 import com.marklogic.client.io.InputStreamHandle;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.StringHandle;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
-
-import static org.junit.Assert.*;
 
 public class BulkIOInputCallerTest {
 
@@ -47,7 +45,7 @@ public class BulkIOInputCallerTest {
     int counter = 0;
     static Map<String, Integer> map;
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() throws Exception {
         docMgr = IOTestUtil.db.newJSONDocumentManager();
         for (int i = 0; i < apiNames.length; i++) {
@@ -90,10 +88,10 @@ public class BulkIOInputCallerTest {
         loader.awaitCompletion();
         checkDocuments("bulkInputTest_1");
         checkDocuments("bulkInputTest_2");
-        assertEquals("Expected 4 documents written, was instead: " + counter, 4, counter);
-        assertTrue("No documents written by first callContext in - bulkInputTest_1 collection.",
+        assertEquals(4, counter);
+        assertTrue(
                 map.get("bulkInputTest_1") >= 1);
-        assertTrue("No documents written by second callContext in - bulkInputTest_2 collection.",
+        assertTrue(
                 map.get("bulkInputTest_2") >= 1);
     }
 
@@ -132,14 +130,14 @@ public class BulkIOInputCallerTest {
         loader.awaitCompletion();
         checkDocuments("bulkInputTest_1");
         checkDocuments("bulkInputTest_2");
-        assertTrue("Number of documents written not as expected.", counter == 4);
-        assertTrue("No documents written by first callContext in - bulkInputTest_1 collection.",
+        assertTrue( counter == 4);
+        assertTrue(
                 map.get("bulkInputTest_1") >= 1);
-        assertTrue("No documents written by second callContext in - bulkInputTest_2 collection.",
+        assertTrue(
                 map.get("bulkInputTest_2") >= 1);
     }
 
-    @AfterClass
+    @AfterAll
     public static void cleanup(){
         IOTestUtil.modMgr.delete(scriptPath, apiPath);
         for(int i=2; i<5; i++) {
@@ -156,9 +154,9 @@ public class BulkIOInputCallerTest {
             String uri = "/marklogic/ds/test/bulkInputCaller/"+collection+"/"+i+".json";
             if(docMgr.exists(uri)!=null) {
                 JsonNode doc = docMgr.read(uri, new JacksonHandle()).get();
-                assertNotNull("Could not find file "+uri, doc);
-                assertEquals("state mismatch", i, doc.get("state").get("next").asInt());
-                assertEquals("state mismatch", 6, doc.get("work").get("max").asInt());
+                assertNotNull(doc);
+                assertEquals( i, doc.get("state").get("next").asInt());
+                assertEquals( 6, doc.get("work").get("max").asInt());
                 counter++;
                 map.put(collection, map.get(collection)!=null?map.get(collection)+1:1);
             }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/BulkIOOutputCallerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/BulkIOOutputCallerTest.java
@@ -10,11 +10,9 @@ import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.query.DeleteQueryDefinition;
 import com.marklogic.client.query.QueryManager;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
 import java.util.HashSet;
@@ -22,8 +20,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class BulkIOOutputCallerTest {
     static ObjectNode[] apiObj = new ObjectNode[2];
@@ -36,10 +33,7 @@ public class BulkIOOutputCallerTest {
     private static final String collectionName_1 = "bulkOutputTest_1";
     private static final String collectionName_2 = "bulkOutputTest_2";
 
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
-    @BeforeClass
+    @BeforeAll
     public static void setup() throws Exception {
         docMgr = IOTestUtil.db.newJSONDocumentManager();
         for (int i = 0; i < apiNames.length; i++) {
@@ -86,10 +80,10 @@ public class BulkIOOutputCallerTest {
         });
 
         bulkCaller.awaitCompletion();
-        assertEquals("exceptions on calls", false, exceptional.get());
-        assertEquals("duplicate output", false, duplicated.get());
-        assertEquals("unexpected output count", expected.size(), actual.size());
-        assertEquals("unexpected output values", expected, actual);
+        assertEquals( false, exceptional.get());
+        assertEquals( false, duplicated.get());
+        assertEquals( expected.size(), actual.size());
+        assertEquals( expected, actual);
     }
 
     @Test
@@ -125,12 +119,12 @@ public class BulkIOOutputCallerTest {
         });
 
         bulkCaller.awaitCompletion();
-        assertEquals("exceptions on calls", false, exceptional.get());
-        assertEquals("duplicate output", false, duplicated.get());
-        assertEquals("unexpected output count", expected.size(), actual.size());
+        assertEquals( false, exceptional.get());
+        assertEquals( false, duplicated.get());
+        assertEquals( expected.size(), actual.size());
     }
 
-    @AfterClass
+    @AfterAll
     public static void cleanup() {
 
         IOTestUtil.modMgr.delete(scriptPath, apiPath);

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/BulkOutputCallerNext.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/BulkOutputCallerNext.java
@@ -22,17 +22,15 @@ import com.marklogic.client.io.InputStreamHandle;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.query.DeleteQueryDefinition;
 import com.marklogic.client.query.QueryManager;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class BulkOutputCallerNext {
     static ObjectNode apiObj;
@@ -43,10 +41,7 @@ public class BulkOutputCallerNext {
 
     private static final String collectionName = "bulkOutputCallerNext";
 
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
-    @BeforeClass
+    @BeforeAll
     public static void setup() throws Exception {
         docMgr = IOTestUtil.db.newJSONDocumentManager();
         apiObj = IOTestUtil.readApi(apiName);
@@ -84,7 +79,7 @@ public class BulkOutputCallerNext {
         }
     }
 
-    @AfterClass
+    @AfterAll
     public static void cleanup() {
 
         QueryManager queryMgr = IOTestUtil.db.newQueryManager();

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/BulkOutputCallerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/BulkOutputCallerTest.java
@@ -20,22 +20,18 @@ import com.marklogic.client.dataservices.OutputCaller;
 import com.marklogic.client.document.JSONDocumentManager;
 import com.marklogic.client.io.InputStreamHandle;
 import com.marklogic.client.io.JacksonHandle;
-import org.hamcrest.core.StringContains;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.internal.matchers.ThrowableMessageMatcher;
-import org.junit.rules.ExpectedException;
+import com.marklogic.client.query.DeleteQueryDefinition;
+import com.marklogic.client.query.QueryManager;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
-import com.marklogic.client.query.DeleteQueryDefinition;
-import com.marklogic.client.query.QueryManager;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class BulkOutputCallerTest {
     static ObjectNode apiObj;
@@ -47,10 +43,7 @@ public class BulkOutputCallerTest {
 
     private static final String collectionName = "bulkOutputTest";
 
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
-    @BeforeClass
+    @BeforeAll
     public static void setup() throws Exception {
         docMgr = IOTestUtil.db.newJSONDocumentManager();
         apiObj = IOTestUtil.readApi(apiName);
@@ -63,10 +56,7 @@ public class BulkOutputCallerTest {
     public void bulkOutputCallerWithNullConsumer() {
         OutputCaller<InputStream> loadEndpt = OutputCaller.on(IOTestUtil.db, new JacksonHandle(apiObj), new InputStreamHandle());
         OutputCaller.BulkOutputCaller<InputStream> loader = loadEndpt.bulkCaller(loadEndpt.newCallContext());
-
-        expectedException.expect(IllegalStateException.class);
-        expectedException.expect(new ThrowableMessageMatcher(new StringContains("Output consumer is null")));
-        loader.awaitCompletion();
+        assertThrows(IllegalStateException.class, () -> loader.awaitCompletion());
     }
 
     @Test
@@ -110,7 +100,7 @@ public class BulkOutputCallerTest {
        assertTrue(output.counter == count);
     }
 
-    @AfterClass
+    @AfterAll
     public static void cleanup() {
         QueryManager queryMgr = IOTestUtil.db.newQueryManager();
         DeleteQueryDefinition deletedef = queryMgr.newDeleteDefinition();

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/ErrorListenerExecEndpointTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/ErrorListenerExecEndpointTest.java
@@ -21,14 +21,14 @@ import com.marklogic.client.dataservices.ExecCaller;
 import com.marklogic.client.dataservices.IOEndpoint;
 import com.marklogic.client.document.JSONDocumentManager;
 import com.marklogic.client.io.JacksonHandle;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ErrorListenerExecEndpointTest {
     static ObjectNode apiObj;
@@ -39,7 +39,7 @@ public class ErrorListenerExecEndpointTest {
     static String finalStateUri1 = "/marklogic/ds/test/errorListenerbulkIOExecCallerbulkExecTest_1.json";
     static String finalStateUri2 = "/marklogic/ds/test/errorListenerbulkIOExecCallerbulkExecTest_2.json";
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() throws Exception {
         docMgr = IOTestUtil.db.newJSONDocumentManager();
         apiObj = IOTestUtil.readApi(apiName);
@@ -77,14 +77,14 @@ public class ErrorListenerExecEndpointTest {
 
         JsonNode finalState1 = docMgr.read(finalStateUri1, new JacksonHandle()).get();
         JsonNode finalState2 = docMgr.read(finalStateUri2, new JacksonHandle()).get();
-        assertEquals("finalState1 is wrong, should be 15, but " + finalState1.get("state").get("next").asText(),
+        assertEquals(
                 finalState1.get("state").get("next").asText(), "15");
-        assertEquals("finalState2 is wrong, should be 26, but " + finalState2.get("state").get("next").asText(),
+        assertEquals(
                 finalState2.get("state").get("next").asText(), "26");
-        assertNotNull("null final state", finalState1);
-        assertTrue("final state not object", finalState1.isObject());
-        assertNotNull("null final state", finalState2);
-        assertTrue("final state not object", finalState2.isObject());
+        assertNotNull( finalState1);
+        assertTrue( finalState1.isObject());
+        assertNotNull( finalState2);
+        assertTrue( finalState2.isObject());
     }
 
     @Test
@@ -115,14 +115,12 @@ public class ErrorListenerExecEndpointTest {
 
         JsonNode finalState1 = docMgr.read(finalStateUri1, new JacksonHandle()).get();
         JsonNode finalState2 = docMgr.read(finalStateUri2, new JacksonHandle()).get();
-        assertTrue("finalState1 is wrong, should less than 15, but " + finalState1.get("state").get("next").asText(),
-                Integer.valueOf(finalState1.get("state").get("next").asText()) < 15);
-        assertEquals("finalState2 is wrong, should be 26, but " + finalState2.get("state").get("next").asText(),
-                finalState2.get("state").get("next").asText(), "26");
-        assertNotNull("null final state", finalState1);
-        assertTrue("final state not object", finalState1.isObject());
-        assertNotNull("null final state", finalState2);
-        assertTrue("final state not object", finalState2.isObject());
+        assertTrue(Integer.valueOf(finalState1.get("state").get("next").asText()) < 15);
+        assertEquals(finalState2.get("state").get("next").asText(), "26");
+        assertNotNull( finalState1);
+        assertTrue( finalState1.isObject());
+        assertNotNull( finalState2);
+        assertTrue( finalState2.isObject());
     }
 
     @Test
@@ -153,23 +151,21 @@ public class ErrorListenerExecEndpointTest {
 
         JsonNode finalState1 = docMgr.read(finalStateUri1, new JacksonHandle()).get();
         JsonNode finalState2 = docMgr.read(finalStateUri2, new JacksonHandle()).get();
-        assertTrue("finalState1 is wrong, should be less than 15, but " + finalState1.get("state").get("next").asText(),
-                finalState1.get("state").get("next").asInt() <= 15);
-        assertTrue("finalState2 is wrong, should be less than 26, but " + finalState2.get("state").get("next").asText(),
-                finalState2.get("state").get("next").asInt() <= 26);
-        assertNotNull("null final state", finalState1);
-        assertTrue("final state not object", finalState1.isObject());
-        assertNotNull("null final state", finalState2);
-        assertTrue("final state not object", finalState2.isObject());
+        assertTrue(finalState1.get("state").get("next").asInt() <= 15);
+        assertTrue(finalState2.get("state").get("next").asInt() <= 26);
+        assertNotNull( finalState1);
+        assertTrue( finalState1.isObject());
+        assertNotNull( finalState2);
+        assertTrue( finalState2.isObject());
     }
 
-    @After
+    @AfterEach
     public void clean() {
         docMgr.delete(finalStateUri1);
         docMgr.delete(finalStateUri2);
     }
 
-    @AfterClass
+    @AfterAll
     public static void cleanup() {
         IOTestUtil.modMgr.delete(scriptPath, apiPath);
     }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/ErrorListenerInputEndpointTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/ErrorListenerInputEndpointTest.java
@@ -21,15 +21,16 @@ import com.marklogic.client.dataservices.InputCaller;
 import com.marklogic.client.document.JSONDocumentManager;
 import com.marklogic.client.io.InputStreamHandle;
 import com.marklogic.client.io.JacksonHandle;
-import org.junit.AfterClass;
-import org.junit.After;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
 import java.util.stream.Stream;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 
 public class ErrorListenerInputEndpointTest {
 
@@ -40,7 +41,7 @@ public class ErrorListenerInputEndpointTest {
     int counter = 0;
     JSONDocumentManager docMgr = IOTestUtil.db.newJSONDocumentManager();
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() throws Exception {
         apiObj = IOTestUtil.readApi(apiName);
         scriptPath = IOTestUtil.getScriptPath(apiObj);
@@ -93,7 +94,7 @@ public class ErrorListenerInputEndpointTest {
         loader.awaitCompletion();
         checkDocuments("bulkInputTest_1");
         checkDocuments("bulkInputTest_2");
-        assertTrue("Number of documents written not as expected." + counter, counter == 8);
+        assertTrue(counter == 8);
     }
 
     @Test
@@ -141,7 +142,7 @@ public class ErrorListenerInputEndpointTest {
         loader.awaitCompletion();
         checkDocuments("bulkInputTest_1");
         checkDocuments("bulkInputTest_2");
-        assertTrue("Number of documents written not as expected." + counter, counter >= 4);
+        assertTrue(counter >= 4);
     }
 
     @Test
@@ -189,10 +190,10 @@ public class ErrorListenerInputEndpointTest {
         loader.awaitCompletion();
         checkDocuments("bulkInputTest_1");
         checkDocuments("bulkInputTest_2");
-        assertTrue("Number of documents written not as expected." + counter, counter >= 1);
+        assertTrue(counter >= 1);
     }
 
-    @After
+    @AfterEach
     public void cleanup(){
 
         for(int i=2; i<=9; i++) {
@@ -213,7 +214,7 @@ public class ErrorListenerInputEndpointTest {
         }
     }
 
-    @AfterClass
+    @AfterAll
     public static void cleanupAfterClass() {
         IOTestUtil.modMgr.delete(scriptPath, apiPath);
     }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/ErrorListenerInputOutputEndpointTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/ErrorListenerInputOutputEndpointTest.java
@@ -22,17 +22,16 @@ import com.marklogic.client.document.JSONDocumentManager;
 import com.marklogic.client.impl.NodeConverter;
 import com.marklogic.client.io.InputStreamHandle;
 import com.marklogic.client.io.JacksonHandle;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ErrorListenerInputOutputEndpointTest {
     static ObjectNode apiObj;
@@ -41,7 +40,7 @@ public class ErrorListenerInputOutputEndpointTest {
     static String apiPath;
     static JSONDocumentManager docMgr;
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() throws Exception {
         docMgr = IOTestUtil.db.newJSONDocumentManager();
         apiObj = IOTestUtil.readApi(apiName);
@@ -107,9 +106,9 @@ public class ErrorListenerInputOutputEndpointTest {
         input.stream().forEach(value -> bulkCaller.accept(IOTestUtil.asInputStream(value)));
         bulkCaller.awaitCompletion();
 
-        assertEquals("mismatch between input and output size"+input+":"+output, input.size(), output.size());
-        assertEquals("mismatch between input and output elements", input, output);
-        assertTrue("wrong output size", output.size() == 16);
+        assertEquals(input.size(), output.size());
+        assertEquals( input, output);
+        assertTrue( output.size() == 16);
     }
 
     @Test
@@ -163,7 +162,7 @@ public class ErrorListenerInputOutputEndpointTest {
 
         input.stream().forEach(value -> bulkCaller.accept(IOTestUtil.asInputStream(value)));
         bulkCaller.awaitCompletion();
-        assertTrue("wrong output size, output = " + output, output.size() < 16 && output.size() >= 8);
+        assertTrue(output.size() < 16 && output.size() >= 8, "wrong output size, output = " + output);
     }
 
     @Test
@@ -217,10 +216,10 @@ public class ErrorListenerInputOutputEndpointTest {
 
         input.stream().forEach(value -> bulkCaller.accept(IOTestUtil.asInputStream(value)));
         bulkCaller.awaitCompletion();
-        assertTrue("wrong output size, output = " + output, output.size() < 16 && output.size() >= 0);
+        assertTrue(output.size() < 16 && output.size() >= 0, "wrong output size, output = " + output);
     }
 
-    @AfterClass
+    @AfterAll
     public static void cleanup() {
         IOTestUtil.modMgr.delete(scriptPath, apiPath);
     }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/ErrorListenerOutputEndpointTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/ErrorListenerOutputEndpointTest.java
@@ -25,11 +25,9 @@ import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.query.DeleteQueryDefinition;
 import com.marklogic.client.query.QueryManager;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
 import java.util.HashSet;
@@ -37,8 +35,8 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ErrorListenerOutputEndpointTest {
     static ObjectNode apiObj;
@@ -51,10 +49,7 @@ public class ErrorListenerOutputEndpointTest {
     private static final String collectionName_1 = "bulkOutputTest_1";
     private static final String collectionName_2 = "bulkOutputTest_2";
 
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
-    @BeforeClass
+    @BeforeAll
     public static void setup() throws Exception {
         docMgr = IOTestUtil.db.newJSONDocumentManager();
         apiObj = IOTestUtil.readApi(apiName);
@@ -102,10 +97,10 @@ public class ErrorListenerOutputEndpointTest {
         });
 
         bulkCaller.awaitCompletion();
-        assertEquals("exceptions on calls", false, exceptional.get());
-        assertEquals("duplicate output", false, duplicated.get());
-        assertEquals("unexpected output count", 30, actual.size());
-        assertEquals("unexpected output values", expected, actual);
+        assertEquals( false, exceptional.get());
+        assertEquals( false, duplicated.get());
+        assertEquals( 30, actual.size());
+        assertEquals( expected, actual);
     }
 
     @Test
@@ -145,9 +140,9 @@ public class ErrorListenerOutputEndpointTest {
         });
 
         bulkCaller.awaitCompletion();
-        assertEquals("exceptions on calls", false, exceptional.get());
-        assertEquals("duplicate output", false, duplicated.get());
-        assertTrue("unexpected output count", actual.size() >= 20);
+        assertEquals( false, exceptional.get());
+        assertEquals( false, duplicated.get());
+        assertTrue( actual.size() >= 20);
     }
 
     @Test
@@ -187,12 +182,12 @@ public class ErrorListenerOutputEndpointTest {
         });
 
         bulkCaller.awaitCompletion();
-        assertEquals("exceptions on calls", false, exceptional.get());
-        assertEquals("duplicate output", false, duplicated.get());
-        assertTrue("unexpected output count", actual.size() < 30);
+        assertEquals( false, exceptional.get());
+        assertEquals( false, duplicated.get());
+        assertTrue( actual.size() < 30);
     }
 
-    @AfterClass
+    @AfterAll
     public static void cleanup() {
 
         IOTestUtil.modMgr.delete(scriptPath, apiPath);

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/IOCallerImplTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/IOCallerImplTest.java
@@ -22,13 +22,13 @@ import com.marklogic.client.dataservices.InputEndpoint;
 import com.marklogic.client.dataservices.InputOutputEndpoint;
 import com.marklogic.client.dataservices.OutputEndpoint;
 import com.marklogic.client.io.JacksonHandle;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class IOCallerImplTest {
     @Test
@@ -134,9 +134,9 @@ public class IOCallerImplTest {
         return new ByteArrayInputStream(value.getBytes());
     }
     private void checkResults(String endpointState, String endpointConstants, InputStream[] results) throws IOException {
-        assertNotNull("null result Stream<InputStream>", results);
+        assertNotNull(results);
 
-        assertEquals("mismatch for result size", 3, results.length);
+        assertEquals( 3, results.length);
 
         checkNoInputState(endpointState, endpointConstants, results[0]);
         checkDoc1(results[1]);
@@ -154,9 +154,9 @@ public class IOCallerImplTest {
         checkendpointConstants(endpointConstants,           resultObj);
 
         JsonNode input = resultObj.get("input");
-        assertNotNull("null for property input", input);
-        assertTrue("property input is not array", input.isArray());
-        assertEquals("mismatch for input size", 2, input.size());
+        assertNotNull( input);
+        assertTrue( input.isArray());
+        assertEquals( 2, input.size());
         checkDoc1(input.get(0));
         checkDoc2(input.get(1));
     }
@@ -181,22 +181,22 @@ public class IOCallerImplTest {
         checkValue("docName", "beta",  doc);
     }
     private ObjectNode checkResult(InputStream result) throws IOException {
-        assertNotNull("null InputStream", result);
+        assertNotNull( result);
         return IOTestUtil.mapper.readValue(result, ObjectNode.class);
     }
     private void checkContainer(String propName, String expected, ObjectNode result) {
         JsonNode actual = result.get(propName);
-        assertNotNull("null for property "+propName, actual);
-        assertEquals("mismatch for property "+propName, expected, actual.toString());
+        assertNotNull(actual);
+        assertEquals(expected, actual.toString(), "mismatch for property "+propName);
     }
     private void checkValue(String propName, int expected, JsonNode result) {
         JsonNode actual = result.get(propName);
-        assertNotNull("null for property "+propName, actual);
-        assertEquals("mismatch for property "+propName, expected, actual.asInt());
+        assertNotNull(actual);
+        assertEquals(expected, actual.asInt());
     }
     private void checkValue(String propName, String expected, JsonNode result) {
         JsonNode actual = result.get(propName);
-        assertNotNull("null for property "+propName, actual);
-        assertEquals("mismatch for property "+propName, expected, actual.asText());
+        assertNotNull(actual);
+        assertEquals(expected, actual.asText(), "mismatch for property "+propName);
     }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/InputEndpointImplTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/InputEndpointImplTest.java
@@ -18,15 +18,14 @@ package com.marklogic.client.test.dataservices;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.client.dataservices.InputEndpoint;
 import com.marklogic.client.io.JacksonHandle;
-
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class InputEndpointImplTest {
 
@@ -35,7 +34,7 @@ public class InputEndpointImplTest {
     static String scriptPath;
     static String apiPath;
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() throws Exception {
         apiObj = IOTestUtil.readApi(apiName);
         scriptPath = IOTestUtil.getScriptPath(apiObj);
@@ -58,8 +57,8 @@ public class InputEndpointImplTest {
 
         ObjectNode resultObj = IOTestUtil.mapper.readValue(result, ObjectNode.class);
         assertNotNull(resultObj);
-        assertEquals("Endpoint value not as expected.",endpointState, resultObj.get("endpointState").toString());
-        assertEquals("Endpoint constants not as expected.",endpointConstants, resultObj.get("endpointConstants").toString());
+        assertEquals(endpointState, resultObj.get("endpointState").toString());
+        assertEquals(endpointConstants, resultObj.get("endpointConstants").toString());
         assertTrue(resultObj.get("input").get(0).toString().contains("doc1"));
         assertTrue(resultObj.get("input").get(1).toString().contains("doc2"));
     }
@@ -130,7 +129,7 @@ public class InputEndpointImplTest {
 
     }
 
-    @AfterClass
+    @AfterAll
     public static void cleanup() {
         IOTestUtil.modMgr.delete(scriptPath, apiPath);
     }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/OutputEndpointImplTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/OutputEndpointImplTest.java
@@ -19,14 +19,14 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.client.dataservices.OutputCaller;
 import com.marklogic.client.io.InputStreamHandle;
 import com.marklogic.client.io.JacksonHandle;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class OutputEndpointImplTest {
     static ObjectNode apiObj;
@@ -34,7 +34,7 @@ public class OutputEndpointImplTest {
     static String scriptPath;
     static String apiPath;
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() throws Exception {
         apiObj = IOTestUtil.readApi(apiName);
         scriptPath = IOTestUtil.getScriptPath(apiObj);
@@ -89,10 +89,10 @@ public class OutputEndpointImplTest {
         assertNotNull(resultArray);
         ObjectNode resultObj = IOTestUtil.mapper.readValue(resultArray[0], ObjectNode.class);
         assertNotNull(resultObj);
-        assertTrue("Result object is empty", resultObj.size() != 0);
+        assertTrue(resultObj.size() != 0);
     }
 
-    @AfterClass
+    @AfterAll
     public static void cleanup() {
         IOTestUtil.modMgr.delete(scriptPath, apiPath);
     }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/document/DocumentWriteOperationTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/document/DocumentWriteOperationTest.java
@@ -26,14 +26,14 @@ import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.query.StructuredQueryBuilder;
 import com.marklogic.client.query.StructuredQueryDefinition;
 import com.marklogic.client.test.Common;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DocumentWriteOperationTest {
 
@@ -62,7 +62,7 @@ public class DocumentWriteOperationTest {
     DocumentMetadataHandle defaultMetadata2 =
             new DocumentMetadataHandle().withQuality(2).withCollections(collectionName);
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() {
         Common.connect();
         textDocumentManager = Common.client.newTextDocumentManager();
@@ -96,7 +96,7 @@ public class DocumentWriteOperationTest {
 
         Iterator<DocumentWriteOperation> itr = batch.iterator();
           while(itr.hasNext()){
-              assertEquals("Document uri not as expected", itr.next().getUri(), list.get(i));
+              assertEquals( itr.next().getUri(), list.get(i));
               i++;
           }
         textDocumentManager.write(batch);
@@ -135,33 +135,33 @@ public class DocumentWriteOperationTest {
 
         Iterator<DocumentWriteOperation> itr = batch.iterator();
         while(itr.hasNext()){
-            assertEquals("Document uri not as expected", itr.next().getUri(), list.get(i));
+            assertEquals( itr.next().getUri(), list.get(i));
             i++;
         }
         textDocumentManager.write(batch);
 
-        assertEquals("Doc 1 metadata not as expected",1,
+        assertEquals(1,
                 textDocumentManager.readMetadata("doc1.txt", new DocumentMetadataHandle()).getQuality());
 
-        assertEquals("Doc 2 metadata not as expected",2,
+        assertEquals(2,
                 textDocumentManager.readMetadata("doc2.txt", new DocumentMetadataHandle()).getQuality());
 
-        assertEquals("Doc 3 metadata not as expected",1,
+        assertEquals(1,
                 textDocumentManager.readMetadata("doc3.txt", new DocumentMetadataHandle()).getQuality());
 
-        assertEquals("Doc 4 metadata not as expected",0,
+        assertEquals(0,
                 textDocumentManager.readMetadata("doc4.txt", new DocumentMetadataHandle()).getQuality());
 
-        assertEquals("Doc 5 metadata not as expected",0,
+        assertEquals(0,
                 textDocumentManager.readMetadata("doc5.txt", new DocumentMetadataHandle()).getQuality());
 
-        assertEquals("Doc 6 metadata not as expected",0,
+        assertEquals(0,
                 textDocumentManager.readMetadata("doc6.txt", new DocumentMetadataHandle()).getQuality());
 
-        assertEquals("Doc 7 metadata not as expected",2,
+        assertEquals(2,
                 textDocumentManager.readMetadata("doc7.txt", new DocumentMetadataHandle()).getQuality());
 
-        assertEquals("Doc 8 metadata not as expected",0,
+        assertEquals(0,
                 textDocumentManager.readMetadata("doc8.txt", new DocumentMetadataHandle()).getQuality());
     }
 
@@ -194,7 +194,7 @@ public class DocumentWriteOperationTest {
 
         Iterator<DocumentWriteOperation> itr = batch.iterator();
         while(itr.hasNext()){
-            assertEquals("Document uri not as expected", itr.next().getUri(), list.get(i));
+            assertEquals( itr.next().getUri(), list.get(i));
             i++;
         }
         textDocumentManager.write(batch);
@@ -230,7 +230,7 @@ public class DocumentWriteOperationTest {
 
         Iterator<DocumentWriteOperation> itr = batch.iterator();
         while(itr.hasNext()){
-            assertEquals("Document uri not as expected", itr.next().getUri(), list.get(i));
+            assertEquals( itr.next().getUri(), list.get(i));
             i++;
         }
         textDocumentManager.write(batch);
@@ -266,7 +266,7 @@ public class DocumentWriteOperationTest {
 
         Iterator<DocumentWriteOperation> itr = batch.iterator();
         while(itr.hasNext()){
-            assertEquals("Document uri not as expected", itr.next().getUri(), list.get(i));
+            assertEquals( itr.next().getUri(), list.get(i));
             i++;
         }
         textDocumentManager.write(batch);
@@ -304,7 +304,7 @@ public class DocumentWriteOperationTest {
 
         Iterator<DocumentWriteOperation> itr = batch.iterator();
         while(itr.hasNext()){
-            assertEquals("Document uri not as expected", itr.next().getUri(), list.get(i));
+            assertEquals( itr.next().getUri(), list.get(i));
             i++;
         }
         textDocumentManager.write(batch);
@@ -358,7 +358,7 @@ public class DocumentWriteOperationTest {
         assertTrue(intersectSet.isEmpty());
     }
 
-    @AfterClass
+    @AfterAll
     public static  void cleanup() {
         QueryManager queryManager = Common.client.newQueryManager();
         DeleteQueryDefinition deletedef = queryManager.newDeleteDefinition();

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/BulkExportOpticResultsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/BulkExportOpticResultsTest.java
@@ -15,9 +15,8 @@
  */
 package com.marklogic.client.test.example.cookbook;
 
-import org.junit.Test;
-
 import com.marklogic.client.example.cookbook.datamovement.BulkExportOpticResults;
+import org.junit.jupiter.api.Test;
 
 public class BulkExportOpticResultsTest {
   @Test

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/BulkExportOpticResultsToWriterTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/BulkExportOpticResultsToWriterTest.java
@@ -15,9 +15,8 @@
  */
 package com.marklogic.client.test.example.cookbook;
 
-import org.junit.Test;
-
 import com.marklogic.client.example.cookbook.datamovement.BulkExportOpticResultsToWriter;
+import org.junit.jupiter.api.Test;
 
 public class BulkExportOpticResultsToWriterTest {
   @Test

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/BulkExportWithDataServiceTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/BulkExportWithDataServiceTest.java
@@ -17,7 +17,7 @@ package com.marklogic.client.test.example.cookbook;
 
 import com.marklogic.client.example.cookbook.datamovement.BulkExportWithDataService;
 import com.marklogic.client.test.Common;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BulkExportWithDataServiceTest {
 
@@ -28,5 +28,5 @@ public class BulkExportWithDataServiceTest {
             Common.newEvalClient("java-unittest-modules")
         ).run();
     }
-    
+
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/ClientCreatorTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/ClientCreatorTest.java
@@ -15,13 +15,12 @@
  */
 package com.marklogic.client.test.example.cookbook;
 
-import static org.junit.Assert.assertTrue;
+import com.marklogic.client.example.cookbook.ClientCreator;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import org.junit.Test;
-
-import com.marklogic.client.example.cookbook.ClientCreator;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ClientCreatorTest {
   @Test
@@ -33,6 +32,6 @@ public class ClientCreatorTest {
     } catch (IOException e) {
       e.printStackTrace();
     }
-    assertTrue("ClientCreator example failed", succeeded);
+    assertTrue( succeeded);
   }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentDeleteTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentDeleteTest.java
@@ -15,13 +15,11 @@
  */
 package com.marklogic.client.test.example.cookbook;
 
-import static org.junit.Assert.assertTrue;
+import com.marklogic.client.example.cookbook.DocumentDelete;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-
-import org.junit.Test;
-
-import com.marklogic.client.example.cookbook.DocumentDelete;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class DocumentDeleteTest {
   @Test
@@ -33,6 +31,6 @@ public class DocumentDeleteTest {
     } catch (IOException e) {
       e.printStackTrace();
     }
-    assertTrue("DocumentDelete example failed", succeeded);
+    assertTrue( succeeded);
   }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentFormatsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentFormatsTest.java
@@ -15,13 +15,11 @@
  */
 package com.marklogic.client.test.example.cookbook;
 
-import static org.junit.Assert.assertTrue;
+import com.marklogic.client.example.cookbook.DocumentFormats;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-
-import org.junit.Test;
-
-import com.marklogic.client.example.cookbook.DocumentFormats;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class DocumentFormatsTest {
   @Test
@@ -33,6 +31,6 @@ public class DocumentFormatsTest {
     } catch (IOException e) {
       e.printStackTrace();
     }
-    assertTrue("DocumentFormats example failed", succeeded);
+    assertTrue( succeeded);
   }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentMetadataReadTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentMetadataReadTest.java
@@ -15,13 +15,11 @@
  */
 package com.marklogic.client.test.example.cookbook;
 
-import static org.junit.Assert.assertTrue;
+import com.marklogic.client.example.cookbook.DocumentMetadataRead;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-
-import org.junit.Test;
-
-import com.marklogic.client.example.cookbook.DocumentMetadataRead;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class DocumentMetadataReadTest {
   @Test
@@ -33,6 +31,6 @@ public class DocumentMetadataReadTest {
     } catch (IOException e) {
       e.printStackTrace();
     }
-    assertTrue("DocumentMetadataRead example failed", succeeded);
+    assertTrue( succeeded);
   }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentMetadataWriteTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentMetadataWriteTest.java
@@ -15,13 +15,11 @@
  */
 package com.marklogic.client.test.example.cookbook;
 
-import static org.junit.Assert.assertTrue;
+import com.marklogic.client.example.cookbook.DocumentMetadataWrite;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-
-import org.junit.Test;
-
-import com.marklogic.client.example.cookbook.DocumentMetadataWrite;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class DocumentMetadataWriteTest {
   @Test
@@ -33,6 +31,6 @@ public class DocumentMetadataWriteTest {
     } catch (IOException e) {
       e.printStackTrace();
     }
-    assertTrue("DocumentMetadataWrite example failed", succeeded);
+    assertTrue( succeeded);
   }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentOutputStreamTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentOutputStreamTest.java
@@ -15,13 +15,11 @@
  */
 package com.marklogic.client.test.example.cookbook;
 
-import static org.junit.Assert.assertTrue;
+import com.marklogic.client.example.cookbook.DocumentOutputStream;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-
-import org.junit.Test;
-
-import com.marklogic.client.example.cookbook.DocumentOutputStream;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class DocumentOutputStreamTest {
   @Test
@@ -33,6 +31,6 @@ public class DocumentOutputStreamTest {
     } catch (IOException e) {
       e.printStackTrace();
     }
-    assertTrue("DocumentOutputStream example failed", succeeded);
+    assertTrue( succeeded);
   }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentReadTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentReadTest.java
@@ -15,15 +15,12 @@
  */
 package com.marklogic.client.test.example.cookbook;
 
-import static org.junit.Assert.assertTrue;
-
-import java.io.IOException;
+import com.marklogic.client.example.cookbook.DocumentRead;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.xpath.XPathExpressionException;
-
-import org.junit.Test;
-
-import com.marklogic.client.example.cookbook.DocumentRead;
+import java.io.IOException;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class DocumentReadTest {
   @Test
@@ -37,6 +34,6 @@ public class DocumentReadTest {
     } catch (XPathExpressionException e) {
       e.printStackTrace();
     }
-    assertTrue("DocumentRead example failed", succeeded);
+    assertTrue( succeeded);
   }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentReadTransformTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentReadTransformTest.java
@@ -15,17 +15,15 @@
  */
 package com.marklogic.client.test.example.cookbook;
 
-import static org.junit.Assert.assertTrue;
-
-import java.io.IOException;
-
-import org.junit.Test;
-
 import com.marklogic.client.FailedRequestException;
 import com.marklogic.client.ForbiddenUserException;
 import com.marklogic.client.ResourceNotFoundException;
 import com.marklogic.client.ResourceNotResendableException;
 import com.marklogic.client.example.cookbook.DocumentReadTransform;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class DocumentReadTransformTest {
   @Test
@@ -39,6 +37,6 @@ public class DocumentReadTransformTest {
     } catch (IOException e) {
       e.printStackTrace();
     }
-    assertTrue("DocumentReadTransform example failed", succeeded);
+    assertTrue( succeeded);
   }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentWriteServerURITest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentWriteServerURITest.java
@@ -15,13 +15,11 @@
  */
 package com.marklogic.client.test.example.cookbook;
 
-import static org.junit.Assert.assertTrue;
+import com.marklogic.client.example.cookbook.DocumentWriteServerURI;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-
-import org.junit.Test;
-
-import com.marklogic.client.example.cookbook.DocumentWriteServerURI;
 
 public class DocumentWriteServerURITest {
   @Test
@@ -33,7 +31,7 @@ public class DocumentWriteServerURITest {
     } catch (IOException e) {
       e.printStackTrace();
     }
-    assertTrue("DocumentWriteServerURI example failed", succeeded);
+    Assertions.assertTrue( succeeded);
   }
 }
 

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentWriteTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentWriteTest.java
@@ -15,13 +15,11 @@
  */
 package com.marklogic.client.test.example.cookbook;
 
-import static org.junit.Assert.assertTrue;
+import com.marklogic.client.example.cookbook.DocumentWrite;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-
-import org.junit.Test;
-
-import com.marklogic.client.example.cookbook.DocumentWrite;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class DocumentWriteTest {
   @Test
@@ -33,6 +31,6 @@ public class DocumentWriteTest {
     } catch (IOException e) {
       e.printStackTrace();
     }
-    assertTrue("DocumentWrite example failed", succeeded);
+    assertTrue( succeeded);
   }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentWriteTransformTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentWriteTransformTest.java
@@ -15,17 +15,15 @@
  */
 package com.marklogic.client.test.example.cookbook;
 
-import static org.junit.Assert.assertTrue;
-
-import java.io.IOException;
-
-import org.junit.Test;
-
 import com.marklogic.client.FailedRequestException;
 import com.marklogic.client.ForbiddenUserException;
 import com.marklogic.client.ResourceNotFoundException;
 import com.marklogic.client.ResourceNotResendableException;
 import com.marklogic.client.example.cookbook.DocumentWriteTransform;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class DocumentWriteTransformTest {
   @Test
@@ -39,6 +37,6 @@ public class DocumentWriteTransformTest {
     } catch (IOException e) {
       e.printStackTrace();
     }
-    assertTrue("DocumentWriteTransform example failed", succeeded);
+    assertTrue( succeeded);
   }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/ExtractRowsViaTemplateTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/ExtractRowsViaTemplateTest.java
@@ -15,9 +15,8 @@
  */
 package com.marklogic.client.test.example.cookbook;
 
-import org.junit.Test;
-
 import com.marklogic.client.example.cookbook.datamovement.ExtractRowsViaTemplate;
+import org.junit.jupiter.api.Test;
 
 public class ExtractRowsViaTemplateTest {
   @Test

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/JAXBDocumentTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/JAXBDocumentTest.java
@@ -15,15 +15,12 @@
  */
 package com.marklogic.client.test.example.cookbook;
 
-import static org.junit.Assert.assertTrue;
-
-import java.io.IOException;
+import com.marklogic.client.example.cookbook.JAXBDocument;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.bind.JAXBException;
-
-import org.junit.Test;
-
-import com.marklogic.client.example.cookbook.JAXBDocument;
+import java.io.IOException;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class JAXBDocumentTest {
   @Test
@@ -37,6 +34,6 @@ public class JAXBDocumentTest {
     } catch (JAXBException e) {
       e.printStackTrace();
     }
-    assertTrue("JAXBDocument example failed", succeeded);
+    assertTrue( succeeded);
   }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/JavascriptExtensionTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/JavascriptExtensionTest.java
@@ -15,13 +15,11 @@
  */
 package com.marklogic.client.test.example.cookbook;
 
-import static org.junit.Assert.assertTrue;
+import com.marklogic.client.example.cookbook.JavascriptResourceExtension;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-
-import org.junit.Test;
-
-import com.marklogic.client.example.cookbook.JavascriptResourceExtension;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class JavascriptExtensionTest {
   @Test
@@ -33,6 +31,6 @@ public class JavascriptExtensionTest {
     } catch (IOException e) {
       e.printStackTrace();
     }
-    assertTrue("JavascriptResourceExtension example failed", succeeded);
+    assertTrue( succeeded);
   }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/JdbcCookbookTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/JdbcCookbookTest.java
@@ -15,22 +15,16 @@
  */
 package com.marklogic.client.test.example.cookbook;
 
-import java.io.IOException;
-
-import javax.sql.DataSource;
-
+import com.marklogic.client.example.cookbook.Util;
+import com.marklogic.client.example.cookbook.Util.ExampleProperties;
+import com.marklogic.client.example.cookbook.datamovement.*;
 import org.hsqldb.server.Server;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
 
-import com.marklogic.client.example.cookbook.Util;
-import com.marklogic.client.example.cookbook.Util.ExampleProperties;
-import com.marklogic.client.example.cookbook.datamovement.BulkExportToJdbc;
-import com.marklogic.client.example.cookbook.datamovement.BulkLoadFromJdbcRaw;
-import com.marklogic.client.example.cookbook.datamovement.BulkLoadFromJdbcWithJoins;
-import com.marklogic.client.example.cookbook.datamovement.BulkLoadFromJdbcWithSimpleJoins;
-import com.marklogic.client.example.cookbook.datamovement.IncrementalLoadFromJdbc;
+import javax.sql.DataSource;
+import java.io.IOException;
 
 public class JdbcCookbookTest {
 
@@ -83,14 +77,14 @@ public class JdbcCookbookTest {
 
   private void populateDataset(Database hsqlDB) {
     hsqlDB.execute("CREATE TABLE employees (" +
-      "emp_no      INTEGER         NOT NULL," + 
-      "birth_date  DATE            NOT NULL," + 
-      "first_name  VARCHAR(14)     NOT NULL," + 
-      "last_name   VARCHAR(16)     NOT NULL," + 
-      "gender      VARCHAR(2)      NOT NULL," +     
-      "hire_date   DATE            NOT NULL," + 
+      "emp_no      INTEGER         NOT NULL," +
+      "birth_date  DATE            NOT NULL," +
+      "first_name  VARCHAR(14)     NOT NULL," +
+      "last_name   VARCHAR(16)     NOT NULL," +
+      "gender      VARCHAR(2)      NOT NULL," +
+      "hire_date   DATE            NOT NULL," +
       "PRIMARY KEY (emp_no));");
-    
+
     hsqlDB.execute("CREATE TABLE titles (" +
       "emp_no      INTEGER         NOT NULL," +
       "title       VARCHAR(50)     NOT NULL," +
@@ -98,14 +92,14 @@ public class JdbcCookbookTest {
       "to_date     DATE," +
       "FOREIGN KEY (emp_no) REFERENCES employees (emp_no) ON DELETE CASCADE," +
       "PRIMARY KEY (emp_no,title, from_date));");
-   
+
     hsqlDB.execute("CREATE TABLE salaries (" +
     "emp_no      INTEGER         NOT NULL," +
     "salary      INTEGER         NOT NULL," +
     "from_date   DATE            NOT NULL," +
     "to_date     DATE            NOT NULL," +
     "FOREIGN KEY (emp_no) REFERENCES employees (emp_no) ON DELETE CASCADE," +
-    "PRIMARY KEY (emp_no, from_date));"); 
+    "PRIMARY KEY (emp_no, from_date));");
 
     hsqlDB.execute("CREATE TABLE employees_export (" +
         "emp_no      INTEGER         NOT NULL," +

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/MoveDataBetweenMarklogicDBsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/MoveDataBetweenMarklogicDBsTest.java
@@ -15,9 +15,8 @@
  */
 package com.marklogic.client.test.example.cookbook;
 
-import org.junit.Test;
-
 import com.marklogic.client.example.cookbook.datamovement.MoveDataBetweenMarklogicDBs;
+import org.junit.jupiter.api.Test;
 
 public class MoveDataBetweenMarklogicDBsTest {
   @Test

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/MultiStatementTransactionTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/MultiStatementTransactionTest.java
@@ -15,13 +15,11 @@
  */
 package com.marklogic.client.test.example.cookbook;
 
-import static org.junit.Assert.assertTrue;
+import com.marklogic.client.example.cookbook.MultiStatementTransaction;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-
-import org.junit.Test;
-
-import com.marklogic.client.example.cookbook.MultiStatementTransaction;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class MultiStatementTransactionTest {
   @Test
@@ -33,6 +31,6 @@ public class MultiStatementTransactionTest {
     } catch (IOException e) {
       e.printStackTrace();
     }
-    assertTrue("MultiStatementTransaction example failed", succeeded);
+    assertTrue( succeeded);
   }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/OptimisticLockingTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/OptimisticLockingTest.java
@@ -15,17 +15,15 @@
  */
 package com.marklogic.client.test.example.cookbook;
 
-import static org.junit.Assert.assertTrue;
-
-import java.io.IOException;
-
-import org.junit.Test;
-
 import com.marklogic.client.FailedRequestException;
 import com.marklogic.client.ForbiddenUserException;
 import com.marklogic.client.ResourceNotFoundException;
 import com.marklogic.client.ResourceNotResendableException;
 import com.marklogic.client.example.cookbook.OptimisticLocking;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class OptimisticLockingTest {
   @Test
@@ -39,6 +37,6 @@ public class OptimisticLockingTest {
     } catch (IOException e) {
       e.printStackTrace();
     }
-    assertTrue("OptimisticLocking example failed", succeeded);
+    assertTrue( succeeded);
   }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/QueryOptionsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/QueryOptionsTest.java
@@ -15,17 +15,15 @@
  */
 package com.marklogic.client.test.example.cookbook;
 
-import static org.junit.Assert.assertTrue;
-
-import java.io.IOException;
-
-import org.junit.Test;
-
 import com.marklogic.client.FailedRequestException;
 import com.marklogic.client.ForbiddenUserException;
 import com.marklogic.client.ResourceNotFoundException;
 import com.marklogic.client.ResourceNotResendableException;
 import com.marklogic.client.example.cookbook.QueryOptions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class QueryOptionsTest {
   @Test
@@ -39,6 +37,6 @@ public class QueryOptionsTest {
     } catch (IOException e) {
       e.printStackTrace();
     }
-    assertTrue("QueryOptions example failed", succeeded);
+    assertTrue( succeeded);
   }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/RawClientAlertTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/RawClientAlertTest.java
@@ -15,13 +15,11 @@
  */
 package com.marklogic.client.test.example.cookbook;
 
-import static org.junit.Assert.assertTrue;
+import com.marklogic.client.example.cookbook.RawClientAlert;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-
-import org.junit.Test;
-
-import com.marklogic.client.example.cookbook.RawClientAlert;
 
 public class RawClientAlertTest {
   @Test
@@ -33,6 +31,6 @@ public class RawClientAlertTest {
     } catch (IOException e) {
       e.printStackTrace();
     }
-    assertTrue("RawClientAlert example failed", succeeded);
+    Assertions.assertTrue( succeeded);
   }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/RawCombinedSearchTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/RawCombinedSearchTest.java
@@ -15,13 +15,11 @@
  */
 package com.marklogic.client.test.example.cookbook;
 
-import static org.junit.Assert.assertTrue;
+import com.marklogic.client.example.cookbook.RawCombinedSearch;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-
-import org.junit.Test;
-
-import com.marklogic.client.example.cookbook.RawCombinedSearch;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class RawCombinedSearchTest {
   @Test
@@ -33,6 +31,6 @@ public class RawCombinedSearchTest {
     } catch (IOException e) {
       e.printStackTrace();
     }
-    assertTrue("RawCombinedSearch example failed", succeeded);
+    assertTrue( succeeded);
   }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/RecordJobInformationTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/RecordJobInformationTest.java
@@ -16,7 +16,7 @@
 package com.marklogic.client.test.example.cookbook;
 
 import com.marklogic.client.example.cookbook.datamovement.RecordJobInformation;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RecordJobInformationTest {
   @Test

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/ResourceExtensionTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/ResourceExtensionTest.java
@@ -15,16 +15,14 @@
  */
 package com.marklogic.client.test.example.cookbook;
 
-import static org.junit.Assert.assertTrue;
-
-import java.io.IOException;
-
-import org.junit.Test;
-
 import com.marklogic.client.FailedRequestException;
 import com.marklogic.client.ForbiddenUserException;
 import com.marklogic.client.ResourceNotFoundException;
 import com.marklogic.client.example.cookbook.ResourceExtension;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ResourceExtensionTest {
   @Test
@@ -38,6 +36,6 @@ public class ResourceExtensionTest {
     } catch (IOException e) {
       e.printStackTrace();
     }
-    assertTrue("ResourceExtension example failed", succeeded);
+    assertTrue( succeeded);
   }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/SearchResponseTransformTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/SearchResponseTransformTest.java
@@ -15,17 +15,15 @@
  */
 package com.marklogic.client.test.example.cookbook;
 
-import static org.junit.Assert.assertTrue;
-
-import java.io.IOException;
-
-import org.junit.Test;
-
 import com.marklogic.client.FailedRequestException;
 import com.marklogic.client.ForbiddenUserException;
 import com.marklogic.client.ResourceNotFoundException;
 import com.marklogic.client.ResourceNotResendableException;
 import com.marklogic.client.example.cookbook.SearchResponseTransform;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class SearchResponseTransformTest {
   @Test
@@ -39,6 +37,6 @@ public class SearchResponseTransformTest {
     } catch (IOException e) {
       e.printStackTrace();
     }
-    assertTrue("SearchResponseTransform example failed", succeeded);
+    assertTrue( succeeded);
   }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/StringSearchTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/StringSearchTest.java
@@ -15,17 +15,15 @@
  */
 package com.marklogic.client.test.example.cookbook;
 
-import static org.junit.Assert.assertTrue;
-
-import java.io.IOException;
-
-import org.junit.Test;
-
 import com.marklogic.client.FailedRequestException;
 import com.marklogic.client.ForbiddenUserException;
 import com.marklogic.client.ResourceNotFoundException;
 import com.marklogic.client.ResourceNotResendableException;
 import com.marklogic.client.example.cookbook.StringSearch;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class StringSearchTest {
   @Test
@@ -39,6 +37,6 @@ public class StringSearchTest {
     } catch (IOException e) {
       e.printStackTrace();
     }
-    assertTrue("StringSearch example failed", succeeded);
+    assertTrue( succeeded);
   }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/StructuredSearchTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/StructuredSearchTest.java
@@ -15,17 +15,15 @@
  */
 package com.marklogic.client.test.example.cookbook;
 
-import static org.junit.Assert.assertTrue;
-
-import java.io.IOException;
-
-import org.junit.Test;
-
 import com.marklogic.client.FailedRequestException;
 import com.marklogic.client.ForbiddenUserException;
 import com.marklogic.client.ResourceNotFoundException;
 import com.marklogic.client.ResourceNotResendableException;
 import com.marklogic.client.example.cookbook.StructuredSearch;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class StructuredSearchTest {
   @Test
@@ -39,6 +37,6 @@ public class StructuredSearchTest {
     } catch (IOException e) {
       e.printStackTrace();
     }
-    assertTrue("StructuredSearch example failed", succeeded);
+    assertTrue( succeeded);
   }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/WriteandReadPOJOsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/WriteandReadPOJOsTest.java
@@ -15,11 +15,8 @@
  */
 package com.marklogic.client.test.example.cookbook;
 
-import static org.junit.Assert.assertTrue;
-
-import org.junit.Test;
-
 import com.marklogic.client.example.cookbook.datamovement.WriteandReadPOJOs;
+import org.junit.jupiter.api.Test;
 
 public class WriteandReadPOJOsTest {
   @Test

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/extension/BatchManagerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/extension/BatchManagerTest.java
@@ -15,16 +15,14 @@
  */
 package com.marklogic.client.test.example.extension;
 
-import static org.junit.Assert.assertTrue;
-
-import java.io.IOException;
-
-import org.junit.Test;
-
 import com.marklogic.client.FailedRequestException;
 import com.marklogic.client.ForbiddenUserException;
 import com.marklogic.client.ResourceNotFoundException;
 import com.marklogic.client.example.extension.BatchManagerExample;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
 
 public class BatchManagerTest {
   @Test
@@ -38,6 +36,6 @@ public class BatchManagerTest {
     } catch (IOException e) {
       e.printStackTrace();
     }
-    assertTrue("BatchExample failed", succeeded);
+    Assertions.assertTrue( succeeded);
   }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/extension/GraphSPARQLExampleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/extension/GraphSPARQLExampleTest.java
@@ -15,14 +15,12 @@
  */
 package com.marklogic.client.test.example.extension;
 
-import static org.junit.Assert.assertTrue;
+import com.marklogic.client.example.extension.GraphSPARQLExample;
+import com.marklogic.client.test.Common;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-
-import org.junit.Test;
-
-import com.marklogic.client.test.Common;
-import com.marklogic.client.example.extension.GraphSPARQLExample;
 
 public class GraphSPARQLExampleTest {
 
@@ -36,7 +34,7 @@ public class GraphSPARQLExampleTest {
     } catch (IOException e) {
       e.printStackTrace();
     }
-    assertTrue("GraphSPARQLExample failed", succeeded);
+    Assertions.assertTrue( succeeded);
   }
 
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/extension/OpenCSVBatcherTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/extension/OpenCSVBatcherTest.java
@@ -15,18 +15,15 @@
  */
 package com.marklogic.client.test.example.extension;
 
-import static org.junit.Assert.assertTrue;
-
-import java.io.IOException;
-
-import javax.xml.parsers.ParserConfigurationException;
-
-import org.junit.Test;
-
 import com.marklogic.client.FailedRequestException;
 import com.marklogic.client.ForbiddenUserException;
 import com.marklogic.client.ResourceNotFoundException;
 import com.marklogic.client.example.extension.OpenCSVBatcherExample;
+import org.junit.jupiter.api.Test;
+
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.IOException;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class OpenCSVBatcherTest {
   @Test
@@ -42,6 +39,6 @@ public class OpenCSVBatcherTest {
     } catch (ParserConfigurationException e) {
       e.printStackTrace();
     }
-    assertTrue("OpenCSVSplitterExample failed", succeeded);
+    assertTrue( succeeded);
   }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/extension/SearchCollectorTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/extension/SearchCollectorTest.java
@@ -15,19 +15,16 @@
  */
 package com.marklogic.client.test.example.extension;
 
-import static org.junit.Assert.assertTrue;
-
-import java.io.IOException;
-
-import javax.xml.parsers.ParserConfigurationException;
-
-import org.junit.Test;
-
 import com.marklogic.client.FailedRequestException;
 import com.marklogic.client.ForbiddenUserException;
 import com.marklogic.client.ResourceNotFoundException;
 import com.marklogic.client.ResourceNotResendableException;
 import com.marklogic.client.example.extension.SearchCollectorExample;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.IOException;
 
 public class SearchCollectorTest {
   @Test
@@ -43,6 +40,6 @@ public class SearchCollectorTest {
     } catch (ParserConfigurationException e) {
       e.printStackTrace();
     }
-    assertTrue("SearchCollectorExample failed", succeeded);
+    Assertions.assertTrue( succeeded);
   }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/handle/HTMLCleanerHandleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/handle/HTMLCleanerHandleTest.java
@@ -15,13 +15,11 @@
  */
 package com.marklogic.client.test.example.handle;
 
-import static org.junit.Assert.assertTrue;
+import com.marklogic.client.example.handle.HTMLCleanerHandleExample;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-
-import org.junit.Test;
-
-import com.marklogic.client.example.handle.HTMLCleanerHandleExample;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class HTMLCleanerHandleTest {
   @Test
@@ -33,6 +31,6 @@ public class HTMLCleanerHandleTest {
     } catch (IOException e) {
       e.printStackTrace();
     }
-    assertTrue("HTMLCleanerHandleExample failed", succeeded);
+    assertTrue( succeeded);
   }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/handle/URIHandleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/handle/URIHandleTest.java
@@ -15,13 +15,11 @@
  */
 package com.marklogic.client.test.example.handle;
 
-import static org.junit.Assert.assertTrue;
+import com.marklogic.client.example.handle.URIHandleExample;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-
-import org.junit.Test;
-
-import com.marklogic.client.example.handle.URIHandleExample;
 
 public class URIHandleTest {
   @Test
@@ -33,6 +31,6 @@ public class URIHandleTest {
     } catch (IOException e) {
       e.printStackTrace();
     }
-    assertTrue("URIHandleExample failed", succeeded);
+    Assertions.assertTrue( succeeded);
   }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/extra/DOM4JHandleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/extra/DOM4JHandleTest.java
@@ -15,29 +15,28 @@
  */
 package com.marklogic.client.test.extra;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
-import static org.junit.Assert.assertNotNull;
-
-import java.io.IOException;
-
-import org.dom4j.Document;
-import org.dom4j.DocumentFactory;
-import org.dom4j.Element;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.xml.sax.SAXException;
-
 import com.marklogic.client.document.XMLDocumentManager;
 import com.marklogic.client.extra.dom4j.DOM4JHandle;
 import com.marklogic.client.test.Common;
+import org.dom4j.Document;
+import org.dom4j.DocumentFactory;
+import org.dom4j.Element;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+
+import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class DOM4JHandleTest {
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     Common.connect();
   }
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
   }
 
@@ -73,7 +72,7 @@ public class DOM4JHandleTest {
 
     // access the document content
     Document readDocument = readHandle.get();
-    assertNotNull("Wrote null dom4j document", readDocument);
+    assertNotNull( readDocument);
     assertXMLEqual("dom4j document not equal",
       writeDocument.asXML(), readDocument.asXML());
 

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/extra/GSONHandleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/extra/GSONHandleTest.java
@@ -15,26 +15,23 @@
  */
 package com.marklogic.client.test.extra;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import com.marklogic.client.document.JSONDocumentManager;
 import com.marklogic.client.extra.gson.GSONHandle;
 import com.marklogic.client.test.Common;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class GSONHandleTest {
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     Common.connect();
   }
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
   }
 
@@ -70,8 +67,8 @@ public class GSONHandleTest {
 
     // access the document content
     JsonObject readRoot = readHandle.get().getAsJsonObject();
-    assertNotNull("Wrote null JSON structure", readRoot);
-    assertTrue("JSON structures not equal",
+    Assertions.assertNotNull( readRoot);
+    Assertions.assertTrue(
       readRoot.equals(writeRoot));
 
     // delete the document

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/extra/JDOMHandleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/extra/JDOMHandleTest.java
@@ -15,28 +15,27 @@
  */
 package com.marklogic.client.test.extra;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
-import static org.junit.Assert.assertNotNull;
-
-import java.io.IOException;
-
-import org.jdom2.Document;
-import org.jdom2.Element;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.xml.sax.SAXException;
-
 import com.marklogic.client.document.XMLDocumentManager;
 import com.marklogic.client.extra.jdom.JDOMHandle;
 import com.marklogic.client.test.Common;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+
+import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class JDOMHandleTest {
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     Common.connect();
   }
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
   }
 
@@ -70,7 +69,7 @@ public class JDOMHandleTest {
 
     // access the document content
     Document readDocument = readHandle.get();
-    assertNotNull("Wrote null JDOM document", readDocument);
+    assertNotNull( readDocument);
     assertXMLEqual("JDOM document not equal",
       writeHandle.toString(), readHandle.toString());
 

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/AbstractOpticUpdateTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/AbstractOpticUpdateTest.java
@@ -16,8 +16,8 @@ import com.marklogic.client.row.RawPlanDefinition;
 import com.marklogic.client.row.RowManager;
 import com.marklogic.client.row.RowRecord;
 import com.marklogic.client.test.Common;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,8 +25,9 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 
 public abstract class AbstractOpticUpdateTest {
 
@@ -36,7 +37,7 @@ public abstract class AbstractOpticUpdateTest {
     protected PlanBuilder op;
     protected ObjectMapper mapper = new ObjectMapper();
 
-    @Before
+    @BeforeEach
     public void setup() {
         // Subclasses of this test are expected to only write URIs starting with /acme/ (which is used so that test
         // URIs show up near the top when exploring the database in qconsole), so delete all of them before running the
@@ -50,7 +51,7 @@ public abstract class AbstractOpticUpdateTest {
         op = rowManager.newPlanBuilder();
     }
 
-    @After
+    @AfterEach
     public void teardown() {
         // Reset back to the default client that non-OpticUpdate tests expect
         Common.client = Common.newClient();
@@ -70,8 +71,9 @@ public abstract class AbstractOpticUpdateTest {
         PlanBuilder.Plan rawPlanToExecute = bindingFunction != null ? bindingFunction.apply(rawPlan) : rawPlan;
 
         List<RowRecord> rowsFromExportedPlan = resultRows(rawPlanToExecute);
-        assertEquals("The row count from the exported list should match that of the rows from the original plan",
-                rowsFromPlan.size(), rowsFromExportedPlan.size());
+        assertEquals(
+                rowsFromPlan.size(), rowsFromExportedPlan.size(),
+			"The row count from the exported list should match that of the rows from the original plan");
     }
 
     protected final void verifyJsonDoc(String uri, Consumer<ObjectNode> verifier) {
@@ -144,7 +146,7 @@ public abstract class AbstractOpticUpdateTest {
 
     /**
      * Defines the required fields for the temporal axes configured for the test project.
-     * 
+     *
      * @return
      */
     protected final ObjectNode newTemporalContent() {
@@ -161,7 +163,8 @@ public abstract class AbstractOpticUpdateTest {
 
     protected final void assertPermissionExists(DocumentMetadataHandle.DocumentPermissions perms, String role,
                                                 DocumentMetadataHandle.Capability capability) {
-        assertTrue("No permissions for role: " + role, perms.containsKey(role));
-        assertTrue("Capability " + capability + " for role " + role + " not found", perms.get(role).contains(capability));
+        assertTrue(perms.containsKey(role), "No permissions for role: " + role);
+        assertTrue(perms.get(role).contains(capability),
+			"Capability " + capability + " for role " + role + " not found");
     }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/ExportTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/ExportTest.java
@@ -7,8 +7,7 @@ import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.test.Common;
 import com.marklogic.client.type.CtsReferenceExpr;
 import com.marklogic.client.type.PlanTripleOption;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/FromDocDescriptorsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/FromDocDescriptorsTest.java
@@ -12,12 +12,12 @@ import com.marklogic.client.io.Format;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.row.RowRecord;
 import com.marklogic.client.test.Common;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.stream.Stream;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * In addition to testing fromDocDescriptors, this class contains tests to verify that default collections and
@@ -123,11 +123,13 @@ public class FromDocDescriptorsTest extends AbstractOpticUpdateTest {
         assertEquals(1, rows.size());
         RowRecord row = rows.get(0);
         assertEquals(uri, row.getString("uri"));
-        assertEquals("Quality still exists as a column because there's no way for fromDocDescriptors to know if the " +
-            "user intentionally set quality to zero or not; however, the assertions below verify that 'quality' is " +
-            "not passed to the 'write' col because the original quality still exists", 0, rows.get(0).getInt("quality"));
+        assertEquals(0, rows.get(0).getInt("quality"),
+			"Quality still exists as a column because there's no way for fromDocDescriptors to know if the " +
+				"user intentionally set quality to zero or not; however, the assertions below verify that 'quality' is " +
+				"not passed to the 'write' col because the original quality still exists");
         assertTrue(row.containsKey("collections"));
-        assertEquals("Row is expected to contain uri, collections, and quality: " + row, 3, row.size());
+        assertEquals(3, row.size(),
+			"Row is expected to contain uri, collections, and quality: " + row);
 
         // Verify only collections were updated
         verifyJsonDoc(uri, doc -> assertEquals("world", doc.get("hello").asText()));
@@ -228,7 +230,7 @@ public class FromDocDescriptorsTest extends AbstractOpticUpdateTest {
             assertEquals("value1", docMetadata.getMetadataValues().get("key1"));
         });
     }
-    
+
     private String writeDocWithAllMetadata() {
         final String uri = "/acme/doc1.json";
         DocumentMetadataHandle metadata = newDefaultMetadata().withCollections("custom1");
@@ -310,12 +312,13 @@ public class FromDocDescriptorsTest extends AbstractOpticUpdateTest {
             new StringHandle("<doc>1</doc>").withFormat(Format.XML));
 
         IllegalArgumentException ex = assertThrows(
-            "Only JSON content is supported for the 5.6.0 release and 11.0 release of MarkLogic",
             IllegalArgumentException.class,
-            () -> op.docDescriptors(writeSet));
-        assertEquals("Unexpected exception: " + ex.getMessage(),
+            () -> op.docDescriptors(writeSet),
+			"Only JSON content is supported for the 5.6.0 release and 11.0 release of MarkLogic");
+        assertEquals(
             "Only JSON content can be used with fromDocDescriptors; non-JSON content found for document with URI: /acme/doc1.xml",
-            ex.getMessage());
+            ex.getMessage(),
+			"Unexpected exception: " + ex.getMessage());
     }
 
     @Test
@@ -362,7 +365,8 @@ public class FromDocDescriptorsTest extends AbstractOpticUpdateTest {
         assertEquals(1, rows.size());
         assertEquals(uri, rows.get(0).getString("uri"));
         assertEquals("modified!", rows.get(0).getContentAs("doc", ObjectNode.class).get("hello").asText());
-        assertEquals("Should only have 'uri' and 'doc' since that's all that the user specified", 2, rows.get(0).size());
+        assertEquals(2, rows.get(0).size(),
+			"Should only have 'uri' and 'doc' since that's all that the user specified");
 
         // Verify only the doc was updated
         verifyJsonDoc(uri, doc -> assertEquals("modified!", doc.get("hello").asText()));

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/FromParamTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/FromParamTest.java
@@ -1,27 +1,22 @@
 package com.marklogic.client.test.rows;
 
-import static org.junit.Assert.assertEquals;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.marklogic.client.document.DocumentWriteSet;
+import com.marklogic.client.expression.PlanBuilder;
+import com.marklogic.client.io.*;
+import com.marklogic.client.io.marker.AbstractWriteHandle;
+import com.marklogic.client.row.RawPlanDefinition;
+import com.marklogic.client.row.RowRecord;
+import com.marklogic.client.test.Common;
+import com.marklogic.client.type.PlanParamExpr;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
-
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.marklogic.client.document.DocumentWriteSet;
-import com.marklogic.client.expression.PlanBuilder;
-import com.marklogic.client.io.BytesHandle;
-import com.marklogic.client.io.DocumentMetadataHandle;
-import com.marklogic.client.io.Format;
-import com.marklogic.client.io.JacksonHandle;
-import com.marklogic.client.io.StringHandle;
-import com.marklogic.client.io.marker.AbstractWriteHandle;
-import com.marklogic.client.row.RawPlanDefinition;
-import com.marklogic.client.row.RowRecord;
-import com.marklogic.client.test.Common;
-import com.marklogic.client.type.PlanParamExpr;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests various scenarios involving the {@code fromParam} accessor and the need to bind a content handle as a parameter

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/FromParamWriteTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/FromParamWriteTest.java
@@ -14,11 +14,11 @@ import com.marklogic.client.row.RawPlanDefinition;
 import com.marklogic.client.row.RowRecord;
 import com.marklogic.client.test.Common;
 import org.apache.commons.lang3.StringUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class FromParamWriteTest extends AbstractOpticUpdateTest {
 
@@ -179,14 +179,15 @@ public class FromParamWriteTest extends AbstractOpticUpdateTest {
 
         verifyJsonDoc(uri, doc -> {
             String systemEnd = doc.get("system-end").asText();
-            assertTrue("system-end should have been populated by ML: " + doc, systemEnd.startsWith("9999"));
-            assertTrue("system-start should have been populated by ML: " + doc,
-                StringUtils.isNotEmpty(doc.get("system-start").asText()));
+            assertTrue(systemEnd.startsWith("9999"), "system-end should have been populated by ML: " + doc);
+            assertTrue(
+                StringUtils.isNotEmpty(doc.get("system-start").asText()),
+				"system-start should have been populated by ML: " + doc);
         });
 
         verifyMetadata(uri, metadata -> {
-            assertTrue("The document should be in the 'latest' collection if it was correctly inserted via " +
-                "temporal.documentInsert", metadata.getCollections().contains("latest"));
+            assertTrue(metadata.getCollections().contains("latest"),
+				"The document should be in the 'latest' collection if it was correctly inserted via temporal.documentInsert");
             assertTrue(metadata.getCollections().contains(temporalCollection));
         });
 
@@ -201,7 +202,7 @@ public class FromParamWriteTest extends AbstractOpticUpdateTest {
         // Verify doc and that we now have 2 versions
         verifyJsonDoc(uri, doc -> assertEquals("world", doc.get("hello").asText()));
         List<RowRecord> rows = resultRows(op.fromDocUris(op.cts.collectionQuery(temporalCollection)));
-        assertEquals("Should have 2 versions in the temporal collection", 2, rows.size());
+        assertEquals(2, rows.size(), "Should have 2 versions in the temporal collection");
     }
 
     @Test
@@ -227,7 +228,7 @@ public class FromParamWriteTest extends AbstractOpticUpdateTest {
 
     private void verifyXmlDocContent(String uri, String expectedContent) {
         verifyXmlDoc(uri, content -> {
-            assertTrue("Unexpected content: " + content, content.contains(expectedContent));
+            assertTrue(content.contains(expectedContent), "Unexpected content: " + content);
         });
     }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/JoinDocColsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/JoinDocColsTest.java
@@ -5,14 +5,14 @@ import com.marklogic.client.expression.PlanBuilder;
 import com.marklogic.client.row.RowRecord;
 import com.marklogic.client.test.Common;
 import com.marklogic.client.type.PlanColumn;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class JoinDocColsTest extends AbstractOpticUpdateTest {
 

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/JoinDocTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/JoinDocTest.java
@@ -6,13 +6,13 @@ import com.marklogic.client.expression.PlanBuilder;
 import com.marklogic.client.row.RowRecord;
 import com.marklogic.client.test.Common;
 import com.marklogic.client.type.CtsReferenceExpr;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Written for bug 58069; see that description for more information.
@@ -36,7 +36,7 @@ public class JoinDocTest extends AbstractOpticUpdateTest {
      * Same as propertiesFragmentsShouldNotBeReturned, but uses fromLexicons so it can run against ML 10.
      *
      * 2022-12-12 This is now running only on ML 11, as it's consistently failing on ML 10. We have a fix slated for
-     * 11.x, and it's not clear yet if it'll be backported to ML 10. 
+     * 11.x, and it's not clear yet if it'll be backported to ML 10.
      */
     @Test
     public void propertiesFragmentShouldNotBeReturnedByFromLexicons() {
@@ -60,11 +60,12 @@ public class JoinDocTest extends AbstractOpticUpdateTest {
 
         List<RowRecord> rows = resultRows(plan);
         System.out.println(rows);
-        assertEquals("If the actual count is double the expected count, then joinDoc is erroneously pulling back " +
-            "properties fragments. These exist because the test database has the 'last modified' flag on by default, " +
-            "resulting the creation of a properties fragment for each URI. This error is very intermittent though " +
-            "and we do not have a reliable way to reproduce it. Once it happens, it will happen reliably for awhile, " +
-            "regardless of the number of URIs being returned by fromDocUris.", docCount, rows.size());
+        assertEquals(docCount, rows.size(),
+			"If the actual count is double the expected count, then joinDoc is erroneously pulling back " +
+				"properties fragments. These exist because the test database has the 'last modified' flag on by default, " +
+				"resulting the creation of a properties fragment for each URI. This error is very intermittent though " +
+				"and we do not have a reliable way to reproduce it. Once it happens, it will happen reliably for awhile, " +
+				"regardless of the number of URIs being returned by fromDocUris.");
     }
 
     private void writeDocs(int docCount) {

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/LockForUpdateTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/LockForUpdateTest.java
@@ -6,12 +6,12 @@ import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.row.RowRecord;
 import com.marklogic.client.test.Common;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class LockForUpdateTest extends AbstractOpticUpdateTest {
 
@@ -54,9 +54,10 @@ public class LockForUpdateTest extends AbstractOpticUpdateTest {
         long duration = System.currentTimeMillis() - start;
         System.out.println("DUR: " + duration);
 
-        assertTrue("Because the eval call slept for 2 seconds, the duration of the plan execution should be at least " +
-            "1500ms, which is much longer than normal; it may not be at least 2 seconds due to the small delay in " +
-            "the Java layer of executing the plan; duration: " + duration, duration > 1500);
+        assertTrue(duration > 1500,
+			"Because the eval call slept for 2 seconds, the duration of the plan execution should be at least " +
+				"1500ms, which is much longer than normal; it may not be at least 2 seconds due to the small delay in " +
+				"the Java layer of executing the plan; duration: " + duration);
 
         // Verify that the collections were set based on the plan, which should have run second
         verifyMetadata(uri, metadata -> {

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RemoveTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RemoveTest.java
@@ -11,11 +11,11 @@ import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.row.RowRecord;
 import com.marklogic.client.test.Common;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class RemoveTest extends AbstractOpticUpdateTest {
 
@@ -128,8 +128,9 @@ public class RemoveTest extends AbstractOpticUpdateTest {
             .write(op.docCols(null, op.xs.stringSeq("uri", "doc", "temporalCollection", "permissions"))));
 
         verifyMetadata(uri, metadata -> {
-            assertTrue("The document should be in the 'latest' collection if it was correctly inserted via " +
-                "temporal.documentInsert", metadata.getCollections().contains("latest"));
+            assertTrue(metadata.getCollections().contains("latest"),
+				"The document should be in the 'latest' collection if it was correctly inserted via " +
+					"temporal.documentInsert");
             assertTrue(metadata.getCollections().contains(temporalCollection));
         });
 
@@ -140,9 +141,9 @@ public class RemoveTest extends AbstractOpticUpdateTest {
             .remove(op.col("tempColl"), op.col("uri")));
 
         verifyMetadata(uri, metadata -> {
-            assertFalse("The doc should still exist but no longer be in the 'latest' collection, as " +
-                    "temporal.documentDelete should have removed it from that collection",
-                metadata.getCollections().contains("latest"));
+            assertFalse(metadata.getCollections().contains("latest"),
+				"The doc should still exist but no longer be in the 'latest' collection, as " +
+					"temporal.documentDelete should have removed it from that collection");
             assertTrue(metadata.getCollections().contains(temporalCollection));
         });
     }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerTest.java
@@ -32,10 +32,10 @@ import com.marklogic.client.row.RowRecord.ColumnKind;
 import com.marklogic.client.test.Common;
 import com.marklogic.client.type.*;
 import com.marklogic.client.util.EditableNamespaceContext;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -54,7 +54,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class RowManagerTest {
   private static String[]             uris           = null;
@@ -67,7 +67,7 @@ public class RowManagerTest {
   private static RowSetPart[]         datatypeStyles = null;
 
   @SuppressWarnings("unchecked")
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() throws IOException, InterruptedException {
     uris = new String[]{"/rowtest/docJoin1.json", "/rowtest/docJoin1.xml", "/rowtest/docJoin1.txt", "/rowtest/embedded.xml"};
     docs = new String[]{
@@ -196,7 +196,7 @@ public class RowManagerTest {
     deleteQuery.setDirectory("/testFromDocUrisWithDirectoryQueryNew/");
     queryMgr.delete(deleteQuery);
   }
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
   }
 
@@ -230,11 +230,11 @@ public class RowManagerTest {
               try (LineNumberReader lineReader = new LineNumberReader(readerHandle.get())) {
                 String line = lineReader.readLine();
                 String[] cols = line.split(",");
-                assertArrayEquals("unexpected header", cols, new String[]{"rowNum","temp"});
+                assertArrayEquals( cols, new String[]{"rowNum","temp"});
 
                 line = lineReader.readLine();
                 cols = line.split(",");
-                assertArrayEquals("unexpected data", cols, new String[]{"2","72"});
+                assertArrayEquals( cols, new String[]{"2","72"});
               }
             }
           }
@@ -243,20 +243,20 @@ public class RowManagerTest {
 // domHandle.write(System.out);
 
           NodeList testList = domHandle.evaluateXPath("/table:table/table:columns/table:column", NodeList.class);
-          assertEquals("unexpected header count in XML", 2, testList.getLength());
+          assertEquals( 2, testList.getLength());
           Element testElement = (Element) testList.item(0);
-          assertEquals("unexpected first header name in XML", "rowNum", testElement.getAttribute("name"));
+          assertEquals( "rowNum", testElement.getAttribute("name"));
           if (datatypeStyle == RowSetPart.HEADER) {
-            assertEquals("unexpected first header type in XML",  "xs:integer", testElement.getAttribute("type"));
+            assertEquals(  "xs:integer", testElement.getAttribute("type"));
           }
           testElement = (Element) testList.item(1);
-          assertEquals("unexpected second header name in XML", "temp", testElement.getAttribute("name"));
+          assertEquals( "temp", testElement.getAttribute("name"));
           if (datatypeStyle == RowSetPart.HEADER) {
-            assertEquals("unexpected second header type in XML",  "xs:string", testElement.getAttribute("type"));
+            assertEquals(  "xs:string", testElement.getAttribute("type"));
           }
 
           testList = domHandle.evaluateXPath("/table:table/table:rows/table:row", NodeList.class);
-          assertEquals("unexpected row count in XML", 1, testList.getLength());
+          assertEquals( 1, testList.getLength());
 
           testList = domHandle.evaluateXPath("/table:table/table:rows/table:row[1]/table:cell", NodeList.class);
           checkSingleRow(testList, datatypeStyle);
@@ -272,7 +272,7 @@ public class RowManagerTest {
               checkHeader(testNode.findValue("columns"), datatypeStyle);
 
               rowsNode = testNode.findValue("rows");
-              assertEquals("unexpected row count in JSON", 1, rowsNode.size());
+              assertEquals( 1, rowsNode.size());
 
               checkSingleRow(rowsNode.get(0), rowstruct, datatypeStyle);
               break;
@@ -280,7 +280,7 @@ public class RowManagerTest {
               checkHeader(testNode.get(0), datatypeStyle);
 
               rowsNode = testNode.get(1);
-              assertEquals("unexpected row count in JSON", 2, rowsNode.size());
+              assertEquals( 2, rowsNode.size());
 
               checkSingleRow(rowsNode, rowstruct, datatypeStyle);
               break;
@@ -313,8 +313,7 @@ public class RowManagerTest {
                     break;
                 }
               }
-              assertEquals("expected one row for json-seq using: "
-                +rowstruct+", "+datatypeStyle, 2, i);
+              assertEquals(2, i);
             }
           }
         }
@@ -347,10 +346,10 @@ public class RowManagerTest {
             checkHeader("XML", xmlRowSet, datatypeStyle);
 
             Iterator<DOMHandle> xmlRowItr = xmlRowSet.iterator();
-            assertTrue("no XML row to iterate", xmlRowItr.hasNext());
+            assertTrue( xmlRowItr.hasNext());
             DOMHandle xmlRow = initNamespaces(xmlRowItr.next());
             checkSingleRow(xmlRow.evaluateXPath("/table:row/table:cell", NodeList.class), datatypeStyle);
-            assertFalse("expected one XML row", xmlRowItr.hasNext());
+            assertFalse( xmlRowItr.hasNext());
 
             xmlRowSet.close();
           }
@@ -360,10 +359,10 @@ public class RowManagerTest {
             checkHeader("XML", xmlRowSetAs, datatypeStyle);
 
             Iterator<Document> xmlRowItrAs = xmlRowSetAs.iterator();
-            assertTrue("no XML rows as to iterate", xmlRowItrAs.hasNext());
+            assertTrue( xmlRowItrAs.hasNext());
             DOMHandle xmlRow = initNamespaces(new DOMHandle().with(xmlRowItrAs.next()));
             checkSingleRow(xmlRow.evaluateXPath("/table:row/table:cell", NodeList.class), datatypeStyle);
-            assertFalse("expected one XML row", xmlRowItrAs.hasNext());
+            assertFalse( xmlRowItrAs.hasNext());
 
             xmlRowSetAs.close();
           }
@@ -373,12 +372,12 @@ public class RowManagerTest {
             checkHeader("JSON", jsonRowSet, datatypeStyle);
 
             Iterator<JacksonHandle> jsonRowItr = jsonRowSet.iterator();
-            assertTrue("no JSON row to iterate", jsonRowItr.hasNext());
+            assertTrue( jsonRowItr.hasNext());
             JacksonHandle jsonRow = jsonRowItr.next();
 // jsonRow.write(System.out);
 
             checkSingleRow(jsonRow.get(), rowstruct, datatypeStyle);
-            assertFalse("expected one JSON row", jsonRowItr.hasNext());
+            assertFalse( jsonRowItr.hasNext());
 
             jsonRowSet.close();
           }
@@ -388,9 +387,9 @@ public class RowManagerTest {
             checkHeader("JSON", jsonRowSetAs, datatypeStyle);
 
             Iterator<JsonNode> jsonRowItrAs = jsonRowSetAs.iterator();
-            assertTrue("no JSON row to iterate", jsonRowItrAs.hasNext());
+            assertTrue( jsonRowItrAs.hasNext());
             checkSingleRow(jsonRowItrAs.next(), rowstruct, datatypeStyle);
-            assertFalse("expected one JSON row", jsonRowItrAs.hasNext());
+            assertFalse( jsonRowItrAs.hasNext());
 
             jsonRowSetAs.close();
           }
@@ -398,10 +397,10 @@ public class RowManagerTest {
           rowrecord: {
             RowSet<RowRecord> recordRowSet = rowMgr.resultRows(plan);
             Iterator<RowRecord> recordRowItr = recordRowSet.iterator();
-            assertTrue("no record row to iterate", recordRowItr.hasNext());
+            assertTrue( recordRowItr.hasNext());
             RowRecord recordRow = recordRowItr.next();
             checkSingleRow(recordRow);
-            assertFalse("expected one record row", recordRowItr.hasNext());
+            assertFalse( recordRowItr.hasNext());
 
             recordRowSet.close();
           }
@@ -470,12 +469,12 @@ public class RowManagerTest {
 
     int rowNum = 0;
     for (RowRecord row: rows) {
-      assertEquals("unexpected lastName value in row record "+rowNum,  lastName[rowNum],  row.getString("lastName"));
-      assertEquals("unexpected firstName value in row record "+rowNum, firstName[rowNum], row.getString("firstName"));
-      assertEquals("unexpected dob value in row record "+rowNum,       dob[rowNum],       row.getString("dob"));
+      assertEquals(lastName[rowNum],  row.getString("lastName"));
+      assertEquals(firstName[rowNum], row.getString("firstName"));
+      assertEquals(dob[rowNum],       row.getString("dob"));
       rowNum++;
     }
-    assertEquals("unexpected count of result records", 2, rowNum);
+    assertEquals( 2, rowNum);
   }
 
   @Test
@@ -529,30 +528,31 @@ public class RowManagerTest {
     RowManager rowManager = Common.client.newRowManager();
     PlanBuilder.ModifyPlan plan = rowManager.newPlanBuilder().fromSql(validQueryThatEventuallyThrowsAnError);
 
-    FailedRequestException ex = assertThrows(
-        "The SQL query is designed to not immediately fail - it will immediately return a 200 status code to the " +
-            "Java Client because the query itself can be executed - but will fail later as it streams rows; " +
-            "specifically, it will fail on the fourth row, which is the 'Davis' row. " +
-            "If chunking is configured correctly for the /v1/rows requests - i.e. if the " +
-            "'TE' header is present - then ML should return trailers in the HTTP response named 'ml-error-code' and " +
-            "'ml-error-message'. Those are intended to indicate that while a 200 was returned, an error occurred later " +
-            "while streaming data back. The Java Client is then expected to detect those trailers and throw a " +
-            "FailedRequestException. If the Java Client does not do that, then no exception will be thrown and this " +
-            "assertion will fail.", FailedRequestException.class, () -> rowManager.resultRows(plan));
+    FailedRequestException ex = assertThrows(FailedRequestException.class, () -> rowManager.resultRows(plan),
+		"The SQL query is designed to not immediately fail - it will immediately return a 200 status code to the " +
+			"Java Client because the query itself can be executed - but will fail later as it streams rows; " +
+			"specifically, it will fail on the fourth row, which is the 'Davis' row. " +
+			"If chunking is configured correctly for the /v1/rows requests - i.e. if the " +
+			"'TE' header is present - then ML should return trailers in the HTTP response named 'ml-error-code' and " +
+			"'ml-error-message'. Those are intended to indicate that while a 200 was returned, an error occurred later " +
+			"while streaming data back. The Java Client is then expected to detect those trailers and throw a " +
+			"FailedRequestException. If the Java Client does not do that, then no exception will be thrown and this " +
+			"assertion will fail.");
 
-    assertEquals("A 500 is expected, even though ML immediately returned a 200 before it started streaming any data " +
-        "back; a 500 is used instead of a 400 here as we don't have a reliable way of knowing if the error " +
-        "occurred due to a bad request by the user, since the query was valid in the sense that it could be " +
-        "executed", 500, ex.getServerStatusCode());
+    assertEquals(500, ex.getServerStatusCode(),
+		"A 500 is expected, even though ML immediately returned a 200 before it started streaming any data " +
+			"back; a 500 is used instead of a 400 here as we don't have a reliable way of knowing if the error " +
+			"occurred due to a bad request by the user, since the query was valid in the sense that it could be " +
+			"executed");
 
-    assertEquals("The server error message is expected to be the value of the 'ml-error-message' trailer",
-        "SQL-TABLENOTFOUND", ex.getServerMessage());
+    assertEquals("SQL-TABLENOTFOUND", ex.getServerMessage(),
+		"The server error message is expected to be the value of the 'ml-error-message' trailer");
 
     assertEquals(
-        "The exception message is expected to be a formatted message containing the values of the 'ml-error-code' and " +
-            "'ml-error-message' trailers",
         "Local message: failed to apply resource at rows: SQL-TABLENOTFOUND, Internal Server Error. Server Message: SQL-TABLENOTFOUND",
-        ex.getMessage());
+        ex.getMessage(),
+		"The exception message is expected to be a formatted message containing the values of the 'ml-error-code' and " +
+			"'ml-error-message' trailers");
   }
 
   @Test
@@ -576,15 +576,15 @@ public class RowManagerTest {
     int rowNum = 0;
     for (RowRecord row: rowMgr.resultRows(builtPlan)) {
 // System.out.println(row.toString());
-      assertEquals("unexpected lastName value in row record "+rowNum,  lastName[rowNum],  row.getString("lastName"));
-      assertEquals("unexpected firstName value in row record "+rowNum, firstName[rowNum], row.getString("firstName"));
+      assertEquals(lastName[rowNum],  row.getString("lastName"));
+      assertEquals(firstName[rowNum], row.getString("firstName"));
 
       double score = row.getDouble("score");
-      assertTrue("unexpected score value of "+score+" in row record "+rowNum, score > 0);
+      assertTrue(score > 0);
 
       rowNum++;
     }
-    assertEquals("unexpected count of result records", 2, rowNum);
+    assertEquals( 2, rowNum);
   }
   @Test
   public void testSearchDocs() {
@@ -601,21 +601,21 @@ public class RowManagerTest {
     for (RowRecord row: rowMgr.resultRows(builtPlan)) {
 // System.out.println(row.toString());
       double score = row.getDouble("score");
-      assertTrue("unexpected score value of "+score+" in row record "+rowNum, score > 0);
-      assertTrue(lastScore+" not greater than "+score+" in row record "+rowNum, lastScore >= score);
+      assertTrue(score > 0);
+      assertTrue(lastScore >= score);
       lastScore = score;
 
       String uri = row.getString("uri");
-      assertNotNull("empty URI", uri);
-      assertTrue("not a musician uri "+uri+" in row record "+rowNum, uri.matches("^/optic/test/musician[0-9]+.json$"));
+      assertNotNull( uri);
+      assertTrue(uri.matches("^/optic/test/musician[0-9]+.json$"));
 
       JsonNode doc = row.getContent("doc", new JacksonHandle()).get();
-      assertNotNull("empty document", doc);
-      assertTrue("not a musician document for uri "+uri+" in row record "+rowNum, doc.has("musician"));
+      assertNotNull( doc);
+      assertTrue(doc.has("musician"));
 
       rowNum++;
     }
-    assertEquals("unexpected count of result records", 2, rowNum);
+    assertEquals( 2, rowNum);
   }
   @Test
   public void testJoinSrcDoc() throws IOException {
@@ -638,15 +638,15 @@ public class RowManagerTest {
 
     int rowNum = 0;
     for (RowRecord row: rowMgr.resultRows(builtPlan)) {
-      assertEquals("unexpected lastName value in row record "+rowNum,  lastName[rowNum],  row.getString("lastName"));
-      assertEquals("unexpected firstName value in row record "+rowNum, firstName[rowNum], row.getString("firstName"));
+      assertEquals(lastName[rowNum],  row.getString("lastName"));
+      assertEquals(firstName[rowNum], row.getString("firstName"));
 
       String instruments = row.getString("instruments");
-      assertNotNull("null instruments value in row record "+rowNum,    instruments);
-      assertTrue("unexpected instruments value in row record "+rowNum, instruments.contains("trumpet"));
+      assertNotNull(instruments);
+      assertTrue(instruments.contains("trumpet"));
       rowNum++;
     }
-    assertEquals("unexpected count of result records", 2, rowNum);
+    assertEquals( 2, rowNum);
   }
   @Test
   public void testJoinDocUri() throws IOException {
@@ -667,12 +667,12 @@ public class RowManagerTest {
 
     int rowNum = 0;
     for (RowRecord row: rowMgr.resultRows(builtPlan)) {
-      assertEquals("unexpected lastName value in row record "+rowNum,       lastName[rowNum],       row.getString("lastName"));
-      assertEquals("unexpected firstName value in row record "+rowNum,      firstName[rowNum],      row.getString("firstName"));
-      assertEquals("unexpected musicianDocUri value in row record "+rowNum, musicianDocUri[rowNum], row.getString("musicianDocUri"));
+      assertEquals(lastName[rowNum],       row.getString("lastName"));
+      assertEquals(firstName[rowNum],      row.getString("firstName"));
+      assertEquals(musicianDocUri[rowNum], row.getString("musicianDocUri"));
       rowNum++;
     }
-    assertEquals("unexpected count of result records", 2, rowNum);
+    assertEquals( 2, rowNum);
   }
   @Test
   public void testTriples() {
@@ -705,11 +705,11 @@ public class RowManagerTest {
         case 1: testRow = 2; break;
       }
 
-      assertEquals("unexpected subject value in row record "+rowNum, triples[testRow][0], row.getString("subject"));
-      assertEquals("unexpected object  value in row record "+rowNum, triples[testRow][2], row.getString("object"));
+      assertEquals(triples[testRow][0], row.getString("subject"));
+      assertEquals(triples[testRow][2], row.getString("object"));
       rowNum++;
     }
-    assertEquals("unexpected count of result records", 2, rowNum);
+    assertEquals( 2, rowNum);
   }
   @Test
   public void testLexicons() throws IOException, XPathExpressionException {
@@ -751,11 +751,11 @@ public class RowManagerTest {
 
     int rowNum = 0;
     for (RowRecord row: rowMgr.resultRows(plan)) {
-      assertEquals("unexpected int value in row record "+rowNum, expectedInts[rowNum], row.getInt("int"));
-      assertEquals("unexpected uri value in row record "+rowNum, expectedUris[rowNum], row.getString("uri"));
+      assertEquals(expectedInts[rowNum], row.getInt("int"));
+      assertEquals(expectedUris[rowNum], row.getString("uri"));
       rowNum++;
     }
-    assertEquals("unexpected count of result records", expectedInts.length, rowNum);
+    assertEquals( expectedInts.length, rowNum);
   }
   @Test
   public void testGroupByUnionWithGroup() {
@@ -842,15 +842,15 @@ public class RowManagerTest {
     int rowNum = 0;
     for (RowRecord row: rowMgr.resultRows(builtPlan)) {
 // System.out.println(row.toString());
-      assertEquals("", c1Flag[rowNum], row.getInt("c1Flag"));
-      assertEquals("", c2Flag[rowNum], row.getInt("c2Flag"));
-      assertEquals("", c1[rowNum], row.getString("c1"));
-      assertEquals("", c2[rowNum], row.getString("c2"));
-      assertEquals("", count[rowNum], row.getInt("count"));
-      assertEquals("", sum[rowNum], row.getInt("sum"));
+      assertEquals( c1Flag[rowNum], row.getInt("c1Flag"));
+      assertEquals( c2Flag[rowNum], row.getInt("c2Flag"));
+      assertEquals( c1[rowNum], row.getString("c1"));
+      assertEquals( c2[rowNum], row.getString("c2"));
+      assertEquals( count[rowNum], row.getInt("count"));
+      assertEquals( sum[rowNum], row.getInt("sum"));
       rowNum++;
     }
-    assertEquals("unexpected count of result records", count.length, rowNum);
+    assertEquals( count.length, rowNum);
   }
   @Test
   public void testArrayContainer() {
@@ -875,9 +875,9 @@ public class RowManagerTest {
                      p.arrayAggregate("va",  "v")));
 
     Iterator<RowRecord> rows = rowMgr.resultRows(builtPlan).iterator();
-    assertTrue("no rows", rows.hasNext());
+    assertTrue( rows.hasNext());
     RowRecord row = rows.next();
-    assertFalse("too many rows", rows.hasNext());
+    assertFalse( rows.hasNext());
 // System.out.println(row);
 
     arrayTestimpl("c1 unequal", c1Expect, row, "c1a");
@@ -892,7 +892,7 @@ public class RowManagerTest {
   private void arrayTestimpl(String msg, Set<String> expect, JsonNode arrayNode) {
     Set<String> actual = new HashSet<>();
     arrayNode.iterator().forEachRemaining(node -> actual.add(node.textValue()));
-    assertEquals(msg, expect, actual);
+    assertEquals(expect, actual, msg);
   }
   @Test
   public void testObjectContainer() {
@@ -915,7 +915,7 @@ public class RowManagerTest {
       objectTestimpl(groupableRows[rowNum], row, "o");
       rowNum++;
     }
-    assertEquals("number of rows unequal", groupableRows.length, rowNum);
+    assertEquals( groupableRows.length, rowNum);
   }
   private void objectTestimpl(Map<String,Object> expected, RowRecord row, String objectName) {
     objectTestimpl(expected, row.getContainer(objectName));
@@ -923,9 +923,9 @@ public class RowManagerTest {
     objectTestimpl(expected, row.getContainerAs(objectName, JsonNode.class));
   }
   private void objectTestimpl(Map<String,Object> expected, JsonNode actual) {
-    assertEquals("c1 unequal", expected.get("c1"), actual.get("c1p").textValue());
-    assertEquals("c2 unequal", expected.get("c2"), actual.get("c2p").textValue());
-    assertEquals("v unequal", expected.get("v"), actual.get("vp").textValue());
+    assertEquals( expected.get("c1"), actual.get("c1p").textValue());
+    assertEquals( expected.get("c2"), actual.get("c2p").textValue());
+    assertEquals( expected.get("v"), actual.get("vp").textValue());
   }
   @Test
   public void testGroupToArrays() {
@@ -947,9 +947,9 @@ public class RowManagerTest {
                 ));
 
     Iterator<RowRecord> rows = rowMgr.resultRows(builtPlan).iterator();
-    assertTrue("no rows", rows.hasNext());
+    assertTrue( rows.hasNext());
     RowRecord row = rows.next();
-    assertFalse("too many rows", rows.hasNext());
+    assertFalse( rows.hasNext());
 // System.out.println(row);
 
     ObjectMapper mapper = new ObjectMapper();
@@ -959,7 +959,7 @@ public class RowManagerTest {
                   .add(mapper.createObjectNode()
                              .put("count", 3).put("sum", 6));
     JsonNode actual = row.getContainer("empty");
-    assertEquals("empty group unequal", expect, actual);
+    assertEquals( expect, actual);
 
     expect = mapper.createArrayNode()
                    .add(mapper.createObjectNode()
@@ -967,7 +967,7 @@ public class RowManagerTest {
                    .add(mapper.createObjectNode()
                               .put("c1", "12").put("count", 2).put("sum", 4));
     actual = row.getContainer("group1");
-    assertEquals("group1 unequal", expect, actual);
+    assertEquals( expect, actual);
 
     expect = mapper.createArrayNode()
                    .add(mapper.createObjectNode()
@@ -975,7 +975,7 @@ public class RowManagerTest {
                    .add(mapper.createObjectNode()
                               .put("c2", "22").put("count", 1).put("sum", 2));
     actual = row.getContainer("group2");
-    assertEquals("group2 unequal", expect, actual);
+    assertEquals( expect, actual);
 
     expect = mapper.createArrayNode()
                    .add(mapper.createObjectNode()
@@ -988,7 +988,7 @@ public class RowManagerTest {
                               .put("c1", "12").put("c2", "22")
                               .put("count", 1).put("sum", 2));
     actual = row.getContainer("all");
-    assertEquals("all group unequal", expect, actual);
+    assertEquals( expect, actual);
   }
   @Test
   public void testFacetBy() {
@@ -1002,9 +1002,9 @@ public class RowManagerTest {
             .facetBy(p.colSeq("c1", "c2"));
 
     Iterator<RowRecord> rows = rowMgr.resultRows(builtPlan).iterator();
-    assertTrue("no rows", rows.hasNext());
+    assertTrue( rows.hasNext());
     RowRecord row = rows.next();
-    assertFalse("too many rows", rows.hasNext());
+    assertFalse( rows.hasNext());
 // System.out.println(row);
 
     ObjectMapper mapper = new ObjectMapper();
@@ -1014,13 +1014,13 @@ public class RowManagerTest {
                    .add(mapper.createObjectNode().put("c1", "11").put("count", 1))
                    .add(mapper.createObjectNode().put("c1", "12").put("count", 2));
     JsonNode actual = row.getContainer("group0");
-    assertEquals("group0 unequal", expect, actual);
+    assertEquals( expect, actual);
 
     expect = mapper.createArrayNode()
                    .add(mapper.createObjectNode().put("c2", "21").put("count", 2))
                    .add(mapper.createObjectNode().put("c2", "22").put("count", 1));
     actual = row.getContainer("group1");
-    assertEquals("group1 unequal", expect, actual);
+    assertEquals( expect, actual);
   }
   @Test
   public void testBindAs() {
@@ -1038,16 +1038,16 @@ public class RowManagerTest {
             .bindAs("concatted", p.fn.concat(p.col("city"), p.xs.string(", WA")));
 
     Iterator<RowRecord> rows = rowMgr.resultRows(plan).iterator();
-    assertTrue("no rows", rows.hasNext());
+    assertTrue( rows.hasNext());
     RowRecord row = rows.next();
-    assertFalse("too many rows", rows.hasNext());
+    assertFalse( rows.hasNext());
 // System.out.println(row.toString());
-    assertEquals("unexpected rowNum",           2,             row.getInt("rowNum"));
-    assertEquals("unexpected city",             "Seattle",     row.getString("city"));
-    assertEquals("unexpected temp",             "72",          row.getString("temp"));
-    assertEquals("unexpected divided column",   8,             row.getInt("divided"));
-    assertEquals("unexpected compared column",  true,          row.getBoolean("compared"));
-    assertEquals("unexpected concatted column", "Seattle, WA", row.getString("concatted"));
+    assertEquals(           2,             row.getInt("rowNum"));
+    assertEquals(             "Seattle",     row.getString("city"));
+    assertEquals(             "72",          row.getString("temp"));
+    assertEquals(   8,             row.getInt("divided"));
+    assertEquals(  true,          row.getBoolean("compared"));
+    assertEquals( "Seattle, WA", row.getString("concatted"));
   }
   @Test
   public void testParams() throws IOException, XPathExpressionException {
@@ -1070,10 +1070,10 @@ public class RowManagerTest {
     );
 
     Iterator<RowRecord> recordRowItr = recordRowSet.iterator();
-    assertTrue("no record row to iterate", recordRowItr.hasNext());
+    assertTrue( recordRowItr.hasNext());
     RowRecord recordRow = recordRowItr.next();
     checkSingleRow(recordRow);
-    assertFalse("expected one record row", recordRowItr.hasNext());
+    assertFalse( recordRowItr.hasNext());
 
     recordRowSet.close();
   }
@@ -1097,22 +1097,22 @@ public class RowManagerTest {
     RowSet<RowRecord> recordRowSet = rowMgr.resultRows(builtPlan);
 
     Iterator<RowRecord> recordRowItr = recordRowSet.iterator();
-    assertTrue("no first node row", recordRowItr.hasNext());
+    assertTrue( recordRowItr.hasNext());
     RowRecord recordRow = recordRowItr.next();
-    assertEquals("first row num", 1,           recordRow.getInt("rowNum"));
-    assertEquals("first cased",   "otherwise", recordRow.getString("cased"));
+    assertEquals( 1,           recordRow.getInt("rowNum"));
+    assertEquals(   "otherwise", recordRow.getString("cased"));
 
-    assertTrue("no second node row", recordRowItr.hasNext());
+    assertTrue( recordRowItr.hasNext());
     recordRow = recordRowItr.next();
-    assertEquals("second row num", 2,        recordRow.getInt("rowNum"));
-    assertEquals("second cased",   "second", recordRow.getString("cased"));
+    assertEquals( 2,        recordRow.getInt("rowNum"));
+    assertEquals(   "second", recordRow.getString("cased"));
 
-    assertTrue("no third node row", recordRowItr.hasNext());
+    assertTrue( recordRowItr.hasNext());
     recordRow = recordRowItr.next();
-    assertEquals("third row num", 3,       recordRow.getInt("rowNum"));
-    assertEquals("third cased",   "third", recordRow.getString("cased"));
+    assertEquals( 3,       recordRow.getInt("rowNum"));
+    assertEquals(   "third", recordRow.getString("cased"));
 
-    assertFalse("expected three record rows", recordRowItr.hasNext());
+    assertFalse( recordRowItr.hasNext());
 
     recordRowSet.close();
   }
@@ -1147,34 +1147,34 @@ public class RowManagerTest {
     RowSet<RowRecord> recordRowSet = rowMgr.resultRows(builtPlan);
 
     Iterator<RowRecord> recordRowItr = recordRowSet.iterator();
-    assertTrue("no JSON node row", recordRowItr.hasNext());
+    assertTrue( recordRowItr.hasNext());
     RowRecord recordRow = recordRowItr.next();
-    assertTrue("no JSON node value", recordRow.containsKey("node"));
-    assertEquals("wrong JSON kind", RowRecord.ColumnKind.CONTENT, recordRow.getKind("node"));
-    assertEquals("no JSON mime type", "application/json", recordRow.getContentMimetype("node"));
+    assertTrue( recordRow.containsKey("node"));
+    assertEquals( RowRecord.ColumnKind.CONTENT, recordRow.getKind("node"));
+    assertEquals( "application/json", recordRow.getContentMimetype("node"));
     JacksonHandle jsonNode = recordRow.getContent("node", new JacksonHandle());
     JsonNode jsonRoot = jsonNode.get();
-    assertEquals("constructed JSON property p1", "s", jsonRoot.findValue("p1").asText());
-    assertEquals("constructed JSON property p2", "New York", jsonRoot.findValue("p2").get(0).asText());
-    assertTrue("no JSON XPath value", recordRow.containsKey("jxpath"));
-    assertEquals("wrong JSON XPathValue", "New York", recordRow.getContentAs("jxpath", String.class));
-    assertEquals("wrong XML XPathValue", RowRecord.ColumnKind.NULL, recordRow.getKind("xxpath"));
+    assertEquals( "s", jsonRoot.findValue("p1").asText());
+    assertEquals( "New York", jsonRoot.findValue("p2").get(0).asText());
+    assertTrue( recordRow.containsKey("jxpath"));
+    assertEquals( "New York", recordRow.getContentAs("jxpath", String.class));
+    assertEquals( RowRecord.ColumnKind.NULL, recordRow.getKind("xxpath"));
 
-    assertTrue("no XML node row", recordRowItr.hasNext());
+    assertTrue( recordRowItr.hasNext());
     recordRow = recordRowItr.next();
-    assertTrue("no XML node value", recordRow.containsKey("node"));
-    assertEquals("wrong XML kind", RowRecord.ColumnKind.CONTENT, recordRow.getKind("node"));
-    assertEquals("no XML mime type", "application/xml", recordRow.getContentMimetype("node"));
+    assertTrue( recordRow.containsKey("node"));
+    assertEquals( RowRecord.ColumnKind.CONTENT, recordRow.getKind("node"));
+    assertEquals( "application/xml", recordRow.getContentMimetype("node"));
     DOMHandle xmlNode = recordRow.getContent("node", new DOMHandle());
     Element xmlRoot = xmlNode.get().getDocumentElement();
-    assertEquals("constructed XML element name", "e", xmlRoot.getLocalName());
-    assertEquals("constructed XML attribute", "s", xmlRoot.getAttribute("a"));
-    assertEquals("constructed XML text", "Seattle", xmlRoot.getTextContent());
-    assertEquals("wrong JSON XPathValue", RowRecord.ColumnKind.NULL, recordRow.getKind("jxpath"));
-    assertTrue("no XML XPath value", recordRow.containsKey("xxpath"));
-    assertEquals("wrong XML XPathValue", "Seattle", recordRow.getContentAs("xxpath", String.class));
+    assertEquals( "e", xmlRoot.getLocalName());
+    assertEquals( "s", xmlRoot.getAttribute("a"));
+    assertEquals( "Seattle", xmlRoot.getTextContent());
+    assertEquals( RowRecord.ColumnKind.NULL, recordRow.getKind("jxpath"));
+    assertTrue( recordRow.containsKey("xxpath"));
+    assertEquals( "Seattle", recordRow.getContentAs("xxpath", String.class));
 
-    assertFalse("expected two rows", recordRowItr.hasNext());
+    assertFalse( recordRowItr.hasNext());
 
     recordRowSet.close();
   }
@@ -1227,16 +1227,16 @@ public class RowManagerTest {
     RowSet<RowRecord> recordRowSet = rowMgr.resultRows(builtPlan);
 
     Iterator<RowRecord> recordRowItr = recordRowSet.iterator();
-    assertTrue("no first group row", recordRowItr.hasNext());
+    assertTrue( recordRowItr.hasNext());
     RowRecord recordRow = recordRowItr.next();
-    assertEquals("first group", 1,     recordRow.getInt("group"));
-    assertEquals("first vals",  "a-b", recordRow.getString("vals"));
+    assertEquals( 1,     recordRow.getInt("group"));
+    assertEquals(  "a-b", recordRow.getString("vals"));
 
     recordRow = recordRowItr.next();
-    assertEquals("second group", 2,     recordRow.getInt("group"));
-    assertEquals("second vals",  "c-d", recordRow.getString("vals"));
+    assertEquals( 2,     recordRow.getInt("group"));
+    assertEquals(  "c-d", recordRow.getString("vals"));
 
-    assertFalse("expected two rows", recordRowItr.hasNext());
+    assertFalse( recordRowItr.hasNext());
 
     recordRowSet.close();
   }
@@ -1255,10 +1255,10 @@ public class RowManagerTest {
 
     int rowNum = 0;
     for (RowRecord row: rowMgr.resultRows(builtPlan)) {
-      assertNotNull("null rowNum value in row record "+rowNum, row.getInt("rowNum"));
-      assertNotNull("null city value in row record "+rowNum, row.getString("city"));
+      assertNotNull(row.getInt("rowNum"));
+      assertNotNull(row.getString("city"));
       int seconds = row.getInt("seconds");
-      assertTrue("unexpected seconds value in row record "+rowNum,  0 <= seconds && seconds < 60);
+      assertTrue(0 <= seconds && seconds < 60);
       rowNum++;
     }
 
@@ -1274,10 +1274,10 @@ public class RowManagerTest {
 
     rowNum = 0;
     for (RowRecord row: rowMgr.resultRows(builtPlan)) {
-      assertNotNull("null rowNum value in row record "+rowNum, row.getInt("rowNum"));
-      assertNotNull("null city value in row record "+rowNum, row.getString("city"));
+      assertNotNull(row.getInt("rowNum"));
+      assertNotNull(row.getString("city"));
       int seconds = row.getInt("seconds");
-      assertTrue("unexpected seconds value in row record "+rowNum,  0 <= seconds && seconds < 60);
+      assertTrue(0 <= seconds && seconds < 60);
       rowNum++;
     }
   }
@@ -1306,8 +1306,8 @@ public class RowManagerTest {
     String stringHandleResult = rowMgr.columnInfo(builtPlan, new StringHandle()).get();
     String stringResult = rowMgr.columnInfoAs(builtPlan, String.class);
     for (String columnInfo : expectedColumnInfos) {
-      assertTrue("Did not find " + columnInfo + " in result: " + stringHandleResult, stringHandleResult.contains(columnInfo));
-      assertTrue("Did not find " + columnInfo + " in result: " + stringResult, stringResult.contains(columnInfo));
+      assertTrue(stringHandleResult.contains(columnInfo));
+      assertTrue(stringResult.contains(columnInfo));
     }
   }
 
@@ -1392,9 +1392,11 @@ public class RowManagerTest {
     List<RowRecord> rows = rowMgr.resultRows(builtPlan).stream().collect(Collectors.toList());
 
     if (Common.markLogicIsVersion11OrHigher()) {
-      assertEquals("Starting in ML 11, dedup is off by default, so 18 rows are expected", 18, rows.size());
+      assertEquals(18, rows.size(),
+		  "Starting in ML 11, dedup is off by default, so 18 rows are expected");
     } else {
-      assertEquals("In ML 10, dedup is on by default, so only 2 rows are expected", 2, rows.size());
+      assertEquals(2, rows.size(),
+		  "In ML 10, dedup is on by default, so only 2 rows are expected");
     }
 
     String stringRoot = rowMgr.explain(builtPlan, new StringHandle()).get();
@@ -1435,8 +1437,8 @@ public class RowManagerTest {
 
     JsonNode jsonBindingsNodes = jacksonHandle.get().path("rows");
     JsonNode node = jsonBindingsNodes.path(0);
-    assertEquals(" nodes not returned from fromSparql method", 6, jsonBindingsNodes.size());
-    assertEquals("Row 1  value incorrect", "Jim", node.path("sparql.firstName").path("value").asText());
+    assertEquals( 6, jsonBindingsNodes.size());
+    assertEquals( "Jim", node.path("sparql.firstName").path("value").asText());
   }
   @Test
   public void testSampleBy() throws IOException {
@@ -1451,7 +1453,7 @@ public class RowManagerTest {
 
     RowSet<RowRecord> rows = rowMgr.resultRows(builtPlan);
     long count = rows.stream().count();
-    assertEquals("count doesn't match", 2, count);
+    assertEquals(2, count);
   }
   @Test
   public void testSampleByNoArg() throws IOException {
@@ -1465,11 +1467,11 @@ public class RowManagerTest {
 
     RowSet<RowRecord> rows = rowMgr.resultRows(builtPlan);
     long count = rows.stream().count();
-    assertEquals("count doesn't match", 4, count);
+    assertEquals(4, count);
   }
 
   @Test
-  @Ignore("Waiting on a fix for https://bugtrack.marklogic.com/58233")
+  @Disabled("Waiting on a fix for https://bugtrack.marklogic.com/58233")
   public void testBug58233() {
     RowManager rowMgr = Common.client.newRowManager();
 
@@ -1504,9 +1506,9 @@ public class RowManagerTest {
             );
 
     Iterator<RowRecord> rows = rowMgr.resultRows(builtPlan).iterator();
-    assertTrue("no rows", rows.hasNext());
+    assertTrue( rows.hasNext());
     RowRecord row = rows.next();
-    assertFalse("too many rows", rows.hasNext());
+    assertFalse( rows.hasNext());
 
     ObjectMapper mapper = new ObjectMapper();
 
@@ -1517,7 +1519,7 @@ public class RowManagerTest {
                     .add(mapper.createObjectNode()
                             .put("r_bucket", 2).put("numRows", 2));
     JsonNode actual = row.getContainer("r");
-    assertEquals("group unequal", expect, actual);
+    assertEquals( expect, actual);
   }
 
   @Test
@@ -1574,34 +1576,34 @@ public class RowManagerTest {
   }
 
   private void checkSingleRow(NodeList row, RowSetPart datatypeStyle) {
-    assertEquals("unexpected column count in XML", 2, row.getLength());
+    assertEquals( 2, row.getLength());
     Element testElement = (Element) row.item(0);
-    assertEquals("unexpected first binding name in XML",  "rowNum", testElement.getAttribute("name"));
+    assertEquals(  "rowNum", testElement.getAttribute("name"));
     if (datatypeStyle == RowSetPart.ROWS) {
-      assertEquals("unexpected first binding type in XML",  "xs:integer", testElement.getAttribute("type"));
+      assertEquals(  "xs:integer", testElement.getAttribute("type"));
     }
-    assertEquals("unexpected first binding value in XML", "2",      testElement.getTextContent());
+    assertEquals( "2",      testElement.getTextContent());
     testElement = (Element) row.item(1);
-    assertEquals("unexpected second binding name in XML",  "temp", testElement.getAttribute("name"));
+    assertEquals(  "temp", testElement.getAttribute("name"));
     if (datatypeStyle == RowSetPart.ROWS) {
-      assertEquals("unexpected second binding type in XML",  "xs:string", testElement.getAttribute("type"));
+      assertEquals(  "xs:string", testElement.getAttribute("type"));
     }
-    assertEquals("unexpected second binding value in XML", "72",   testElement.getTextContent());
+    assertEquals( "72",   testElement.getTextContent());
   }
   private void checkHeader(String format, RowSet<?> rowset, RowSetPart datatypeStyle) {
     String[] columnNames = rowset.getColumnNames();
-    assertEquals("unexpected column name count in "+format, 2, columnNames.length);
+    assertEquals(2, columnNames.length);
     checkFirstHeader(  format, columnNames[0] );
     checkSecondHeader( format, columnNames[1] );
     if (datatypeStyle == RowSetPart.HEADER) {
       String[] columnTypes = rowset.getColumnTypes();
-      assertEquals("unexpected column type count in "+format, 2, columnTypes.length);
+      assertEquals(2, columnTypes.length);
       checkFirstType(  format, columnTypes[0] );
       checkSecondType( format, columnTypes[1] );
     }
   }
   private void checkHeader(JsonNode header, RowSetPart datatypeStyle) {
-    assertEquals("unexpected header count in JSON", 2, header.size());
+    assertEquals( 2, header.size());
 
     switch(datatypeStyle) {
       case ROWS:
@@ -1671,10 +1673,10 @@ public class RowManagerTest {
     checkSecondHeader("JSON", colNode.get("name").asText());
   }
   private void checkFirstHeader(String format, String name) {
-    assertEquals("unexpected first header name in "+format,  "rowNum", name);
+    assertEquals("rowNum", name, "unexpected first header name in "+format);
   }
   private void checkSecondHeader(String format, String name) {
-    assertEquals("unexpected second header name in "+format, "temp",  name);
+    assertEquals("temp",  name, "unexpected second header name in "+format);
   }
   private void checkFirstObject(JsonNode object) {
     checkFirstType("JSON", object.get("type").asText());
@@ -1685,24 +1687,24 @@ public class RowManagerTest {
     checkSecondValue("JSON", object.get("value").asText());
   }
   private void checkFirstType(String format, String type) {
-    assertEquals("unexpected first binding type in "+format, "xs:integer",  type);
+    assertEquals("xs:integer",  type, "unexpected first binding type in "+format);
   }
   private void checkFirstValue(String format, String value) {
-    assertEquals("unexpected first binding value in "+format, "2",  value);
+    assertEquals("2",  value, "unexpected first binding value in "+format);
   }
   private void checkSecondType(String format, String type) {
-    assertEquals("unexpected second binding type in "+format, "xs:string",  type);
+    assertEquals("xs:string",  type, "unexpected second binding type in "+format);
   }
   private void checkSecondValue(String format, String value) {
-    assertEquals("unexpected second binding value in "+format, "72",  value);
+    assertEquals("72",  value, "unexpected second binding value in "+format);
   }
   private void checkSingleRow(RowRecord row) {
-    assertEquals("unexpected first binding value in row record", "2",  row.getString("rowNum"));
+    assertEquals( "2",  row.getString("rowNum"));
 
-    assertEquals("unexpected first binding value in row record", "72", row.getString("temp"));
+    assertEquals( "72", row.getString("temp"));
   }
   private void checkColumnNames(String[] colNames, RowSet<?> rowSet) {
-    assertArrayEquals("unmatched column names", colNames, rowSet.getColumnNames());
+    assertArrayEquals( colNames, rowSet.getColumnNames());
   }
   private void checkXMLDocRows(RowSet<DOMHandle> rowSet)
     throws XPathExpressionException, TransformerConfigurationException, TransformerException, TransformerFactoryConfigurationError, SAXException, IOException
@@ -1715,27 +1717,27 @@ public class RowManagerTest {
 
       rowCount++;
 
-      assertEquals("unexpected column count in XML", 3, row.getLength());
+      assertEquals( 3, row.getLength());
 
       Element testElement = (Element) row.item(0);
-      assertEquals("unexpected first binding name in XML", "rowNum",  testElement.getAttribute("name"));
-      assertEquals("unexpected first binding value in XML", String.valueOf(rowCount), testElement.getTextContent());
+      assertEquals( "rowNum",  testElement.getAttribute("name"));
+      assertEquals( String.valueOf(rowCount), testElement.getTextContent());
 
       testElement = (Element) row.item(1);
-      assertEquals("unexpected second binding name in XML", "uri",               testElement.getAttribute("name"));
-      assertEquals("unexpected second binding value in XML", uris[rowCount - 1], testElement.getTextContent());
+      assertEquals( "uri",               testElement.getAttribute("name"));
+      assertEquals( uris[rowCount - 1], testElement.getTextContent());
 
       testElement = (Element) row.item(2);
-      assertEquals("unexpected third binding name in XML", "doc", testElement.getAttribute("name"));
+      assertEquals( "doc", testElement.getAttribute("name"));
       if (uris[rowCount - 1].endsWith(".xml")) {
         assertXMLEqual("unexpected third binding value in XML",
           docs[rowCount - 1], nodeToString(testElement.getElementsByTagName("a").item(0))
         );
       } else {
-        assertEquals("unexpected third binding value in XML", docs[rowCount - 1], testElement.getTextContent());
+        assertEquals( docs[rowCount - 1], testElement.getTextContent());
       }
     }
-    assertEquals("row count for XML document join", 3, rowCount);
+    assertEquals( 3, rowCount);
   }
   private void checkJSONDocRows(RowSet<JacksonHandle> rowSet) {
     int rowCount = 0;
@@ -1745,51 +1747,51 @@ public class RowManagerTest {
       rowCount++;
 
       String value = row.findValue("rowNum").findValue("value").asText();
-      assertEquals("unexpected first binding value in JSON", String.valueOf(rowCount), value);
+      assertEquals( String.valueOf(rowCount), value);
 
       value = row.findValue("uri").findValue("value").asText();
-      assertEquals("unexpected second binding value in JSON", uris[rowCount - 1], value);
+      assertEquals( uris[rowCount - 1], value);
 
       if (uris[rowCount - 1].endsWith(".json")) {
         value = row.findValue("doc").findValue("value").toString();
-        assertEquals("unexpected third binding value in JSON", docs[rowCount - 1].replace(" ", ""), value);
+        assertEquals( docs[rowCount - 1].replace(" ", ""), value);
       } else {
         value = row.findValue("doc").findValue("value").asText();
-        assertEquals("unexpected third binding value in JSON", docs[rowCount - 1], value);
+        assertEquals( docs[rowCount - 1], value);
       }
     }
-    assertEquals("row count for JSON document join", 3, rowCount);
+    assertEquals( 3, rowCount);
   }
   private void checkRecordDocRows(RowSet<RowRecord> rowSet) throws SAXException, IOException {
     int rowCount = 0;
     for (RowRecord row: rowSet) {
       rowCount++;
 
-      assertEquals("unexpected first binding kind in row record", ColumnKind.ATOMIC_VALUE, row.getKind("rowNum"));
-      assertEquals("unexpected first binding datatype in row record", "xs:integer", row.getDatatype("rowNum"));
-      assertEquals("unexpected first binding value in row record", rowCount, row.getInt("rowNum"));
+      assertEquals( ColumnKind.ATOMIC_VALUE, row.getKind("rowNum"));
+      assertEquals( "xs:integer", row.getDatatype("rowNum"));
+      assertEquals( rowCount, row.getInt("rowNum"));
 
-      assertEquals("unexpected second binding kind in row record", ColumnKind.ATOMIC_VALUE, row.getKind("uri"));
-      assertEquals("unexpected second binding datatype in row record", "xs:string", row.getDatatype("uri"));
-      assertEquals("unexpected second binding value in row record", uris[rowCount - 1], row.getString("uri"));
+      assertEquals( ColumnKind.ATOMIC_VALUE, row.getKind("uri"));
+      assertEquals( "xs:string", row.getDatatype("uri"));
+      assertEquals( uris[rowCount - 1], row.getString("uri"));
 
-      assertEquals("unexpected third binding kind in row record", ColumnKind.CONTENT, row.getKind("doc"));
+      assertEquals( ColumnKind.CONTENT, row.getKind("doc"));
       String doc = row.getContent("doc", new StringHandle()).get();
       if (uris[rowCount - 1].endsWith(".json")) {
-        assertEquals("unexpected third binding format in row record",     Format.JSON,        row.getContentFormat("doc"));
-        assertEquals("unexpected third binding mimetype in row record",   "application/json", row.getContentMimetype("doc"));
-        assertEquals("unexpected third binding JSON value in row record", docs[rowCount - 1], doc);
+        assertEquals(     Format.JSON,        row.getContentFormat("doc"));
+        assertEquals(   "application/json", row.getContentMimetype("doc"));
+        assertEquals( docs[rowCount - 1], doc);
       } else if (uris[rowCount - 1].endsWith(".xml")) {
-        assertEquals("unexpected third binding format in row record",      Format.XML,         row.getContentFormat("doc"));
-        assertEquals("unexpected third binding mimetype in row record",    "application/xml",  row.getContentMimetype("doc"));
+        assertEquals(      Format.XML,         row.getContentFormat("doc"));
+        assertEquals(    "application/xml",  row.getContentMimetype("doc"));
         assertXMLEqual("unexpected third binding XML value in row record", docs[rowCount - 1], doc);
       } else {
-        assertEquals("unexpected third binding format in row record",   Format.TEXT,        row.getContentFormat("doc"));
-        assertEquals("unexpected third binding mimetype in row record", "text/plain",       row.getContentMimetype("doc"));
-        assertEquals("unexpected third binding value in row record",    docs[rowCount - 1], doc);
+        assertEquals(   Format.TEXT,        row.getContentFormat("doc"));
+        assertEquals( "text/plain",       row.getContentMimetype("doc"));
+        assertEquals(    docs[rowCount - 1], doc);
       }
     }
-    assertEquals("row count for record document join", 3, rowCount);
+    assertEquals( 3, rowCount);
   }
   private String nodeToString(Node node) throws TransformerException, TransformerFactoryConfigurationError
   {

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowRecordTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowRecordTest.java
@@ -15,48 +15,30 @@
  */
 package com.marklogic.client.test.rows;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.StringReader;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
 import com.marklogic.client.expression.PlanBuilder;
 import com.marklogic.client.row.RowManager;
 import com.marklogic.client.row.RowRecord;
 import com.marklogic.client.row.RowSet;
 import com.marklogic.client.test.Common;
-import com.marklogic.client.type.ItemVal;
-import com.marklogic.client.type.PlanExprCol;
-import com.marklogic.client.type.PlanPrefixer;
-import com.marklogic.client.type.XsAnyAtomicTypeVal;
-import com.marklogic.client.type.XsBooleanVal;
-import com.marklogic.client.type.XsByteVal;
-import com.marklogic.client.type.XsDoubleVal;
-import com.marklogic.client.type.XsFloatVal;
-import com.marklogic.client.type.XsIntVal;
-import com.marklogic.client.type.XsLongVal;
-import com.marklogic.client.type.XsShortVal;
+import com.marklogic.client.type.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class RowRecordTest {
   protected static RowManager  rowMgr = null;
   protected static PlanBuilder p      = null;
 
   protected static Map<String,ItemVal> datatypedValues = null;
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     Common.connect();
     rowMgr = Common.client.newRowManager();
@@ -92,7 +74,7 @@ public class RowRecordTest {
     datatypedValues.put("langString",        p.rdf.langString("abc", "en"));
     datatypedValues.put("iri",               p.sem.iri("http://a/b"));
   }
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     p      = null;
     rowMgr = null;
@@ -114,7 +96,7 @@ public class RowRecordTest {
     for (int prefix=0; prefix < prefixes.length; prefix++) {
       PlanPrefixer prefixer = p.prefixer(prefixes[prefix]);
       for (int suffix=0; suffix < suffixes.length; suffix++) {
-        assertEquals("prefixer "+prefix+","+suffix,
+        assertEquals(
           p.sem.iri(results[prefix][suffix]).getString(),
           prefixer.iri(suffixes[suffix]).getString()
         );
@@ -144,7 +126,7 @@ public class RowRecordTest {
 
     RowSet<RowRecord>   rowSet = rowMgr.resultRows(plan);
     Iterator<RowRecord> rowItr = rowSet.iterator();
-    assertTrue("no row to test for datatypes", rowItr.hasNext());
+    assertTrue( rowItr.hasNext());
 
     RowRecord row = rowItr.next();
     datatypedValues.forEach((key,expected) -> {
@@ -157,12 +139,12 @@ public class RowRecordTest {
         if (isFloatingPoint && expectedStr.length() < actualStr.length()) {
           actualStr = actualStr.substring(0, expectedStr.length());
         }
-        assertEquals("string comparison for: "+key, expectedStr, actualStr);
+        assertEquals(expectedStr, actualStr);
 
         RowRecord.ColumnKind expectedKind = RowRecord.ColumnKind.ATOMIC_VALUE;
         RowRecord.ColumnKind actualKind   =
           useKey ? row.getKind(key) : row.getKind(col);
-        assertEquals("column kind for: "+key, expectedKind, actualKind);
+        assertEquals(expectedKind, actualKind);
 
         String actualDatatype =
           useKey ? row.getDatatype(key) : row.getDatatype(col);
@@ -198,7 +180,7 @@ public class RowRecordTest {
                 expectedTypePrefix = "sem";
                 break;
             }
-            assertEquals("column datatype for: "+key,
+            assertEquals(
               expectedTypePrefix+":"+expectedTypeName,
               actualDatatype
             );
@@ -217,14 +199,14 @@ public class RowRecordTest {
               String name = expectedClass.getSimpleName();
               name = name.substring(0, name.length() - "Impl".length());
               try {
-                assertNotNull("null value for: "+key,
+                assertNotNull(
                   useKey ? row.getValueAs(key, expectedClass) : row.getValueAs(col, expectedClass));
 
                 @SuppressWarnings("unchecked")
                 Class<? extends XsAnyAtomicTypeVal> expectedInterface =
                   (Class<? extends XsAnyAtomicTypeVal>) Class.forName("com.marklogic.client.type.Xs"+name);
 
-                assertNotNull("null value for: "+key,
+                assertNotNull(
                   useKey ? row.getValueAs(key, expectedInterface) : row.getValueAs(col, expectedInterface));
               } catch (Exception e) {
                 throw new RuntimeException(e);
@@ -235,40 +217,40 @@ public class RowRecordTest {
 
         switch(key) {
           case "boolean":
-            assertEquals("boolean overload", ((XsBooleanVal) expected).getBoolean(),
+            assertEquals(((XsBooleanVal) expected).getBoolean(),
               useKey ? row.getBoolean(key) : row.getBoolean(col));
             break;
           case "byte":
-            assertEquals("byte overload", ((XsByteVal) expected).getByte(),
+            assertEquals(((XsByteVal) expected).getByte(),
               useKey ? row.getByte(key) : row.getByte(col));
             break;
           case "double":
-            assertEquals("double overload", ((XsDoubleVal) expected).getDouble(),
+            assertEquals(((XsDoubleVal) expected).getDouble(),
               useKey ? row.getDouble(key) : row.getDouble(col),
               0.1);
             break;
           case "float":
-            assertEquals("float overload", ((XsFloatVal) expected).getFloat(),
+            assertEquals(((XsFloatVal) expected).getFloat(),
               useKey ? row.getFloat(key) : row.getFloat(col),
               0.1);
             break;
           case "int":
-            assertEquals("int overload", ((XsIntVal) expected).getInt(),
+            assertEquals(((XsIntVal) expected).getInt(),
               useKey ? row.getInt(key) : row.getInt(col));
             break;
           case "long":
-            assertEquals("long overload", ((XsLongVal) expected).getLong(),
+            assertEquals(((XsLongVal) expected).getLong(),
               useKey ? row.getLong(key) : row.getLong(col));
             break;
           case "short":
-            assertEquals("short overload", ((XsShortVal) expected).getShort(),
+            assertEquals(((XsShortVal) expected).getShort(),
               useKey ? row.getShort(key) : row.getShort(col));
             break;
         }
       }
     });
 
-    assertFalse("too many results for datatypes", rowItr.hasNext());
+    assertFalse( rowItr.hasNext());
     rowSet.close();
   }
 
@@ -281,23 +263,23 @@ public class RowRecordTest {
 
     RowSet<RowRecord>   rowSet = rowMgr.resultRows(plan);
     Iterator<RowRecord> rowItr = rowSet.iterator();
-    assertTrue("no row to test for datatypes", rowItr.hasNext());
+    assertTrue( rowItr.hasNext());
 
     RowRecord row = rowItr.next();
 
     for (String colName: new String[]{"opticUnitTest.musician.lastName", "musician.lastName", "lastName"}) {
       RowRecord.ColumnKind expectedKind = RowRecord.ColumnKind.ATOMIC_VALUE;
       RowRecord.ColumnKind actualKind   = row.getKind(colName);
-      assertEquals("kind for alias: "+colName, expectedKind, actualKind);
+      assertEquals(expectedKind, actualKind);
 
       String datatype = row.getDatatype(colName);
-      assertEquals("datatype for alias: "+colName, "xs:string", datatype);
+      assertEquals("xs:string", datatype);
 
       String value = row.getString(colName);
-      assertEquals("value for alias: "+colName, "Armstrong", value);
+      assertEquals("Armstrong", value);
     }
 
-    assertFalse("too many results for alias", rowItr.hasNext());
+    assertFalse( rowItr.hasNext());
     rowSet.close();
   }
 
@@ -309,7 +291,7 @@ public class RowRecordTest {
     expected.add("int:{kind: \"ATOMIC_VALUE\", type: \"xs:integer\", value: 2},");
     expected.add("str:{kind: \"ATOMIC_VALUE\", type: \"xs:string\", value: \"string four\"},");
 
-    Map<String,Object> literalRow = new HashMap<String,Object>();
+    Map<String,Object> literalRow = new HashMap<>();
     literalRow.put("bool", true);
     literalRow.put("int",  2);
     literalRow.put("dec",  3.3);
@@ -320,7 +302,7 @@ public class RowRecordTest {
 
     RowSet<RowRecord>   rowSet = rowMgr.resultRows(plan);
     Iterator<RowRecord> rowItr = rowSet.iterator();
-    assertTrue("no row to test for datatypes", rowItr.hasNext());
+    assertTrue( rowItr.hasNext());
 
     RowRecord row = rowItr.next();
 
@@ -331,7 +313,7 @@ public class RowRecordTest {
       .map(line -> (line.endsWith(",") ? line : line.concat(",")))
       .collect(Collectors.toSet());
 
-    assertTrue("stringified record", expected.equals(actual));
+    assertTrue( expected.equals(actual));
 
     rowSet.close();
   }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/TraceLabelAndOptimizeTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/TraceLabelAndOptimizeTest.java
@@ -3,11 +3,11 @@ package com.marklogic.client.test.rows;
 import com.marklogic.client.FailedRequestException;
 import com.marklogic.client.row.RowRecord;
 import com.marklogic.client.test.Common;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * The actual usage of trace label has to be manually verified by inspecting logs. And there's not a reliable way to
@@ -41,10 +41,8 @@ public class TraceLabelAndOptimizeTest extends AbstractOpticUpdateTest {
             FailedRequestException.class,
             () -> rowManager.execute(op.fromDocUris(op.cts.documentQuery("/doesnt-matter")))
         );
-        assertTrue(
-            "Unexpected message: " + ex.getMessage(),
-            ex.getMessage().contains("optimize can only be a positive integer")
-        );
+        assertTrue(ex.getMessage().contains("optimize can only be a positive integer"),
+			"Unexpected message: " + ex.getMessage());
     }
 
     @Test
@@ -58,9 +56,7 @@ public class TraceLabelAndOptimizeTest extends AbstractOpticUpdateTest {
             FailedRequestException.class,
             () -> resultRows(op.fromDocUris(op.cts.documentQuery("/doesnt-matter")))
         );
-        assertTrue(
-            "Unexpected message: " + ex.getMessage(),
-            ex.getMessage().contains("optimize can only be a positive integer")
-        );
+        assertTrue(ex.getMessage().contains("optimize can only be a positive integer"),
+			"Unexpected message: " + ex.getMessage());
     }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/TransformDocTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/TransformDocTest.java
@@ -10,15 +10,14 @@ import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.io.marker.AbstractWriteHandle;
 import com.marklogic.client.row.RowRecord;
 import com.marklogic.client.test.Common;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TransformDocTest extends AbstractOpticUpdateTest {
 
@@ -43,10 +42,9 @@ public class TransformDocTest extends AbstractOpticUpdateTest {
         ObjectNode transformedDoc = results.get(0).getContentAs("doc", ObjectNode.class);
         assertEquals("world", transformedDoc.get("hello").asText());
         assertEquals("my value", transformedDoc.get("yourParam").asText());
-        assertEquals(
-            "The transform is expected to receive the incoming doc via the 'doc' param and then toss it into the " +
-                "response under the key 'thedoc'",
-            "content", transformedDoc.get("theDoc").get("some").asText());
+        assertEquals("content", transformedDoc.get("theDoc").get("some").asText(),
+			"The transform is expected to receive the incoming doc via the 'doc' param and then toss it into the " +
+				"response under the key 'thedoc'");
     }
 
     @Test
@@ -118,7 +116,7 @@ public class TransformDocTest extends AbstractOpticUpdateTest {
 
         ObjectNode transformedDoc = results.get(0).getContentAs("doc", ObjectNode.class);
         assertEquals("world", transformedDoc.get("hello").asText());
-        assertFalse("myParam was not specified, so yourParam should not exist", transformedDoc.has("yourParam"));
+        assertFalse(transformedDoc.has("yourParam"), "myParam was not specified, so yourParam should not exist");
         assertEquals("content", transformedDoc.get("theDoc").get("some").asText());
     }
 
@@ -141,7 +139,8 @@ public class TransformDocTest extends AbstractOpticUpdateTest {
             .write();
 
         List<RowRecord> rows = resultRows(plan);
-        assertEquals("Two docs should have been written because the transform returns an array of 2 objects", 2, rows.size());
+        assertEquals(2, rows.size(),
+			"Two docs should have been written because the transform returns an array of 2 objects");
         rows.forEach(row -> {
             final String uri = row.getString("uri");
             final ObjectNode returnedDoc = row.getContentAs("doc", ObjectNode.class);
@@ -164,7 +163,8 @@ public class TransformDocTest extends AbstractOpticUpdateTest {
             .transformDoc(op.col("doc"), op.transformDef("/etc/optic/test/transformDoc-throwsError.mjs"));
 
         FailedRequestException ex = assertThrows(FailedRequestException.class, () -> rowManager.execute(plan));
-        assertTrue("Unexpected message: " + ex.getMessage(), ex.getMessage().contains("throw Error(\"This is intentional\")"));
+        assertTrue(ex.getMessage().contains("throw Error(\"This is intentional\")"),
+			"Unexpected message: " + ex.getMessage());
     }
 
     @Test
@@ -218,13 +218,13 @@ public class TransformDocTest extends AbstractOpticUpdateTest {
 
         String xml = getRowContentWithoutXmlDeclaration(results.get(0), "doc");
         String message = "Unexpected XML doc: " + xml;
-        // marklogic-junit would make this much easier/nicer once we change this project
+        // TODO marklogic-junit would make this much easier/nicer once we change this project
         // to use JUnit 5
-        assertTrue(message, xml.startsWith("<result>"));
-        assertTrue(message, xml.contains("<doc>1</doc>"));
-        assertTrue(message, xml.contains("<hello>world</hello>"));
-        assertTrue(message, xml.contains("<yourParam>my value</yourParam"));
-        assertTrue(message, xml.endsWith("</result>"));
+        assertTrue(xml.startsWith("<result>"), message);
+        assertTrue(xml.contains("<doc>1</doc>"), message);
+        assertTrue(xml.contains("<hello>world</hello>"), message);
+        assertTrue(xml.contains("<yourParam>my value</yourParam"), message);
+        assertTrue(xml.endsWith("</result>"), message);
     }
 
     @Test
@@ -249,9 +249,9 @@ public class TransformDocTest extends AbstractOpticUpdateTest {
 
         String xml = getRowContentWithoutXmlDeclaration(results.get(0), "doc");
         String message = "Unexpected XML doc: " + xml;
-        assertTrue(message, xml.startsWith("<result>"));
-        assertTrue(message, xml.contains("<hello>world</hello>"));
-        assertTrue(message, xml.contains("<yourParam/>"));
-        assertTrue(message, xml.endsWith("</result>"));
+        assertTrue(xml.startsWith("<result>"), message);
+        assertTrue(xml.contains("<hello>world</hello>"), message);
+        assertTrue(xml.contains("<yourParam/>"), message);
+        assertTrue(xml.endsWith("</result>"), message);
     }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/UnnestTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/UnnestTest.java
@@ -5,15 +5,15 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.client.expression.PlanBuilder;
 import com.marklogic.client.row.RowRecord;
 import com.marklogic.client.test.Common;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.util.StringUtils;
 
 import java.util.List;
 import java.util.stream.Stream;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Test demonstrates the primary use case for unnest, which is, for a given row, to create N rows based on a column in
@@ -26,7 +26,7 @@ public class UnnestTest extends AbstractOpticUpdateTest {
     /**
      * Inserts a test document for testing with the unnestSchema/unnestView view.
      */
-    @Before
+    @BeforeEach
     public void insertTestDocument() {
         if (!Common.markLogicIsVersion11OrHigher()) {
             return;
@@ -76,9 +76,9 @@ public class UnnestTest extends AbstractOpticUpdateTest {
         List<RowRecord> rows = resultRows(plan);
         assertEquals(3, rows.size());
         assertEquals("Alice", rows.get(0).getString(SINGLE_NAME_COLUMN));
-        assertEquals(
-            "The ordinality column is expected to capture the index of the value in the array that it came from, " +
-                "where the index is 1-based, not 0-based", 2, rows.get(0).getInt("index"));
+        assertEquals(2, rows.get(0).getInt("index"),
+			"The ordinality column is expected to capture the index of the value in the array that it came from, " +
+				"where the index is 1-based, not 0-based");
         assertEquals("Bob", rows.get(1).getString(SINGLE_NAME_COLUMN));
         assertEquals(1, rows.get(1).getInt("index"));
         assertEquals("Cindy", rows.get(2).getString(SINGLE_NAME_COLUMN));

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/UpdateUseCasesTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/UpdateUseCasesTest.java
@@ -11,14 +11,14 @@ import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.row.RowRecord;
 import com.marklogic.client.test.Common;
 import com.marklogic.client.type.PlanSystemColumn;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Intended to capture interesting use cases, particularly those called out in the functional spec.
@@ -64,7 +64,7 @@ public class UpdateUseCasesTest extends AbstractOpticUpdateTest {
 
         verifyJsonDoc(firstUri, doc -> assertEquals("modified", doc.get("hello").asText()));
         verifyMetadata(firstUri, metadata -> {
-            assertTrue("The collection in the initial insert should have been retained",
+            assertTrue(
                 metadata.getCollections().contains("test1"));
         });
         assertNull(Common.client.newDocumentManager().exists(missingUri));
@@ -98,8 +98,9 @@ public class UpdateUseCasesTest extends AbstractOpticUpdateTest {
             .write();
 
         List<RowRecord> rows = resultRows(plan);
-        assertEquals("Only doc2 should be returned; doc1 should have been filtered out by the notExistsJoin " +
-            "since it already exists", 1, rows.size());
+        assertEquals(1, rows.size(),
+			"Only doc2 should be returned; doc1 should have been filtered out by the notExistsJoin " +
+				"since it already exists");
         assertEquals("/acme/doc2.json", rows.get(0).getString("uri"));
 
         // doc1 should not have been modified since it was filtered out from the plan
@@ -132,9 +133,8 @@ public class UpdateUseCasesTest extends AbstractOpticUpdateTest {
 
         rowManager.execute(plan);
 
-        verifyJsonDoc(duplicateUri, doc -> assertEquals(
-            "The first writeOp with the duplicate URI should have been retained via groupBy and written",
-            1, doc.get("value").asInt()));
+        verifyJsonDoc(duplicateUri, doc -> assertEquals(1, doc.get("value").asInt(),
+			"The first writeOp with the duplicate URI should have been retained via groupBy and written"));
         verifyJsonDoc("/acme/a2.json", doc -> assertEquals(2, doc.get("value").asInt()));
     }
 
@@ -213,7 +213,7 @@ public class UpdateUseCasesTest extends AbstractOpticUpdateTest {
         assertEquals("/acme/Davis.json", rows.get(1).getString("uri"));
 
         verifyJsonDoc("/acme/Coltrane.json", doc -> {
-            assertEquals("This is added by the transform", "world", doc.get("hello").asText());
+            assertEquals("world", doc.get("hello").asText(), "This is added by the transform");
             assertEquals("John", doc.get("theDoc").get("musician").get("firstName").asText());
         });
 
@@ -257,7 +257,8 @@ public class UpdateUseCasesTest extends AbstractOpticUpdateTest {
             .write();
 
         List<RowRecord> rows = resultRows(plan);
-        assertEquals("Should contain 1 row for the audit log doc since that was the result of the last write", 1, rows.size());
+        assertEquals(1, rows.size(),
+			"Should contain 1 row for the audit log doc since that was the result of the last write");
 
         // Verify the 3 audited docs
         assertEquals(3, getCollectionSize("audited-doc"));

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/ValidateDocTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/ValidateDocTest.java
@@ -26,21 +26,21 @@ import com.marklogic.client.io.Format;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.row.RowRecord;
 import com.marklogic.client.test.Common;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.*;
 import java.util.stream.Collectors;
 
 import static com.marklogic.client.io.Format.XML;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ValidateDocTest extends AbstractOpticUpdateTest {
 
     private Set<String> expectedUris = new HashSet<>();
     private DataMovementManager dataMovementManager;
 
-    @Before
+    @BeforeEach
     public void moreSetup(){
         dataMovementManager = Common.client.newDataMovementManager();
     }
@@ -69,7 +69,7 @@ public class ValidateDocTest extends AbstractOpticUpdateTest {
                 op.schemaDefinition("xmlSchema").withMode("lax")
             );
         XMLDocumentManager mgr = Common.client.newXMLDocumentManager();
-        expectedUris.forEach(uri -> assertNotNull("URI was not written: " + uri, mgr.exists(uri)));
+        expectedUris.forEach(uri -> assertNotNull(mgr.exists(uri), "URI was not written: " + uri));
 
         List<RowRecord> rows = resultRows(plan);
 
@@ -78,7 +78,7 @@ public class ValidateDocTest extends AbstractOpticUpdateTest {
             return uri;
         }).collect(Collectors.toList());
         assertEquals(uriCountToWrite, persistedUris.size());
-        expectedUris.forEach(uri -> assertTrue("persistedUris does not contain "+uri, persistedUris.contains(uri)));
+        expectedUris.forEach(uri -> assertTrue(persistedUris.contains(uri), "persistedUris does not contain "+uri));
     }
 
     @Test
@@ -126,7 +126,7 @@ public class ValidateDocTest extends AbstractOpticUpdateTest {
         }
          assertTrue(uris.size() == 4);
         for(int i=0;i<4;i++){
-            assertTrue("uris does not contain /acme/"+i+".xml",uris.contains("/acme/"+i+".xml"));
+            assertTrue(uris.contains("/acme/"+i+".xml"), "uris does not contain /acme/"+i+".xml");
         }
     }
 
@@ -218,9 +218,9 @@ public class ValidateDocTest extends AbstractOpticUpdateTest {
         List<RowRecord> rows = resultRows(plan);
         assertEquals(1, rows.size());
         DocumentManager docMgr = Common.client.newDocumentManager();
-        assertTrue("Document /acme/doc1.xml should not exist",docMgr.exists("/acme/doc1.xml") == null);
-        assertTrue("Document /acme/doc2.xml should not exist",docMgr.exists("/acme/doc2.xml") == null);
-        assertTrue("Document /acme/doc3.xml does not exist",docMgr.exists("/acme/doc3.xml") != null);
+        assertTrue(docMgr.exists("/acme/doc1.xml") == null);
+        assertTrue(docMgr.exists("/acme/doc2.xml") == null);
+        assertTrue(docMgr.exists("/acme/doc3.xml") != null);
     }
 
     @Test
@@ -246,15 +246,15 @@ public class ValidateDocTest extends AbstractOpticUpdateTest {
         assertTrue(expectedUris.size()==2);
         rowManager.execute(plan.write());
         DocumentManager docMgr = Common.client.newDocumentManager();
-        assertTrue("Document /acme/doc1.json does not exist",docMgr.exists("/acme/doc1.json")!=null);
-        assertTrue("Document /acme/doc2.json does not exist",docMgr.exists("/acme/doc2.json")!=null);
-        assertTrue("Contents for /acme/doc1.json not as expected.",
+        assertTrue(docMgr.exists("/acme/doc1.json")!=null);
+        assertTrue(docMgr.exists("/acme/doc2.json")!=null);
+        assertTrue(
                 docMgr.read("/acme/doc1.json").next().getContent(new StringHandle()).toString().equals("{\"count\":1, \"total\":2}"));
-        assertTrue("Contents for /acme/doc2.json not as expected.",
+        assertTrue(
                 docMgr.read("/acme/doc2.json").next().getContent(new StringHandle()).toString().equals("{\"count\":2, \"total\":3}"));
 
-        assertTrue("/acme/doc1.json is not returned.",expectedUris.contains("/acme/doc1.json"));
-        assertTrue("/acme/doc2.json is not returned.",expectedUris.contains("/acme/doc2.json"));
+        assertTrue(expectedUris.contains("/acme/doc1.json"));
+        assertTrue(expectedUris.contains("/acme/doc2.json"));
     }
 
     @Test
@@ -285,28 +285,28 @@ public class ValidateDocTest extends AbstractOpticUpdateTest {
 
         rowManager.execute(plan.write());
         DocumentManager docMgr = Common.client.newDocumentManager();
-        assertTrue("Document /acme/doc1.json does not exist",docMgr.exists("/acme/doc1.json")!=null);
-        assertTrue("Contents for /acme/doc1.json not as expected.",
+        assertTrue(docMgr.exists("/acme/doc1.json")!=null);
+        assertTrue(
                 docMgr.read("/acme/doc1.json").next().getContent(new StringHandle()).toString().equals("{\"count\":1, \"total\":2}"));
-        assertTrue("Document /acme/doc2.json should not exist",docMgr.exists("/acme/doc2.json") == null);
-        assertTrue("Document /acme/doc3.json does not exist",docMgr.exists("/acme/doc3.json") != null);
-        assertTrue("Contents for /acme/doc3.json not as expected.",
+        assertTrue(docMgr.exists("/acme/doc2.json") == null);
+        assertTrue(docMgr.exists("/acme/doc3.json") != null);
+        assertTrue(
                 docMgr.read("/acme/doc3.json").next().getContent(new StringHandle()).toString().equals("{\"count\":2, \"total\":13}"));
-        assertTrue("Document /acme/doc4.json should not exist",docMgr.exists("/acme/doc4.json") == null);
+        assertTrue(docMgr.exists("/acme/doc4.json") == null);
 
-        assertTrue("Document /acme/doc5.json does not exist",docMgr.exists("/acme/doc5.json") != null);
-        assertTrue("Contents for /acme/doc5.json not as expected.",
+        assertTrue(docMgr.exists("/acme/doc5.json") != null);
+        assertTrue(
                 docMgr.read("/acme/doc5.json").next().getContent(new StringHandle()).toString().equals("{\"count\":3, \"total\":33}"));
 
-        assertTrue("Document /acme/doc6.json does not exist",docMgr.exists("/acme/doc6.json") != null);
-        assertTrue("Contents for /acme/doc6.json not as expected.",
+        assertTrue(docMgr.exists("/acme/doc6.json") != null);
+        assertTrue(
                 docMgr.read("/acme/doc6.json").next().getContent(new StringHandle()).toString().equals("{\"count\":4, \"total\":34}"));
 
-        assertTrue("Document /acme/doc7.json should not exist",docMgr.exists("/acme/doc7.json") == null);
+        assertTrue(docMgr.exists("/acme/doc7.json") == null);
         assertTrue(expectedUris.size()==4);
-         assertTrue("expectedUris does not contain /acme/doc1.json", expectedUris.contains("/acme/doc1.json"));
-         assertTrue("expectedUris does not contain /acme/doc3.json",expectedUris.contains("/acme/doc3.json"));
-         assertTrue("expectedUris does not contain /acme/doc5.json",expectedUris.contains("/acme/doc5.json"));
-         assertTrue("expectedUris does not contain /acme/doc6.json",expectedUris.contains("/acme/doc6.json"));
+         assertTrue( expectedUris.contains("/acme/doc1.json"));
+         assertTrue(expectedUris.contains("/acme/doc3.json"));
+         assertTrue(expectedUris.contains("/acme/doc5.json"));
+         assertTrue(expectedUris.contains("/acme/doc6.json"));
     }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/util/Refers.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/util/Refers.java
@@ -15,10 +15,9 @@
  */
 package com.marklogic.client.test.util;
 
+import javax.xml.bind.annotation.XmlRootElement;
 import java.util.List;
 import java.util.Map;
-
-import javax.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement
 public class Refers {

--- a/ml-development-tools/build.gradle
+++ b/ml-development-tools/build.gradle
@@ -15,8 +15,12 @@ dependencies {
     implementation 'com.fasterxml.jackson.module:jackson-module-kotlin:2.13.4'
     implementation 'com.networknt:json-schema-validator:1.0.73'
 
-    testCompileOnly gradleTestKit()
-    testImplementation 'com.squareup.okhttp3:okhttp:4.10.0'
+	// Not yet migrating this project to JUnit 5. Will reconsider it once we have a reason to enhance
+	// this project.
+	testImplementation 'junit:junit:4.13.2'
+	testImplementation 'xmlunit:xmlunit:1.6'
+	testCompileOnly gradleTestKit()
+	testImplementation 'com.squareup.okhttp3:okhttp:4.10.0'
 }
 
 // Added to avoid problem where processResources fails because - somehow - the plugin properties file is getting


### PR DESCRIPTION
Nearly every test was touched here due to the change in import. 

Another source of changes was accounting for JUnit 5's move of "String message" from being the first arg to the lazy arg. All existing  assertion messages (which was nearly all of them) simply restated what the assertion itself already made clear and thus were redundant, and so they were removed.

Upgraded xmlunit to 2.9.0 but still using the "legacy" APIs to minimize changes to any tests using xmlunit. 

No application code is changed by this. 