### PR TITLE
DEVEXP-143: Extracted methods for constructing an OkHttp Client

### DIFF
--- a/marklogic-client-api/build.gradle
+++ b/marklogic-client-api/build.gradle
@@ -29,6 +29,10 @@ dependencies {
 	testImplementation 'org.junit.jupiter:junit-jupiter:5.9.1'
 	testImplementation 'org.xmlunit:xmlunit-legacy:2.9.0'
 
+	// Allows talking to the Manage API. It depends on the Java Client itself, which will usually be a slightly older
+	// version, but that should not have any impact on the tests.
+	testImplementation "com.marklogic:ml-app-deployer:4.4.0"
+
 	testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.13.4'
     testImplementation "org.mockito:mockito-core:4.9.0"
     testImplementation "org.mockito:mockito-inline:4.9.0"

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/OkHttpUtil.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/OkHttpUtil.java
@@ -1,0 +1,136 @@
+package com.marklogic.client.impl.okhttp;
+
+import com.marklogic.client.DatabaseClientFactory;
+import okhttp3.ConnectionPool;
+import okhttp3.CookieJar;
+import okhttp3.Dns;
+import okhttp3.OkHttpClient;
+
+import javax.net.SocketFactory;
+import javax.net.ssl.*;
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Contains convenience methods for constructing an OkHttpClient.Builder so that it can be used in places other than
+ * only {@code OkHttpServices}. This code was moved here from OkHttpServices without any modification during the move
+ * (other than the method {@code initializeSslContext} being extracted for readability purposes).
+ */
+public abstract class OkHttpUtil {
+
+	final private static ConnectionPool connectionPool = new ConnectionPool();
+
+	/**
+	 * @return an OkHttpClient.Builder initialized with a sensible set of defaults that can then have authentication
+	 * configured
+	 */
+	public static OkHttpClient.Builder newClientBuilder() {
+		return new OkHttpClient.Builder()
+			.followRedirects(false)
+			.followSslRedirects(false)
+			// all clients share a single connection pool
+			.connectionPool(connectionPool)
+			// cookies are ignored (except when a Transaction is being used)
+			.cookieJar(CookieJar.NO_COOKIES)
+			// no timeouts since some of our clients' reads and writes can be massive
+			.readTimeout(0, TimeUnit.SECONDS)
+			.writeTimeout(0, TimeUnit.SECONDS)
+			// prefer ipv4 to ipv6
+			.dns(new DnsImpl());
+	}
+
+	/**
+	 * Configure the hostname verifier for the given OkHttpClient.Builder based on the given SSLHostnameVerifier.
+	 *
+	 * @param clientBuilder
+	 * @param sslVerifier
+	 */
+	public static void configureHostnameVerifier(OkHttpClient.Builder clientBuilder, DatabaseClientFactory.SSLHostnameVerifier sslVerifier) {
+		HostnameVerifier hostnameVerifier = null;
+		if (DatabaseClientFactory.SSLHostnameVerifier.ANY.equals(sslVerifier)) {
+			hostnameVerifier = (hostname, session) -> true;
+		} else if (DatabaseClientFactory.SSLHostnameVerifier.COMMON.equals(sslVerifier) ||
+			DatabaseClientFactory.SSLHostnameVerifier.STRICT.equals(sslVerifier)) {
+			hostnameVerifier = null;
+		} else if (sslVerifier != null) {
+			hostnameVerifier = new DatabaseClientFactory.SSLHostnameVerifier.HostnameVerifierAdapter(sslVerifier);
+		}
+		if (hostnameVerifier != null) {
+			clientBuilder.hostnameVerifier(hostnameVerifier);
+		}
+	}
+
+	/**
+	 * Configure the socket factory used by the given OkHttpClient.Builder based on whether SSL is required or not.
+	 *
+	 * @param clientBuilder
+	 * @param sslContext
+	 * @param trustManager
+	 */
+	public static void configureSocketFactory(OkHttpClient.Builder clientBuilder, SSLContext sslContext, X509TrustManager trustManager) {
+		/**
+		 * Per https://square.github.io/okhttp/3.x/okhttp/okhttp3/OkHttpClient.Builder.html#sslSocketFactory-javax.net.ssl.SSLSocketFactory- ,
+		 * OkHttp requires a TrustManager to be specified so that it can build a clean certificate chain. If trustManager
+		 * is not null, then the given sslContext is assumed to have been initialized already. If trustManager is
+		 * null, then the given sslContext is assumed to not have been initialized, and an attempt is made to initialize
+		 * it using the JVM's default TrustManager.
+		 */
+		if (sslContext == null) {
+			clientBuilder.socketFactory(new SocketFactoryDelegator(SocketFactory.getDefault()));
+		} else if (trustManager != null) {
+			clientBuilder.sslSocketFactory(new SSLSocketFactoryDelegator(sslContext.getSocketFactory()), trustManager);
+		} else {
+			initializeSslContext(clientBuilder, sslContext);
+		}
+	}
+
+	/**
+	 * This would be for an uninitialized SSLContext that depends on the default TrustManagerFactory.
+	 *
+	 * @param clientBuilder
+	 * @param sslContext
+	 */
+	private static void initializeSslContext(OkHttpClient.Builder clientBuilder, SSLContext sslContext) {
+		try {
+			TrustManagerFactory trustMgrFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+			trustMgrFactory.init((KeyStore) null);
+			TrustManager[] trustMgrs = trustMgrFactory.getTrustManagers();
+			if (trustMgrs == null || trustMgrs.length == 0) {
+				throw new IllegalArgumentException("no trust manager and could not get default trust manager");
+			}
+			if (!(trustMgrs[0] instanceof X509TrustManager)) {
+				throw new IllegalArgumentException("no trust manager and default is not an X509TrustManager");
+			}
+			sslContext.init(null, trustMgrs, null);
+			clientBuilder.sslSocketFactory(new SSLSocketFactoryDelegator(sslContext.getSocketFactory()), (X509TrustManager) trustMgrs[0]);
+		} catch (KeyStoreException e) {
+			throw new IllegalArgumentException("no trust manager and cannot initialize factory for default", e);
+		} catch (NoSuchAlgorithmException e) {
+			throw new IllegalArgumentException("no trust manager and no algorithm for default manager", e);
+		} catch (KeyManagementException e) {
+			throw new IllegalArgumentException("no trust manager and cannot initialize context with default", e);
+		}
+	}
+
+	static class DnsImpl implements Dns {
+		@Override
+		public List<InetAddress> lookup(String hostname) throws UnknownHostException {
+			List<InetAddress> rawAddresses = Dns.SYSTEM.lookup(hostname);
+			List<InetAddress> ipv4Addresses = new ArrayList<>();
+			for (InetAddress address : rawAddresses) {
+				if (address instanceof Inet4Address) {
+					ipv4Addresses.add(address);
+				}
+			}
+			return ipv4Addresses.isEmpty() ? rawAddresses : ipv4Addresses;
+		}
+	}
+}

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/SSLSocketFactoryDelegator.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/SSLSocketFactoryDelegator.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.marklogic.client.impl;
+package com.marklogic.client.impl.okhttp;
 
 import javax.net.ssl.SSLSocketFactory;
 import java.io.IOException;

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/SocketFactoryDelegator.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/SocketFactoryDelegator.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.marklogic.client.impl;
+package com.marklogic.client.impl.okhttp;
 
 import javax.net.SocketFactory;
 import java.io.IOException;

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/CheckSSLConnectionTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/CheckSSLConnectionTest.java
@@ -1,0 +1,53 @@
+package com.marklogic.client.test;
+
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.DatabaseClientFactory;
+import com.marklogic.client.MarkLogicIOException;
+import com.marklogic.client.test.junit5.RequireSSLExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(RequireSSLExtension.class)
+class CheckSSLConnectionTest {
+
+	/**
+	 * Simple check for ensuring that an SSL connection can be made when the app server requires SSL to be used. This
+	 * uses a naive test-only "trust all" approach for trusting certificates. That is fine for this test, as the intent
+	 * is simply to ensure that some kind of SSL connection can be made. In production, a user would be expected to
+	 * use a real TrustManager.
+	 *
+	 * @throws Exception
+	 */
+	@Test
+	void trustAllManager() throws Exception {
+		SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
+		sslContext.init(null, new TrustManager[]{Common.TRUST_ALL_MANAGER}, null);
+
+		DatabaseClient client = Common.makeNewClient(Common.HOST, Common.PORT,
+			Common.newSecurityContext(Common.USER, Common.PASS)
+				.withSSLContext(sslContext, Common.TRUST_ALL_MANAGER)
+				.withSSLHostnameVerifier(DatabaseClientFactory.SSLHostnameVerifier.ANY));
+
+		DatabaseClient.ConnectionResult result = client.checkConnection();
+		assertEquals(0, result.getStatusCode(), "A value of zero implies that a connection was successfully made, " +
+			"which should happen since a 'trust all' manager is being used");
+		assertNull(result.getErrorMessage());
+	}
+
+	@Test
+	void defaultSslContext() throws Exception {
+		DatabaseClient client = Common.makeNewClient(Common.HOST, Common.PORT,
+			Common.newSecurityContext(Common.USER, Common.PASS)
+				.withSSLContext(SSLContext.getDefault(), Common.TRUST_ALL_MANAGER)
+				.withSSLHostnameVerifier(DatabaseClientFactory.SSLHostnameVerifier.ANY));
+
+		assertThrows(MarkLogicIOException.class, () -> client.checkConnection(),
+			"The connection should fail because the JVM's default SSL Context does not have a CA certificate that " +
+				"corresponds to the test-only certificate that the app server is using for this test");
+	}
+}

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/junit5/RequireSSLExtension.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/junit5/RequireSSLExtension.java
@@ -1,0 +1,62 @@
+package com.marklogic.client.test.junit5;
+
+import com.marklogic.client.ext.helper.LoggingObject;
+import com.marklogic.client.test.Common;
+import com.marklogic.mgmt.ManageClient;
+import com.marklogic.mgmt.resource.appservers.ServerManager;
+import com.marklogic.mgmt.resource.security.CertificateTemplateManager;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * Use this on tests that require an app server to require SSL connections. The app server will be modified to require
+ * SSL connections before any test runs and will then be restored back to normal after all tests in the test class run.
+ */
+public class RequireSSLExtension extends LoggingObject implements BeforeAllCallback, AfterAllCallback {
+
+	private ManageClient manageClient;
+	private final static String TEMPLATE_NAME = "java-unittest-template";
+	private final static String TEMPLATE = "<certificate-template-properties xmlns=\"http://marklogic.com/manage\">\n" +
+		"  <template-name>" + TEMPLATE_NAME + "</template-name>\n" +
+		"  <template-description>Sample description</template-description>\n" +
+		"  <key-type>rsa</key-type>\n" +
+		"  <key-options />\n" +
+		"  <req>\n" +
+		"    <version>0</version>\n" +
+		"    <subject>\n" +
+		"      <countryName>US</countryName>\n" +
+		"      <stateOrProvinceName>CA</stateOrProvinceName>\n" +
+		"      <localityName>San Carlos</localityName>\n" +
+		"      <organizationName>MarkLogic</organizationName>\n" +
+		"      <organizationalUnitName>Engineering</organizationalUnitName>\n" +
+		"      <emailAddress>java-unittest@marklogic.com</emailAddress>\n" +
+		"    </subject>\n" +
+		"  </req>\n" +
+		"</certificate-template-properties>";
+
+	@Override
+	public void beforeAll(ExtensionContext context) {
+		manageClient = Common.newManageClient();
+		CertificateTemplateManager mgr = new CertificateTemplateManager(manageClient);
+		mgr.save(TEMPLATE);
+		mgr.generateTemporaryCertificate(TEMPLATE_NAME, Common.HOST);
+		logger.info("Requiring SSL on app server: " + Common.SERVER_NAME);
+		setSslCertificateTemplate(TEMPLATE_NAME);
+	}
+
+	@Override
+	public void afterAll(ExtensionContext context) {
+		setSslCertificateTemplate("");
+		logger.info("Removing requirement for SSL on app server: " + Common.SERVER_NAME);
+		new CertificateTemplateManager(manageClient).delete(TEMPLATE);
+	}
+
+	private void setSslCertificateTemplate(String templateName) {
+		new ServerManager(manageClient).save(
+			Common.newServerPayload()
+				.put("ssl-certificate-template", templateName)
+				.toString()
+		);
+	}
+}

--- a/marklogic-client-api/src/test/resources/logback-test.xml
+++ b/marklogic-client-api/src/test/resources/logback-test.xml
@@ -11,5 +11,9 @@
   <root level="info">
     <appender-ref ref="STDOUT" />
   </root>
-    
+
+	<logger name="com.marklogic.mgmt" level="WARN" additivity="false">
+		<appender-ref ref="STDOUT" />
+	</logger>
+
 </configuration>


### PR DESCRIPTION
This is a pure refactor, no functionality change. The intent is to make it easy for the upcoming MarkLogic cloud authenticator to reuse this code for making an HTTPS call to get a token. 