### PR TITLE
DEVEXP-143: Now supporting authentication for MarkLogic Cloud

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,3 +10,7 @@ mlPassword=admin
 
 # Whether tests should run with the expectation that they'll use a basePath and talk to a reverse proxy server
 testUseReverseProxyServer=false
+
+# For testing cloud-based authentication; define in gradle-local.properties with valid values for a MarkLogic Cloud instance
+tokenKey=
+tokenHost=

--- a/marklogic-client-api/build.gradle
+++ b/marklogic-client-api/build.gradle
@@ -236,3 +236,10 @@ task testRows(type: Test) {
 	description = "Run all 'rows' tests; i.e. those exercising Optic and Optic Update functionality"
 	include "com/marklogic/client/test/rows/**"
 }
+
+task debugCloudAuth(type: JavaExec) {
+	description = "Test program for manual testing of cloud-based authentication against a MarkLogic Cloud instance"
+	main = 'com.marklogic.client.test.MarkLogicCloudAuthenticationDebugger'
+	classpath = sourceSets.test.runtimeClasspath
+	args = [tokenHost, tokenKey]
+}

--- a/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClientFactory.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClientFactory.java
@@ -447,7 +447,47 @@ public class DatabaseClientFactory {
       this.trustManager = trustManager;
       return this;
     }
+  }
 
+  public static class MarkLogicCloudAuthContext extends AuthContext {
+      private String tokenEndpoint;
+      private String grantType;
+      private String key;
+
+      public MarkLogicCloudAuthContext(String key) {
+          this(key, "/token", "apikey");
+      }
+
+      public MarkLogicCloudAuthContext(String key, String tokenEndpoint, String grantType) {
+          this.key = key;
+          this.tokenEndpoint = tokenEndpoint;
+          this.grantType = grantType;
+      }
+
+      public String getTokenEndpoint() {
+          return tokenEndpoint;
+      }
+
+      public String getGrantType() {
+          return grantType;
+      }
+
+      public String getKey() {
+          return key;
+      }
+
+	  @Override
+      public MarkLogicCloudAuthContext withSSLContext(SSLContext context, X509TrustManager trustManager) {
+          this.sslContext = context;
+          this.trustManager = trustManager;
+          return this;
+      }
+
+      @Override
+      public MarkLogicCloudAuthContext withSSLHostnameVerifier(SSLHostnameVerifier verifier) {
+          this.sslVerifier = verifier;
+          return this;
+      }
   }
 
   public static class BasicAuthContext extends AuthContext {

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/OkHttpServices.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/OkHttpServices.java
@@ -22,6 +22,7 @@ import com.marklogic.client.DatabaseClientFactory.BasicAuthContext;
 import com.marklogic.client.DatabaseClientFactory.CertificateAuthContext;
 import com.marklogic.client.DatabaseClientFactory.DigestAuthContext;
 import com.marklogic.client.DatabaseClientFactory.KerberosAuthContext;
+import com.marklogic.client.DatabaseClientFactory.MarkLogicCloudAuthContext;
 import com.marklogic.client.DatabaseClientFactory.SAMLAuthContext;
 import com.marklogic.client.DatabaseClientFactory.SSLHostnameVerifier;
 import com.marklogic.client.DatabaseClientFactory.SecurityContext;
@@ -213,7 +214,11 @@ public class OkHttpServices implements RESTServices {
 	  } else if (securityContext instanceof SAMLAuthContext) {
 		  configureSAMLAuth((SAMLAuthContext) securityContext, clientBuilder);
 		  checkFirstRequest = false;
-	  } else {
+	  } else if (securityContext instanceof MarkLogicCloudAuthContext) {
+		  authenticationConfigurer = new MarkLogicCloudAuthenticationConfigurer(host, port);
+		  checkFirstRequest = false;
+	  }
+	  else {
 		  throw new IllegalArgumentException("Unsupported security context: " + securityContext.getClass());
 	  }
 

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/MarkLogicCloudAuthenticationConfigurer.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/MarkLogicCloudAuthenticationConfigurer.java
@@ -1,0 +1,95 @@
+package com.marklogic.client.impl.okhttp;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marklogic.client.DatabaseClientFactory.MarkLogicCloudAuthContext;
+import okhttp3.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+public class MarkLogicCloudAuthenticationConfigurer implements AuthenticationConfigurer<MarkLogicCloudAuthContext> {
+
+	private final static Logger logger = LoggerFactory.getLogger(MarkLogicCloudAuthenticationConfigurer.class);
+
+	private String host;
+	private int port;
+
+	public MarkLogicCloudAuthenticationConfigurer(String host, int port) {
+		this.host = host;
+		this.port = port;
+	}
+
+	@Override
+	public void configureAuthentication(OkHttpClient.Builder clientBuilder, MarkLogicCloudAuthContext securityContext) {
+		final Response response = callTokenEndpoint(securityContext);
+		final String accessToken = getAccessTokenFromResponse(response);
+		if (logger.isInfoEnabled()) {
+			logger.info("Successfully obtained authentication token");
+		}
+		clientBuilder
+			.addInterceptor(chain -> {
+				Request authenticatedRequest = chain.request().newBuilder()
+					.header("Authorization", "Bearer " + accessToken)
+					.build();
+				return chain.proceed(authenticatedRequest);
+			});
+	}
+
+	private Response callTokenEndpoint(MarkLogicCloudAuthContext securityContext) {
+		final HttpUrl tokenUrl = buildTokenUrl(securityContext);
+		OkHttpClient.Builder clientBuilder = OkHttpUtil.newClientBuilder();
+		// Initial testing has shown that neither the OkHttp socket factory nor hostname verifier need to be configured
+		// for the goal of invoking the token endpoint.
+
+		if (logger.isInfoEnabled()) {
+			logger.info("Calling token endpoint at: " + tokenUrl);
+		}
+
+		final Call call = clientBuilder
+			.build()
+			.newCall(new Request.Builder()
+				.url(tokenUrl)
+				.post(newFormBody(securityContext))
+				.build()
+			);
+
+		try {
+			return call.execute();
+		} catch (IOException e) {
+			throw new RuntimeException(String.format("Unable to call token endpoint at %s; cause: %s",
+				tokenUrl, e.getMessage(), e));
+		}
+	}
+
+	protected HttpUrl buildTokenUrl(MarkLogicCloudAuthContext securityContext) {
+		return new HttpUrl.Builder()
+			.scheme(securityContext.getSSLContext() != null ? "https" : "http")
+			.host(host)
+			.port(port)
+			.build()
+			.resolve(securityContext.getTokenEndpoint()).newBuilder().build();
+	}
+
+	protected FormBody newFormBody(MarkLogicCloudAuthContext securityContext) {
+		return new FormBody.Builder()
+			.add("grant_type", securityContext.getGrantType())
+			.add("key", securityContext.getKey()).build();
+	}
+
+	private String getAccessTokenFromResponse(Response response) {
+		String responseBody = null;
+		JsonNode payload;
+		try {
+			responseBody = response.body().string();
+			payload = new ObjectMapper().readTree(responseBody);
+		} catch (IOException ex) {
+			throw new RuntimeException("Unable to get access token; response: " + responseBody, ex);
+		}
+		if (!payload.has("access_token")) {
+			throw new RuntimeException("Unable to get access token; unexpected JSON response: " + payload);
+		}
+		return payload.get("access_token").asText();
+	}
+}

--- a/marklogic-client-api/src/test/java/com/marklogic/client/impl/okhttp/MarkLogicCloudAuthenticationConfigurerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/impl/okhttp/MarkLogicCloudAuthenticationConfigurerTest.java
@@ -1,0 +1,74 @@
+package com.marklogic.client.impl.okhttp;
+
+import com.marklogic.client.DatabaseClientFactory;
+import okhttp3.FormBody;
+import okhttp3.HttpUrl;
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.SSLContext;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Since we don't yet have a reliable way to test against a MarkLogic cloud instance, including some small unit tests
+ * to ensure that certain things are built as expected.
+ */
+public class MarkLogicCloudAuthenticationConfigurerTest {
+
+	@Test
+	void buildTokenUrl() throws Exception {
+		HttpUrl tokenUrl = new MarkLogicCloudAuthenticationConfigurer("somehost", 443).buildTokenUrl(
+			new DatabaseClientFactory.MarkLogicCloudAuthContext("doesnt-matter")
+				.withSSLContext(SSLContext.getDefault(), null)
+		);
+		assertEquals("https://somehost/token", tokenUrl.toString(),
+			"When the port is 443, OkHttp won't include it in the URL");
+	}
+
+	@Test
+	void buildTokenUrlWithNonStandardPort() throws Exception {
+		HttpUrl tokenUrl = new MarkLogicCloudAuthenticationConfigurer("somehost", 444).buildTokenUrl(
+			new DatabaseClientFactory.MarkLogicCloudAuthContext("doesnt-matter")
+				.withSSLContext(SSLContext.getDefault(), null)
+		);
+		assertEquals("https://somehost:444/token", tokenUrl.toString(),
+			"If the port isn't 443, then OkHttp will include it in the URL");
+	}
+
+	/**
+	 * It is not yet known how fixed the token path is, so the constructor is allowing for it to be overridden
+	 * as an escape hatch.
+	 */
+	@Test
+	void buildTokenUrlWithCustomTokenPath() throws Exception {
+		HttpUrl tokenUrl = new MarkLogicCloudAuthenticationConfigurer("otherhost", 443).buildTokenUrl(
+			new DatabaseClientFactory.MarkLogicCloudAuthContext("doesnt-matter", "/customToken", "doesnt-matter")
+				.withSSLContext(SSLContext.getDefault(), null)
+		);
+		assertEquals("https://otherhost/customToken", tokenUrl.toString());
+	}
+
+	@Test
+	void newFormBody() {
+		FormBody body = new MarkLogicCloudAuthenticationConfigurer("doesnt-matter", 443)
+			.newFormBody(new DatabaseClientFactory.MarkLogicCloudAuthContext("myKey"));
+		assertEquals("grant_type", body.name(0));
+		assertEquals("apikey", body.value(0));
+		assertEquals("key", body.name(1));
+		assertEquals("myKey", body.value(1));
+	}
+
+	/**
+	 * It is not yet known how fixed the grant_type value is, so the constructor is allowing for it to be overridden
+	 * as an escape hatch.
+	 */
+	@Test
+	void newFormBodyWithOverrides() {
+		FormBody body = new MarkLogicCloudAuthenticationConfigurer("doesnt-matter", 443)
+			.newFormBody(new DatabaseClientFactory.MarkLogicCloudAuthContext("myKey", "doesnt-matter", "custom-grant-type"));
+		assertEquals("grant_type", body.name(0));
+		assertEquals("custom-grant-type", body.value(0));
+		assertEquals("key", body.name(1));
+		assertEquals("myKey", body.value(1));
+	}
+}

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/MarkLogicCloudAuthenticationDebugger.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/MarkLogicCloudAuthenticationDebugger.java
@@ -1,0 +1,45 @@
+package com.marklogic.client.test;
+
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.DatabaseClientFactory;
+import com.marklogic.client.io.JacksonHandle;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+/**
+ * We don't yet have a way to run tests against a MarkLogic Cloud instance. In the meantime, this program and its
+ * related Gradle task can be used for easy manual testing.
+ */
+public class MarkLogicCloudAuthenticationDebugger {
+
+	public static void main(String[] args) throws Exception {
+		String cloudHost = args[0];
+		String apiKey = args[1];
+		int port = 443;
+		String database = null;
+		DatabaseClient.ConnectionType connectionType = null;
+		String basePath = "/ml/etest/ml/manage/";
+		X509TrustManager trustManager = Common.TRUST_ALL_MANAGER;
+		SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
+		sslContext.init(null, new TrustManager[]{trustManager}, null);
+
+		DatabaseClient client = DatabaseClientFactory.newClient(
+			cloudHost, port, basePath, database,
+			new DatabaseClientFactory.MarkLogicCloudAuthContext(apiKey)
+				.withSSLContext(sslContext, trustManager)
+			, connectionType);
+
+		DatabaseClient.ConnectionResult result = client.checkConnection();
+		if (result.getStatusCode() != 0) {
+			throw new RuntimeException("Unable to connect: " + result.getStatusCode() + ":" + result.getErrorMessage());
+		}
+
+		System.out.println(client.newQueryManager().search(
+			client.newQueryManager().newStructuredQueryBuilder().directory(0, "/")
+			, new JacksonHandle()).get().toPrettyString());
+
+		System.out.println("Successfully finished cloud-based authentication test");
+	}
+}


### PR DESCRIPTION
Only downside is there's not yet a way to do this in an automated test against a real cloud instance. So relying on small unit tests and manual testing for now. 