### PR TITLE
DEVEXP-149: Fixing buggy usage of StringUtils

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,11 +39,6 @@ subprojects {
         mavenCentral()
     }
 
-    dependencies {
-        compileOnly group: 'org.apache.commons', name: 'commons-lang3', version:'3.10'
-        compileOnly group: 'org.apache.httpcomponents', name: 'httpclient', version:'4.5.12'
-    }
-
 	test {
 		systemProperty "file.encoding", "UTF-8"
 		systemProperty "javax.xml.stream.XMLOutputFactory", "com.sun.xml.internal.stream.XMLOutputFactoryImpl"

--- a/marklogic-client-api-functionaltests/build.gradle
+++ b/marklogic-client-api-functionaltests/build.gradle
@@ -32,6 +32,8 @@ dependencies {
   testImplementation group: 'ch.qos.logback', name: 'logback-classic', version:'1.2.11'
 	testImplementation 'org.junit.jupiter:junit-jupiter:5.9.1'
 	testImplementation 'org.xmlunit:xmlunit-legacy:2.9.0'
+	testImplementation 'org.apache.commons:commons-lang3:3.12.0'
+	testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
 }
 
 task runFragileTests(type: Test) {

--- a/marklogic-client-api/build.gradle
+++ b/marklogic-client-api/build.gradle
@@ -40,14 +40,21 @@ dependencies {
     testImplementation group: 'org.hsqldb', name: 'hsqldb', version:'2.5.1'
 // schema validation issue with testImplementation group: 'xerces', name: 'xercesImpl', version:'2.12.0'
     testImplementation group: 'org.opengis.cite.xerces', name: 'xercesImpl-xsd11', version:'2.12-beta-r1667115'
+		testImplementation 'org.apache.commons:commons-lang3:3.12.0'
+		testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
 
-    compileOnly group: 'org.jdom', name: 'jdom2', version:'2.0.6'
-    compileOnly group: 'dom4j', name: 'dom4j', version:'1.6.1'
-    compileOnly group: 'com.google.code.gson', name: 'gson', version:'2.8.6'
-    compileOnly group: 'net.sourceforge.htmlcleaner', name: 'htmlcleaner', version:'2.24'
-    compileOnly group: 'com.opencsv', name: 'opencsv', version: '4.6'
-    compileOnly group: 'org.geonames', name: 'geonames', version:'1.0'
-    compileOnly 'org.springframework:spring-jdbc:5.3.23'
+	// Only used by extras (which some examples then depend on)
+	compileOnly 'org.apache.httpcomponents:httpclient:4.5.14'
+	compileOnly 'org.jdom:jdom2:2.0.6.1'
+	compileOnly 'dom4j:dom4j:1.6.1'
+	compileOnly 'com.google.code.gson:gson:2.10'
+	compileOnly 'com.opencsv:opencsv:4.6'
+	compileOnly 'org.geonames:geonames:1.0'
+
+	// Only used by examples
+	compileOnly 'org.apache.commons:commons-lang3:3.12.0'
+	compileOnly 'org.springframework:spring-jdbc:5.3.24'
+	compileOnly 'net.sourceforge.htmlcleaner:htmlcleaner:2.26'
 }
 
 // Ensure that mlHost and mlPassword can override the defaults of localhost/admin if they've been modified

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/DocDescriptorUtil.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/DocDescriptorUtil.java
@@ -12,7 +12,6 @@ import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.Format;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.marker.AbstractWriteHandle;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.LoggerFactory;
 
 import java.util.Map;
@@ -44,7 +43,8 @@ class DocDescriptorUtil {
         String uri = writeOp.getUri();
         docDescriptor.put("uri", uri);
 
-        if (StringUtils.isNotBlank(writeOp.getTemporalDocumentURI())) {
+		final String temporalURI = writeOp.getTemporalDocumentURI();
+        if (temporalURI != null && temporalURI.trim().length() > 0) {
             docDescriptor.put("temporalCollection", writeOp.getTemporalDocumentURI());
         }
 


### PR DESCRIPTION
Moved the global dependencies to the precise places where they're needed to minimize confusion. Removed usage of StringUtils in DocDescriptorUtil, which was passing in the tests but failed in the real world since commons.lang3 is a compileOnly dependency.

A PR coming soon will move all the cookbook examples to a separate project, allowing us to get rid of several of these compileOnly dependencies to further avoid the chance of this bug occurring again. 