### PR TITLE
Bumping Jackson to 2.14.1

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -4,7 +4,7 @@ Copyright © 2022 MarkLogic Corporation. MarkLogic and the MarkLogic logo are tr
 
 This project is licensed under the Apache License, Version 2.0 (the "License"); you may not use this project except in compliance with the License. You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0 
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
@@ -6370,7 +6370,7 @@ License Text (http://spdx.org/licenses/Apache-2.0)
 Made available under the Apache License 2.0. See Appendix for full text.
 
 Source materials are available for download at: https://github.com/FasterXML/jackson-annotations
-Jackson Annotations 2.13.2
+Jackson Annotations 2.14.1
 Attribution Statements
 http://wiki.fasterxml.com/JacksonHome
 
@@ -6403,7 +6403,7 @@ License Text (http://www.apache.org/licenses/LICENSE-2.0.txt)
 Made available under the Apache License 2.0. See Appendix for full text.
 
 Source materials are available for download at: https://github.com/FasterXML/jackson-core
-Jackson Core 2.13.2
+Jackson Core 2.14.1
 Attribution Statements
 http://wiki.fasterxml.com/JacksonHome
 
@@ -6450,7 +6450,7 @@ License Text (http://www.apache.org/licenses/LICENSE-2.0.txt)
 Made available under the Apache License 2.0. See Appendix for full text.
 
 Source materials are available for download at: https://github.com/FasterXML/jackson-databind
-Jackson Databind 2.13.1
+Jackson Databind 2.14.1
 Attribution Statements
 http://wiki.fasterxml.com/JacksonHome
 
@@ -11015,8 +11015,8 @@ License Text
 Apache License 2.0
 https://spdx.org/licenses/Apache-2.0.html
 
-Apache License 
-Version 2.0, January 2004 
+Apache License
+Version 2.0, January 2004
 http://www.apache.org/licenses/
 TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -11076,16 +11076,16 @@ To apply the Apache License to your work, attach the following boilerplate notic
 
 Copyright [yyyy] [name of copyright owner]
 
-Licensed under the Apache License, Version 2.0 (the "License"); 
-you may not use this file except in compliance with the License. 
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
 http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software 
-distributed under the License is distributed on an "AS IS" BASIS, 
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
-See the License for the specific language governing permissions and 
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
 limitations under the License.
 
  
@@ -11121,7 +11121,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 Common Development and Distribution License 1.1
 https://spdx.org/licenses/CDDL-1.1.html
 
-COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) 
+COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL)
 Version 1.1
 
 1. Definitions.
@@ -11157,14 +11157,14 @@ C. Any new file that is contributed or otherwise made available under the terms 
 
 2. License Grants.
 
-2.1. The Initial Developer Grant. 
+2.1. The Initial Developer Grant.
 Conditioned upon Your compliance with Section 3.1 below and subject to third party intellectual property claims, the Initial Developer hereby grants You a world-wide, royalty-free, non-exclusive license:
 (a) under intellectual property rights (other than patent or trademark) Licensable by Initial Developer, to use, reproduce, modify, display, perform, sublicense and distribute the Original Software (or portions thereof), with or without Modifications, and/or as part of a Larger Work; and
 (b) under Patent Claims infringed by the making, using or selling of Original Software, to make, have made, use, practice, sell, and offer for sale, and/or otherwise dispose of the Original Software (or portions thereof).
 (c) The licenses granted in Sections 2.1(a) and (b) are effective on the date Initial Developer first distributes or otherwise makes the Original Software available to a third party under the terms of this License.
 (d) Notwithstanding Section 2.1(b) above, no patent license is granted: (1) for code that You delete from the Original Software, or (2) for infringements caused by: (i) the modification of the Original Software, or (ii) the combination of the Original Software with other software or devices.
 
-2.2. Contributor Grant. 
+2.2. Contributor Grant.
 Conditioned upon Your compliance with Section 3.1 below and subject to third party intellectual property claims, each Contributor hereby grants You a world-wide, royalty-free, non-exclusive license:
 (a) under intellectual property rights (other than patent or trademark) Licensable by Contributor to use, reproduce, modify, display, perform, sublicense and distribute the Modifications created by such Contributor (or portions thereof), either on an unmodified basis, with other Modifications, as Covered Software and/or as part of a Larger Work; and
 (b) under Patent Claims infringed by the making, using, or selling of Modifications made by that Contributor either alone and/or in combination with its Contributor Version (or portions of such combination), to make, use, sell, offer for sale, have made, and/or otherwise dispose of: (1) Modifications made by that Contributor (or portions thereof); and (2) the combination of Modifications made by that Contributor with its Contributor Version (or portions of such combination).
@@ -11173,36 +11173,36 @@ Conditioned upon Your compliance with Section 3.1 below and subject to third par
 
 3. Distribution Obligations.
 
-3.1. Availability of Source Code. 
+3.1. Availability of Source Code.
 Any Covered Software that You distribute or otherwise make available in Executable form must also be made available in Source Code form and that Source Code form must be distributed only under the terms of this License. You must include a copy of this License with every copy of the Source Code form of the Covered Software You distribute or otherwise make available. You must inform recipients of any such Covered Software in Executable form as to how they can obtain such Covered Software in Source Code form in a reasonable manner on or through a medium customarily used for software exchange.
 
-3.2. Modifications. 
+3.2. Modifications.
 The Modifications that You create or to which You contribute are governed by the terms of this License. You represent that You believe Your Modifications are Your original creation(s) and/or You have sufficient rights to grant the rights conveyed by this License.
 
-3.3. Required Notices. 
+3.3. Required Notices.
 You must include a notice in each of Your Modifications that identifies You as the Contributor of the Modification. You may not remove or alter any copyright, patent or trademark notices contained within the Covered Software, or any notices of licensing or any descriptive text giving attribution to any Contributor or the Initial Developer.
 
-3.4. Application of Additional Terms. 
+3.4. Application of Additional Terms.
 You may not offer or impose any terms on any Covered Software in Source Code form that alters or restricts the applicable version of this License or the recipients' rights hereunder. You may choose to offer, and to charge a fee for, warranty, support, indemnity or liability obligations to one or more recipients of Covered Software. However, you may do so only on Your own behalf, and not on behalf of the Initial Developer or any Contributor. You must make it absolutely clear that any such warranty, support, indemnity or liability obligation is offered by You alone, and You hereby agree to indemnify the Initial Developer and every Contributor for any liability incurred by the Initial Developer or such Contributor as a result of warranty, support, indemnity or liability terms You offer.
 
-3.5. Distribution of Executable Versions. 
+3.5. Distribution of Executable Versions.
 You may distribute the Executable form of the Covered Software under the terms of this License or under the terms of a license of Your choice, which may contain terms different from this License, provided that You are in compliance with the terms of this License and that the license for the Executable form does not attempt to limit or alter the recipient's rights in the Source Code form from the rights set forth in this License. If You distribute the Covered Software in Executable form under a different license, You must make it absolutely clear that any terms which differ from this License are offered by You alone, not by the Initial Developer or Contributor. You hereby agree to indemnify the Initial Developer and every Contributor for any liability incurred by the Initial Developer or such Contributor as a result of any such terms You offer.
 
-3.6. Larger Works. 
+3.6. Larger Works.
 You may create a Larger Work by combining Covered Software with other code not governed by the terms of this License and distribute the Larger Work as a single product. In such a case, You must make sure the requirements of this License are fulfilled for the Covered Software.
 
 4. Versions of the License.
 
-4.1. New Versions. 
+4.1. New Versions.
 Oracle is the initial license steward and may publish revised and/or new versions of this License from time to time. Each version will be given a distinguishing version number. Except as provided in Section 4.3, no one other than the license steward has the right to modify this License.
 
-4.2. Effect of New Versions. 
+4.2. Effect of New Versions.
 You may always continue to use, distribute or otherwise make the Covered Software available under the terms of the version of the License under which You originally received the Covered Software. If the Initial Developer includes a notice in the Original Software prohibiting it from being distributed or otherwise made available under any subsequent version of the License, You must distribute and make the Covered Software available under the terms of the version of the License under which You originally received the Covered Software. Otherwise, You may also choose to use, distribute or otherwise make the Covered Software available under the terms of any subsequent version of the License published by the license steward.
 
-4.3. Modified Versions. 
+4.3. Modified Versions.
 When You are an Initial Developer and You want to create a new license for Your Original Software, You may create and use a modified version of this License if You: (a) rename the license and remove any references to the name of the license steward (except to note that the license differs from this License); and (b) otherwise make it clear that the license contains terms which differ from this License.
 
-5. DISCLAIMER OF WARRANTY. 
+5. DISCLAIMER OF WARRANTY.
 COVERED SOFTWARE IS PROVIDED UNDER THIS LICENSE ON AN “AS IS” BASIS, WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, WITHOUT LIMITATION, WARRANTIES THAT THE COVERED SOFTWARE IS FREE OF DEFECTS, MERCHANTABLE, FIT FOR A PARTICULAR PURPOSE OR NON-INFRINGING. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE COVERED SOFTWARE IS WITH YOU. SHOULD ANY COVERED SOFTWARE PROVE DEFECTIVE IN ANY RESPECT, YOU (NOT THE INITIAL DEVELOPER OR ANY OTHER CONTRIBUTOR) ASSUME THE COST OF ANY NECESSARY SERVICING, REPAIR OR CORRECTION. THIS DISCLAIMER OF WARRANTY CONSTITUTES AN ESSENTIAL PART OF THIS LICENSE. NO USE OF ANY COVERED SOFTWARE IS AUTHORIZED HEREUNDER EXCEPT UNDER THIS DISCLAIMER.
 
 6. TERMINATION.
@@ -11227,7 +11227,7 @@ This License represents the complete agreement concerning subject matter hereof.
 10. RESPONSIBILITY FOR CLAIMS.
 As between Initial Developer and the Contributors, each party is responsible for claims and damages arising, directly or indirectly, out of its utilization of rights under this License and You agree to work with Initial Developer and Contributors to distribute such responsibility on an equitable basis. Nothing herein is intended or shall be deemed to constitute any admission of liability.
 
-NOTICE PURSUANT TO SECTION 9 OF THE COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) 
+NOTICE PURSUANT TO SECTION 9 OF THE COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL)
 The code released under the CDDL shall be governed by the laws of the State of California (excluding conflict-of-law provisions). Any litigation relating to this License shall be subject to the jurisdiction of the Federal Courts of the Northern District of California and the state courts of the State of California, with venue lying in Santa Clara County, California.
 
  
@@ -11307,7 +11307,7 @@ b. Subject to the above terms and conditions, the license granted here is perpet
 
 8. Miscellaneous
 
-a. Each time You Distribute or Publicly Perform the Work or a Collection, the Licensor offers to the 
+a. Each time You Distribute or Publicly Perform the Work or a Collection, the Licensor offers to the
 recipient a license to the Work on the same terms and conditions as the license granted to You under this License.
 
 b. Each time You Distribute or Publicly Perform an Adaptation, Licensor offers to the recipient a license to the original Work on the same terms and conditions as the license granted to You under this License.
@@ -11331,14 +11331,14 @@ Creative Commons may be contacted at http://creativecommons.org/.
 Do What The F*ck You Want To Public License
 https://spdx.org/licenses/WTFPL.html
 
-DO WHAT THE F*CK YOU WANT TO PUBLIC LICENSE 
+DO WHAT THE F*CK YOU WANT TO PUBLIC LICENSE
 Version 2, December 2004
 
 Copyright (C) 2004 Sam Hocevar <sam@hocevar.net>
 
 Everyone is permitted to copy and distribute verbatim or modified copies of this license document, and changing it is allowed as long as the name is changed.
 
-DO WHAT THE F*CK YOU WANT TO PUBLIC LICENSE 
+DO WHAT THE F*CK YOU WANT TO PUBLIC LICENSE
 TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
 
 0. You just DO WHAT THE F*CK YOU WANT TO.
@@ -11353,12 +11353,12 @@ THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC LICE
 
 1. DEFINITIONS
 
-"Contribution" means: 
-a) in the case of the initial Contributor, the initial code and documentation distributed under this Agreement, and 
-b) in the case of each subsequent Contributor: 
-i) changes to the Program, and 
+"Contribution" means:
+a) in the case of the initial Contributor, the initial code and documentation distributed under this Agreement, and
+b) in the case of each subsequent Contributor:
+i) changes to the Program, and
 ii) additions to the Program;
-where such changes and/or additions to the Program originate from and are distributed by that particular Contributor. A Contribution 'originates' from a Contributor if it was added to the Program by such Contributor itself or anyone acting on such Contributor's behalf. Contributions do not include additions to the Program which: (i) are separate modules of software distributed in conjunction with the Program under their own license agreement, and (ii) are not derivative works of the Program. 
+where such changes and/or additions to the Program originate from and are distributed by that particular Contributor. A Contribution 'originates' from a Contributor if it was added to the Program by such Contributor itself or anyone acting on such Contributor's behalf. Contributions do not include additions to the Program which: (i) are separate modules of software distributed in conjunction with the Program under their own license agreement, and (ii) are not derivative works of the Program.
 
 "Contributor" means any person or entity that distributes the Program.
 
@@ -11378,35 +11378,35 @@ c) Recipient understands that although each Contributor grants the licenses to i
 
 d) Each Contributor represents that to its knowledge it has sufficient copyright rights in its Contribution, if any, to grant the copyright license set forth in this Agreement.
 
-3. REQUIREMENTS 
+3. REQUIREMENTS
 A Contributor may choose to distribute the Program in object code form under its own license agreement, provided that:
 
 a) it complies with the terms and conditions of this Agreement; and
 
-b) its license agreement: 
-i) effectively disclaims on behalf of all Contributors all warranties and conditions, express and implied, including warranties or conditions of title and non-infringement, and implied warranties or conditions of merchantability and fitness for a particular purpose; 
-ii) effectively excludes on behalf of all Contributors all liability for damages, including direct, indirect, special, incidental and consequential damages, such as lost profits; 
-iii) states that any provisions which differ from this Agreement are offered by that Contributor alone and not by any other party; and 
+b) its license agreement:
+i) effectively disclaims on behalf of all Contributors all warranties and conditions, express and implied, including warranties or conditions of title and non-infringement, and implied warranties or conditions of merchantability and fitness for a particular purpose;
+ii) effectively excludes on behalf of all Contributors all liability for damages, including direct, indirect, special, incidental and consequential damages, such as lost profits;
+iii) states that any provisions which differ from this Agreement are offered by that Contributor alone and not by any other party; and
 iv) states that source code for the Program is available from such Contributor, and informs licensees how to obtain it in a reasonable manner on or through a medium customarily used for software exchange.
 
 When the Program is made available in source code form:
 
 a) it must be made available under this Agreement; and
 
-b) a copy of this Agreement must be included with each copy of the Program. 
+b) a copy of this Agreement must be included with each copy of the Program.
 Contributors may not remove or alter any copyright notices contained within the Program.
 
 Each Contributor must identify itself as the originator of its Contribution, if any, in a manner that reasonably allows subsequent Recipients to identify the originator of the Contribution.
 
-4. COMMERCIAL DISTRIBUTION 
+4. COMMERCIAL DISTRIBUTION
 Commercial distributors of software may accept certain responsibilities with respect to end users, business partners and the like. While this license is intended to facilitate the commercial use of the Program, the Contributor who includes the Program in a commercial product offering should do so in a manner which does not create potential liability for other Contributors. Therefore, if a Contributor includes the Program in a commercial product offering, such Contributor ("Commercial Contributor") hereby agrees to defend and indemnify every other Contributor ("Indemnified Contributor") against any losses, damages and costs (collectively "Losses") arising from claims, lawsuits and other legal actions brought by a third party against the Indemnified Contributor to the extent caused by the acts or omissions of such Commercial Contributor in connection with its distribution of the Program in a commercial product offering. The obligations in this section do not apply to any claims or Losses relating to any actual or alleged intellectual property infringement. In order to qualify, an Indemnified Contributor must: a) promptly notify the Commercial Contributor in writing of such claim, and b) allow the Commercial Contributor to control, and cooperate with the Commercial Contributor in, the defense and any related settlement negotiations. The Indemnified Contributor may participate in any such claim at its own expense.
 
 For example, a Contributor might include the Program in a commercial product offering, Product X. That Contributor is then a Commercial Contributor. If that Commercial Contributor then makes performance claims, or offers warranties related to Product X, those performance claims and warranties are such Commercial Contributor's responsibility alone. Under this section, the Commercial Contributor would have to defend claims against the other Contributors related to those performance claims and warranties, and if a court requires any other Contributor to pay any damages as a result, the Commercial Contributor must pay those damages.
 
-5. NO WARRANTY 
+5. NO WARRANTY
 EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is solely responsible for determining the appropriateness of using and distributing the Program and assumes all risks associated with its exercise of rights under this Agreement , including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and unavailability or interruption of operations.
 
-6. DISCLAIMER OF LIABILITY 
+6. DISCLAIMER OF LIABILITY
 EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
 7. GENERAL
@@ -11508,7 +11508,7 @@ https://spdx.org/licenses/ISC.html
 
 ISC License
 
-Copyright (c) 2004-2010 by Internet Systems Consortium, Inc. ("ISC") 
+Copyright (c) 2004-2010 by Internet Systems Consortium, Inc. ("ISC")
 Copyright (c) 1995-2003 by Internet Software Consortium
 
 Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
@@ -11737,7 +11737,7 @@ This is free and unencumbered software released into the public domain.
 
 Anyone is free to copy, modify, publish, use, compile, sell, or distribute this software, either in source code form or as a compiled binary, for any purpose, commercial or non-commercial, and by any means.
 
-In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain. We make this dedication for the benefit of the public at large and to the detriment of our heirs and 
+In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain. We make this dedication for the benefit of the public at large and to the detriment of our heirs and
 successors. We intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -18,7 +18,7 @@ dependencies {
 	api 'com.squareup.okhttp3:okhttp:4.10.0'
 	api 'io.github.rburgst:okhttp-digest:2.7'
 	api 'org.slf4j:slf4j-api:1.7.36'
-	api 'com.fasterxml.jackson.core:jackson-databind:2.13.4.2'
+	api 'com.fasterxml.jackson.core:jackson-databind:2.14.1'
 	api 'org.hsqldb:hsqldb:2.5.2'
 	api 'org.jdom:jdom2:2.0.6.1'
 	api 'dom4j:dom4j:1.6.1'

--- a/marklogic-client-api-functionaltests/build.gradle
+++ b/marklogic-client-api-functionaltests/build.gradle
@@ -20,16 +20,16 @@ task testSandbox(type:Test) {
 
 dependencies {
   implementation project (':marklogic-client-api')
-  implementation group: 'org.skyscreamer', name: 'jsonassert', version: '1.5.0'
-  implementation group: 'org.slf4j', name: 'slf4j-api', version:'1.7.36'
+  implementation 'org.skyscreamer:jsonassert:1.5.0'
+  implementation 'org.slf4j:slf4j-api:1.7.36'
   implementation 'commons-io:commons-io:2.11.0'
-  implementation group: 'com.squareup.okhttp3', name: 'okhttp', version:'4.10.0'
-  implementation 'com.fasterxml.jackson.core:jackson-core:2.13.4'
-  implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4.2'
+  implementation 'com.squareup.okhttp3:okhttp:4.10.0'
+  implementation 'com.fasterxml.jackson.core:jackson-core:2.14.1'
+  implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.1'
   implementation "org.jdom:jdom2:2.0.6.1"
-  implementation "com.marklogic:ml-app-deployer:4.3.6"
+  implementation "com.marklogic:ml-app-deployer:4.4.0"
 
-  testImplementation group: 'ch.qos.logback', name: 'logback-classic', version:'1.2.11'
+  testImplementation 'ch.qos.logback:logback-classic:1.3.5'
 	testImplementation 'org.junit.jupiter:junit-jupiter:5.9.1'
 	testImplementation 'org.xmlunit:xmlunit-legacy:2.9.0'
 	testImplementation 'org.apache.commons:commons-lang3:3.12.0'

--- a/marklogic-client-api/build.gradle
+++ b/marklogic-client-api/build.gradle
@@ -21,11 +21,11 @@ dependencies {
 	implementation 'com.sun.mail:javax.mail:1.6.2'
 	implementation 'javax.ws.rs:javax.ws.rs-api:2.1.1'
 	implementation 'org.slf4j:slf4j-api:1.7.36'
-	implementation 'com.fasterxml.jackson.core:jackson-core:2.13.4'
-	implementation 'com.fasterxml.jackson.core:jackson-annotations:2.13.4'
-	implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4.2'
-	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.13.4'
-	
+	implementation 'com.fasterxml.jackson.core:jackson-core:2.14.1'
+	implementation 'com.fasterxml.jackson.core:jackson-annotations:2.14.1'
+	implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.1'
+	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.14.1'
+
 	// Only used by extras (which some examples then depend on)
 	compileOnly 'org.apache.httpcomponents:httpclient:4.5.14'
 	compileOnly 'org.jdom:jdom2:2.0.6.1'
@@ -40,10 +40,10 @@ dependencies {
 	// version, but that should not have any impact on the tests.
 	testImplementation "com.marklogic:ml-app-deployer:4.4.0"
 
-	testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.13.4'
-	testImplementation "org.mockito:mockito-core:4.9.0"
-	testImplementation "org.mockito:mockito-inline:4.9.0"
-	testImplementation 'ch.qos.logback:logback-classic:1.2.11'
+	testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.14.1'
+	testImplementation "org.mockito:mockito-core:4.10.0"
+	testImplementation "org.mockito:mockito-inline:4.10.0"
+	testImplementation 'ch.qos.logback:logback-classic:1.3.5'
 // schema validation issue with testImplementation 'xerces:xercesImpl:2.12.0'
 	testImplementation 'org.opengis.cite.xerces:xercesImpl-xsd11:2.12-beta-r1667115'
 	testImplementation 'org.apache.commons:commons-lang3:3.12.0'

--- a/ml-development-tools/build.gradle
+++ b/ml-development-tools/build.gradle
@@ -12,8 +12,8 @@ dependencies {
     compileOnly gradleApi()
     implementation project(':marklogic-client-api')
     implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.6.20'
-    implementation 'com.fasterxml.jackson.module:jackson-module-kotlin:2.13.4'
-    implementation 'com.networknt:json-schema-validator:1.0.73'
+    implementation 'com.fasterxml.jackson.module:jackson-module-kotlin:2.14.1'
+    implementation 'com.networknt:json-schema-validator:1.0.76'
 
 	// Not yet migrating this project to JUnit 5. Will reconsider it once we have a reason to enhance
 	// this project.

--- a/pom.xml
+++ b/pom.xml
@@ -70,25 +70,25 @@ It is not intended to be used to build this project.
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.13.4</version>
+      <version>2.14.1</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.13.4</version>
+      <version>2.14.1</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.13.4.2</version>
+      <version>2.14.1</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-csv</artifactId>
-      <version>2.13.4</version>
+      <version>2.14.1</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Also changed all dependencies to use the shorter syntax instead of including the words group/name/version. 

Bumped logback to 1.3.5 as well. And mockito to 4.10.0. 

And bumped json-schema-validator to 1.0.76 so that it also is using Jackson 2.14. 
