### PR TITLE
Tweaking logging of batches in RowBatcherImpl

### DIFF
--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/RowBatcherImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/RowBatcherImpl.java
@@ -371,7 +371,14 @@ class RowBatcherImpl<T>  extends BatcherImpl implements RowBatcher<T> {
 
         this.batchCount = (getRowEstimate() / super.getBatchSize()) + 1;
         this.batchSize = Long.divideUnsigned(MAX_UNSIGNED_LONG, this.batchCount);
-        logger.info("batch count: {}, batch size: {}", batchCount, batchSize);
+		// It is not expected that batch size will be meaningful to a user. It is more likely to be confusing since it's
+		// not the same value that a user would have provided via withBatchSize. And we don't want to log it when it's
+		// -1, which will be the case for a single batch.
+		if (logger.isDebugEnabled() && this.batchSize > 0) {
+			logger.debug("batch count: {}, calculated batch size: {}", batchCount, batchSize);
+		} else {
+			logger.info("batch count: {}", batchCount);
+		}
 
         if (this.hostInfos != null && getMoveMgr().getConnectionType() == DatabaseClient.ConnectionType.DIRECT) {
             RowManager.RowSetPart    datatypeStyle = getRowManager().getDatatypeStyle();
@@ -414,7 +421,7 @@ class RowBatcherImpl<T>  extends BatcherImpl implements RowBatcher<T> {
         String upperBoundStr = Long.toUnsignedString(
                 (currentBatch == this.batchCount) ? MAX_UNSIGNED_LONG : (lowerBound + (this.batchSize - 1))
         );
-        logger.info("current batch: {}, lower bound: {}, upper bound: {}", currentBatch, lowerBoundStr, upperBoundStr);
+        logger.debug("current batch: {}, lower bound: {}, upper bound: {}", currentBatch, lowerBoundStr, upperBoundStr);
 
         PlanBuilder.Plan plan = this.pagedPlan
                 .bindParam(LOWER_BOUND, lowerBoundStr)

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/RowBatcherTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/RowBatcherTest.java
@@ -238,8 +238,11 @@ public class RowBatcherTest {
                         .withThreadCount(threads);
     }
     private RowBatcher<Document> xmlBatcher(int threads) {
+		// Bumped the batch size to MAX_VALUE to ensure that at least one test for RowBatcher uses a single batch. This
+		// ensures that a change made to RowBatcherImpl to only log the batch size when batch count is > 1 works
+		// properly when there's a single batch.
         return moveMgr.newRowBatcher(new DOMHandle())
-                .withBatchSize(30)
+                .withBatchSize(Integer.MAX_VALUE)
                 .withThreadCount(threads);
     }
     private RowBatcher<String> csvBatcher(int threads) {


### PR DESCRIPTION
Logging the batchSize at the info level is confusing to a user, who will most likely see a value very different from what they provided via `withBatchSize`. 

And changed the "current batch" logging from info to debug. This logging is fairly meaningless to a user, who has no idea what lower/upper bounds refer to. And if the user wants to see logging for each batch, they can simply add their own listener. 