### PR TITLE
Disabling TestE2ENumberOfConcurrentUsers

### DIFF
--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/ClientApiFunctionalTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/ClientApiFunctionalTest.java
@@ -21,10 +21,7 @@ import okhttp3.Credentials;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.springframework.util.StringUtils;
 
 import java.io.File;
@@ -313,6 +310,9 @@ public class ClientApiFunctionalTest extends AbstractFunctionalTest {
 	// This test sets the App Server concurrent users to be 1 instead of 0
 	// (default). Expect to see ForbiddenUser when same user logins multiple times.
 	@Test
+	@Disabled("Disabling on 2023-01-03; this succeeds consistently locally, but fairly consistently fails on Jenkins. " +
+		"Not sure yet if it's due to the sleep time in the DS module or not. This is also not testing the Java Client " +
+		"but rather it's testing the 'concurrent request limit' feature of a MarkLogic app server.")
 	public void TestE2ENumberOfConcurrentUsers() throws InterruptedException {
 		StringBuilder msgEx = new StringBuilder();
 		Thread w1, w2, w3;

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/data/api/TestE2EIntegerParamReturnDoubleErrorCond.sjs
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/data/api/TestE2EIntegerParamReturnDoubleErrorCond.sjs
@@ -19,8 +19,9 @@ return encodeURI(retFloatPriceValue);
 
 else if (itemCnt == 1000 && price == 1000 ) {
 	// If price is 1000, it's expected that the TestE2ENumberOfConcurrentUsers test is being run, in which case we need
-	// to sleep for a little bit to ensure that multiple requests from the same user do not succeed.
-	xdmp.sleep(500);
+	// to sleep for a little to ensure that multiple requests from the same user do not succeed. This unfortunately
+	// is not 100% reliable and the associated test may intermittently fail.
+	xdmp.sleep(2000);
 	retFloatPriceValue = 10000.00;
 	return encodeURI(retFloatPriceValue);
 }


### PR DESCRIPTION
Increased the sleep amount to hopefully avoid intermittent failure