### PR TITLE
Added test for onBatchFailure

### DIFF
--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/RowBatcherFuncTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/RowBatcherFuncTest.java
@@ -80,11 +80,7 @@ public class RowBatcherFuncTest extends AbstractFunctionalTest {
                          resultAmt.add(resDoc.get(i).get("opticFunctionalTest.detail.amount").asDouble());
                      }
                 }
-        })
-        .onFailure((fevt, mythrows)-> {
-            failedBuf.append("Batch Failures in " + fevt.getJobBatchNumber() + "batch from "+ fevt.getLowerBound() + "to" + fevt.getUpperBound());
-                }
-        );
+        });
         dmManager.startJob(rowsBatcherOfJsonObj);
         rowsBatcherOfJsonObj.awaitCompletion();
         for (Double d : resultAmt) {
@@ -133,11 +129,7 @@ public class RowBatcherFuncTest extends AbstractFunctionalTest {
                     resultAmt.add(resDoc.get(i).get("opticFunctionalTest.detail.amount").asDouble());
                 }
             }
-        })
-                .onFailure((fevt, mythrows)-> {
-                            failedBuf.append("Batch Failures in " + fevt.getJobBatchNumber() + "batch from "+ fevt.getLowerBound() + "to" + fevt.getUpperBound());
-                        }
-                );
+        });
         dmManager.startJob(rowsBatcherOfJsonObj);
         rowsBatcherOfJsonObj.awaitCompletion();
         for (Double d : resultAmt) {
@@ -188,11 +180,7 @@ public class RowBatcherFuncTest extends AbstractFunctionalTest {
                     resultAmt.add(resDoc.get(i).get("added").asDouble());
                 }
             }
-        })
-                .onFailure((fevt, mythrows) -> {
-                            failedBuf.append("Batch Failures in " + fevt.getJobBatchNumber() + "batch from " + fevt.getLowerBound() + "to" + fevt.getUpperBound());
-                        }
-                );
+        });
         dmManager.startJob(rowsBatcherOfJsonObj);
         rowsBatcherOfJsonObj.awaitCompletion();
         for (Double d : resultAmt) {
@@ -243,9 +231,7 @@ public class RowBatcherFuncTest extends AbstractFunctionalTest {
             else {
                 rows.forEach(row -> citiesFound.add(row.get("myCity.city").asText()));
             }
-            }).onFailure((fevt, mythrows) -> {
-                failedBuf.append("Batch Failures in " + fevt.getJobBatchNumber() + "batch from " + fevt.getLowerBound() + "to" + fevt.getUpperBound());
-            } );
+            });
         dmManager.startJob(rowsBatcherOfJsonObj);
         rowsBatcherOfJsonObj.awaitCompletion();
 
@@ -297,8 +283,6 @@ public class RowBatcherFuncTest extends AbstractFunctionalTest {
                     resultAmt2.add(resDoc.get(i).get("opticFunctionalTest.detail.amount").asDouble());
                 }
             }
-        }).onFailure((fevt, mythrows)-> {
-            failedBuf.append("Batch Failures in " + fevt.getJobBatchNumber() + "batch from "+ fevt.getLowerBound() + "to" + fevt.getUpperBound());
         });
         dmManager.startJob(rowsBatcherOfJsonObj);
         rowsBatcherOfJsonObj.awaitCompletion();
@@ -352,8 +336,6 @@ public class RowBatcherFuncTest extends AbstractFunctionalTest {
         try {
             rowsBatcherOfJsonObj.withBatchView(plan3);
             rowsBatcherOfJsonObj.onSuccess(e -> {
-            }).onFailure((fevt, mythrows) -> {
-                                failedBuf.append("Batch Failures in " + fevt.getJobBatchNumber() + "batch from " + fevt.getLowerBound() + "to" + fevt.getUpperBound());
             });
             dmManager.startJob(rowsBatcherOfJsonObj);
             rowsBatcherOfJsonObj.awaitCompletion();
@@ -405,8 +387,6 @@ public class RowBatcherFuncTest extends AbstractFunctionalTest {
                     s.length();
                     //System.out.println("Thread id : " + Thread.currentThread().getId() + " is named as " + Thread.currentThread().getName());
                 }
-        }).onFailure((fevt, mythrows) -> {
-                failedBuf.append("Batch Failures in " + fevt.getJobBatchNumber() + "batch from " + fevt.getLowerBound() + "to" + fevt.getUpperBound());
         });
         dmManager.startJob(rowsBatcherOfJsonObj);
         rowsBatcherOfJsonObj.awaitCompletion();

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/RowBatcherFailureTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/RowBatcherFailureTest.java
@@ -1,0 +1,60 @@
+package com.marklogic.client.test.datamovement;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.FailedRequestException;
+import com.marklogic.client.datamovement.DataMovementManager;
+import com.marklogic.client.datamovement.RowBatcher;
+import com.marklogic.client.expression.PlanBuilder;
+import com.marklogic.client.io.JacksonHandle;
+import com.marklogic.client.row.RowManager;
+import com.marklogic.client.test.Common;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class RowBatcherFailureTest {
+
+	@Test
+	void invalidQuery() {
+		DatabaseClient client = Common.newClient();
+		DataMovementManager dmm = client.newDataMovementManager();
+
+		RowManager rowManager = client.newRowManager();
+		PlanBuilder op = rowManager.newPlanBuilder();
+		PlanBuilder.ModifyPlan plan = op
+			.fromView("opticUnitTest", "musician")
+			.where(op.eq(op.col("dob"), op.xs.string("this is not a valid date")));
+
+		List<JsonNode> returnedRows = new ArrayList<>();
+		List<Throwable> batchFailures = new ArrayList<>();
+
+		RowBatcher rowBatcher = dmm.newRowBatcher(new JacksonHandle())
+			.withBatchView(plan)
+			.withBatchSize(Integer.MAX_VALUE) // guarantees a single batch
+			.onSuccess(batch -> returnedRows.add(batch.getRowsDoc()))
+			.onFailure(((batch, throwable) -> batchFailures.add(throwable)));
+
+		dmm.startJob(rowBatcher);
+		rowBatcher.awaitCompletion();
+		dmm.stopJob(rowBatcher);
+
+		assertEquals(0, returnedRows.size(), "The query is invalid, so no rows should have been captured by the " +
+			"success listener");
+
+		assertEquals(1, batchFailures.size(), "The query is invalid, so the failure listener should have been invoked " +
+			"once. Somewhat surprisingly, this doesn't cause a failure when the RowBatcher is created. This is due to " +
+			"the 'estimate' query in internal/viewinfo only querying on the schema + view, thereby ignoring every other " +
+			"part of the query. So the invalid query won't be detected until the first call is made to MarkLogic to " +
+			"get rows back.");
+		Throwable failure = batchFailures.get(0);
+		assertTrue(failure instanceof FailedRequestException);
+		FailedRequestException ex = (FailedRequestException) failure;
+		assertTrue(ex.getMessage().contains("Invalid cast: \"this is not a valid date\" cast as xs:date"),
+			"Unexpected error message: " + ex.getMessage() + "; should have failed because the date is not valid");
+	}
+}

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/RowBatcherTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/RowBatcherTest.java
@@ -340,11 +340,6 @@ public class RowBatcherTest {
                         System.out.println(e.getMessage());
                         e.printStackTrace(System.out);
                     }
-                })
-                .onFailure((event, throwable) -> {
-                    failed.set(true);
-                    System.out.println("failed batch="+event.getJobBatchNumber()+
-                            " from "+event.getLowerBound()+" through "+event.getUpperBound());
                 });
 
         moveMgr.startJob(rowBatcher);
@@ -416,11 +411,6 @@ public class RowBatcherTest {
                         System.out.println(e.getMessage());
                         e.printStackTrace(System.out);
                     }
-                })
-                .onFailure((event, throwable) -> {
-                    failed.set(true);
-                    System.out.println("failed batch="+event.getJobBatchNumber()+
-                            " from "+event.getLowerBound()+" through "+event.getUpperBound());
                 });
 
         moveMgr.startJob(rowBatcher);
@@ -523,11 +513,6 @@ public class RowBatcherTest {
                         System.out.println(e.getMessage());
                         e.printStackTrace(System.out);
                     }
-                })
-                .onFailure((event, throwable) -> {
-                    failed.set(true);
-                    System.out.println("failed batch="+event.getJobBatchNumber()+
-                            " from "+event.getLowerBound()+" through "+event.getUpperBound());
                 });
 
         moveMgr.startJob(rowBatcher);
@@ -613,11 +598,6 @@ public class RowBatcherTest {
                         System.out.println(e.getMessage());
                         e.printStackTrace(System.out);
                     }
-                })
-                .onFailure((event, throwable) -> {
-                    failed.set(true);
-                    System.out.println("failed batch="+event.getJobBatchNumber()+
-                            " from "+event.getLowerBound()+" through "+event.getUpperBound());
                 });
 
         moveMgr.startJob(rowBatcher);


### PR DESCRIPTION
This test now produces a real failure that results in the onBatchFailure listener being invoked. 

We had about a dozen tests calling onBatchFailure before, but none of them were actually doing something to cause the failure listener to be invoked. Tellingly, removing the `onBatchFailure listener` used in each of these tests still resulted in the tests passing, which confirms that the listeners were never being invoked. So the onBatchFailure call was removed from each of these tests to prevent anyone from thinking it was actually being tested in those tests. 