### PR TITLE
DEVEXP-164: Added new factory method for DatabaseClient

### DIFF
--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/AbstractFunctionalTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/AbstractFunctionalTest.java
@@ -56,9 +56,8 @@ public abstract class AbstractFunctionalTest extends BasicJavaClientREST {
         System.out.println("ML version: " + version.getVersionString());
         isML11OrHigher = version.getMajor() >= 11;
 
-		client = newClientAsUser(OPTIC_USER, OPTIC_USER_PASSWORD);
-		schemasClient = newClient(getRestServerHostName(), getRestServerPort(), "java-functest-schemas",
-			newSecurityContext(OPTIC_USER, OPTIC_USER_PASSWORD), null);
+		client = newDatabaseClientBuilder().build();
+		schemasClient = newClientForDatabase("java-functest-schemas");
 		adminModulesClient = newAdminModulesClient();
 
         // Required to ensure that tests using the "/ext/" prefix work reliably. Expand to other directories as needed.

--- a/marklogic-client-api-functionaltests/src/test/resources/test.properties
+++ b/marklogic-client-api-functionaltests/src/test/resources/test.properties
@@ -1,6 +1,14 @@
-securityContextType=digest
+# Standard properties for constructing a DatabaseClient
+marklogic.client.host=localhost
+marklogic.client.port=8014
+marklogic.client.securityContextType=digest
+marklogic.client.username=opticUser
+marklogic.client.password=0pt1c
+marklogic.client.basePath=
+marklogic.client.type=direct
+
+# Custom properties used by ConnectedRESTQA
 restSSLset=false
-restHost=localhost
 restSSLHost=localhost
 mlAdminUser=admin
 mlAdminPassword=admin
@@ -8,13 +16,11 @@ mlRestReadUser=rest-reader
 mlRestReadPassword=x
 mlAppServerName=REST-Java-Client-API-Server
 mlAppServerSSLName=REST-Java-Client-API-SSL-Server
+
+# Used by "slow" functional tests that don't use the test-app's application
 httpPort=8011
-# For fastfunctest tests
-fastHttpPort=8014
 httpsPort=8013
-adminPort=8002
-basePath=
-lbHost=false
+
 ml_certificate_password=welcome
 ml_certificate_file=user.p12
 

--- a/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClientBuilder.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClientBuilder.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2022 MarkLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.marklogic.client;
+
+import com.marklogic.client.impl.DatabaseClientPropertySource;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.X509TrustManager;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Intended to support programmatically building a {@code DatabaseClient} via chained "with" methods for setting
+ * each possible input allowed for connecting to and authenticating with MarkLogic. While the
+ * {@code DatabaseClientFactory.Bean} class is intended for use in a context such as a Spring container, it requires
+ * that a user have already assembled the appropriate {@code DatabaseClientFactory.SecurityContext}. This builder
+ * instead is intended for a more dynamic environment - in particular, one where the desired authentication strategy is
+ * not known until runtime. A client can then collect inputs from a user at runtime and call the appropriate methods on
+ * this builder. The builder will handle constructing the correct {@code DatabaseClientFactory.SecurityContext} and
+ * using that to construct a {@code DatabaseClient}.
+ *
+ * @since 6.1.0
+ */
+public class DatabaseClientBuilder {
+
+	public final static String PREFIX = "marklogic.client.";
+	private final Map<String, Object> props;
+
+	public DatabaseClientBuilder() {
+		this.props = new HashMap<>();
+	}
+
+	/**
+	 * Initialize the builder with the given set of properties.
+	 *
+	 * @param props
+	 */
+	public DatabaseClientBuilder(Map<String, Object> props) {
+		this();
+		this.props.putAll(props);
+	}
+
+	/**
+	 * @return a {@code DatabaseClient} based on the inputs that have been provided via the "with" builder methods
+	 * and any inputs provided via this instance's constructor
+	 */
+	public DatabaseClient build() {
+		return DatabaseClientFactory.newClient(getPropertySource());
+	}
+
+	/**
+	 * @return an instance of {@code DatabaseClientFactory.Bean}  based on the inputs that have been provided via
+	 * the "with" builder methods and any inputs provided via this instance's constructor
+	 */
+	public DatabaseClientFactory.Bean buildBean() {
+		return new DatabaseClientPropertySource(getPropertySource()).newClientBean();
+	}
+
+	/**
+	 * @return a function that acts as a property source, specifically for use with the
+	 * {@code DatabaseClientFactory.newClient} method that accepts this type of function.
+	 */
+	private Function<String, Object> getPropertySource() {
+		return propertyName -> props.get(propertyName);
+	}
+
+	public DatabaseClientBuilder withHost(String host) {
+		props.put(PREFIX + "host", host);
+		return this;
+	}
+
+	public DatabaseClientBuilder withPort(int port) {
+		props.put(PREFIX + "port", port);
+		return this;
+	}
+
+	public DatabaseClientBuilder withBasePath(String basePath) {
+		props.put(PREFIX + "basePath", basePath);
+		return this;
+	}
+
+	public DatabaseClientBuilder withDatabase(String database) {
+		props.put(PREFIX + "database", database);
+		return this;
+	}
+
+	public DatabaseClientBuilder withUsername(String username) {
+		props.put(PREFIX + "username", username);
+		return this;
+	}
+
+	public DatabaseClientBuilder withPassword(String password) {
+		props.put(PREFIX + "password", password);
+		return this;
+	}
+
+	public DatabaseClientBuilder withSecurityContext(DatabaseClientFactory.SecurityContext securityContext) {
+		props.put(PREFIX + "securityContext", securityContext);
+		return this;
+	}
+
+	public DatabaseClientBuilder withSecurityContextType(String type) {
+		props.put(PREFIX + "securityContextType", type);
+		return this;
+	}
+
+	public DatabaseClientBuilder withConnectionType(DatabaseClient.ConnectionType type) {
+		props.put(PREFIX + "connectionType", type);
+		return this;
+	}
+
+	public DatabaseClientBuilder withCloudApiKey(String cloudApiKey) {
+		props.put(PREFIX + "cloud.apiKey", cloudApiKey);
+		return this;
+	}
+
+	public DatabaseClientBuilder withCertificateFile(String file) {
+		props.put(PREFIX + "certificate.file", file);
+		return this;
+	}
+
+	public DatabaseClientBuilder withCertificatePassword(String password) {
+		props.put(PREFIX + "certificate.password", password);
+		return this;
+	}
+
+	public DatabaseClientBuilder withKerberosPrincipal(String principal) {
+		props.put(PREFIX + "kerberos.principal", principal);
+		return this;
+	}
+
+	public DatabaseClientBuilder withSAMLToken(String token) {
+		props.put(PREFIX + "saml.token", token);
+		return this;
+	}
+
+	public DatabaseClientBuilder withSSLContext(SSLContext sslContext) {
+		props.put(PREFIX + "sslContext", sslContext);
+		return this;
+	}
+
+	public DatabaseClientBuilder withSSLProtocol(String sslProtocol) {
+		props.put(PREFIX + "sslProtocol", sslProtocol);
+		return this;
+	}
+
+	public DatabaseClientBuilder withTrustManager(X509TrustManager trustManager) {
+		props.put(PREFIX + "trustManager", trustManager);
+		return this;
+	}
+
+	public DatabaseClientBuilder withSSLHostnameVerifier(DatabaseClientFactory.SSLHostnameVerifier sslHostnameVerifier) {
+		props.put(PREFIX + "sslHostnameVerifier", sslHostnameVerifier);
+		return this;
+	}
+}
+
+
+

--- a/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClientFactory.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClientFactory.java
@@ -49,14 +49,11 @@ import javax.net.ssl.SSLSession;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 
-import com.marklogic.client.impl.RESTServices;
+import com.marklogic.client.impl.*;
 import okhttp3.OkHttpClient;
 
 import com.marklogic.client.extra.okhttpclient.OkHttpClientConfigurator;
 import com.marklogic.client.extra.httpclient.HttpClientConfigurator;
-import com.marklogic.client.impl.DatabaseClientImpl;
-import com.marklogic.client.impl.HandleFactoryRegistryImpl;
-import com.marklogic.client.impl.OkHttpServices;
 import com.marklogic.client.io.marker.ContentHandle;
 import com.marklogic.client.io.marker.ContentHandleFactory;
 
@@ -1218,6 +1215,47 @@ public class DatabaseClientFactory {
       return certPassword;
     }
   }
+
+	/**
+	 * Creates a client to access the database by means of a REST server with connection and authentication information
+	 * retrieved from the given {@code propertySource}. The {@code propertySource} function will be invoked once for
+	 * each of the below properties, giving the function a chance to return a value associated with the property if
+	 * desired. The set of values returned for the below property names will then be used to construct and return a new
+	 * {@code DatabaseClient} instance.
+	 *
+	 * <ol>
+	 *     <li>marklogic.client.host = required; must be a String</li>
+	 *     <li>marklogic.client.port = required; must be an int, Integer, or String that can be parse as an int</li>
+	 *     <li>marklogic.client.basePath = must be a String</li>
+	 *     <li>marklogic.client.database = must be a String</li>
+	 *     <li>marklogic.client.connectionType = must be a String or instance of {@code ConnectionType}</li>
+	 *     <li>marklogic.client.securityContext = an instance of {@code SecurityContext}; if set, then all other
+	 *     properties pertaining to the construction of a {@code SecurityContext} will be ignored</li>
+	 *     <li>marklogic.client.securityContextType = required if marklogic.client.securityContext is not set;
+	 *     must be a String and one of "basic", "digest", "cloud", "kerberos", "certificate", or "saml"</li>
+	 *     <li>marklogic.client.username = must be a String; required for basic and digest authentication</li>
+	 *     <li>marklogic.client.password = must be a String; required for basic and digest authentication</li>
+	 *     <li>marklogic.client.cloud.apiKey = must be a String; required for cloud authentication</li>
+	 *     <li>marklogic.client.kerberos.principal = must be a String</li>
+	 *     <li>marklogic.client.certificate.file = must be a String; required for certificate authentication</li>
+	 *     <li>marklogic.client.certificate.password = must be a String; required for certificate authentication</li>
+	 *     <li>marklogic.client.saml.token = must be a String; required for SAML authentication</li>
+	 *     <li>marklogic.client.sslContext = must be an instance of {@code javax.net.ssl.SSLContext}</li>
+	 *     <li>marklogic.client.sslProtocol = must be a String; if "default', then uses the JVM default SSL
+	 *     context; else, the value is passed to the {@code getInstance} method in {@code javax.net.ssl.SSLContext}</li>
+	 *     <li>marklogic.client.sslHostnameVerifier = must either be an instance of {@code SSLHostnameVerifier} or
+	 *     a String with a value of either "any", "common", or "strict"</li>
+	 *     <li>marklogic.client.trustManager = must be an instance of {@code javax.net.ssl.X509TrustManager};
+	 *     if not specified and an SSL context is configured, an attempt will be made to use the JVM's default trust manager</li>
+	 * </ol>
+	 *
+	 * @param propertySource
+	 * @return
+	 * @since 6.1.0
+	 */
+	public static DatabaseClient newClient(Function<String, Object> propertySource) {
+		return new DatabaseClientPropertySource(propertySource).newClient();
+	}
 
   /**
    * Creates a client to access the database by means of a REST server

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/DatabaseClientPropertySource.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/DatabaseClientPropertySource.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) 2022 MarkLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.marklogic.client.impl;
+
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.DatabaseClientBuilder;
+import com.marklogic.client.DatabaseClientFactory;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.X509TrustManager;
+import java.security.NoSuchAlgorithmException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+/**
+ * Contains the implementation for the {@code DatabaseClientFactory.newClient} method that accepts a function as a
+ * property source. Implementation is here primarily to ease readability and avoid making the factory class any larger
+ * than it already is.
+ */
+public class DatabaseClientPropertySource {
+
+	private final static String PREFIX = DatabaseClientBuilder.PREFIX;
+
+	private final Function<String, Object> propertySource;
+
+	// Map of consumer functions that handle properties related to the connection to MarkLogic, but not to authentication
+	private static Map<String, BiConsumer<DatabaseClientFactory.Bean, Object>> connectionPropertyHandlers;
+
+	static {
+		connectionPropertyHandlers = new LinkedHashMap<>();
+		connectionPropertyHandlers.put(PREFIX + "host", (bean, value) -> bean.setHost((String) value));
+		connectionPropertyHandlers.put(PREFIX + "port", (bean, value) -> {
+			if (value instanceof String) {
+				bean.setPort(Integer.parseInt((String) value));
+			} else {
+				bean.setPort((int) value);
+			}
+		});
+		connectionPropertyHandlers.put(PREFIX + "database", (bean, value) -> bean.setDatabase((String) value));
+		connectionPropertyHandlers.put(PREFIX + "basePath", (bean, value) -> bean.setBasePath((String) value));
+		connectionPropertyHandlers.put(PREFIX + "connectionType", (bean, value) -> {
+			if (value instanceof DatabaseClient.ConnectionType) {
+				bean.setConnectionType((DatabaseClient.ConnectionType) value);
+			} else if (value instanceof String) {
+				String val = (String) value;
+				if (val.trim().length() > 0) {
+					bean.setConnectionType(DatabaseClient.ConnectionType.valueOf(val.toUpperCase()));
+				}
+			} else
+				throw new IllegalArgumentException("Connection type must either be a String or an instance of ConnectionType");
+		});
+	}
+
+	public DatabaseClientPropertySource(Function<String, Object> propertySource) {
+		this.propertySource = propertySource;
+	}
+
+	public DatabaseClient newClient() {
+		DatabaseClientFactory.Bean bean = newClientBean();
+		// For consistency with how clients have been created - i.e. not via a Bean class, but via
+		// DatabaseClientFactory.newClient methods - this does not make use of the bean.newClient() method but rather
+		// uses the fully-overloaded newClient method. This ensures that later calls to e.g.
+		// DatabaseClientFactory.getHandleRegistry() will still impact the DatabaseClient returned by this method
+		// (and this behavior is expected by some existing tests).
+		return DatabaseClientFactory.newClient(bean.getHost(), bean.getPort(), bean.getBasePath(), bean.getDatabase(),
+			bean.getSecurityContext(), bean.getConnectionType());
+
+	}
+
+	public DatabaseClientFactory.Bean newClientBean() {
+		final DatabaseClientFactory.Bean bean = new DatabaseClientFactory.Bean();
+		connectionPropertyHandlers.forEach((propName, consumer) -> {
+			Object propValue = propertySource.apply(propName);
+			if (propValue != null) {
+				consumer.accept(bean, propValue);
+			}
+		});
+		bean.setSecurityContext(newSecurityContext());
+		if (bean.getSecurityContext() != null && bean.getSecurityContext().getSSLContext() != null && bean.getPort() == 0) {
+			bean.setPort(443);
+		}
+		return bean;
+	}
+
+	private DatabaseClientFactory.SecurityContext newSecurityContext() {
+		DatabaseClientFactory.SecurityContext securityContext = (DatabaseClientFactory.SecurityContext)
+			propertySource.apply(PREFIX + "securityContext");
+		if (securityContext != null) {
+			return securityContext;
+		}
+
+		String type = (String) propertySource.apply(PREFIX + "securityContextType");
+		if (type == null || type.trim().length() == 0) {
+			throw new IllegalArgumentException("Must define a security context or security context type");
+		}
+		securityContext = newSecurityContext(type);
+
+		SSLContext sslContext = determineSSLContext();
+		if (sslContext != null) {
+			securityContext.withSSLContext(sslContext, determineTrustManager());
+		}
+		securityContext.withSSLHostnameVerifier(determineHostnameVerifier());
+		return securityContext;
+	}
+
+	private DatabaseClientFactory.SecurityContext newSecurityContext(String type) {
+		switch (type.toLowerCase()) {
+			case "basic":
+				return newBasicAuthContext();
+			case "digest":
+				return newDigestAuthContext();
+			case "cloud":
+				return newCloudAuthContext();
+			case "kerberos":
+				return newKerberosAuthContext();
+			case "certificate":
+				return newCertificateAuthContext();
+			case "saml":
+				return newSAMLAuthContext();
+			default:
+				throw new IllegalArgumentException("Unrecognized security context type: " + type);
+		}
+	}
+
+	private DatabaseClientFactory.SecurityContext newBasicAuthContext() {
+		return new DatabaseClientFactory.BasicAuthContext(
+			(String) propertySource.apply(PREFIX + "username"),
+			(String) propertySource.apply(PREFIX + "password")
+		);
+	}
+
+	private DatabaseClientFactory.SecurityContext newDigestAuthContext() {
+		return new DatabaseClientFactory.DigestAuthContext(
+			(String) propertySource.apply(PREFIX + "username"),
+			(String) propertySource.apply(PREFIX + "password")
+		);
+	}
+
+	private DatabaseClientFactory.SecurityContext newCloudAuthContext() {
+		return new DatabaseClientFactory.MarkLogicCloudAuthContext(
+			(String) propertySource.apply(PREFIX + "cloud.apiKey")
+		);
+	}
+
+	private DatabaseClientFactory.SecurityContext newCertificateAuthContext() {
+		try {
+			return new DatabaseClientFactory.CertificateAuthContext(
+				(String) propertySource.apply(PREFIX + "certificate.file"),
+				(String) propertySource.apply(PREFIX + "certificate.password"),
+				determineTrustManager()
+			);
+		} catch (Exception e) {
+			throw new RuntimeException("Unable to create CertificateAuthContext; cause " + e.getMessage(), e);
+		}
+	}
+
+	private DatabaseClientFactory.SecurityContext newKerberosAuthContext() {
+		return new DatabaseClientFactory.KerberosAuthContext(
+			(String) propertySource.apply(PREFIX + "kerberos.principal")
+		);
+	}
+
+	private DatabaseClientFactory.SecurityContext newSAMLAuthContext() {
+		return new DatabaseClientFactory.SAMLAuthContext(
+			(String) propertySource.apply(PREFIX + "saml.token")
+		);
+	}
+
+	private SSLContext determineSSLContext() {
+		Object sslContext = propertySource.apply(PREFIX + "sslContext");
+		if (sslContext instanceof SSLContext) {
+			return (SSLContext) sslContext;
+		}
+		String protocol = (String) propertySource.apply(PREFIX + "sslProtocol");
+		if (protocol != null) {
+			if ("default".equalsIgnoreCase(protocol)) {
+				try {
+					return SSLContext.getDefault();
+				} catch (NoSuchAlgorithmException e) {
+					throw new RuntimeException("Unable to obtain default SSLContext; cause: " + e.getMessage(), e);
+				}
+			}
+			try {
+				// Note that if only a protocol is specified, and not a TrustManager, an attempt will later be made
+				// to use the JVM's default TrustManager
+				return SSLContext.getInstance(protocol);
+			} catch (NoSuchAlgorithmException e) {
+				throw new RuntimeException("Unable to get SSLContext instance with protocol: " + protocol
+					+ "; cause: " + e.getMessage(), e);
+			}
+		}
+		return null;
+	}
+
+	private X509TrustManager determineTrustManager() {
+		Object trustManagerObject = propertySource.apply(PREFIX + "trustManager");
+		if (trustManagerObject != null) {
+			if (trustManagerObject instanceof X509TrustManager) {
+				return (X509TrustManager) trustManagerObject;
+			}
+			throw new IllegalArgumentException(
+				String.format("Trust manager must be an instance of %s", X509TrustManager.class.getName()));
+		}
+		return null;
+	}
+
+	private DatabaseClientFactory.SSLHostnameVerifier determineHostnameVerifier() {
+		Object verifierObject = propertySource.apply(PREFIX + "sslHostnameVerifier");
+		if (verifierObject instanceof DatabaseClientFactory.SSLHostnameVerifier) {
+			return (DatabaseClientFactory.SSLHostnameVerifier) verifierObject;
+		} else if (verifierObject instanceof String) {
+			String verifier = (String) verifierObject;
+			if ("ANY".equalsIgnoreCase(verifier)) {
+				return DatabaseClientFactory.SSLHostnameVerifier.ANY;
+			} else if ("COMMON".equalsIgnoreCase(verifier)) {
+				return DatabaseClientFactory.SSLHostnameVerifier.COMMON;
+			} else if ("STRICT".equalsIgnoreCase(verifier)) {
+				return DatabaseClientFactory.SSLHostnameVerifier.STRICT;
+			}
+			throw new IllegalArgumentException(String.format("Unrecognized value for SSLHostnameVerifier: %s", verifier));
+		}
+		return null;
+	}
+}

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/MarkLogicCloudAuthenticationConfigurer.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/MarkLogicCloudAuthenticationConfigurer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2022 MarkLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.marklogic.client.impl.okhttp;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -23,6 +38,11 @@ public class MarkLogicCloudAuthenticationConfigurer implements AuthenticationCon
 
 	@Override
 	public void configureAuthentication(OkHttpClient.Builder clientBuilder, MarkLogicCloudAuthContext securityContext) {
+		final String apiKey = securityContext.getKey();
+		if (apiKey == null || apiKey.trim().length() < 1) {
+			throw new IllegalArgumentException("No API key provided");
+		}
+
 		final Response response = callTokenEndpoint(securityContext);
 		final String accessToken = getAccessTokenFromResponse(response);
 		if (logger.isInfoEnabled()) {

--- a/marklogic-client-api/src/test/java/com/marklogic/client/impl/DatabaseClientPropertySourceTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/impl/DatabaseClientPropertySourceTest.java
@@ -1,0 +1,75 @@
+package com.marklogic.client.impl;
+
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.DatabaseClientBuilder;
+import com.marklogic.client.DatabaseClientFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Intent of this test is to cover code that cannot be covered by DatabaseClientBuilderTest.
+ */
+public class DatabaseClientPropertySourceTest {
+
+	private Map<String, Object> props;
+	private DatabaseClientFactory.Bean bean;
+	private static final String PREFIX = DatabaseClientBuilder.PREFIX;
+	private static final String VERIFIER_PROPERTY = PREFIX + "sslHostnameVerifier";
+	private static final String CONNECTION_TYPE_PROPERTY = PREFIX + "connectionType";
+
+	@BeforeEach
+	void beforeEach() {
+		props = new HashMap() {{
+			put(PREFIX + "securityContextType", "digest");
+		}};
+	}
+
+	@Test
+	void anyHostnameVerifier() {
+		props.put(VERIFIER_PROPERTY, "any");
+		bean = buildBean();
+		assertEquals(DatabaseClientFactory.SSLHostnameVerifier.ANY, bean.getSecurityContext().getSSLHostnameVerifier());
+	}
+
+	@Test
+	void commonHostnameVerifier() {
+		props.put(VERIFIER_PROPERTY, "COMmon");
+		bean = buildBean();
+		assertEquals(DatabaseClientFactory.SSLHostnameVerifier.COMMON, bean.getSecurityContext().getSSLHostnameVerifier());
+	}
+
+	@Test
+	void strictHostnameVerifier() {
+		props.put(VERIFIER_PROPERTY, "STRICT");
+		bean = buildBean();
+		assertEquals(DatabaseClientFactory.SSLHostnameVerifier.STRICT, bean.getSecurityContext().getSSLHostnameVerifier());
+	}
+
+	@Test
+	void gatewayConnectionType() {
+		props.put(CONNECTION_TYPE_PROPERTY, "gateway");
+		bean = buildBean();
+		assertEquals(DatabaseClient.ConnectionType.GATEWAY, bean.getConnectionType());
+
+		props.put(CONNECTION_TYPE_PROPERTY, "GATEWAY");
+		bean = buildBean();
+		assertEquals(DatabaseClient.ConnectionType.GATEWAY, bean.getConnectionType());
+	}
+
+	@Test
+	void stringPort() {
+		props.put(PREFIX + "port", "8000");
+		bean = buildBean();
+		assertEquals(8000, bean.getPort());
+	}
+
+	private DatabaseClientFactory.Bean buildBean() {
+		DatabaseClientPropertySource source = new DatabaseClientPropertySource(propertyName -> props.get(propertyName));
+		return source.newClientBean();
+	}
+}

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/CheckSSLConnectionTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/CheckSSLConnectionTest.java
@@ -10,7 +10,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith(RequireSSLExtension.class)
 class CheckSSLConnectionTest {
@@ -36,10 +38,11 @@ class CheckSSLConnectionTest {
 		SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
 		sslContext.init(null, new TrustManager[]{Common.TRUST_ALL_MANAGER}, null);
 
-		DatabaseClient client = Common.makeNewClient(Common.HOST, Common.PORT,
-			Common.newSecurityContext(Common.USER, Common.PASS)
-				.withSSLContext(sslContext, Common.TRUST_ALL_MANAGER)
-				.withSSLHostnameVerifier(DatabaseClientFactory.SSLHostnameVerifier.ANY));
+		DatabaseClient client = Common.newClientBuilder()
+			.withSSLContext(sslContext)
+			.withTrustManager(Common.TRUST_ALL_MANAGER)
+			.withSSLHostnameVerifier(DatabaseClientFactory.SSLHostnameVerifier.ANY)
+			.build();
 
 		DatabaseClient.ConnectionResult result = client.checkConnection();
 		assertEquals(0, result.getStatusCode(), "A value of zero implies that a connection was successfully made, " +
@@ -49,10 +52,11 @@ class CheckSSLConnectionTest {
 
 	@Test
 	void defaultSslContext() throws Exception {
-		DatabaseClient client = Common.makeNewClient(Common.HOST, Common.PORT,
-			Common.newSecurityContext(Common.USER, Common.PASS)
-				.withSSLContext(SSLContext.getDefault(), Common.TRUST_ALL_MANAGER)
-				.withSSLHostnameVerifier(DatabaseClientFactory.SSLHostnameVerifier.ANY));
+		DatabaseClient client = Common.newClientBuilder()
+			.withSSLContext(SSLContext.getDefault())
+			.withTrustManager(Common.TRUST_ALL_MANAGER)
+			.withSSLHostnameVerifier(DatabaseClientFactory.SSLHostnameVerifier.ANY)
+			.build();
 
 		assertThrows(MarkLogicIOException.class, () -> client.checkConnection(),
 			"The connection should fail because the JVM's default SSL Context does not have a CA certificate that " +

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/DatabaseClientBuilderTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/DatabaseClientBuilderTest.java
@@ -1,0 +1,234 @@
+package com.marklogic.client.test;
+
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.DatabaseClientBuilder;
+import com.marklogic.client.DatabaseClientFactory;
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.SSLContext;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * These tests only verify that the Bean instance is built correctly, as in order to verify each connection type, we
+ * need working test setups for all the different authentication types, which we don't yet have.
+ */
+public class DatabaseClientBuilderTest {
+
+	private DatabaseClientFactory.Bean bean;
+
+	@Test
+	void minimumConnectionProperties() {
+		bean = new DatabaseClientBuilder()
+			.withHost("myhost")
+			.withPort(8000)
+			.withSecurityContextType("digest")
+			.buildBean();
+
+		assertEquals("myhost", bean.getHost());
+		assertEquals(8000, bean.getPort());
+		assertNull(bean.getDatabase());
+		assertNull(bean.getBasePath());
+		assertNull(bean.getConnectionType());
+		assertTrue(bean.getSecurityContext() instanceof DatabaseClientFactory.DigestAuthContext);
+	}
+
+	@Test
+	void allConnectionProperties() {
+		bean = new DatabaseClientBuilder()
+			.withHost("myhost")
+			.withPort(8000)
+			.withSecurityContextType("digest")
+			.withBasePath("/my/path")
+			.withDatabase("Documents")
+			.withConnectionType(DatabaseClient.ConnectionType.DIRECT)
+			.buildBean();
+
+		assertEquals("myhost", bean.getHost());
+		assertEquals(8000, bean.getPort());
+		assertEquals("Documents", bean.getDatabase());
+		assertEquals("/my/path", bean.getBasePath());
+		assertEquals(DatabaseClient.ConnectionType.DIRECT, bean.getConnectionType());
+		assertTrue(bean.getSecurityContext() instanceof DatabaseClientFactory.DigestAuthContext);
+	}
+
+	@Test
+	void noSecurityContextOrType() {
+		IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> new DatabaseClientBuilder()
+			.withHost("some-host")
+			.withPort(10)
+			.buildBean());
+		assertEquals("Must define a security context or security context type", ex.getMessage());
+	}
+
+	@Test
+	void invalidSecurityContextType() {
+		IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> new DatabaseClientBuilder()
+			.withHost("another-host")
+			.withPort(200)
+			.withSecurityContextType("invalid-type")
+			.buildBean());
+		assertEquals("Unrecognized security context type: invalid-type", ex.getMessage());
+	}
+
+	@Test
+	void digest() {
+		bean = Common.newClientBuilder()
+			.withUsername("my-user")
+			.withPassword("my-password")
+			.withSecurityContextType("digest")
+			.buildBean();
+
+		DatabaseClientFactory.DigestAuthContext context = (DatabaseClientFactory.DigestAuthContext) bean.getSecurityContext();
+		assertEquals("my-user", context.getUser());
+		assertEquals("my-password", context.getPassword());
+	}
+
+	@Test
+	void basic() {
+		bean = Common.newClientBuilder()
+			.withUsername("my-user")
+			.withPassword("my-password")
+			.withSecurityContextType("basic")
+			.buildBean();
+
+		DatabaseClientFactory.BasicAuthContext context = (DatabaseClientFactory.BasicAuthContext) bean.getSecurityContext();
+		assertEquals("my-user", context.getUser());
+		assertEquals("my-password", context.getPassword());
+	}
+
+	@Test
+	void cloudWithBasePath() {
+		bean = Common.newClientBuilder()
+			.withSecurityContextType("cloud")
+			.withCloudApiKey("my-key")
+			.withBasePath("/my/path")
+			.buildBean();
+
+		DatabaseClientFactory.MarkLogicCloudAuthContext context =
+			(DatabaseClientFactory.MarkLogicCloudAuthContext) bean.getSecurityContext();
+		assertEquals("my-key", context.getKey());
+		assertEquals("/my/path", bean.getBasePath());
+	}
+
+	@Test
+	void cloudNoApiKey() {
+		IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> Common.newClientBuilder()
+			.withSecurityContextType("cloud")
+			.withBasePath("/my/path")
+			.build());
+		assertEquals("No API key provided", ex.getMessage());
+	}
+
+	@Test
+	void kerberos() {
+		bean = Common.newClientBuilder()
+			.withSecurityContextType("kerberos")
+			.withKerberosPrincipal("someone")
+			.buildBean();
+
+		DatabaseClientFactory.KerberosAuthContext context = (DatabaseClientFactory.KerberosAuthContext) bean.getSecurityContext();
+		assertEquals("someone", context.getKrbOptions().get("principal"));
+	}
+
+	@Test
+	void certificate() {
+		DatabaseClientBuilder builder = Common.newClientBuilder()
+			.withSecurityContextType("CERTificate")
+			.withCertificateFile("not.found")
+			.withCertificatePassword("passwd");
+
+		Exception ex = assertThrows(Exception.class, () -> builder.buildBean());
+		assertTrue(ex.getMessage().contains("Unable to create CertificateAuthContext"),
+			"We don't yet have a real test for certificate authentication, so there's not yet a certificate store " +
+				"to test against; just making sure that an attempt is made to create a CertificateAuthContext");
+	}
+
+	@Test
+	void saml() {
+		bean = Common.newClientBuilder()
+			.withSecurityContextType("saml")
+			.withSAMLToken("my-token")
+			.buildBean();
+
+		DatabaseClientFactory.SAMLAuthContext context = (DatabaseClientFactory.SAMLAuthContext) bean.getSecurityContext();
+		assertEquals("my-token", context.getToken());
+	}
+
+	@Test
+	void defaultSslContext() throws Exception {
+		bean = Common.newClientBuilder()
+			.withSSLContext(SSLContext.getDefault())
+			.buildBean();
+
+		assertNotNull(bean.getSecurityContext().getSSLContext());
+	}
+
+	@Test
+	void sslProtocol() {
+		bean = Common.newClientBuilder()
+			.withSSLProtocol("TLSv1.2")
+			.buildBean();
+
+		assertNotNull(bean.getSecurityContext().getSSLContext());
+		assertNull(bean.getSecurityContext().getTrustManager());
+		assertNull(bean.getSecurityContext().getSSLHostnameVerifier());
+	}
+
+	@Test
+	void invalidSslProtocol() {
+		RuntimeException ex = assertThrows(RuntimeException.class, () -> Common.newClientBuilder()
+			.withSSLProtocol("not-valid-value")
+			.buildBean());
+
+		assertTrue(ex.getMessage().startsWith("Unable to get SSLContext instance with protocol: not-valid-value"),
+			"Unexpected error message: " + ex.getMessage());
+	}
+
+	@Test
+	void sslProtocolAndTrustManager() {
+		bean = Common.newClientBuilder()
+			.withSSLProtocol("TLSv1.2")
+			.withTrustManager(Common.TRUST_ALL_MANAGER)
+			.buildBean();
+
+		assertNotNull(bean.getSecurityContext().getSSLContext());
+		assertNotNull(bean.getSecurityContext().getTrustManager());
+		assertEquals(Common.TRUST_ALL_MANAGER, bean.getSecurityContext().getTrustManager());
+		assertNull(bean.getSecurityContext().getSSLHostnameVerifier());
+	}
+
+	@Test
+	void sslProtocolAndTrustManagerAndHostnameVerifier() {
+		bean = Common.newClientBuilder()
+			.withSSLProtocol("TLSv1.2")
+			.withSSLHostnameVerifier(DatabaseClientFactory.SSLHostnameVerifier.COMMON)
+			.withTrustManager(Common.TRUST_ALL_MANAGER)
+			.buildBean();
+
+		DatabaseClientFactory.SecurityContext context = bean.getSecurityContext();
+		assertNotNull(context.getSSLContext());
+		assertNotNull(context.getTrustManager());
+		assertEquals(Common.TRUST_ALL_MANAGER, context.getTrustManager());
+		assertEquals(DatabaseClientFactory.SSLHostnameVerifier.COMMON, context.getSSLHostnameVerifier());
+	}
+
+	@Test
+	void sslContextWithNoPort() throws Exception {
+		bean = new DatabaseClientBuilder()
+			.withSecurityContextType("DIGEST")
+			.withSSLContext(SSLContext.getDefault())
+			.buildBean();
+
+		assertTrue(bean.getSecurityContext() instanceof DatabaseClientFactory.DigestAuthContext);
+		assertNotNull(bean.getSecurityContext().getSSLContext());
+		assertEquals(443, bean.getPort(),
+			"If an SSLContext is provided with no port, then assume 443, as that's the standard port for HTTPS calls. " +
+				"That makes life a little simpler for MarkLogic Cloud users as well, as they don't need to worry about " +
+				"setting the port.");
+	}
+}

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/DatabaseClientFactoryTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/DatabaseClientFactoryTest.java
@@ -161,8 +161,7 @@ public class DatabaseClientFactoryTest {
 
     DatabaseClientFactory.addConfigurator(configurator);
 
-    DatabaseClient client = Common.makeNewClient(
-      Common.HOST, Common.PORT, Common.newSecurityContext(Common.USER, Common.PASS));
+	DatabaseClient client = Common.newClientBuilder().build();
     try {
       assertTrue( configurator.isConfigured);
       OkHttpClient okClient = (OkHttpClient) client.getClientImplementation();

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/DatabaseClientTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/DatabaseClientTest.java
@@ -15,11 +15,14 @@
  */
 package com.marklogic.client.test;
 
-import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.DatabaseClient.ConnectionResult;
 import com.marklogic.client.admin.QueryOptionsManager;
 import com.marklogic.client.alerting.RuleManager;
-import com.marklogic.client.document.*;
+import com.marklogic.client.document.BinaryDocumentManager;
+import com.marklogic.client.document.GenericDocumentManager;
+import com.marklogic.client.document.JSONDocumentManager;
+import com.marklogic.client.document.TextDocumentManager;
+import com.marklogic.client.document.XMLDocumentManager;
 import com.marklogic.client.eval.ServerEvaluationCall;
 import com.marklogic.client.pojo.PojoRepository;
 import com.marklogic.client.query.QueryManager;
@@ -28,7 +31,9 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DatabaseClientTest {
   @BeforeAll
@@ -115,21 +120,13 @@ public class DatabaseClientTest {
 
   @Test
   public void testCheckConnectionWithValidUser() {
-
-	DatabaseClient marklogic = Common.makeNewClient(Common.HOST,
-		        Common.PORT, Common.newSecurityContext(
-				        Common.SERVER_ADMIN_USER, Common.SERVER_ADMIN_PASS));
-
-    ConnectionResult connResult = marklogic.checkConnection();
+    ConnectionResult connResult = Common.newClient().checkConnection();
     assertTrue(connResult.isConnected());
   }
 
   @Test
   public void testCheckConnectionWithInvalidUser() {
-	DatabaseClient marklogic = Common.makeNewClient(Common.HOST,
-		        Common.PORT, Common.newSecurityContext("invalid", "invalid"));
-
-    ConnectionResult connResult = marklogic.checkConnection();
+    ConnectionResult connResult = Common.newClientBuilder().withUsername("invalid").withPassword("invalid").build().checkConnection();
     assertFalse(connResult.isConnected());
     assertTrue(connResult.getStatusCode() == 401);
     assertTrue(connResult.getErrorMessage().equalsIgnoreCase("Unauthorized"));

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/HandleAsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/HandleAsTest.java
@@ -201,7 +201,7 @@ public class HandleAsTest {
 
   @Test
   public void testSearch() throws JAXBException {
-    DatabaseClientFactory.Bean clientFactoryBean = makeClientBeanFactory();
+    DatabaseClientFactory.Bean clientFactoryBean = makeClientFactoryBean();
 
     clientFactoryBean.getHandleRegistry().register(
       JAXBHandle.newFactory(Product.class)
@@ -304,7 +304,7 @@ public class HandleAsTest {
   public void testHandleRegistry() {
     int[] iterations = {1,2};
     for (int i: iterations) {
-      DatabaseClientFactory.Bean clientFactoryBean = (i == 1) ? null : makeClientFactory();
+      DatabaseClientFactory.Bean clientFactoryBean = (i == 1) ? null : makeClientFactoryBean();
 
       HandleFactoryRegistry registry =
         (i == 1) ? DatabaseClientFactory.getHandleRegistry()
@@ -322,7 +322,7 @@ public class HandleAsTest {
 
       // instantiate a client with a copy of the registry
       DatabaseClient client =
-        (i == 1) ? Common.newClient()
+        (i == 1) ? DatabaseClientFactory.newClient(Common.HOST, Common.PORT, Common.newSecurityContext(Common.USER, Common.PASS))
                  : clientFactoryBean.newClient();
 
       registry.unregister(StringBuilder.class);
@@ -362,7 +362,7 @@ public class HandleAsTest {
     }
   }
 
-  private DatabaseClientFactory.Bean makeClientFactory() {
+  private DatabaseClientFactory.Bean makeClientFactoryBean() {
     DatabaseClientFactory.Bean clientFactoryBean = new DatabaseClientFactory.Bean();
     clientFactoryBean.setHost(Common.HOST);
     clientFactoryBean.setPort(Common.PORT);
@@ -370,16 +370,6 @@ public class HandleAsTest {
 	clientFactoryBean.setSecurityContext(Common.newSecurityContext(Common.USER, Common.PASS));
     return clientFactoryBean;
   }
-
-  private DatabaseClientFactory.Bean makeClientBeanFactory() {
-    DatabaseClientFactory.Bean clientFactoryBean = new DatabaseClientFactory.Bean();
-    clientFactoryBean.setHost(Common.HOST);
-    clientFactoryBean.setPort(Common.PORT);
-    clientFactoryBean.setBasePath(Common.BASE_PATH);
-    clientFactoryBean.setSecurityContext(Common.newSecurityContext(Common.USER, Common.PASS));
-    return clientFactoryBean;
-  }
-
 
   static public class BufferHandle
     extends BaseHandle<String, String>

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/ResourceServicesTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/ResourceServicesTest.java
@@ -166,7 +166,7 @@ public class ResourceServicesTest {
   @Test
   /** Avoid regression on https://github.com/marklogic/java-client-api/issues/761 */
   public void test_issue_761() {
-    DatabaseClient client = Common.newClient("Documents");
+    DatabaseClient client = Common.newClientBuilder().withDatabase("Documents").build();
     try {
       client.newServerConfigManager().newResourceExtensionsManager()
         .listServices(new DOMHandle());

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/SemanticsPermissionsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/SemanticsPermissionsTest.java
@@ -28,10 +28,8 @@ import static org.junit.jupiter.api.Assertions.*;
 public class SemanticsPermissionsTest {
   private static GraphManager gmgr;
   private static String graphUri = "SemanticsPermissionsTest";
-  private static DatabaseClient readPrivilegedClient = Common.makeNewClient(
-    Common.HOST, Common.PORT, Common.newSecurityContext(Common.READ_PRIVILIGED_USER, Common.READ_PRIVILIGED_PASS));
-  private static DatabaseClient writePrivilegedClient = Common.makeNewClient(
-    Common.HOST, Common.PORT, Common.newSecurityContext(Common.WRITE_PRIVILIGED_USER, Common.WRITE_PRIVILIGED_PASS));
+  private static DatabaseClient readPrivilegedClient = Common.newClientBuilder().withUsername("read-privileged").build();
+  private static DatabaseClient writePrivilegedClient = Common.newClientBuilder().withUsername("write-privileged").build();
 
   @BeforeAll
   public static void beforeClass() {

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/RowBatcherTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/RowBatcherTest.java
@@ -78,7 +78,11 @@ public class RowBatcherTest {
     private static void setupIndex() {
         final String tdeUri = TEST_COLLECTION+".tdex";
 
-        DatabaseClient schemasDB = Common.newServerAdminClient("java-unittest-schemas");
+        DatabaseClient schemasDB = Common.newClientBuilder()
+			.withDatabase("java-unittest-schemas")
+			.withUsername(Common.SERVER_ADMIN_USER)
+			.withPassword(Common.SERVER_ADMIN_PASS)
+			.build();
         XMLDocumentManager schemaMgr = schemasDB.newXMLDocumentManager();
 
         if (schemaMgr.exists(tdeUri) == null) {
@@ -184,7 +188,7 @@ public class RowBatcherTest {
     @Test
     public void testJsonRows1ThreadForDB() throws Exception {
         runJsonRowsTest(jsonBatcher(
-                Common.newClient("java-unittest").newDataMovementManager(),
+                Common.newClientBuilder().withDatabase("java-unittest").build().newDataMovementManager(),
                 1));
     }
     @Test

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/AbstractOpticUpdateTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/AbstractOpticUpdateTest.java
@@ -46,7 +46,7 @@ public abstract class AbstractOpticUpdateTest {
                 .xquery("cts:uri-match('/acme/*') ! xdmp:document-delete(.)")
                 .evalAs(String.class);
 
-        Common.client = Common.newClientAsUser("writer-no-default-permissions");
+        Common.client = Common.newClientBuilder().withUsername("writer-no-default-permissions").build();
         rowManager = Common.client.newRowManager();
         op = rowManager.newPlanBuilder();
     }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/FromDocDescriptorsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/FromDocDescriptorsTest.java
@@ -45,7 +45,7 @@ public class FromDocDescriptorsTest extends AbstractOpticUpdateTest {
         writeSet.add(newWriteOp(secondUri, newDefaultMetadata().withCollections("custom1", "custom2"),
             mapper.createObjectNode().put("hello", "two")));
 
-        Common.client = Common.newClientAsUser(USER_WITH_DEFAULT_COLLECTIONS_AND_PERMISSIONS);
+        Common.client = Common.newClientBuilder().withUsername(USER_WITH_DEFAULT_COLLECTIONS_AND_PERMISSIONS).build();
         Common.client.newRowManager().execute(op
             .fromDocDescriptors(op.docDescriptors(writeSet))
             .write());
@@ -87,7 +87,7 @@ public class FromDocDescriptorsTest extends AbstractOpticUpdateTest {
     @Test
     public void updateOnlyDocWithUserWithDefaultCollectionsAndPermissions() {
         // Set up client as user with default collections and permissions
-        Common.client = Common.newClientAsUser(USER_WITH_DEFAULT_COLLECTIONS_AND_PERMISSIONS);
+        Common.client = Common.newClientBuilder().withUsername(USER_WITH_DEFAULT_COLLECTIONS_AND_PERMISSIONS).build();
         rowManager = Common.client.newRowManager();
         op = rowManager.newPlanBuilder();
 


### PR DESCRIPTION
Also added a `DatabaseClientBuilder`, as I found that to greatly simplify our tests that construct clients in a variety of ways. Helps shield callers from having to know all the property names as well. 