### PR TITLE
DEVEXP-169 Extracted method for building an OkHttpClient

### DIFF
--- a/marklogic-client-api/src/main/java/com/marklogic/client/extra/okhttpclient/OkHttpClientBuilderFactory.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/extra/okhttpclient/OkHttpClientBuilderFactory.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022 MarkLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.marklogic.client.extra.okhttpclient;
+
+import com.marklogic.client.DatabaseClientFactory;
+import com.marklogic.client.impl.okhttp.OkHttpUtil;
+import okhttp3.OkHttpClient;
+
+/**
+ * Exposes the mechanism for constructing an {@code OkHttpClient.Builder} in the same fashion as when a
+ * {@code DatabaseClient} is constructed. Primarily intended for reuse in the ml-app-deployer library. If the
+ * Java Client moves to a different HTTP client library, this will no longer work.
+ *
+ * @since 6.1.0
+ */
+public interface OkHttpClientBuilderFactory {
+
+	static OkHttpClient.Builder newOkHttpClientBuilder(String host, int port, DatabaseClientFactory.SecurityContext securityContext) {
+		return OkHttpUtil.newOkHttpClientBuilder(host, port, securityContext);
+	}
+}

--- a/marklogic-client-api/src/test/java/com/marklogic/client/extra/okhttpclient/OkHttpClientBuilderFactoryTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/extra/okhttpclient/OkHttpClientBuilderFactoryTest.java
@@ -1,0 +1,25 @@
+package com.marklogic.client.extra.okhttpclient;
+
+import com.marklogic.client.DatabaseClientFactory;
+import com.marklogic.client.test.Common;
+import okhttp3.OkHttpClient;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class OkHttpClientBuilderFactoryTest {
+
+	@Test
+	void smokeTest() {
+		DatabaseClientFactory.Bean bean = Common.newClientBuilder().buildBean();
+		OkHttpClient.Builder builder = OkHttpClientBuilderFactory.newOkHttpClientBuilder(
+			bean.getHost(), bean.getPort(), bean.getSecurityContext());
+		assertNotNull(builder);
+
+		OkHttpClient client = builder.build();
+		assertNotNull(client, "This is simply verifying that the public/extra method doesn't throw an error. It's " +
+			"expected to reuse the same approach that constructing a DatabaseClient does. And it's expected that " +
+			"with ml-app-deployer 4.5.0 depending on this method for any calls to MarkLogic, tests will fail in that " +
+			"project if there's ever an issue with this method");
+	}
+}


### PR DESCRIPTION
This is intended for ml-app-deployer and is in the "extra" package, which is pseudo-public - it's public, but with a caveat that you'll need to bring your own OkHttp dependency to compile against it and it may not work in a future version. 