### PR TITLE
Forcing port to 443 when using MarkLogic cloud authentication

### DIFF
--- a/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClientFactory.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClientFactory.java
@@ -1383,6 +1383,13 @@ public class DatabaseClientFactory {
                                          SecurityContext securityContext,
                                          DatabaseClient.ConnectionType connectionType) {
       RESTServices services = new OkHttpServices();
+	  // As of 6.1.0, the following optimization is made as it's guaranteed that if the user is connecting to a
+	  // MarkLogic Cloud instance, then port 443 will be used. Every path for constructing a DatabaseClient goes through
+	  // this method, ensuring that this optimization will always be applied, and thus freeing the user from having to
+	  // worry about what port to configure when using MarkLogic Cloud.
+	  if (securityContext instanceof MarkLogicCloudAuthContext) {
+		  port = 443;
+	  }
       services.connect(host, port, basePath, database, securityContext);
 
       if (clientConfigurator != null) {

--- a/marklogic-client-api/src/main/java/com/marklogic/client/extra/okhttpclient/OkHttpClientBuilderFactory.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/extra/okhttpclient/OkHttpClientBuilderFactory.java
@@ -28,7 +28,7 @@ import okhttp3.OkHttpClient;
  */
 public interface OkHttpClientBuilderFactory {
 
-	static OkHttpClient.Builder newOkHttpClientBuilder(String host, int port, DatabaseClientFactory.SecurityContext securityContext) {
-		return OkHttpUtil.newOkHttpClientBuilder(host, port, securityContext);
+	static OkHttpClient.Builder newOkHttpClientBuilder(String host, DatabaseClientFactory.SecurityContext securityContext) {
+		return OkHttpUtil.newOkHttpClientBuilder(host, securityContext);
 	}
 }

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/DatabaseClientPropertySource.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/DatabaseClientPropertySource.java
@@ -91,9 +91,6 @@ public class DatabaseClientPropertySource {
 			}
 		});
 		bean.setSecurityContext(newSecurityContext());
-		if (bean.getSecurityContext() != null && bean.getSecurityContext().getSSLContext() != null && bean.getPort() == 0) {
-			bean.setPort(443);
-		}
 		return bean;
 	}
 

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/OkHttpServices.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/OkHttpServices.java
@@ -197,7 +197,7 @@ public class OkHttpServices implements RESTServices {
 	  this.database = database;
 	  this.baseUri = HttpUrlBuilder.newBaseUrl(host, port, basePath, securityContext.getSSLContext());
 
-	  OkHttpClient.Builder clientBuilder = OkHttpUtil.newOkHttpClientBuilder(host, port, securityContext);
+	  OkHttpClient.Builder clientBuilder = OkHttpUtil.newOkHttpClientBuilder(host, securityContext);
 
 	  Properties props = System.getProperties();
 	  if (props.containsKey(OKHTTP_LOGGINGINTERCEPTOR_LEVEL)) {

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/MarkLogicCloudAuthenticationConfigurer.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/MarkLogicCloudAuthenticationConfigurer.java
@@ -29,11 +29,9 @@ public class MarkLogicCloudAuthenticationConfigurer implements AuthenticationCon
 	private final static Logger logger = LoggerFactory.getLogger(MarkLogicCloudAuthenticationConfigurer.class);
 
 	private String host;
-	private int port;
 
-	public MarkLogicCloudAuthenticationConfigurer(String host, int port) {
+	public MarkLogicCloudAuthenticationConfigurer(String host) {
 		this.host = host;
-		this.port = port;
 	}
 
 	@Override
@@ -84,10 +82,12 @@ public class MarkLogicCloudAuthenticationConfigurer implements AuthenticationCon
 	}
 
 	protected HttpUrl buildTokenUrl(MarkLogicCloudAuthContext securityContext) {
+		// For the near future, it's guaranteed that https and 443 will be required for connecting to MarkLogic Cloud,
+		// so providing the ability to customize this would be misleading.
 		return new HttpUrl.Builder()
-			.scheme(securityContext.getSSLContext() != null ? "https" : "http")
+			.scheme("https")
 			.host(host)
-			.port(port)
+			.port(443)
 			.build()
 			.resolve(securityContext.getTokenEndpoint()).newBuilder().build();
 	}

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/OkHttpUtil.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/OkHttpUtil.java
@@ -36,7 +36,7 @@ public abstract class OkHttpUtil {
 
 	final private static ConnectionPool connectionPool = new ConnectionPool();
 
-	public static OkHttpClient.Builder newOkHttpClientBuilder(String host, int port, DatabaseClientFactory.SecurityContext securityContext) {
+	public static OkHttpClient.Builder newOkHttpClientBuilder(String host, DatabaseClientFactory.SecurityContext securityContext) {
 		OkHttpClient.Builder clientBuilder = OkHttpUtil.newClientBuilder();
 		AuthenticationConfigurer authenticationConfigurer = null;
 
@@ -53,7 +53,7 @@ public abstract class OkHttpUtil {
 		} else if (securityContext instanceof DatabaseClientFactory.SAMLAuthContext) {
 			configureSAMLAuth((DatabaseClientFactory.SAMLAuthContext) securityContext, clientBuilder);
 		} else if (securityContext instanceof DatabaseClientFactory.MarkLogicCloudAuthContext) {
-			authenticationConfigurer = new MarkLogicCloudAuthenticationConfigurer(host, port);
+			authenticationConfigurer = new MarkLogicCloudAuthenticationConfigurer(host);
 		} else {
 			throw new IllegalArgumentException("Unsupported security context: " + securityContext.getClass());
 		}

--- a/marklogic-client-api/src/test/java/com/marklogic/client/extra/okhttpclient/OkHttpClientBuilderFactoryTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/extra/okhttpclient/OkHttpClientBuilderFactoryTest.java
@@ -12,8 +12,7 @@ public class OkHttpClientBuilderFactoryTest {
 	@Test
 	void smokeTest() {
 		DatabaseClientFactory.Bean bean = Common.newClientBuilder().buildBean();
-		OkHttpClient.Builder builder = OkHttpClientBuilderFactory.newOkHttpClientBuilder(
-			bean.getHost(), bean.getPort(), bean.getSecurityContext());
+		OkHttpClient.Builder builder = OkHttpClientBuilderFactory.newOkHttpClientBuilder(bean.getHost(), bean.getSecurityContext());
 		assertNotNull(builder);
 
 		OkHttpClient client = builder.build();

--- a/marklogic-client-api/src/test/java/com/marklogic/client/impl/okhttp/MarkLogicCloudAuthenticationConfigurerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/impl/okhttp/MarkLogicCloudAuthenticationConfigurerTest.java
@@ -17,22 +17,11 @@ public class MarkLogicCloudAuthenticationConfigurerTest {
 
 	@Test
 	void buildTokenUrl() throws Exception {
-		HttpUrl tokenUrl = new MarkLogicCloudAuthenticationConfigurer("somehost", 443).buildTokenUrl(
+		HttpUrl tokenUrl = new MarkLogicCloudAuthenticationConfigurer("somehost").buildTokenUrl(
 			new DatabaseClientFactory.MarkLogicCloudAuthContext("doesnt-matter")
 				.withSSLContext(SSLContext.getDefault(), null)
 		);
-		assertEquals("https://somehost/token", tokenUrl.toString(),
-			"When the port is 443, OkHttp won't include it in the URL");
-	}
-
-	@Test
-	void buildTokenUrlWithNonStandardPort() throws Exception {
-		HttpUrl tokenUrl = new MarkLogicCloudAuthenticationConfigurer("somehost", 444).buildTokenUrl(
-			new DatabaseClientFactory.MarkLogicCloudAuthContext("doesnt-matter")
-				.withSSLContext(SSLContext.getDefault(), null)
-		);
-		assertEquals("https://somehost:444/token", tokenUrl.toString(),
-			"If the port isn't 443, then OkHttp will include it in the URL");
+		assertEquals("https://somehost/token", tokenUrl.toString());
 	}
 
 	/**
@@ -41,7 +30,7 @@ public class MarkLogicCloudAuthenticationConfigurerTest {
 	 */
 	@Test
 	void buildTokenUrlWithCustomTokenPath() throws Exception {
-		HttpUrl tokenUrl = new MarkLogicCloudAuthenticationConfigurer("otherhost", 443).buildTokenUrl(
+		HttpUrl tokenUrl = new MarkLogicCloudAuthenticationConfigurer("otherhost").buildTokenUrl(
 			new DatabaseClientFactory.MarkLogicCloudAuthContext("doesnt-matter", "/customToken", "doesnt-matter")
 				.withSSLContext(SSLContext.getDefault(), null)
 		);
@@ -50,7 +39,7 @@ public class MarkLogicCloudAuthenticationConfigurerTest {
 
 	@Test
 	void newFormBody() {
-		FormBody body = new MarkLogicCloudAuthenticationConfigurer("doesnt-matter", 443)
+		FormBody body = new MarkLogicCloudAuthenticationConfigurer("doesnt-matter")
 			.newFormBody(new DatabaseClientFactory.MarkLogicCloudAuthContext("myKey"));
 		assertEquals("grant_type", body.name(0));
 		assertEquals("apikey", body.value(0));
@@ -64,7 +53,7 @@ public class MarkLogicCloudAuthenticationConfigurerTest {
 	 */
 	@Test
 	void newFormBodyWithOverrides() {
-		FormBody body = new MarkLogicCloudAuthenticationConfigurer("doesnt-matter", 443)
+		FormBody body = new MarkLogicCloudAuthenticationConfigurer("doesnt-matter")
 			.newFormBody(new DatabaseClientFactory.MarkLogicCloudAuthContext("myKey", "doesnt-matter", "custom-grant-type"));
 		assertEquals("grant_type", body.name(0));
 		assertEquals("custom-grant-type", body.value(0));

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/DatabaseClientBuilderTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/DatabaseClientBuilderTest.java
@@ -216,19 +216,4 @@ public class DatabaseClientBuilderTest {
 		assertEquals(Common.TRUST_ALL_MANAGER, context.getTrustManager());
 		assertEquals(DatabaseClientFactory.SSLHostnameVerifier.COMMON, context.getSSLHostnameVerifier());
 	}
-
-	@Test
-	void sslContextWithNoPort() throws Exception {
-		bean = new DatabaseClientBuilder()
-			.withSecurityContextType("DIGEST")
-			.withSSLContext(SSLContext.getDefault())
-			.buildBean();
-
-		assertTrue(bean.getSecurityContext() instanceof DatabaseClientFactory.DigestAuthContext);
-		assertNotNull(bean.getSecurityContext().getSSLContext());
-		assertEquals(443, bean.getPort(),
-			"If an SSLContext is provided with no port, then assume 443, as that's the standard port for HTTPS calls. " +
-				"That makes life a little simpler for MarkLogic Cloud users as well, as they don't need to worry about " +
-				"setting the port.");
-	}
 }


### PR DESCRIPTION
443 is written in stone for now, and thus the UX can be simpler by forcing the port to that value. 