### PR TITLE
Applying SSL context and trust manager to "/token" call

### DIFF
--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/MarkLogicCloudAuthenticationConfigurer.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/MarkLogicCloudAuthenticationConfigurer.java
@@ -58,8 +58,9 @@ public class MarkLogicCloudAuthenticationConfigurer implements AuthenticationCon
 	private Response callTokenEndpoint(MarkLogicCloudAuthContext securityContext) {
 		final HttpUrl tokenUrl = buildTokenUrl(securityContext);
 		OkHttpClient.Builder clientBuilder = OkHttpUtil.newClientBuilder();
-		// Initial testing has shown that neither the OkHttp socket factory nor hostname verifier need to be configured
-		// for the goal of invoking the token endpoint.
+		// Current assumption is that the SSL config provided for connecting to MarkLogic should also be applicable
+		// for connecting to MarkLogic Cloud's "/token" endpoint.
+		OkHttpUtil.configureSocketFactory(clientBuilder, securityContext.getSSLContext(), securityContext.getTrustManager());
 
 		if (logger.isInfoEnabled()) {
 			logger.info("Calling token endpoint at: " + tokenUrl);

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/OkHttpUtil.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/OkHttpUtil.java
@@ -145,7 +145,7 @@ public abstract class OkHttpUtil {
 	 * @param sslContext
 	 * @param trustManager
 	 */
-	private static void configureSocketFactory(OkHttpClient.Builder clientBuilder, SSLContext sslContext, X509TrustManager trustManager) {
+	static void configureSocketFactory(OkHttpClient.Builder clientBuilder, SSLContext sslContext, X509TrustManager trustManager) {
 		/**
 		 * Per https://square.github.io/okhttp/3.x/okhttp/okhttp3/OkHttpClient.Builder.html#sslSocketFactory-javax.net.ssl.SSLSocketFactory- ,
 		 * OkHttp requires a TrustManager to be specified so that it can build a clean certificate chain. If trustManager


### PR DESCRIPTION
Discovered this while doing some manual testing. The main ML Cloud instance that has been used for testing is not verifying certificates, and thus this line of code for configuring an SSL socket factory was not required. But if certificates are verified (which I ran into while doing some local testing using an emulated ML Cloud instance), we'll presumably want to construct an SSL socket factory using the same SSLContext and TrustManager that the Java Client uses when it constructs a DatabaseClient. 

Can only test this via manual testing, until we have a way to run automated tests against an ML Cloud instance. 