### PR TITLE
Improving how cloud auth applies default SSLContext

### DIFF
--- a/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClientBuilder.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClientBuilder.java
@@ -121,7 +121,6 @@ public class DatabaseClientBuilder {
 	}
 
 	/**
-	 *
 	 * @param type must be one of "basic", "digest", "cloud", "kerberos", "certificate", or "saml"
 	 * @return
 	 */
@@ -143,17 +142,9 @@ public class DatabaseClientBuilder {
 	}
 
 	public DatabaseClientBuilder withMarkLogicCloudAuth(String apiKey, String basePath) {
-		withSecurityContextType(SECURITY_CONTEXT_TYPE_MARKLOGIC_CLOUD)
+		return withSecurityContextType(SECURITY_CONTEXT_TYPE_MARKLOGIC_CLOUD)
 			.withCloudApiKey(apiKey)
 			.withBasePath(basePath);
-
-		// Assume sensible defaults for establishing an SSL connection. In the scenario where the user's JVM's
-		// truststore has a certificate matching that of the MarkLogic Cloud instance, this saves the user from having
-		// to configure anything except the API key and base path.
-		if (null == props.get(PREFIX + "sslProtocol") && null == props.get(PREFIX + "sslContext")) {
-			withSSLProtocol("default");
-		}
-		return this;
 	}
 
 	public DatabaseClientBuilder withKerberosAuth(String principal) {

--- a/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClientFactory.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClientFactory.java
@@ -1230,7 +1230,8 @@ public class DatabaseClientFactory {
 	 *     <li>marklogic.client.database = must be a String</li>
 	 *     <li>marklogic.client.connectionType = must be a String or instance of {@code ConnectionType}</li>
 	 *     <li>marklogic.client.securityContext = an instance of {@code SecurityContext}; if set, then all other
-	 *     properties pertaining to the construction of a {@code SecurityContext} will be ignored</li>
+	 *     properties pertaining to the construction of a {@code SecurityContext} will be ignored, including the
+	 *     properties pertaing to SSL</li>
 	 *     <li>marklogic.client.securityContextType = required if marklogic.client.securityContext is not set;
 	 *     must be a String and one of "basic", "digest", "cloud", "kerberos", "certificate", or "saml"</li>
 	 *     <li>marklogic.client.username = must be a String; required for basic and digest authentication</li>

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/DatabaseClientBuilderTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/DatabaseClientBuilderTest.java
@@ -26,7 +26,7 @@ public class DatabaseClientBuilderTest {
 		bean = new DatabaseClientBuilder()
 			.withHost("myhost")
 			.withPort(8000)
-			.withSecurityContextType("digest")
+			.withBasicAuth("someuser", "someword")
 			.buildBean();
 
 		assertEquals("myhost", bean.getHost());
@@ -34,7 +34,7 @@ public class DatabaseClientBuilderTest {
 		assertNull(bean.getDatabase());
 		assertNull(bean.getBasePath());
 		assertNull(bean.getConnectionType());
-		assertTrue(bean.getSecurityContext() instanceof DatabaseClientFactory.DigestAuthContext);
+		assertTrue(bean.getSecurityContext() instanceof DatabaseClientFactory.BasicAuthContext);
 	}
 
 	@Test
@@ -42,7 +42,7 @@ public class DatabaseClientBuilderTest {
 		bean = new DatabaseClientBuilder()
 			.withHost("myhost")
 			.withPort(8000)
-			.withSecurityContextType("digest")
+			.withDigestAuth("someuser", "someword")
 			.withBasePath("/my/path")
 			.withDatabase("Documents")
 			.withConnectionType(DatabaseClient.ConnectionType.DIRECT)
@@ -62,7 +62,7 @@ public class DatabaseClientBuilderTest {
 			.withHost("some-host")
 			.withPort(10)
 			.buildBean());
-		assertEquals("Must define a security context or security context type", ex.getMessage());
+		assertEquals("Security context should be set, or security context type must be of type String", ex.getMessage());
 	}
 
 	@Test
@@ -124,7 +124,7 @@ public class DatabaseClientBuilderTest {
 			.withSecurityContextType("cloud")
 			.withBasePath("/my/path")
 			.build());
-		assertEquals("No API key provided", ex.getMessage());
+		assertEquals("cloud.apiKey must be of type String", ex.getMessage());
 	}
 
 	@Test


### PR DESCRIPTION
The check is now made in `DatabaseClientPropertySource`, which is at a lower level than `DatabaseClientBuilder`. This ensures that e.g. an ml-gradle user gets the benefit of not having to specify "sslProtocol=default" if their intent is to use their JVM's default truststore. 

Also improved the type-checking in DatabaseClientPropertySource so that a friendly error message is thrown for any value that is of an incorrect type. 