### PR TITLE
Added custom mappings to reverse proxy server

### DIFF
--- a/test-app/build.gradle
+++ b/test-app/build.gradle
@@ -34,5 +34,5 @@ task runBlockingReverseProxyServer(type: JavaExec) {
 		"sudo ./gradlew runBlockingReverseProxyServer -PrpsHttpsPort=443 ."
 	classpath = sourceSets.main.runtimeClasspath
 	main = "com.marklogic.client.test.ReverseProxyServer"
-	args = [rpsMarkLogicServer, rpsProxyServer, rpsHttpPort, rpsHttpsPort]
+	args = [rpsMarkLogicServer, rpsProxyServer, rpsHttpPort, rpsHttpsPort, rpsCustomMappings]
 }

--- a/test-app/gradle.properties
+++ b/test-app/gradle.properties
@@ -11,3 +11,6 @@ rpsMarkLogicServer=localhost
 rpsProxyServer=localhost
 rpsHttpPort=8020
 rpsHttpsPort=0
+# Comma-delimited sequence of path1,port1,path2,port2,etc
+# Example: rpsCustomMappings=/my/server,8005,/my/other/server,9090
+rpsCustomMappings=


### PR DESCRIPTION
This supports testing ml-gradle where a user wants to both deploy a REST app server and load REST extensions, which requires loading them via that REST app server. The user will need to define `restBasePath` . The RPS now makes it easy to define a mapping from the value of `restBasePath` to whatever port the REST app server is listening on. 