### PR TITLE
Renamed securityContextType property to authType

### DIFF
--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ConnectedRESTQA.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ConnectedRESTQA.java
@@ -50,7 +50,7 @@ public abstract class ConnectedRESTQA {
 
 	protected static Properties testProperties = null;
 
-	protected static String securityContextType;
+	protected static String authType;
 	protected static String restServerName = null;
 	private static String restSslServerName = null;
 	private static String ssl_enabled = null;
@@ -2101,7 +2101,7 @@ public abstract class ConnectedRESTQA {
 			testProperties.setProperty("httpPort", "8020");
 			testProperties.setProperty("marklogic.client.port", "8020");
 			testProperties.setProperty("marklogic.client.basePath", "testFunctional");
-			testProperties.setProperty("marklogic.client.securityContextType", "basic");
+			testProperties.setProperty("marklogic.client.authType", "basic");
 		}
 	}
 
@@ -2119,7 +2119,7 @@ public abstract class ConnectedRESTQA {
 
 		overrideTestPropertiesWithSystemProperties(properties);
 
-		securityContextType = properties.getProperty("marklogic.client.securityContextType");
+		authType = properties.getProperty("marklogic.client.authType");
 		restServerName = properties.getProperty("mlAppServerName");
 		restSslServerName = properties.getProperty("mlAppServerSSLName");
 
@@ -2151,9 +2151,9 @@ public abstract class ConnectedRESTQA {
 		testProperties = properties;
 
 		System.out.println("For 'slow' tests, will connect to: " + host_name + ":" + http_port + "; basePath: " +  basePath +
-			"; auth: " + securityContextType);
+			"; auth: " + authType);
 		System.out.println("For 'fast' tests, will connect to: " + host_name + ":" + fast_http_port + "; basePath: " +  basePath +
-			"; auth: " + securityContextType);
+			"; auth: " + authType);
 	}
 
 	public static boolean isLBHost() {
@@ -2598,7 +2598,7 @@ public abstract class ConnectedRESTQA {
 	}
 
 	public static DatabaseClientFactory.SecurityContext newSecurityContext(String username, String password) {
-		if ("basic".equalsIgnoreCase(securityContextType)) {
+		if ("basic".equalsIgnoreCase(authType)) {
 			return new DatabaseClientFactory.BasicAuthContext(username, password);
 		}
 		return new DatabaseClientFactory.DigestAuthContext(username, password);

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientConnection.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientConnection.java
@@ -32,7 +32,6 @@ import com.marklogic.client.io.DocumentMetadataHandle.DocumentMetadataValues;
 import com.marklogic.client.query.*;
 import org.custommonkey.xmlunit.exceptions.XpathException;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
@@ -1019,7 +1018,7 @@ public class TestDatabaseClientConnection extends BasicJavaClientREST {
     System.out.println("In tear down");
 
     if (!IsSecurityEnabled()) {
-		setAuthenticationAndDefaultUser(restServerName, securityContextType, "nobody");
+		setAuthenticationAndDefaultUser(restServerName, authType, "nobody");
     }
     // Associate the Server with Documents. Due to test orders being
     // undeterministic not sure which DB will be associated.

--- a/marklogic-client-api-functionaltests/src/test/resources/test.properties
+++ b/marklogic-client-api-functionaltests/src/test/resources/test.properties
@@ -1,7 +1,7 @@
 # Standard properties for constructing a DatabaseClient
 marklogic.client.host=localhost
 marklogic.client.port=8014
-marklogic.client.securityContextType=digest
+marklogic.client.authType=digest
 marklogic.client.username=opticUser
 marklogic.client.password=0pt1c
 marklogic.client.basePath=

--- a/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClientBuilder.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClientBuilder.java
@@ -38,12 +38,12 @@ import java.util.function.Function;
 public class DatabaseClientBuilder {
 
 	public final static String PREFIX = "marklogic.client.";
-	public final static String SECURITY_CONTEXT_TYPE_BASIC = "basic";
-	public final static String SECURITY_CONTEXT_TYPE_DIGEST = "digest";
-	public final static String SECURITY_CONTEXT_TYPE_MARKLOGIC_CLOUD = "cloud";
-	public final static String SECURITY_CONTEXT_TYPE_KERBEROS = "kerberos";
-	public final static String SECURITY_CONTEXT_TYPE_CERTIFICATE = "certificate";
-	public final static String SECURITY_CONTEXT_TYPE_SAML = "saml";
+	public final static String AUTH_TYPE_BASIC = "basic";
+	public final static String AUTH_TYPE_DIGEST = "digest";
+	public final static String AUTH_TYPE_MARKLOGIC_CLOUD = "cloud";
+	public final static String AUTH_TYPE_KERBEROS = "kerberos";
+	public final static String AUTH_TYPE_CERTIFICATE = "certificate";
+	public final static String AUTH_TYPE_SAML = "saml";
 
 	private final Map<String, Object> props;
 
@@ -124,42 +124,42 @@ public class DatabaseClientBuilder {
 	 * @param type must be one of "basic", "digest", "cloud", "kerberos", "certificate", or "saml"
 	 * @return
 	 */
-	public DatabaseClientBuilder withSecurityContextType(String type) {
-		props.put(PREFIX + "securityContextType", type);
+	public DatabaseClientBuilder withAuthType(String type) {
+		props.put(PREFIX + "authType", type);
 		return this;
 	}
 
 	public DatabaseClientBuilder withBasicAuth(String username, String password) {
-		return withSecurityContextType(SECURITY_CONTEXT_TYPE_BASIC)
+		return withAuthType(AUTH_TYPE_BASIC)
 			.withUsername(username)
 			.withPassword(password);
 	}
 
 	public DatabaseClientBuilder withDigestAuth(String username, String password) {
-		return withSecurityContextType(SECURITY_CONTEXT_TYPE_DIGEST)
+		return withAuthType(AUTH_TYPE_DIGEST)
 			.withUsername(username)
 			.withPassword(password);
 	}
 
 	public DatabaseClientBuilder withMarkLogicCloudAuth(String apiKey, String basePath) {
-		return withSecurityContextType(SECURITY_CONTEXT_TYPE_MARKLOGIC_CLOUD)
+		return withAuthType(AUTH_TYPE_MARKLOGIC_CLOUD)
 			.withCloudApiKey(apiKey)
 			.withBasePath(basePath);
 	}
 
 	public DatabaseClientBuilder withKerberosAuth(String principal) {
-		return withSecurityContextType(SECURITY_CONTEXT_TYPE_KERBEROS)
+		return withAuthType(AUTH_TYPE_KERBEROS)
 			.withKerberosPrincipal(principal);
 	}
 
 	public DatabaseClientBuilder withCertificateAuth(String file, String password) {
-		return withSecurityContextType(SECURITY_CONTEXT_TYPE_CERTIFICATE)
+		return withAuthType(AUTH_TYPE_CERTIFICATE)
 			.withCertificateFile(file)
 			.withCertificatePassword(password);
 	}
 
 	public DatabaseClientBuilder withSAMLAuth(String token) {
-		return withSecurityContextType(SECURITY_CONTEXT_TYPE_SAML)
+		return withAuthType(AUTH_TYPE_SAML)
 			.withSAMLToken(token);
 	}
 

--- a/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClientFactory.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClientFactory.java
@@ -452,14 +452,14 @@ public class DatabaseClientFactory {
 	public static class MarkLogicCloudAuthContext extends AuthContext {
       private String tokenEndpoint;
       private String grantType;
-      private String key;
+      private String apiKey;
 
-      public MarkLogicCloudAuthContext(String key) {
-          this(key, "/token", "apikey");
+      public MarkLogicCloudAuthContext(String apiKey) {
+          this(apiKey, "/token", "apikey");
       }
 
-      public MarkLogicCloudAuthContext(String key, String tokenEndpoint, String grantType) {
-          this.key = key;
+      public MarkLogicCloudAuthContext(String apiKey, String tokenEndpoint, String grantType) {
+          this.apiKey = apiKey;
           this.tokenEndpoint = tokenEndpoint;
           this.grantType = grantType;
       }
@@ -472,8 +472,8 @@ public class DatabaseClientFactory {
           return grantType;
       }
 
-      public String getKey() {
-          return key;
+      public String getApiKey() {
+          return apiKey;
       }
 
 	  @Override
@@ -1230,16 +1230,18 @@ public class DatabaseClientFactory {
 	 *     <li>marklogic.client.database = must be a String</li>
 	 *     <li>marklogic.client.connectionType = must be a String or instance of {@code ConnectionType}</li>
 	 *     <li>marklogic.client.securityContext = an instance of {@code SecurityContext}; if set, then all other
-	 *     properties pertaining to the construction of a {@code SecurityContext} will be ignored, including the
-	 *     properties pertaing to SSL</li>
-	 *     <li>marklogic.client.securityContextType = required if marklogic.client.securityContext is not set;
-	 *     must be a String and one of "basic", "digest", "cloud", "kerberos", "certificate", or "saml"</li>
+	 *     authentication properties pertaining to the construction of a {@code SecurityContext} will be ignored,
+	 *     including the properties pertaining to SSL; this is effectively an escape hatch for providing a
+	 *     {@code SecurityContext} in case an appropriate one cannot be created via the other supported properties</li>
+	 *     <li>marklogic.client.authType = determines the type of authentication to use; required if
+	 *     marklogic.client.securityContext is not set; must be a String and one of "basic", "digest", "cloud",
+	 *     "kerberos", "certificate", or "saml"</li>
 	 *     <li>marklogic.client.username = must be a String; required for basic and digest authentication</li>
 	 *     <li>marklogic.client.password = must be a String; required for basic and digest authentication</li>
-	 *     <li>marklogic.client.cloud.apiKey = must be a String; required for cloud authentication</li>
-	 *     <li>marklogic.client.kerberos.principal = must be a String</li>
 	 *     <li>marklogic.client.certificate.file = must be a String; required for certificate authentication</li>
 	 *     <li>marklogic.client.certificate.password = must be a String; required for certificate authentication</li>
+	 *     <li>marklogic.client.cloud.apiKey = must be a String; required for cloud authentication</li>
+	 *     <li>marklogic.client.kerberos.principal = must be a String; required for Kerberos authentication</li>
 	 *     <li>marklogic.client.saml.token = must be a String; required for SAML authentication</li>
 	 *     <li>marklogic.client.sslContext = must be an instance of {@code javax.net.ssl.SSLContext}</li>
 	 *     <li>marklogic.client.sslProtocol = must be a String; if "default', then uses the JVM default SSL

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/DatabaseClientPropertySource.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/DatabaseClientPropertySource.java
@@ -136,14 +136,14 @@ public class DatabaseClientPropertySource {
 			throw new IllegalArgumentException("Security context must be of type " + DatabaseClientFactory.SecurityContext.class.getName());
 		}
 
-		Object typeValue = propertySource.apply(PREFIX + "securityContextType");
+		Object typeValue = propertySource.apply(PREFIX + "authType");
 		if (typeValue == null || !(typeValue instanceof String)) {
-			throw new IllegalArgumentException("Security context should be set, or security context type must be of type String");
+			throw new IllegalArgumentException("Security context should be set, or auth type must be of type String");
 		}
-		final String securityContextType = (String)typeValue;
-		final SSLInputs sslInputs = buildSSLInputs(securityContextType);
+		final String authType = (String)typeValue;
+		final SSLInputs sslInputs = buildSSLInputs(authType);
 
-		DatabaseClientFactory.SecurityContext securityContext = newSecurityContext(securityContextType, sslInputs);
+		DatabaseClientFactory.SecurityContext securityContext = newSecurityContext(authType, sslInputs);
 
 		X509TrustManager trustManager = determineTrustManager(sslInputs);
 		SSLContext sslContext = sslInputs.getSslContext() != null ?
@@ -160,20 +160,20 @@ public class DatabaseClientPropertySource {
 
 	private DatabaseClientFactory.SecurityContext newSecurityContext(String type, SSLInputs sslInputs) {
 		switch (type.toLowerCase()) {
-			case DatabaseClientBuilder.SECURITY_CONTEXT_TYPE_BASIC:
+			case DatabaseClientBuilder.AUTH_TYPE_BASIC:
 				return newBasicAuthContext();
-			case DatabaseClientBuilder.SECURITY_CONTEXT_TYPE_DIGEST:
+			case DatabaseClientBuilder.AUTH_TYPE_DIGEST:
 				return newDigestAuthContext();
-			case DatabaseClientBuilder.SECURITY_CONTEXT_TYPE_MARKLOGIC_CLOUD:
+			case DatabaseClientBuilder.AUTH_TYPE_MARKLOGIC_CLOUD:
 				return newCloudAuthContext();
-			case DatabaseClientBuilder.SECURITY_CONTEXT_TYPE_KERBEROS:
+			case DatabaseClientBuilder.AUTH_TYPE_KERBEROS:
 				return newKerberosAuthContext();
-			case DatabaseClientBuilder.SECURITY_CONTEXT_TYPE_CERTIFICATE:
+			case DatabaseClientBuilder.AUTH_TYPE_CERTIFICATE:
 				return newCertificateAuthContext(sslInputs);
-			case DatabaseClientBuilder.SECURITY_CONTEXT_TYPE_SAML:
+			case DatabaseClientBuilder.AUTH_TYPE_SAML:
 				return newSAMLAuthContext();
 			default:
-				throw new IllegalArgumentException("Unrecognized security context type: " + type);
+				throw new IllegalArgumentException("Unrecognized auth type: " + type);
 		}
 	}
 
@@ -302,11 +302,11 @@ public class DatabaseClientPropertySource {
 	 * Uses the given propertySource to construct the inputs pertaining to constructing an SSLContext and an
 	 * X509TrustManager.
 	 *
-	 * @param securityContextType used for applying "default" as the SSL protocol for MarkLogic cloud authentication in
+	 * @param authType used for applying "default" as the SSL protocol for MarkLogic cloud authentication in
 	 *                            case the user does not define their own SSLContext or SSL protocol
 	 * @return
 	 */
-	private SSLInputs buildSSLInputs(String securityContextType) {
+	private SSLInputs buildSSLInputs(String authType) {
 		SSLContext sslContext = null;
 		Object val = propertySource.apply(PREFIX + "sslContext");
 		if (val != null) {
@@ -320,7 +320,7 @@ public class DatabaseClientPropertySource {
 		String sslProtocol = getNullableStringValue("sslProtocol");
 		if (sslContext == null &&
 			(sslProtocol == null || sslProtocol.trim().length() == 0) &&
-			DatabaseClientBuilder.SECURITY_CONTEXT_TYPE_MARKLOGIC_CLOUD.equalsIgnoreCase(securityContextType)) {
+			DatabaseClientBuilder.AUTH_TYPE_MARKLOGIC_CLOUD.equalsIgnoreCase(authType)) {
 			sslProtocol = "default";
 		}
 

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/MarkLogicCloudAuthenticationConfigurer.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/MarkLogicCloudAuthenticationConfigurer.java
@@ -36,7 +36,7 @@ public class MarkLogicCloudAuthenticationConfigurer implements AuthenticationCon
 
 	@Override
 	public void configureAuthentication(OkHttpClient.Builder clientBuilder, MarkLogicCloudAuthContext securityContext) {
-		final String apiKey = securityContext.getKey();
+		final String apiKey = securityContext.getApiKey();
 		if (apiKey == null || apiKey.trim().length() < 1) {
 			throw new IllegalArgumentException("No API key provided");
 		}
@@ -97,7 +97,7 @@ public class MarkLogicCloudAuthenticationConfigurer implements AuthenticationCon
 	protected FormBody newFormBody(MarkLogicCloudAuthContext securityContext) {
 		return new FormBody.Builder()
 			.add("grant_type", securityContext.getGrantType())
-			.add("key", securityContext.getKey()).build();
+			.add("key", securityContext.getApiKey()).build();
 	}
 
 	private String getAccessTokenFromResponse(Response response) {

--- a/marklogic-client-api/src/test/java/com/marklogic/client/impl/DatabaseClientPropertySourceTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/impl/DatabaseClientPropertySourceTest.java
@@ -27,7 +27,7 @@ public class DatabaseClientPropertySourceTest {
 	@BeforeEach
 	void beforeEach() {
 		props = new HashMap() {{
-			put(PREFIX + "securityContextType", "digest");
+			put(PREFIX + "authType", "digest");
 			put(PREFIX + "username", "someuser");
 			put(PREFIX + "password", "someword");
 		}};
@@ -74,7 +74,7 @@ public class DatabaseClientPropertySourceTest {
 
 	@Test
 	void cloudAuthWithNoSslInputs() {
-		props.put(PREFIX + "securityContextType", "cloud");
+		props.put(PREFIX + "authType", "cloud");
 		props.put(PREFIX + "cloud.apiKey", "abc123");
 		props.put(PREFIX + "basePath", "/my/path");
 
@@ -84,7 +84,7 @@ public class DatabaseClientPropertySourceTest {
 		assertTrue(bean.getSecurityContext() instanceof DatabaseClientFactory.MarkLogicCloudAuthContext);
 
 		DatabaseClientFactory.MarkLogicCloudAuthContext context = (DatabaseClientFactory.MarkLogicCloudAuthContext) bean.getSecurityContext();
-		assertEquals("abc123", context.getKey());
+		assertEquals("abc123", context.getApiKey());
 
 		assertNotNull(context.getSSLContext(), "If cloud is chosen with no SSL protocol or context, the default JVM " +
 			"SSLContext should be used");

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/Common.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/Common.java
@@ -51,7 +51,7 @@ public class Common {
 
   final public static boolean USE_REVERSE_PROXY_SERVER = Boolean.parseBoolean(System.getProperty("TEST_USE_REVERSE_PROXY_SERVER", "false"));
   final public static int     PORT          = USE_REVERSE_PROXY_SERVER ? 8020 : Integer.parseInt(System.getProperty("TEST_PORT", "8012"));
-  final public static String SECURITY_CONTEXT_TYPE = USE_REVERSE_PROXY_SERVER ? "basic" : System.getProperty("TEST_SECURITY_CONTEXT_TYPE", "digest");
+  final public static String AUTH_TYPE = USE_REVERSE_PROXY_SERVER ? "basic" : System.getProperty("TEST_AUTH_TYPE", "digest");
   final public static String BASE_PATH = USE_REVERSE_PROXY_SERVER ? "test/marklogic/unit" : System.getProperty("TEST_BASE_PATH", null);
   final public static boolean WITH_WAIT     = Boolean.parseBoolean(System.getProperty("TEST_WAIT", "false"));
   final public static int     PROPERTY_WAIT = Integer.parseInt(System.getProperty("TEST_PROPERTY_WAIT", WITH_WAIT ? "8200" : "0"));
@@ -114,7 +114,7 @@ public class Common {
   }
 
   public static DatabaseClientFactory.SecurityContext newSecurityContext(String username, String password) {
-    if ("basic".equalsIgnoreCase(SECURITY_CONTEXT_TYPE)) {
+    if ("basic".equalsIgnoreCase(AUTH_TYPE)) {
       return new DatabaseClientFactory.BasicAuthContext(username, password);
     }
     return new DatabaseClientFactory.DigestAuthContext(username, password);
@@ -127,7 +127,7 @@ public class Common {
 		  .withBasePath(BASE_PATH)
 		  .withUsername(USER)
 		  .withPassword(PASS) // Most of the test users all have the same password, so we can use a default one here
-		  .withSecurityContextType(SECURITY_CONTEXT_TYPE)
+		  .withAuthType(AUTH_TYPE)
 		  .withConnectionType(CONNECTION_TYPE);
   }
 

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/DatabaseClientBuilderTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/DatabaseClientBuilderTest.java
@@ -62,17 +62,17 @@ public class DatabaseClientBuilderTest {
 			.withHost("some-host")
 			.withPort(10)
 			.buildBean());
-		assertEquals("Security context should be set, or security context type must be of type String", ex.getMessage());
+		assertEquals("Security context should be set, or auth type must be of type String", ex.getMessage());
 	}
 
 	@Test
-	void invalidSecurityContextType() {
+	void invalidAuthType() {
 		IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> new DatabaseClientBuilder()
 			.withHost("another-host")
 			.withPort(200)
-			.withSecurityContextType("invalid-type")
+			.withAuthType("invalid-type")
 			.buildBean());
-		assertEquals("Unrecognized security context type: invalid-type", ex.getMessage());
+		assertEquals("Unrecognized auth type: invalid-type", ex.getMessage());
 	}
 
 	@Test
@@ -105,7 +105,7 @@ public class DatabaseClientBuilderTest {
 
 		DatabaseClientFactory.MarkLogicCloudAuthContext context =
 			(DatabaseClientFactory.MarkLogicCloudAuthContext) bean.getSecurityContext();
-		assertEquals("my-key", context.getKey());
+		assertEquals("my-key", context.getApiKey());
 		assertEquals("/my/path", bean.getBasePath());
 
 		assertNotNull(context.getSSLContext(), "If no sslProtocol or sslContext is set, the JVM's default SSL " +
@@ -121,7 +121,7 @@ public class DatabaseClientBuilderTest {
 	@Test
 	void cloudNoApiKey() {
 		IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> Common.newClientBuilder()
-			.withSecurityContextType("cloud")
+			.withAuthType("cloud")
 			.withBasePath("/my/path")
 			.build());
 		assertEquals("cloud.apiKey must be of type String", ex.getMessage());


### PR DESCRIPTION
Based on review of Node Client. authType now seems preferable because:

1. It's consistent with the Node Client
2. It's shorter and easier to remember/type
3. All concrete impls of SecurityContext are suffixed with "AuthContext"