### PR TITLE
Removed factory methods that have been broken since 4.2.0

### DIFF
--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestDatabaseAuthentication.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestDatabaseAuthentication.java
@@ -52,25 +52,6 @@ public class TestDatabaseAuthentication extends AbstractFunctionalTest {
 	}
 
   @Test
-  public void testAuthenticationNone()
-  {
-    System.out.println("Running testAuthenticationNone");
-    if (!IsSecurityEnabled()) {
-		setAuthenticationAndDefaultUser(restServerName, "application-level", "rest-admin");
-      // connect the client
-      StringBuilder str = new StringBuilder();
-      try {
-		  // This does not need to specify basePath since it's expected to fail
-		  DatabaseClientFactory.newClient(getRestServerHostName(), getRestServerPort());
-      } catch (Exception ex) {
-        str.append(ex.getMessage());
-      }
-      assertEquals( "makeSecurityContext should only be called with BASIC or DIGEST Authentication",
-          str.toString().trim());
-    }
-  }
-
-  @Test
   public void testAuthenticationBasic() throws IOException
   {
     if (!IsSecurityEnabled()) {

--- a/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClientFactory.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClientFactory.java
@@ -1259,37 +1259,6 @@ public class DatabaseClientFactory {
 	}
 
   /**
-   * Creates a client to access the database by means of a REST server
-   * without any authentication. Such clients can be convenient for
-   * experimentation but should not be used in production.
-   *
-   * @param host	the host with the REST server
-   * @param port	the port for the REST server
-   * @return	a new client for making database requests
-   */
-  static public DatabaseClient newClient(String host, int port) {
-    return newClient(host, port, null, null, null, null, null, null);
-  }
-
-  /**
-   * Creates a client to access the database by means of a REST server
-   * without any authentication. Such clients can be convenient for
-   * experimentation but should not be used in production.
-   *
-   * A data service interface can only call an endpoint for the configured content database
-   * of the appserver. You cannot specify the database when constructing a client for working
-   * with a data service.
-   *
-   * @param host	the host with the REST server
-   * @param port	the port for the REST server
-   * @param database	the database to access (default: configured database for the REST server)
-   * @return	a new client for making database requests
-   */
-  static public DatabaseClient newClient(String host, int port, String database) {
-    return newClient(host, port, database, null, null, null, null, null);
-  }
-
-  /**
    * Creates a client to access the database by means of a REST server.
    *
    * @param host the host with the REST server

--- a/marklogic-client-api/src/main/java/com/marklogic/client/eval/ServerEvaluationCall.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/eval/ServerEvaluationCall.java
@@ -29,7 +29,7 @@ import com.marklogic.client.util.EditableNamespaceContext;
  * for a server-side {@link #xquery xquery} or {@link #javascript javascript} eval or
  * invoke ({@link #modulePath modulePath}) call. ServerEvaluationCall also
  * conveniently has the eval* methods which execute those calls and return the
- * results.  You must call one and only one of the following methods: xquery, 
+ * results.  You must call one and only one of the following methods: xquery,
  * javascript, or modulePath.  The xquery
  * and javascript methods initialize this call for server-side eval and accept
  * source code as a String or a TextWriteHandle (in case you are streaming the
@@ -89,8 +89,7 @@ import com.marklogic.client.util.EditableNamespaceContext;
  * }</pre>
  *
  * <p>Each call can be executed within a {@link #transaction transaction}, within a
- * {@link DatabaseClientFactory#newClient(String, int, String) particular database},
- * and with particular {@link #namespaceContext namespaces} available for expansion
+ * particular database, and with particular {@link #namespaceContext namespaces} available for expansion
  * of prefixed variable names.</p>
  *
  * <p>Each call can be executed with only one expected response of a particular {@link


### PR DESCRIPTION
These don't work because they don't provide a security context. And since the 4.2.0 release and a change to OkHttpServices on 2019-01-07 that made a security context required, they haven't worked. I was going to deprecate them initially, but in the event that a pre 4.2.0 user upgrades directly to 6.1.0, I think a compile time error would be far better than waiting for either method to fail at runtime (and both are guaranteed to fail). 