### PR TITLE
Renamed to withCloudAuth

### DIFF
--- a/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClientBuilder.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClientBuilder.java
@@ -141,7 +141,7 @@ public class DatabaseClientBuilder {
 			.withPassword(password);
 	}
 
-	public DatabaseClientBuilder withMarkLogicCloudAuth(String apiKey, String basePath) {
+	public DatabaseClientBuilder withCloudAuth(String apiKey, String basePath) {
 		return withAuthType(AUTH_TYPE_MARKLOGIC_CLOUD)
 			.withCloudApiKey(apiKey)
 			.withBasePath(basePath);

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/DatabaseClientBuilderTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/DatabaseClientBuilderTest.java
@@ -100,7 +100,7 @@ public class DatabaseClientBuilderTest {
 	@Test
 	void cloudWithBasePath() {
 		bean = Common.newClientBuilder()
-			.withMarkLogicCloudAuth("my-key", "/my/path")
+			.withCloudAuth("my-key", "/my/path")
 			.buildBean();
 
 		DatabaseClientFactory.MarkLogicCloudAuthContext context =

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/MarkLogicCloudAuthenticationDebugger.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/MarkLogicCloudAuthenticationDebugger.java
@@ -23,7 +23,7 @@ public class MarkLogicCloudAuthenticationDebugger {
 		// Expected to default to the JVM's default SSL context and default trust manager
 		DatabaseClient client = new DatabaseClientBuilder()
 			.withHost(cloudHost)
-			.withMarkLogicCloudAuth(apiKey, basePath)
+			.withCloudAuth(apiKey, basePath)
 			// Have to use "ANY", as the default is "COMMON", which won't work for our selfsigned cert
 			.withSSLHostnameVerifier(DatabaseClientFactory.SSLHostnameVerifier.ANY)
 			.build();


### PR DESCRIPTION
I realized that `withMarkLogicCloudAuth` was inconsistent with how "cloud" is consistently used instead of "MarkLogic Cloud". Doesn't impact any libraries. 