### PR TITLE
Updated copyright to 2023

### DIFF
--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/ApplyTransformTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/ApplyTransformTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/DeleteListenerTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/DeleteListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/ExportListenerTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/ExportListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/ExportToWriterListenerTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/ExportToWriterListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/QBFailover.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/QBFailover.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/QueryBatcherJobReportTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/QueryBatcherJobReportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/StringQueryHostBatcherTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/StringQueryHostBatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/UrisToWriterListenerFuncTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/UrisToWriterListenerFuncTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/WBFailover.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/WBFailover.java
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2022 MarkLogic Corporation
+* Copyright (c) 2023 MarkLogic Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/WriteBatcherJobReportTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/WriteBatcherJobReportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/WriteHostBatcherTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/WriteHostBatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestAggregates.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestAggregates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestAppServerConstraints.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestAppServerConstraints.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBug18026.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBug18026.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBug18920.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBug18920.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBug26248.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBug26248.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkReadSample1.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkReadSample1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkReadWriteMetaDataChange.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkReadWriteMetaDataChange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkReadWriteWithJacksonDataBind.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkReadWriteWithJacksonDataBind.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkReadWriteWithJacksonHandle.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkReadWriteWithJacksonHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkReadWriteWithJacksonParserHandle.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkReadWriteWithJacksonParserHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkSearchEWithQBE.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkSearchEWithQBE.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkSearchWithStringQueryDef.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkSearchWithStringQueryDef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkSearchWithStrucQueryDef.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkSearchWithStrucQueryDef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkWriteMetadata1.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkWriteMetadata1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkWriteMetadata2.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkWriteMetadata2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkWriteMetadatawithRawXML.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkWriteMetadatawithRawXML.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkWriteSample1.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkWriteSample1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkWriteWithTransactions.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkWriteWithTransactions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkWriteWithTransformations.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkWriteWithTransformations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestCRUDModulesDb.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestCRUDModulesDb.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -179,7 +179,7 @@ public class TestCRUDModulesDb extends AbstractFunctionalTest {
 
         // read it back
         String xqueryModuleAsString = libsMgr.read(Path, new StringHandle()).get();
-        assertTrue( xqueryModuleAsString.startsWith("Copyright (c) 2022 MarkLogic Corporation"));
+        assertTrue( xqueryModuleAsString.startsWith("Copyright (c) 2023 MarkLogic Corporation"));
 
         // get the list of descriptors
         ExtensionLibraryDescriptor[] descriptors = libsMgr.list();

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestConstraintCombination.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestConstraintCombination.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestDatabaseAuthentication.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestDatabaseAuthentication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestDocumentEncoding.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestDocumentEncoding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestDocumentFormat.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestDocumentFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestDocumentMimetype.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestDocumentMimetype.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestDoublePrecisionGeoOps.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestDoublePrecisionGeoOps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestEvalJavaScript.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestEvalJavaScript.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestEvalXquery.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestEvalXquery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestFieldConstraint.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestFieldConstraint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestHandles.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestHandles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestJSResourceExtensions.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestJSResourceExtensions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestJacksonAnnotationsTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestJacksonAnnotationsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestJacksonDateTimeFormat.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestJacksonDateTimeFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestLinkResultDocuments.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestLinkResultDocuments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestMetadata.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestMetadataXML.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestMetadataXML.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestMultithreading.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestMultithreading.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestNamespaces.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestNamespaces.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticEnhancements.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticEnhancements.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnCtsQuery.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnCtsQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnFromSparql.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnFromSparql.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnLexicons.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnLexicons.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnLiterals.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnLiterals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnMixedViews.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnMixedViews.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnTriples.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnTriples.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnViews.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnViews.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOptimisticLocking.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOptimisticLocking.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOBasicSearch.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOBasicSearch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOMissingIdGetSetMethod.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOMissingIdGetSetMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOQueryBuilderContainerQuery.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOQueryBuilderContainerQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOQueryBuilderGeoQueries.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOQueryBuilderGeoQueries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOQueryBuilderValueQuery.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOQueryBuilderValueQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOReadWrite1.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOReadWrite1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOReadWriteWithTransactions.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOReadWriteWithTransactions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOSpecialCharRead.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOSpecialCharRead.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOWithDocsStoredByOthers.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOWithDocsStoredByOthers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOWithStringQD.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOWithStringQD.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOWithStrucQD.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOWithStrucQD.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOwithQBEQueryDef.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOwithQBEQueryDef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPartialUpdate.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPartialUpdate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPatchCardinality.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPatchCardinality.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestQueryByExample.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestQueryByExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestQueryOptionBuilder.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestQueryOptionBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestRawAlert.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestRawAlert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestRawCombinedQuery.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestRawCombinedQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestRawCombinedQueryGeo.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestRawCombinedQueryGeo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestRawCtsQueryDefinition.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestRawCtsQueryDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestRawStructuredQuery.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestRawStructuredQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestRequestLogger.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestRequestLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestResponseTransform.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestResponseTransform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestRollbackTransaction.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestRollbackTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestRuntimeDBselection.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestRuntimeDBselection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestSearchMultibyte.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestSearchMultibyte.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestSearchMultipleForests.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestSearchMultipleForests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestSearchOnJSON.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestSearchOnJSON.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestSearchOnProperties.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestSearchOnProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestSearchOptions.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestSearchOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestSearchSuggestion.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestSearchSuggestion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestSemanticsGraphManager.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestSemanticsGraphManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestServerAssignedDocumentURI.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestServerAssignedDocumentURI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestSparqlQueryManager.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestSparqlQueryManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestStandaloneGeoQuery.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestStandaloneGeoQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestStandaloneQuery.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestStandaloneQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestStructuredQuery.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestStructuredQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestStructuredQueryMildNot.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestStructuredQueryMildNot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestStructuredSearchGeo.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestStructuredSearchGeo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestTransformXMLWithXSLT.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestTransformXMLWithXSLT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestValueConstraint.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestValueConstraint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestWordConstraint.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestWordConstraint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestWriteTextDoc.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestWriteTextDoc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestXMLDocumentRepair.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestXMLDocumentRepair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestXMLMultiByte.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestXMLMultiByte.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/Artifact.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/Artifact.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactIndexedOnCalendar.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactIndexedOnCalendar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactIndexedOnDateTime.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactIndexedOnDateTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactIndexedOnFloat.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactIndexedOnFloat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactIndexedOnInt.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactIndexedOnInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactIndexedOnIntAsString.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactIndexedOnIntAsString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactIndexedOnInteger.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactIndexedOnInteger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import com.marklogic.client.pojo.annotation.PathIndexProperty;
 import com.marklogic.client.pojo.annotation.PathIndexProperty.ScalarType;
 
 /*
- * This class is similar to the Artifact class. It is used to test path range index 
+ * This class is similar to the Artifact class. It is used to test path range index
  * using the inventory field with Integer type.
  * Property name been annotated with @Id.
  */

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactIndexedOnMultipleFields.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactIndexedOnMultipleFields.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import com.marklogic.client.pojo.annotation.PathIndexProperty.ScalarType;
 /*
  * This class is similar to the Artifact class. It is used to test path range index on multiple class fields
  * Property name been annotated with @Id.
- * 
+ *
  */
 public class ArtifactIndexedOnMultipleFields {
   @Id

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactIndexedOnString.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactIndexedOnString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactIndexedOnStringSub.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactIndexedOnStringSub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,8 @@ import com.marklogic.client.pojo.annotation.PathIndexProperty.ScalarType;
 
 /* This class is used to test range path index creation, when the Annotation is
  * in the super class and sub class adds an additional annotation entry.
- * 
- * Used to test annotation in a hierarchy. 
+ *
+ * Used to test annotation in a hierarchy.
  */
 public class ArtifactIndexedOnStringSub extends ArtifactIndexedOnString {
   @PathIndexProperty(scalarType = ScalarType.DOUBLE)

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactIndexedOnUri.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactIndexedOnUri.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactIndexedUnSupportedDataType.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactIndexedUnSupportedDataType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactMultipleIndexedOnInt.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ArtifactMultipleIndexedOnInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,8 @@ import com.marklogic.client.pojo.annotation.PathIndexProperty.ScalarType;
 
 /* This class is used to test range path index creation, when the Annotation is
  * in the super class and also in sub class on the same class property with same data type.
- * 
- * Used to test annotation with collisions in a hierarchy. 
+ *
+ * Used to test annotation with collisions in a hierarchy.
  */
 
 public class ArtifactMultipleIndexedOnInt extends ArtifactIndexedOnInt {

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/BasicJavaClientREST.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/BasicJavaClientREST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -115,7 +115,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 {
   /**
    * Write document using InputStreamHandle
-   * 
+   *
    * @param client
    * @param filename
    * @param uri
@@ -147,7 +147,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * Write document using InputStreamHandle with metadata
-   * 
+   *
    * @param client
    * @param filename
    * @param uri
@@ -181,7 +181,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * Reading document using InputStreamHandle
-   * 
+   *
    * @param client
    * @param uri
    * @param type
@@ -207,7 +207,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * Reading document using InputSourceHandle
-   * 
+   *
    * @param client
    * @param uri
    * @param type
@@ -234,7 +234,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * Reading document using SourceHandle
-   * 
+   *
    * @param client
    * @param uri
    * @param type
@@ -261,7 +261,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * Update document using InputStreamHandle
-   * 
+   *
    * @param client
    * @param filename
    * @param uri
@@ -293,7 +293,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * Write document using BytesHandle
-   * 
+   *
    * @param client
    * @param filename
    * @param uri
@@ -335,7 +335,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * Write document using BytesHandle with metadata
-   * 
+   *
    * @param client
    * @param filename
    * @param uri
@@ -378,7 +378,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * Write document using StringHandle with metadata
-   * 
+   *
    * @param client
    * @param filename
    * @param uri
@@ -414,7 +414,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * Write document using StringHandle
-   * 
+   *
    * @param client
    * @param filename
    * @param uri
@@ -449,7 +449,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * Write document using JAXBHandle with metadata
-   * 
+   *
    * @param client
    * @param product
    * @param uri
@@ -481,7 +481,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * Write document using OutputStreamHandle with metadata
-   * 
+   *
    * @param client
    * @param filename
    * @param uri
@@ -599,7 +599,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * Write document to databae using ReaderHandle
-   * 
+   *
    * @param client
    *          : the database client connection
    * @param filename
@@ -636,7 +636,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * Update document using ReaderHandle
-   * 
+   *
    * @param client
    * @param filename
    * @param uri
@@ -709,7 +709,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * Read document using ReaderHandle
-   * 
+   *
    * @param client
    * @param uri
    * @param type
@@ -735,7 +735,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * Read document using XMLEventReaderHandle
-   * 
+   *
    * @param client
    * @param uri
    * @param type
@@ -776,7 +776,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * Write document using DOMHandle
-   * 
+   *
    * @param client
    * @param filename
    * @param uri
@@ -811,7 +811,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * Returning a content of the document
-   * 
+   *
    */
 
   public Document getDocumentContent(String xmltype) throws IOException, ParserConfigurationException, SAXException
@@ -830,7 +830,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * Update document using DOMHandle
-   * 
+   *
    * @param client
    * @param filename
    * @param uri
@@ -865,7 +865,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * Read document using DOMHandle
-   * 
+   *
    * @param client
    * @param uri
    * @param type
@@ -891,7 +891,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * Read document using StringHandle
-   * 
+   *
    * @param client
    * @param uri
    * @param type
@@ -918,7 +918,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * Write document using FileHandle
-   * 
+   *
    * @param client
    * @param filename
    * @param uri
@@ -948,7 +948,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * Read document using FileHandle
-   * 
+   *
    * @param client
    * @param uri
    * @param type
@@ -974,7 +974,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * Update document using FileHandle
-   * 
+   *
    * @param client
    * @param filename
    * @param uri
@@ -1004,7 +1004,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * Update document using FileHandle
-   * 
+   *
    * @param client
    * @param filename
    * @param uri
@@ -1040,7 +1040,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * Read document using BytesHandle
-   * 
+   *
    * @param client
    * @param uri
    * @param type
@@ -1065,7 +1065,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * get Binary Size From Byte
-   * 
+   *
    * @param fileRead
    * @throws IOException
    */
@@ -1080,7 +1080,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * Read document using BytesHandle
-   * 
+   *
    * @param client
    * @param filename
    * @param uri
@@ -1129,7 +1129,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * Delete document
-   * 
+   *
    * @param client
    * @param uri
    * @param type
@@ -1148,7 +1148,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * Check if document exist
-   * 
+   *
    * @param client
    * @param uri
    * @return
@@ -1157,17 +1157,17 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
    * public DocumentDescriptor isDocumentExist(DatabaseClient client, String
    * uri, String type) { // create doc manager DocumentManager docMgr = null;
    * docMgr = documentManagerSelector(client, docMgr, type);
-   * 
+   *
    * String checkDocId = uri;
-   * 
+   *
    * DocumentDescriptor docExist;
-   * 
+   *
    * docExist = docMgr.exists(checkDocId); return docExist; }
    */
 
   /**
    * Read metadata from document
-   * 
+   *
    * @param client
    * @param uri
    * @param type
@@ -1194,7 +1194,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * Set query option in XML
-   * 
+   *
    * @param client
    * @param queryOptionName
    * @throws FileNotFoundException
@@ -1221,7 +1221,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * Copy Files from One location to Other
-   * 
+   *
    * @param Source
    *          File
    * @param target
@@ -1268,7 +1268,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * Set query option in JSON
-   * 
+   *
    * @param client
    * @param queryOptionName
    * @throws FileNotFoundException
@@ -1341,7 +1341,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * Get the size of binary file
-   * 
+   *
    * @param fileRead
    * @return
    * @throws IOException
@@ -1361,7 +1361,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * Get document properties in string
-   * 
+   *
    * @param properties
    * @return
    */
@@ -1381,7 +1381,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * Get document permissions in string
-   * 
+   *
    * @param permissions
    * @return
    */
@@ -1401,7 +1401,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * Get document collections in string
-   * 
+   *
    * @param collections
    * @return
    */
@@ -1420,7 +1420,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * Function to select and create document manager based on the type
-   * 
+   *
    * @param client
    * @param docMgr
    * @param type
@@ -1455,7 +1455,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * Get the expected XML document
-   * 
+   *
    * @param filename
    * @return
    * @throws ParserConfigurationException
@@ -1473,7 +1473,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * Get the expected JSON document
-   * 
+   *
    * @param filename
    * @return
    * @throws JsonParseException
@@ -1491,7 +1491,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * Get the metadata xml
-   * 
+   *
    * @param filename
    * @return
    * @throws ParserConfigurationException
@@ -1510,7 +1510,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
   /**
    * Convert string to xml document. Used on actual read content for XML
    * comparison
-   * 
+   *
    * @param readContent
    * @return
    * @throws ParserConfigurationException
@@ -1530,7 +1530,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * Convert XMLStreamReader To String
-   * 
+   *
    * @param reader
    * @return String
    * @throws XMLStreamException
@@ -1552,7 +1552,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * Convert xml document to string. Useful for debugging purpose
-   * 
+   *
    * @param readContent
    * @return
    * @throws TransformerException
@@ -1570,7 +1570,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * Convert inputstream to string. Used on InputStreamHandle
-   * 
+   *
    * @param fileRead
    * @return
    * @throws IOException
@@ -1591,7 +1591,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * Convert inputsource to string. Used on InputSourceHandle
-   * 
+   *
    * @param fileRead
    * @return
    * @throws IOException
@@ -1611,7 +1611,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * Convert source to string. Used on SourceHandle
-   * 
+   *
    * @param reader
    * @return
    * @throws IOException
@@ -1631,7 +1631,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * Convert reader to string. Used on ReaderHandle
-   * 
+   *
    * @param fileRead
    * @return
    * @throws IOException
@@ -1651,7 +1651,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * Convert file to string. Used on FileHandle
-   * 
+   *
    * @param fileRead
    * @return
    * @throws FileNotFoundException
@@ -1667,7 +1667,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
 
   /**
    * Load geo data for geo spatial tests
-   * 
+   *
    * @throws IOException
    * @throws NoSuchAlgorithmException
    * @throws KeyManagementException

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/BulkIOCallersFnTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/BulkIOCallersFnTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/Company.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/Company.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ConnectedRESTQA.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ConnectedRESTQA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/GeoCompany.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/GeoCompany.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/GeoSpecialArtifact.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/GeoSpecialArtifact.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/Product.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/Product.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/SpecialGeoArtifact.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/SpecialGeoArtifact.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestAutomatedPathRangeIndex.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestAutomatedPathRangeIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBiTempMetaValues.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBiTempMetaValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBiTemporal.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBiTemporal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBug18736.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBug18736.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBug18993.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBug18993.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBug21159.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBug21159.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientConnection.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientKerberosFromFile.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientKerberosFromFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientWithCertBasedAuth.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientWithCertBasedAuth.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientWithKerberos.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientWithKerberos.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestEvalwithRunTimeDBnTransactions.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestEvalwithRunTimeDBnTransactions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestPointInTimeQuery.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestPointInTimeQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestSSLConnection.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestSSLConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestSandBox.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestSandBox.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ThreadClass.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ThreadClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ThreadSearch.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ThreadSearch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ThreadWrite.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ThreadWrite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/data/JSResource.js
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/data/JSResource.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-// module that exports get, post, put and delete 
-function get(context, params) { 
+// module that exports get, post, put and delete
+function get(context, params) {
  context.outputTypes = ["application/json"];
  var arg1 = params.arg1;
  var arg2 = params.arg2;
  var x = arg1.toString();
 
-   
+
 return {
 	"argument1": x,
 	"argument2": arg2,
@@ -31,13 +31,13 @@ return {
     "document-content": fn.doc(),
     "response": xdmp.getResponseCode(),
 	"outputTypes": context.outputTypes,
-	
+
   }
 };
-function post(context, params, input) { 
-    
+function post(context, params, input) {
+
    var argUrl = params.uri;
-        	
+
     xdmp.eval(" \
     declareUpdate(); \
     var argUrl; \
@@ -50,7 +50,7 @@ function post(context, params, input) {
    return ({"response": xdmp.getResponseCode()})
 
  };
- 
+
 // Function responding to PUT method - must use local name 'put'.
 function put(context, params, input) {
     var argUrl = params.uri;

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/data/custom-lib.xqy
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/data/custom-lib.xqy
@@ -1,12 +1,12 @@
 (:
-  Copyright (c) 2022 MarkLogic Corporation
- 
+  Copyright (c) 2023 MarkLogic Corporation
+
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
- 
+
      http://www.apache.org/licenses/LICENSE-2.0
- 
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -39,5 +39,5 @@ declare function custom-lib:underwrite(
                 $node/node(),
                 $element/node()
                 }
-				
+
 };

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/data/javascriptQueries.sjs
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/data/javascriptQueries.sjs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/data/module.xqy
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/data/module.xqy
@@ -1,13 +1,13 @@
 xquery version "1.0-ml";
 (:
-  Copyright (c) 2022 MarkLogic Corporation
- 
+  Copyright (c) 2023 MarkLogic Corporation
+
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
- 
+
      http://www.apache.org/licenses/LICENSE-2.0
- 
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/data/readme.txt
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/data/readme.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2022 MarkLogic Corporation
+Copyright (c) 2023 MarkLogic Corporation
 
 MarkLogic Client API for Java version ${project.version}
 
@@ -33,7 +33,7 @@ Notes:
 
 At this time, the QueryOptions class provides a representation for query options
 read from the database but cannot be used to write query options to the database.
-Instead, create query options as an XML or JSON structure.  Please see the 
+Instead, create query options as an XML or JSON structure.  Please see the
 QueryOptions and StringOptionsSearch cookbook examples as well as the
 query-options-template.xml template file.
 

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/data/result-decorator-test.xqy
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/data/result-decorator-test.xqy
@@ -1,12 +1,12 @@
 (:
-  Copyright (c) 2022 MarkLogic Corporation
- 
+  Copyright (c) 2023 MarkLogic Corporation
+
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
- 
+
      http://www.apache.org/licenses/LICENSE-2.0
- 
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -39,10 +39,10 @@ declare function rd:decorator(
   let $mimetype := xdmp:uri-content-type($uri)
   return (
     attribute href { concat("/documents/are/here?uri=", $uri) },
- 
+
     if (empty($mimetype)) then ()
     else attribute mimetype {$mimetype},
- 
+
     if (empty($format)) then ()
     else attribute format { $format },
 	element my-elem { "Result Decorated" }
@@ -57,10 +57,10 @@ declare function rd:decoratorWithoutMimeType(
   let $mimetype := xdmp:uri-content-type($uri)
   return (
     attribute href { concat("/documents/are/here?uri=", $uri) },
- 
+
    if (empty($mimetype)) then ()
     else attribute mimetype {"Null"},
- 
+
     if (empty($format)) then ()
     else attribute format { $format },
 	element my-elem { "Result Decorated" }
@@ -75,10 +75,10 @@ declare function rd:decorate-element(
     let $mimetype := xdmp:uri-content-type($uri)
     return (
         element search:href { concat("/documents/are/here?uri=", $uri) },
- 
+
         if (empty($mimetype)) then ()
         else element search:mimetype {$mimetype},
- 
+
         if (empty($format)) then ()
         else element search:format { $format }
         )
@@ -92,10 +92,10 @@ declare function rd:decorate-with-attribute(
     let $mimetype := xdmp:uri-content-type($uri)
     return (
         attribute href { concat("/documents/are/here?uri=", $uri) },
- 
+
         if (empty($mimetype)) then ()
         else attribute mimetype {$mimetype},
- 
+
         if (empty($format)) then ()
         else attribute format { $format }
         )

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/data/xquery-modules-with-diff-variable-types.xqy
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/data/xquery-modules-with-diff-variable-types.xqy
@@ -1,12 +1,12 @@
 (:
-  Copyright (c) 2022 MarkLogic Corporation
- 
+  Copyright (c) 2023 MarkLogic Corporation
+
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
- 
+
      http://www.apache.org/licenses/LICENSE-2.0
- 
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,10 +32,10 @@ declare variable $myNull  external;
     $myXmlNode//comment(),
     $myXmlNode//text(),
     $myXmlNode//*,
-    $myXmlNode/@attr,    
+    $myXmlNode/@attr,
     $myXmlNode//processing-instruction(),
-    $myInteger,  
-    $myDecimal, 
-    $myDouble, 
+    $myInteger,
+    $myDecimal,
+    $myDouble,
     $myFloat
     )

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/rules/rule-transform.xqy
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/rules/rule-transform.xqy
@@ -1,12 +1,12 @@
 (:
-  Copyright (c) 2022 MarkLogic Corporation
- 
+  Copyright (c) 2023 MarkLogic Corporation
+
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
- 
+
      http://www.apache.org/licenses/LICENSE-2.0
- 
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,7 +24,7 @@ declare function ruleTransform:transform(
               $context as map:map,
               $params as map:map,
               $content as document-node()
-) as document-node() 
+) as document-node()
 {
     let $rules := $content/node()/*
     return

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/transforms/add-attr-xquery-transform.xqy
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/transforms/add-attr-xquery-transform.xqy
@@ -1,12 +1,12 @@
 (:
-  Copyright (c) 2022 MarkLogic Corporation
- 
+  Copyright (c) 2023 MarkLogic Corporation
+
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
- 
+
      http://www.apache.org/licenses/LICENSE-2.0
- 
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,7 +29,7 @@ declare function example:transform(
     let $value := (map:get($params,"value"),"UNDEFINED")[1]
     let $name := (map:get($params, "name"), "transformed")[1]
     let $root  := $content/*
-    return 
+    return
     (
     document {
       $root/preceding-sibling::node(),

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/transforms/add-element-xquery-invalid-bitemp-transform.xqy
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/transforms/add-element-xquery-invalid-bitemp-transform.xqy
@@ -1,12 +1,12 @@
 (:
-  Copyright (c) 2022 MarkLogic Corporation
- 
+  Copyright (c) 2023 MarkLogic Corporation
+
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
- 
+
      http://www.apache.org/licenses/LICENSE-2.0
- 
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,7 +31,7 @@ declare function example:transform(
     let $root  := $content/*
     let $element-name := "javaValidStartERI"
     let $element-value := "2007-12-31T11:59:59"
-    return 
+    return
     (
     document {
       $root/preceding-sibling::node(),

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/transforms/add-element-xquery-transform.xqy
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/transforms/add-element-xquery-transform.xqy
@@ -1,12 +1,12 @@
 (:
-  Copyright (c) 2022 MarkLogic Corporation
- 
+  Copyright (c) 2023 MarkLogic Corporation
+
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
- 
+
      http://www.apache.org/licenses/LICENSE-2.0
- 
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,7 +31,7 @@ declare function example:transform(
     let $root  := $content/*
     let $element-name := "new-element"
     let $element-value := "2007-12-31T11:59:59"
-    return 
+    return
     (
     document {
       $root/preceding-sibling::node(),

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/transforms/timestampTransform.js
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/transforms/timestampTransform.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClient.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClientBuilder.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClientBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClientFactory.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/QueryBatcherImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/QueryBatcherImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -961,7 +961,7 @@ public class QueryBatcherImpl extends BatcherImpl implements QueryBatcher {
             final List<String> uris = uriQueue;
             final boolean finalLastBatch = lastBatch;
             final long results = resultsSoFar.addAndGet(uris.size());
-            if(maxUris <= results) 
+            if(maxUris <= results)
                 lastBatch = true;
             uriQueue = new ArrayList<>(getBatchSize());
             Runnable processBatch = new Runnable() {

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/RowBatcherImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/RowBatcherImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/eval/ServerEvaluationCall.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/eval/ServerEvaluationCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  */
 package com.marklogic.client.eval;
 
-import com.marklogic.client.DatabaseClientFactory;
 import com.marklogic.client.FailedRequestException;
 import com.marklogic.client.ForbiddenUserException;
 import com.marklogic.client.Transaction;

--- a/marklogic-client-api/src/main/java/com/marklogic/client/extra/okhttpclient/OkHttpClientBuilderFactory.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/extra/okhttpclient/OkHttpClientBuilderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/DatabaseClientImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/DatabaseClientImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/DatabaseClientPropertySource.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/DatabaseClientPropertySource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/DocDescriptorUtil.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/DocDescriptorUtil.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2023 MarkLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.marklogic.client.impl;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/OkHttpServices.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/OkHttpServices.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/RESTServices.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/RESTServices.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -283,7 +283,7 @@ public interface RESTServices {
     RequestLogger reqlog, String path, Transaction transaction, RequestParameters params, R output)
     throws  ResourceNotFoundException, ForbiddenUserException, FailedRequestException;
   ConnectionResult checkConnection();
-  
+
   // backdoor
   Object getClientImplementation();
 
@@ -442,12 +442,12 @@ public interface RESTServices {
     public CallField toBuffered() {
     	return this;
     }
-    
+
     @Override
     public int hashCode() {
         return getParamName().hashCode();
     }
-    
+
     @Override
     public boolean equals(Object arg0) {
       if (!(arg0 instanceof CallField)) return false;
@@ -508,7 +508,7 @@ public interface RESTServices {
       super(paramName);
       this.paramValues = paramValues;
     }
-    
+
     @Override
     public BufferedMultipleAtomicCallField toBuffered() {
     	return new BufferedMultipleAtomicCallField(super.getParamName(), paramValues);
@@ -526,29 +526,29 @@ public interface RESTServices {
       super(paramName);
       this.paramValues = paramValues;
     }
-    
+
     @Override
     public Stream<? extends BufferableHandle> getParamValues() {
       return paramValues;
     }
-    
+
     @Override
     public BufferedMultipleNodeCallField toBuffered() {
     	return new BufferedMultipleNodeCallField(super.getParamName(), paramValues);
     }
-    
+
   }
   class BufferedMultipleAtomicCallField extends MultipleAtomicCallField {
 	private final String[] paramValues;
 	public BufferedMultipleAtomicCallField(String paramName, Stream<String> paramValues) {
         this(paramName, paramValues.toArray(String[]::new));
     }
-	
+
 	public BufferedMultipleAtomicCallField(String paramName, String[] paramValues) {
 	    super(paramName);
 	    this.paramValues = paramValues;
 	}
-  
+
 	@Override
 	public Stream<String> getParamValues() {
 		return Stream.of(paramValues);
@@ -574,12 +574,12 @@ public interface RESTServices {
 	  void setParamValues(BufferableHandle[] paramValues) {
 	      this.paramValues = paramValues;
 	  }
-	  
+
 	  public BufferedMultipleNodeCallField toBuffered() {
           return new BufferedMultipleNodeCallField(super.getParamName(), NodeConverter.bufferAsBytes(paramValues));
       }
   }
-  
+
   interface CallRequest {
     boolean hasStreamingPart();
     SessionState getSession();

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/SSLUtil.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/SSLUtil.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2023 MarkLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.marklogic.client.impl;
 
 import javax.net.ssl.TrustManager;

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/AuthenticationConfigurer.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/AuthenticationConfigurer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2023 MarkLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.marklogic.client.impl.okhttp;
 
 import com.marklogic.client.DatabaseClientFactory;

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/BasicAuthenticationConfigurer.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/BasicAuthenticationConfigurer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2023 MarkLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.marklogic.client.impl.okhttp;
 
 import com.burgstaller.okhttp.digest.Credentials;

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/DigestAuthenticationConfigurer.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/DigestAuthenticationConfigurer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2023 MarkLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.marklogic.client.impl.okhttp;
 
 import com.burgstaller.okhttp.AuthenticationCacheInterceptor;

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/HttpUrlBuilder.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/HttpUrlBuilder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2023 MarkLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.marklogic.client.impl.okhttp;
 
 import okhttp3.HttpUrl;

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/MarkLogicCloudAuthenticationConfigurer.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/MarkLogicCloudAuthenticationConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/OkHttpUtil.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/OkHttpUtil.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2023 MarkLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.marklogic.client.impl.okhttp;
 
 import com.marklogic.client.DatabaseClientFactory;
@@ -28,6 +43,8 @@ import java.util.concurrent.TimeUnit;
  * Contains convenience methods for constructing an OkHttpClient.Builder so that it can be used in places other than
  * only {@code OkHttpServices}. This code was moved here from OkHttpServices without any modification during the move
  * (other than the method {@code initializeSslContext} being extracted for readability purposes).
+ *
+ * @since 6.1.0
  */
 public abstract class OkHttpUtil {
 

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/SSLSocketFactoryDelegator.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/SSLSocketFactoryDelegator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/SocketFactoryDelegator.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/SocketFactoryDelegator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/AlertingTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/AlertingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/BinaryDocumentTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/BinaryDocumentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/BitemporalFeaturesTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/BitemporalFeaturesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/BitemporalTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/BitemporalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/BufferableHandleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/BufferableHandleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/BulkReadWriteTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/BulkReadWriteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/City.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/City.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/ClosingHandlesTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/ClosingHandlesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/CombinedQueryBuilderTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/CombinedQueryBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/Common.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/Common.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/ConditionalDocumentTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/ConditionalDocumentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/Country.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/Country.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/CtsQueryDefinitionTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/CtsQueryDefinitionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/DOMSearchResultTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/DOMSearchResultTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/DatabaseClientFactoryTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/DatabaseClientFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/DatabaseClientTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/DatabaseClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/DeleteSearchTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/DeleteSearchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/DocumentMetadataHandleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/DocumentMetadataHandleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/EvalTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/EvalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/ExtensionLibrariesTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/ExtensionLibrariesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/FailedRequestTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/FailedRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/GenericDocumentTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/GenericDocumentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/GeospatialRegionQueriesTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/GeospatialRegionQueriesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/GraphsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/GraphsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/HandleAccessorTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/HandleAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/HandleAsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/HandleAsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/InvalidUserTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/InvalidUserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/JAXBHandleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/JAXBHandleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/JSONDocumentTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/JSONDocumentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/JacksonDatabindTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/JacksonDatabindTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/JacksonHandleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/JacksonHandleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/JacksonStreamTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/JacksonStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/MarkLogicCloudAuthenticationDebugger.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/MarkLogicCloudAuthenticationDebugger.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2023 MarkLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.marklogic.client.test;
 
 import com.marklogic.client.DatabaseClient;

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/NamespacesManagerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/NamespacesManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/PageTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/PageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/PlanExpressionTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/PlanExpressionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/PlanGeneratedBase.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/PlanGeneratedBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/PlanGeneratedTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/PlanGeneratedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/PojoFacadeTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/PojoFacadeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/QueryByExampleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/QueryByExampleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/QueryOptionsListHandleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/QueryOptionsListHandleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/QueryOptionsManagerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/QueryOptionsManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/RawCtsQueryDefinitionTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/RawCtsQueryDefinitionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/RawQueryDefinitionTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/RawQueryDefinitionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/RequestLoggerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/RequestLoggerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/ResourceExtensionsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/ResourceExtensionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/ResourceServicesTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/ResourceServicesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/SPARQLManagerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/SPARQLManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/SPARQLQueryDefinitionTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/SPARQLQueryDefinitionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/SPARQLQueryManagerImplTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/SPARQLQueryManagerImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/SSLTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/SSLTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/SearchFacetTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/SearchFacetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/SemanticsPermissionsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/SemanticsPermissionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/ServerConfigurationManagerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/ServerConfigurationManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/StringSearchTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/StringSearchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/StructuredQueryBuilderTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/StructuredQueryBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/StructuredSearchTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/StructuredSearchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/SuggestTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/SuggestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/TextDocumentTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/TextDocumentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/TimeTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/TimeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/TransformExtensionsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/TransformExtensionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/TransformTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/TransformTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/TuplesHandleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/TuplesHandleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/ValueConverterTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/ValueConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/ValuesHandleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/ValuesHandleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/XMLDocumentTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/XMLDocumentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/ApplyTransformTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/ApplyTransformTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/DeleteListenerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/DeleteListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/ExportToWriterListenerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/ExportToWriterListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/FilteredForestConfigTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/FilteredForestConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/ForestConfigTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/ForestConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/JSONSplitterTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/JSONSplitterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/JacksonCSVSplitterTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/JacksonCSVSplitterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/LegalHoldsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/LegalHoldsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/PathSplitterTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/PathSplitterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/PointInTimeQueryTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/PointInTimeQueryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/ProgressListenerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/ProgressListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/QueryBatcherImplTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/QueryBatcherImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/QueryBatcherIteratorTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/QueryBatcherIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/QueryBatcherTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/QueryBatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/RowBatcherTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/RowBatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/ScenariosTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/ScenariosTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/UnarySplitterTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/UnarySplitterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ public class UnarySplitterTest {
     static final private String xmlFile = "src/test/resources/data" + File.separator + "/pathSplitter/people.xml";
     static final private String xmlContent = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
             "<!--\n" +
-            " Copyright (c) 2022 MarkLogic Corporation\n" +
+            " Copyright (c) 2023 MarkLogic Corporation\n" +
             "\n" +
             " Licensed under the Apache License, Version 2.0 (the \"License\");\n" +
             " you may not use this file except in compliance with the License.\n" +

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/WriteBatcherTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/WriteBatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/XMLSplitterTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/XMLSplitterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/javadocExamples/PackageExamplesTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/javadocExamples/PackageExamplesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/javadocExamples/UrisToWriterListenerExamplesTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/javadocExamples/UrisToWriterListenerExamplesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/BulkIOEndpointTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/BulkIOEndpointTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/BulkIOInputCallerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/BulkIOInputCallerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/BulkInputCallerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/BulkInputCallerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/BulkOutputCallerNext.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/BulkOutputCallerNext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/BulkOutputCallerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/BulkOutputCallerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/ErrorListenerExecEndpointTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/ErrorListenerExecEndpointTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/ErrorListenerInputEndpointTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/ErrorListenerInputEndpointTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/ErrorListenerInputOutputEndpointTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/ErrorListenerInputOutputEndpointTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/ErrorListenerOutputEndpointTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/ErrorListenerOutputEndpointTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/IOCallerImplTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/IOCallerImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/IOTestUtil.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/IOTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/InputEndpointImplTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/InputEndpointImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/OutputEndpointImplTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/OutputEndpointImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/document/DocumentWriteOperationTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/document/DocumentWriteOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/BulkExportOpticResultsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/BulkExportOpticResultsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/BulkExportOpticResultsToWriterTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/BulkExportOpticResultsToWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/BulkExportWithDataServiceTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/BulkExportWithDataServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/ClientCreatorTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/ClientCreatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentDeleteTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentDeleteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentFormatsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentFormatsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentMetadataReadTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentMetadataReadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentMetadataWriteTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentMetadataWriteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentOutputStreamTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentOutputStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentReadTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentReadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentReadTransformTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentReadTransformTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentWriteServerURITest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentWriteServerURITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentWriteTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentWriteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentWriteTransformTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/DocumentWriteTransformTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/ExtractRowsViaTemplateTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/ExtractRowsViaTemplateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/JAXBDocumentTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/JAXBDocumentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/JavascriptExtensionTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/JavascriptExtensionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/JdbcCookbookTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/JdbcCookbookTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/MoveDataBetweenMarklogicDBsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/MoveDataBetweenMarklogicDBsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/MultiStatementTransactionTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/MultiStatementTransactionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/OptimisticLockingTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/OptimisticLockingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/QueryOptionsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/QueryOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/RawClientAlertTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/RawClientAlertTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/RawCombinedSearchTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/RawCombinedSearchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/RecordJobInformationTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/RecordJobInformationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/ResourceExtensionTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/ResourceExtensionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/SearchResponseTransformTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/SearchResponseTransformTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/StringSearchTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/StringSearchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/StructuredSearchTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/StructuredSearchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/WriteandReadPOJOsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/WriteandReadPOJOsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/extension/BatchManagerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/extension/BatchManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/extension/GraphSPARQLExampleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/extension/GraphSPARQLExampleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/extension/OpenCSVBatcherTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/extension/OpenCSVBatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/extension/SearchCollectorTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/extension/SearchCollectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/handle/HTMLCleanerHandleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/handle/HTMLCleanerHandleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/handle/URIHandleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/handle/URIHandleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/extra/DOM4JHandleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/extra/DOM4JHandleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/extra/GSONHandleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/extra/GSONHandleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/extra/JDOMHandleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/extra/JDOMHandleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowRecordTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowRecordTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/ValidateDocTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/ValidateDocTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/util/Referred.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/util/Referred.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/util/Refers.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/util/Refers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-app/src/main/java/com/marklogic/client/test/ReverseProxyServer.java
+++ b/test-app/src/main/java/com/marklogic/client/test/ReverseProxyServer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2023 MarkLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.marklogic.client.test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;


### PR DESCRIPTION
Did this for all test files in marklogic-client-api and marklogic-client-api-functionaltests, as all tests were changed from JUnit 4 to JUnit 5.

Only updated the year in marklogic-client-api/src/main for Java files that were actually modified for 6.1.0. 