### PR TITLE
Disabling JdbcCookbookTest

### DIFF
--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -20,8 +20,10 @@ dependencies {
 	api 'org.slf4j:slf4j-api:1.7.36'
 	api 'com.fasterxml.jackson.core:jackson-databind:2.14.1'
 
-	// hsqldb 2.6+ requires Java 11+
-	api 'org.hsqldb:hsqldb:2.5.2'
+	// hsqldb < 2.7 has a High CVE - https://nvd.nist.gov/vuln/detail/CVE-2022-41853 .
+	// And hsqldb 2.6+ requires Java 11+. So this is ignored, along with the associated test,
+	// until the Java Client can drop Java 8 support.
+	// api 'org.hsqldb:hsqldb:2.7.1'
 
 	api 'org.jdom:jdom2:2.0.6.1'
 	api 'org.dom4j:dom4j:2.1.3'

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/JdbcCookbookTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/JdbcCookbookTest.java
@@ -17,8 +17,12 @@ package com.marklogic.client.test.example.cookbook;
 
 import com.marklogic.client.example.cookbook.Util;
 import com.marklogic.client.example.cookbook.Util.ExampleProperties;
-import com.marklogic.client.example.cookbook.datamovement.*;
-import org.hsqldb.server.Server;
+import com.marklogic.client.example.cookbook.datamovement.BulkExportToJdbc;
+import com.marklogic.client.example.cookbook.datamovement.BulkLoadFromJdbcRaw;
+import com.marklogic.client.example.cookbook.datamovement.BulkLoadFromJdbcWithJoins;
+import com.marklogic.client.example.cookbook.datamovement.BulkLoadFromJdbcWithSimpleJoins;
+import com.marklogic.client.example.cookbook.datamovement.IncrementalLoadFromJdbc;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
@@ -29,7 +33,7 @@ import java.io.IOException;
 public class JdbcCookbookTest {
 
   class Database {
-    Server hsqlDBServer;
+//    Server hsqlDBServer;
     JdbcTemplate jdbcTemplate;
     Database() throws IOException {
       setupHSQLDBServer();
@@ -37,11 +41,11 @@ public class JdbcCookbookTest {
     }
 
     private void setupHSQLDBServer() {
-      hsqlDBServer = new Server();
-      hsqlDBServer.setDatabaseName(0, "employees");
-      hsqlDBServer.setDatabasePath(0, "mem:employees");
-      hsqlDBServer.setPort(9002);
-      hsqlDBServer.start();
+//      hsqlDBServer = new Server();
+//      hsqlDBServer.setDatabaseName(0, "employees");
+//      hsqlDBServer.setDatabasePath(0, "mem:employees");
+//      hsqlDBServer.setPort(9002);
+//      hsqlDBServer.start();
     }
 
     private DataSource getDataSource() throws IOException {
@@ -54,10 +58,12 @@ public class JdbcCookbookTest {
     }
 
     public void tearDown() {
-      hsqlDBServer.stop();
+//      hsqlDBServer.stop();
     }
   }
 
+	@Disabled("Disabled until the Java Client drops Java 8 support, which then allows for the most recent version " +
+		"of org.hsqldb:hsqldb to be used, thus avoiding a High CVE.")
   @Test
   public void testMain() throws Exception {
     Database hsqlDB = new Database();


### PR DESCRIPTION
See the comment - this is to address a High CVE on the hsqldb depedency. That dependency is only used by this test, which only tests a couple cookbook example programs.
