### PR TITLE
Bumping undertow from 2.2.21 to 2.2.24

### DIFF
--- a/test-app/build.gradle
+++ b/test-app/build.gradle
@@ -5,8 +5,8 @@ plugins {
 }
 
 dependencies {
-	implementation "io.undertow:undertow-core:2.2.21.Final"
-	implementation "io.undertow:undertow-servlet:2.2.21.Final"
+	implementation "io.undertow:undertow-core:2.2.24.Final"
+	implementation "io.undertow:undertow-servlet:2.2.24.Final"
 	implementation "com.marklogic:ml-javaclient-util:4.4.0"
 	implementation 'org.slf4j:slf4j-api:1.7.36'
 	implementation 'ch.qos.logback:logback-classic:1.3.5'


### PR DESCRIPTION
This addresses CVE in https://issues.redhat.com/browse/UNDERTOW-2212 .

Note that undertow is only used in the test application and is not part of any production code. 
