### PR TITLE
Improved error message when metadata serialization fails

### DIFF
--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/DocumentMetadataHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/DocumentMetadataHandle.java
@@ -787,12 +787,8 @@ public class DocumentMetadataHandle
 
       serializer.flush();
       serializer.close();
-    } catch (XMLStreamException e) {
-      throw new MarkLogicIOException("Failed to serialize metadata", e);
-    } catch (TransformerFactoryConfigurationError e) {
-      throw new MarkLogicIOException("Failed to serialize metadata", e);
-    } catch (TransformerException e) {
-      throw new MarkLogicIOException("Failed to serialize metadata", e);
+    } catch (Exception e) {
+		throw new MarkLogicIOException("Failed to serialize metadata: cause: " + e.getMessage(), e);
     }
   }
 


### PR DESCRIPTION
Reason is that when this occurs in a DMSDK setting, only the message is logged, which isn't helpful at all for debugging.
