### PR TITLE
Forcing usage of okio 3.4.0

### DIFF
--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -18,7 +18,7 @@ dependencies {
 	api 'com.squareup.okhttp3:okhttp:4.10.0'
 	api 'io.github.rburgst:okhttp-digest:2.7'
 	api 'org.slf4j:slf4j-api:1.7.36'
-	api 'com.fasterxml.jackson.core:jackson-databind:2.14.1'
+	api 'com.fasterxml.jackson.core:jackson-databind:2.14.3'
 
 	// hsqldb < 2.7 has a High CVE - https://nvd.nist.gov/vuln/detail/CVE-2022-41853 .
 	// And hsqldb 2.6+ requires Java 11+. So this is ignored, along with the associated test,
@@ -26,11 +26,11 @@ dependencies {
 	// api 'org.hsqldb:hsqldb:2.7.1'
 
 	api 'org.jdom:jdom2:2.0.6.1'
-	api 'org.dom4j:dom4j:2.1.3'
-	api 'com.google.code.gson:gson:2.10'
+	api 'org.dom4j:dom4j:2.1.4'
+	api 'com.google.code.gson:gson:2.10.1'
 	api 'net.sourceforge.htmlcleaner:htmlcleaner:2.26'
 	api 'com.opencsv:opencsv:4.6'
-	api 'org.springframework:spring-jdbc:5.3.27'
+	api 'org.springframework:spring-jdbc:5.3.29'
 	api 'org.apache.commons:commons-lang3:3.12.0'
 	api 'org.apache.httpcomponents:httpclient:4.5.14'
 }

--- a/marklogic-client-api-functionaltests/build.gradle
+++ b/marklogic-client-api-functionaltests/build.gradle
@@ -20,17 +20,18 @@ task testSandbox(type:Test) {
 
 dependencies {
   implementation project (':marklogic-client-api')
-  implementation 'org.skyscreamer:jsonassert:1.5.0'
+  implementation 'org.skyscreamer:jsonassert:1.5.1'
   implementation 'org.slf4j:slf4j-api:1.7.36'
   implementation 'commons-io:commons-io:2.11.0'
-  implementation 'com.squareup.okhttp3:okhttp:4.10.0'
-  implementation 'com.fasterxml.jackson.core:jackson-core:2.14.1'
-  implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.1'
+	implementation 'com.squareup.okio:okio:3.4.0'
+  implementation 'com.squareup.okhttp3:okhttp:4.11.0'
+  implementation 'com.fasterxml.jackson.core:jackson-core:2.14.3'
+  implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.3'
   implementation "org.jdom:jdom2:2.0.6.1"
-  implementation "com.marklogic:ml-app-deployer:4.4.0"
+  implementation "com.marklogic:ml-app-deployer:4.5.2"
 
   testImplementation 'ch.qos.logback:logback-classic:1.3.5'
-	testImplementation 'org.junit.jupiter:junit-jupiter:5.9.1'
+	testImplementation 'org.junit.jupiter:junit-jupiter:5.9.2'
 	testImplementation 'org.xmlunit:xmlunit-legacy:2.9.0'
 	testImplementation 'org.apache.commons:commons-lang3:3.12.0'
 	testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'

--- a/marklogic-client-api/build.gradle
+++ b/marklogic-client-api/build.gradle
@@ -15,9 +15,13 @@ dependencies {
 		implementation 'org.glassfish.jaxb:jaxb-runtime:2.3.8'
 		implementation 'org.glassfish.jaxb:jaxb-core:2.3.0.1'
 	}
+
+	// Forcing usage of 3.4.0 instead of 3.2.0 to address vulnerability - https://security.snyk.io/vuln/SNYK-JAVA-COMSQUAREUPOKIO-5820002
+	implementation 'com.squareup.okio:okio:3.4.0'
 	implementation 'com.squareup.okhttp3:okhttp:4.11.0'
 	implementation 'com.squareup.okhttp3:logging-interceptor:4.11.0'
 	implementation 'io.github.rburgst:okhttp-digest:2.7'
+	
 	implementation 'com.sun.mail:javax.mail:1.6.2'
 	implementation 'javax.ws.rs:javax.ws.rs-api:2.1.1'
 	implementation 'org.slf4j:slf4j-api:1.7.36'
@@ -31,12 +35,12 @@ dependencies {
 	compileOnly 'commons-codec:commons-codec:1.15'
 	compileOnly 'org.apache.httpcomponents:httpclient:4.5.14'
 	compileOnly 'org.jdom:jdom2:2.0.6.1'
-	compileOnly 'org.dom4j:dom4j:2.1.3'
-	compileOnly 'com.google.code.gson:gson:2.10'
+	compileOnly 'org.dom4j:dom4j:2.1.4'
+	compileOnly 'com.google.code.gson:gson:2.10.1'
 
 	testImplementation 'org.junit.jupiter:junit-jupiter:5.9.3'
 	// Forcing junit version to avoid vulnerability with older version in xmlunit
-	testImplementation 'junit:junit:4.13.1'
+	testImplementation 'junit:junit:4.13.2'
 	testImplementation 'org.xmlunit:xmlunit-legacy:2.9.1'
 	testImplementation project(':examples')
 
@@ -47,6 +51,7 @@ dependencies {
 	// Starting with mockito 5.x, Java 11 is required, so sticking with 4.x as we have to support Java 8.
 	testImplementation "org.mockito:mockito-core:4.11.0"
 	testImplementation "org.mockito:mockito-inline:4.11.0"
+	testImplementation 'com.squareup.okio:okio:3.4.0'
 	testImplementation "com.squareup.okhttp3:mockwebserver:4.11.0"
 
 	testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.14.3'
@@ -57,7 +62,7 @@ dependencies {
 	testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
 	testImplementation 'com.opencsv:opencsv:4.6'
 	testImplementation 'org.geonames:geonames:1.0'
-	testImplementation 'org.skyscreamer:jsonassert:1.5.0'
+	testImplementation 'org.skyscreamer:jsonassert:1.5.1'
 }
 
 // Ensure that mlHost and mlPassword can override the defaults of localhost/admin if they've been modified

--- a/test-app/build.gradle
+++ b/test-app/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'com.marklogic.ml-gradle' version '4.4.0'
+	id 'com.marklogic.ml-gradle' version '4.5.2'
 	id 'java'
 	id "com.github.psxpaul.execfork" version "0.2.2"
 }
@@ -7,11 +7,12 @@ plugins {
 dependencies {
 	implementation "io.undertow:undertow-core:2.2.24.Final"
 	implementation "io.undertow:undertow-servlet:2.2.24.Final"
-	implementation "com.marklogic:ml-javaclient-util:4.4.0"
+	implementation "com.marklogic:ml-javaclient-util:4.5.1"
 	implementation 'org.slf4j:slf4j-api:1.7.36'
 	implementation 'ch.qos.logback:logback-classic:1.3.5'
-	implementation "com.fasterxml.jackson.core:jackson-databind:2.14.1"
-	implementation 'com.squareup.okhttp3:okhttp:4.10.0'
+	implementation "com.fasterxml.jackson.core:jackson-databind:2.14.3"
+	implementation 'com.squareup.okio:okio:3.4.0'
+	implementation 'com.squareup.okhttp3:okhttp:4.11.0'
 }
 
 // See https://github.com/psxpaul/gradle-execfork-plugin for docs.


### PR DESCRIPTION
Latest OkHttp 4.x is still on 3.2.0, which is affected by https://security.snyk.io/vuln/SNYK-JAVA-COMSQUAREUPOKIO-5820002 . 

Bumped up patch version of a few other dependencies as well; those only impact test and build dependencies and do not impact anything that's published.
