### PR TITLE
Added example of removing the Accept-Encoding header

### DIFF
--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -12,10 +12,13 @@ dependencies {
 	}
 	implementation project(':marklogic-client-api')
 
+	// Forcing usage of 3.4.0 instead of 3.2.0 to address vulnerability - https://security.snyk.io/vuln/SNYK-JAVA-COMSQUAREUPOKIO-5820002
+	implementation 'com.squareup.okio:okio:3.4.0'
+
 	// The 'api' configuration is used so that the test configuration in marklogic-client-api doesn't have to declare
 	// all of these dependencies. This library project won't otherwise be depended on by anything else as it's not
 	// setup for publishing.
-	api 'com.squareup.okhttp3:okhttp:4.10.0'
+	api 'com.squareup.okhttp3:okhttp:4.11.0'
 	api 'io.github.rburgst:okhttp-digest:2.7'
 	api 'org.slf4j:slf4j-api:1.7.36'
 	api 'com.fasterxml.jackson.core:jackson-databind:2.14.3'

--- a/examples/src/main/java/com/marklogic/client/example/cookbook/ConfigureOkHttp.java
+++ b/examples/src/main/java/com/marklogic/client/example/cookbook/ConfigureOkHttp.java
@@ -1,0 +1,37 @@
+package com.marklogic.client.example.cookbook;
+
+import com.marklogic.client.DatabaseClientFactory;
+import com.marklogic.client.extra.okhttpclient.OkHttpClientConfigurator;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+
+/**
+ * Provides examples of configuring the underlying OkHttp client for various use cases.
+ */
+public class ConfigureOkHttp {
+
+	/**
+	 * OkHttp 4.x includes a header of "Accept-Encoding=gzip" by default. The following shows how to use an OkHttp
+	 * interceptor to remove this header from every request. By doing this via a configurator passed to
+	 * {@code DatabaseClientFactory}, every {@code DatabaseClient} created via the factory will inherit this
+	 * interceptor.
+	 *
+	 * Note that while the Accept-Encoding header can contain multiple values - see
+	 * https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Encoding for examples - the MarkLogic Java
+	 * Client does not set this header and OkHttp only sets it to "gzip" for every request. Thus, removing the
+	 * header should not result in losing any other values besides "gzip" for the header. You are free to
+	 * customize this as you wish though; this is primarily intended as an example for how to customize OkHttp
+	 * when using the MarkLogic Java Client.
+	 */
+	public static void removeAcceptEncodingGzipHeader() {
+		DatabaseClientFactory.addConfigurator(new OkHttpClientConfigurator() {
+			@Override
+			public void configure(OkHttpClient.Builder builder) {
+				builder.addNetworkInterceptor(chain -> {
+					Request newRequest = chain.request().newBuilder().removeHeader("Accept-Encoding").build();
+					return chain.proceed(newRequest);
+				});
+			}
+		});
+	}
+}


### PR DESCRIPTION
This is for customers that do not want responses to be gzip-encoded.