### PR TITLE
Renamed test roles to make it clear they're for the Java Client

### DIFF
--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/SemanticsPermissionsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/SemanticsPermissionsTest.java
@@ -36,8 +36,8 @@ public class SemanticsPermissionsTest {
     Common.connect();
     gmgr = Common.client.newGraphManager();
     String triple = "<s> <p> <o>.";
-    GraphPermissions perms = gmgr.permission("read-privileged", Capability.READ)
-      .permission("write-privileged", Capability.UPDATE);
+    GraphPermissions perms = gmgr.permission("java-test-read-privileged", Capability.READ)
+      .permission("java-test-write-privileged", Capability.UPDATE);
     gmgr.write(graphUri, new StringHandle(triple).withMimetype(RDFMimeTypes.NTRIPLES), perms);
   }
 
@@ -62,7 +62,7 @@ public class SemanticsPermissionsTest {
   }
 
   @Test
-  public void B_testWritePermission() throws Exception {
+  public void B_testWritePermission() {
     // a negative test to ensure a user without update privilege can't write
     try {
       GraphManager readPrivilegedGmgr = readPrivilegedClient.newGraphManager();
@@ -74,41 +74,41 @@ public class SemanticsPermissionsTest {
   }
 
   @Test
-  public void C_testGetPermissions() throws Exception {
+  public void C_testGetPermissions() {
     GraphManager readPrivilegedGmgr = readPrivilegedClient.newGraphManager();
     GraphPermissions permissions = readPrivilegedGmgr.getPermissions(graphUri);
     assertEquals(6, permissions.size());
-    assertNotNull(permissions.get("read-privileged"));
-    assertNotNull(permissions.get("write-privileged"));
-    assertEquals(1, permissions.get("read-privileged").size());
-    assertEquals(1, permissions.get("write-privileged").size());
-    assertEquals(Capability.READ, permissions.get("read-privileged").iterator().next());
-    assertEquals(Capability.UPDATE, permissions.get("write-privileged").iterator().next());
+    assertNotNull(permissions.get("java-test-read-privileged"));
+    assertNotNull(permissions.get("java-test-write-privileged"));
+    assertEquals(1, permissions.get("java-test-read-privileged").size());
+    assertEquals(1, permissions.get("java-test-write-privileged").size());
+    assertEquals(Capability.READ, permissions.get("java-test-read-privileged").iterator().next());
+    assertEquals(Capability.UPDATE, permissions.get("java-test-write-privileged").iterator().next());
   }
 
   @Test
-  public void D_testWritePermissions() throws Exception {
+  public void D_testWritePermissions() {
     GraphPermissions perms = gmgr.newGraphPermissions();
-    perms = perms.permission("read-privileged", Capability.EXECUTE);
+    perms = perms.permission("java-test-read-privileged", Capability.EXECUTE);
     gmgr.writePermissions(graphUri, perms);
     GraphPermissions permissions = gmgr.getPermissions(graphUri);
     assertEquals(5, permissions.size());
-    assertNotNull(permissions.get("read-privileged"));
-    assertEquals(1, permissions.get("read-privileged").size());
-    for ( Capability capability : permissions.get("read-privileged") ) {
+    assertNotNull(permissions.get("java-test-read-privileged"));
+    assertEquals(1, permissions.get("java-test-read-privileged").size());
+    for ( Capability capability : permissions.get("java-test-read-privileged") ) {
       assertEquals(Capability.EXECUTE, capability);
     }
   }
 
   @Test
-  public void E_testMergePermissions() throws Exception {
-    GraphPermissions perms = gmgr.permission("read-privileged", Capability.READ);
+  public void E_testMergePermissions() {
+    GraphPermissions perms = gmgr.permission("java-test-read-privileged", Capability.READ);
     gmgr.mergePermissions(graphUri, perms);
     GraphPermissions permissions = gmgr.getPermissions(graphUri);
     assertEquals(5, permissions.size());
-    assertNotNull(permissions.get("read-privileged"));
-    assertEquals(2, permissions.get("read-privileged").size());
-    for ( Capability capability : permissions.get("read-privileged") ) {
+    assertNotNull(permissions.get("java-test-read-privileged"));
+    assertEquals(2, permissions.get("java-test-read-privileged").size());
+    for ( Capability capability : permissions.get("java-test-read-privileged") ) {
       if ( capability == null ) fail("capability should not be null");
       if ( capability != Capability.READ && capability != Capability.EXECUTE ) {
         fail("capabilities should be read or execute, not [" + capability + "]");
@@ -117,27 +117,27 @@ public class SemanticsPermissionsTest {
   }
 
   @Test
-  public void F_testDeletePermissions() throws Exception {
+  public void F_testDeletePermissions() {
     gmgr.deletePermissions(graphUri);
     GraphPermissions permissions = gmgr.getPermissions(graphUri);
     assertEquals(4, permissions.size());
-    assertNull(permissions.get("read-privileged"));
+    assertNull(permissions.get("java-test-read-privileged"));
   }
 
   @Test
-  public void G_testSPARQLInsertPermissions() throws Exception {
+  public void G_testSPARQLInsertPermissions() {
     String localGraphUri = graphUri + ".SPARQLPermissions";
     String sparql = "INSERT DATA { GRAPH <" + localGraphUri + "> { <s2> <p2> <o2> } }";
     SPARQLQueryManager sparqlMgr = Common.client.newSPARQLQueryManager();
     SPARQLQueryDefinition qdef = sparqlMgr.newQueryDefinition(sparql)
-      .withUpdatePermission("write-privileged", Capability.READ)
-      .withUpdatePermission("write-privileged", Capability.UPDATE);
+      .withUpdatePermission("java-test-write-privileged", Capability.READ)
+      .withUpdatePermission("java-test-write-privileged", Capability.UPDATE);
     sparqlMgr.executeUpdate(qdef);
     GraphPermissions getPermissions = gmgr.getPermissions(localGraphUri);
     assertEquals(5, getPermissions.size());
-    assertNotNull(getPermissions.get("write-privileged"));
-    assertEquals(2, getPermissions.get("write-privileged").size());
-    for ( Capability capability : getPermissions.get("write-privileged") ) {
+    assertNotNull(getPermissions.get("java-test-write-privileged"));
+    assertEquals(2, getPermissions.get("java-test-write-privileged").size());
+    for ( Capability capability : getPermissions.get("java-test-write-privileged") ) {
       if ( capability == null ) fail("capability should not be null");
       if ( capability != Capability.READ && capability != Capability.UPDATE ) {
         fail("capabilities should be read or update, not [" + capability + "]");

--- a/test-app/src/main/ml-config/security/roles/java-test-delete-graph.json
+++ b/test-app/src/main/ml-config/security/roles/java-test-delete-graph.json
@@ -1,5 +1,5 @@
 {
-  "role-name": "rest-delete-graph",
+  "role-name": "java-test-delete-graph",
   "description": "Addresses a bug found in ML 10.0-8.3 and ML 10.0-9.2 where term-query is needed to delete a graph",
   "privilege": [
     {

--- a/test-app/src/main/ml-config/security/roles/java-test-delete-temporal.json
+++ b/test-app/src/main/ml-config/security/roles/java-test-delete-temporal.json
@@ -1,5 +1,5 @@
 {
-  "role-name": "rest-delete-temporal",
+  "role-name": "java-test-delete-temporal",
   "description": "Allows for temporal documents to be deleted as part of test cleanup",
   "privilege": [
     {

--- a/test-app/src/main/ml-config/security/roles/java-test-evaluator.json
+++ b/test-app/src/main/ml-config/security/roles/java-test-evaluator.json
@@ -1,6 +1,6 @@
 {
-  "role-name": "rest-evaluator",
-  "description": "rest-evaluator",
+  "role-name": "java-test-evaluator",
+  "description": "Test role for the java-client-api project that can use the /v1/eval endpoint",
   "role": [
     "rest-writer"
   ],

--- a/test-app/src/main/ml-config/security/roles/java-test-read-privileged.json
+++ b/test-app/src/main/ml-config/security/roles/java-test-read-privileged.json
@@ -1,6 +1,6 @@
 {
-  "role-name": "read-privileged",
-  "description": "read-privileged",
+  "role-name": "java-test-read-privileged",
+  "description": "java-client-api test role",
   "privilege": [
     {
       "privilege-name": "rest-reader",

--- a/test-app/src/main/ml-config/security/roles/java-test-write-privileged.json
+++ b/test-app/src/main/ml-config/security/roles/java-test-write-privileged.json
@@ -1,6 +1,6 @@
 {
-  "role-name": "write-privileged",
-  "description": "write-privileged",
+  "role-name": "java-test-write-privileged",
+  "description": "java-client-api test role",
   "privilege": [
     {
       "privilege-name": "rest-writer",

--- a/test-app/src/main/ml-config/security/users/read-privileged.json
+++ b/test-app/src/main/ml-config/security/users/read-privileged.json
@@ -1,8 +1,8 @@
 {
   "user-name": "read-privileged",
-  "description": "read-privileged user",
+  "description": "Test user for the java-client-api project",
   "role": [
-    "read-privileged"
+    "java-test-read-privileged"
   ],
   "password": "x"
 }

--- a/test-app/src/main/ml-config/security/users/rest-admin.json
+++ b/test-app/src/main/ml-config/security/users/rest-admin.json
@@ -3,7 +3,7 @@
   "description": "rest-admin user",
   "role": [
     "rest-admin",
-    "rest-delete-temporal"
+    "java-test-delete-temporal"
   ],
   "password": "x"
 }

--- a/test-app/src/main/ml-config/security/users/rest-evaluator.json
+++ b/test-app/src/main/ml-config/security/users/rest-evaluator.json
@@ -1,8 +1,8 @@
 {
   "user-name": "rest-evaluator",
-  "description": "rest-evaluator user",
+  "description": "Test user for the java-client-api-project",
   "role": [
-    "rest-evaluator"
+    "java-test-evaluator"
   ],
   "password": "x"
 }

--- a/test-app/src/main/ml-config/security/users/rest-writer.json
+++ b/test-app/src/main/ml-config/security/users/rest-writer.json
@@ -3,7 +3,7 @@
   "description": "rest-writer user",
   "role": [
     "rest-writer",
-    "rest-delete-graph"
+    "java-test-delete-graph"
   ],
   "password": "x"
 }

--- a/test-app/src/main/ml-config/security/users/write-privileged.json
+++ b/test-app/src/main/ml-config/security/users/write-privileged.json
@@ -1,8 +1,8 @@
 {
   "user-name": "write-privileged",
-  "description": "write-privileged user",
+  "description": "Test user for the java-client-api project",
   "role": [
-    "write-privileged"
+    "java-test-write-privileged"
   ],
   "password": "x"
 }

--- a/test-app/src/main/ml-config/security/users/writer-no-default-permissions.json
+++ b/test-app/src/main/ml-config/security/users/writer-no-default-permissions.json
@@ -3,7 +3,7 @@
   "description": "test user that does not have the rest-writer role so as to avoid having default permissions",
   "role": [
     "test-rest-writer",
-    "rest-delete-graph",
+    "java-test-delete-graph",
     "rest-extension-user",
     "rest-reader"
   ],


### PR DESCRIPTION
Avoids me thinking that e.g. "rest-evaluator" is an actual MarkLogic OOTB role. 

Tossed "java-test-" on as a prefix for several existing test-only roles. 