### PR TITLE
DEVEXP-469 Optimistic locking failures now throw concrete exceptions

### DIFF
--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBug18920.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBug18920.java
@@ -16,6 +16,7 @@
 
 package com.marklogic.client.fastfunctest;
 
+import com.marklogic.client.ContentNoVersionException;
 import com.marklogic.client.FailedRequestException;
 import com.marklogic.client.admin.ServerConfigurationManager;
 import com.marklogic.client.admin.ServerConfigurationManager.UpdatePolicy;
@@ -29,6 +30,8 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestBug18920 extends AbstractFunctionalTest {
@@ -81,23 +84,9 @@ public class TestBug18920 extends AbstractFunctionalTest {
     String docUri = desc.getUri();
     System.out.println(docUri);
 
-    String exception = "";
-    String statusCode = "";
-    String expectedException = "com.marklogic.client.FailedRequestException: Local message: Content version required to write document. Server Message: RESTAPI-CONTENTNOVERSION: (err:FOER0000) No content version supplied:  uri /bug18920/xml-original.xml";
-    int expCode = 0;
     // update document with no content version
-    try {
-      docMgr.write(docUri, handle);
-    } catch (FailedRequestException e) {
-      exception = e.toString();
-      statusCode = e.getFailedRequest().getMessageCode();
-      expCode = e.getFailedRequest().getStatusCode();
-    }
-    System.out.println("Exception is " + exception);
-    System.out.println("Status message --- codenumber are " + statusCode + " --- " + expCode);
-    assertTrue( statusCode.contains("RESTAPI-CONTENTNOVERSION"));
-    assertTrue( expCode == 428);
-    assertTrue( exception.contains(expectedException));
+	  ContentNoVersionException ex = assertThrows(ContentNoVersionException.class, () -> docMgr.write(docUri, handle));
+	  assertEquals(428, ex.getServerStatusCode());
   }
 
   @AfterAll

--- a/marklogic-client-api/src/main/java/com/marklogic/client/ContentNoVersionException.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/ContentNoVersionException.java
@@ -1,0 +1,16 @@
+package com.marklogic.client;
+
+import com.marklogic.client.impl.FailedRequest;
+
+/**
+ * Represents a "RESTAPI-CONTENTNOVERSION" error from the REST API that can occur when using optimistic locking.
+ *
+ * @since 6.3.0
+ */
+public class ContentNoVersionException extends FailedRequestException {
+
+	public ContentNoVersionException(String message, FailedRequest failedRequest) {
+		super(message, failedRequest);
+	}
+
+}

--- a/marklogic-client-api/src/main/java/com/marklogic/client/ContentWrongVersionException.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/ContentWrongVersionException.java
@@ -1,0 +1,16 @@
+package com.marklogic.client;
+
+import com.marklogic.client.impl.FailedRequest;
+
+/**
+ * Represents a "RESTAPI-CONTENTWRONGVERSION" error from the REST API that can occur when using optimistic locking.
+ *
+ * @since 6.3.0
+ */
+public class ContentWrongVersionException extends FailedRequestException {
+
+	public ContentWrongVersionException(String message, FailedRequest failedRequest) {
+		super(message, failedRequest);
+	}
+
+}

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/OkHttpServices.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/OkHttpServices.java
@@ -18,13 +18,7 @@ package com.marklogic.client.impl;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marklogic.client.*;
 import com.marklogic.client.DatabaseClient.ConnectionResult;
-import com.marklogic.client.DatabaseClientFactory.BasicAuthContext;
-import com.marklogic.client.DatabaseClientFactory.CertificateAuthContext;
 import com.marklogic.client.DatabaseClientFactory.DigestAuthContext;
-import com.marklogic.client.DatabaseClientFactory.KerberosAuthContext;
-import com.marklogic.client.DatabaseClientFactory.MarkLogicCloudAuthContext;
-import com.marklogic.client.DatabaseClientFactory.SAMLAuthContext;
-import com.marklogic.client.DatabaseClientFactory.SSLHostnameVerifier;
 import com.marklogic.client.DatabaseClientFactory.SecurityContext;
 import com.marklogic.client.bitemporal.TemporalDescriptor;
 import com.marklogic.client.bitemporal.TemporalDocumentManager.ProtectionLevel;
@@ -437,7 +431,7 @@ public class OkHttpServices implements RESTServices {
     if (status == STATUS_PRECONDITION_REQUIRED) {
       FailedRequest failure = extractErrorFields(response);
       if (failure.getMessageCode().equals("RESTAPI-CONTENTNOVERSION")) {
-        throw new FailedRequestException(
+        throw new ContentNoVersionException(
           "Content version required to delete document", failure);
       }
       throw new FailedRequestException(
@@ -450,9 +444,7 @@ public class OkHttpServices implements RESTServices {
     if (status == STATUS_PRECONDITION_FAILED) {
       FailedRequest failure = extractErrorFields(response);
       if (failure.getMessageCode().equals("RESTAPI-CONTENTWRONGVERSION")) {
-        throw new FailedRequestException(
-          "Content version must match to delete document",
-          failure);
+        throw new ContentWrongVersionException("Content version must match to delete document", failure);
       } else if (failure.getMessageCode().equals("RESTAPI-EMPTYBODY")) {
         throw new FailedRequestException(
           "Empty request body sent to server", failure);
@@ -1308,8 +1300,7 @@ public class OkHttpServices implements RESTServices {
     if (status == STATUS_PRECONDITION_REQUIRED) {
       FailedRequest failure = extractErrorFields(response);
       if (failure.getMessageCode().equals("RESTAPI-CONTENTNOVERSION")) {
-        throw new FailedRequestException(
-          "Content version required to write document", failure);
+        throw new ContentNoVersionException("Content version required to write document", failure);
       }
       throw new FailedRequestException(
         "Precondition required to write document", failure);
@@ -1321,8 +1312,7 @@ public class OkHttpServices implements RESTServices {
     if (status == STATUS_PRECONDITION_FAILED) {
       FailedRequest failure = extractErrorFields(response);
       if (failure.getMessageCode().equals("RESTAPI-CONTENTWRONGVERSION")) {
-        throw new FailedRequestException(
-          "Content version must match to write document", failure);
+        throw new ContentWrongVersionException("Content version must match to write document", failure);
       } else if (failure.getMessageCode().equals("RESTAPI-EMPTYBODY")) {
         throw new FailedRequestException(
           "Empty request body sent to server", failure);
@@ -1453,8 +1443,7 @@ public class OkHttpServices implements RESTServices {
     if (status == STATUS_PRECONDITION_REQUIRED) {
       FailedRequest failure = extractErrorFields(response);
       if (failure.getMessageCode().equals("RESTAPI-CONTENTNOVERSION")) {
-        throw new FailedRequestException(
-          "Content version required to write document", failure);
+        throw new ContentNoVersionException("Content version required to write document", failure);
       }
       throw new FailedRequestException(
         "Precondition required to write document", failure);
@@ -1466,8 +1455,7 @@ public class OkHttpServices implements RESTServices {
     if (status == STATUS_PRECONDITION_FAILED) {
       FailedRequest failure = extractErrorFields(response);
       if (failure.getMessageCode().equals("RESTAPI-CONTENTWRONGVERSION")) {
-        throw new FailedRequestException(
-          "Content version must match to write document", failure);
+        throw new ContentWrongVersionException("Content version must match to write document", failure);
       } else if (failure.getMessageCode().equals("RESTAPI-EMPTYBODY")) {
         throw new FailedRequestException(
           "Empty request body sent to server", failure);
@@ -4398,7 +4386,7 @@ public class OkHttpServices implements RESTServices {
           failure);
       }
       if ("RESTAPI-CONTENTNOVERSION".equals(failure.getMessageCode())) {
-        throw new FailedRequestException("Content version required to " +
+        throw new ContentNoVersionException("Content version required to " +
           operation + " " + entityType + " at " + path, failure);
       } else if (status == STATUS_FORBIDDEN) {
         throw new ForbiddenUserException("User is not allowed to "


### PR DESCRIPTION
Users no longer need to parse out exception messages. And now `TestOptimisticLocking` doesn't need to either, which allowed me to delete a bunch of code from it in favor of asserting on specific exception classes. 

This is a non-breaking change as the new exceptions are subclasses of `FailedRequestException` and contain the same error message. 