### PR TITLE
DEVEXP-562 Can now prevent Accept-Encoding=gzip header being used

### DIFF
--- a/examples/src/main/java/com/marklogic/client/example/cookbook/ConfigureOkHttp.java
+++ b/examples/src/main/java/com/marklogic/client/example/cookbook/ConfigureOkHttp.java
@@ -22,7 +22,10 @@ public class ConfigureOkHttp {
 	 * header should not result in losing any other values besides "gzip" for the header. You are free to
 	 * customize this as you wish though; this is primarily intended as an example for how to customize OkHttp
 	 * when using the MarkLogic Java Client.
-	 */
+	 *
+	 * As of Java Client 6.3.0, this can now be accomplished via the {@code DatabaseClientFactory} class and
+	 * {@code RemoveAcceptEncodingConfigurator}.
+ 	 */
 	public static void removeAcceptEncodingGzipHeader() {
 		DatabaseClientFactory.addConfigurator(new OkHttpClientConfigurator() {
 			@Override

--- a/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClientBuilder.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClientBuilder.java
@@ -148,7 +148,6 @@ public class DatabaseClientBuilder {
 	}
 
 	/**
-	 *
 	 * @param apiKey
 	 * @param basePath
 	 * @param tokenDuration length in minutes until the generated access token expires
@@ -174,7 +173,6 @@ public class DatabaseClientBuilder {
 	}
 
 	/**
-	 *
 	 * @param sslContext
 	 * @param trustManager
 	 * @return
@@ -248,6 +246,17 @@ public class DatabaseClientBuilder {
 
 	public DatabaseClientBuilder withSSLHostnameVerifier(DatabaseClientFactory.SSLHostnameVerifier sslHostnameVerifier) {
 		props.put(PREFIX + "sslHostnameVerifier", sslHostnameVerifier);
+		return this;
+	}
+
+	/**
+	 * Prevents the underlying OkHttp library from sending an "Accept-Encoding-gzip" request header on each request.
+	 *
+	 * @return
+	 * @since 6.3.0
+	 */
+	public DatabaseClientBuilder withGzippedResponsesDisabled() {
+		props.put(PREFIX + "disableGzippedResponses", true);
 		return this;
 	}
 }

--- a/marklogic-client-api/src/main/java/com/marklogic/client/extra/okhttpclient/RemoveAcceptEncodingConfigurator.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/extra/okhttpclient/RemoveAcceptEncodingConfigurator.java
@@ -1,0 +1,22 @@
+package com.marklogic.client.extra.okhttpclient;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+
+/**
+ * Can be used with {@code DatabaseClientFactory.addConfigurator} to remove the "Accept-Encoding=gzip" request header
+ * that the underlying OkHttp library adds by default. This is useful in a scenario where many small HTTP responses
+ * are expected to be returned by MarkLogic, and thus the costs of gzipping the responses may outweigh the benefits.
+ *
+ * @since 6.3.0
+ */
+public class RemoveAcceptEncodingConfigurator implements OkHttpClientConfigurator {
+
+	@Override
+	public void configure(OkHttpClient.Builder builder) {
+		builder.addNetworkInterceptor(chain -> {
+			Request newRequest = chain.request().newBuilder().removeHeader("Accept-Encoding").build();
+			return chain.proceed(newRequest);
+		});
+	}
+}

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/DatabaseClientPropertySource.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/DatabaseClientPropertySource.java
@@ -18,6 +18,7 @@ package com.marklogic.client.impl;
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.DatabaseClientBuilder;
 import com.marklogic.client.DatabaseClientFactory;
+import com.marklogic.client.extra.okhttpclient.RemoveAcceptEncodingConfigurator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -89,6 +90,17 @@ public class DatabaseClientPropertySource {
 				}
 			} else {
 				throw new IllegalArgumentException("Connection type must either be a String or an instance of ConnectionType");
+			}
+		});
+		connectionPropertyHandlers.put(PREFIX + "disableGzippedResponses", (bean, value) -> {
+			boolean disableGzippedResponses = false;
+			if (value instanceof Boolean && Boolean.TRUE.equals(value)) {
+				disableGzippedResponses = true;
+			} else if (value instanceof String) {
+				disableGzippedResponses = Boolean.parseBoolean((String)value);
+			}
+			if (disableGzippedResponses) {
+				DatabaseClientFactory.addConfigurator(new RemoveAcceptEncodingConfigurator());
 			}
 		});
 	}

--- a/marklogic-client-api/src/test/java/com/marklogic/client/impl/DatabaseClientPropertySourceTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/impl/DatabaseClientPropertySourceTest.java
@@ -108,6 +108,21 @@ public class DatabaseClientPropertySourceTest {
 		assertEquals("Cloud token duration must be numeric", ex.getMessage());
 	}
 
+	@Test
+	void disableGzippedResponses() {
+		final String prop = PREFIX + "disableGzippedResponses";
+
+		props.put(PREFIX + prop, "true");
+		// Won't throw an error, but we can't verify the results because the list of configurators in
+		// DatabaseClientFactory is private.
+		buildBean();
+
+		// Verifying this doesn't throw an error either; the impl should be using Boolean.parseBoolean which only cares
+		// if the value equals 'true'.
+		props.put(prop, "123");
+		buildBean();
+	}
+
 	private DatabaseClientFactory.Bean buildBean() {
 		DatabaseClientPropertySource source = new DatabaseClientPropertySource(propertyName -> props.get(propertyName));
 		return source.newClientBean();

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/DatabaseClientFactoryTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/DatabaseClientFactoryTest.java
@@ -168,6 +168,7 @@ public class DatabaseClientFactoryTest {
       assertEquals(testConnectTimeoutMillis, okClient.connectTimeoutMillis());
     } finally {
       client.release();
+	  DatabaseClientFactory.removeConfigurators();
     }
   }
 

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/extra/DisableGzippedResponsesTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/extra/DisableGzippedResponsesTest.java
@@ -1,0 +1,67 @@
+package com.marklogic.client.test.extra;
+
+import com.marklogic.client.DatabaseClientFactory;
+import com.marklogic.client.extra.okhttpclient.OkHttpClientConfigurator;
+import com.marklogic.client.test.Common;
+import com.marklogic.client.test.junit5.RequiresML11;
+import okhttp3.Interceptor;
+import okhttp3.Response;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@ExtendWith(RequiresML11.class)
+public class DisableGzippedResponsesTest {
+
+	@AfterEach
+	void afterEach() {
+		DatabaseClientFactory.removeConfigurators();
+	}
+
+	@Test
+	void test() {
+		// Add a DatabaseClientFactory configurator that uses an OkHttp interceptor to capture the value of the
+		// Content-Encoding response header. That is the easiest way to verify whether the Accept-Encoding:gzip request
+		// header is being sent or not.
+		TestInterceptor testInterceptor = new TestInterceptor();
+		DatabaseClientFactory.addConfigurator((OkHttpClientConfigurator) builder -> builder.addNetworkInterceptor(testInterceptor));
+
+
+		final String testUri = "/optic/test/musician1.json";
+
+		Common.newClient().newJSONDocumentManager().read(testUri);
+		assertEquals("gzip", testInterceptor.contentEncoding, "MarkLogic 11 now supports the Accept-Encoding:gzip " +
+			"header. The OkHttp library used by the Java Client includes this request header by default. So we " +
+			"expect for responses from the REST API to be gzipped, which is indicated by the Content-Encoding " +
+			"response header having a value of 'gzip'.");
+
+		Common.newClientBuilder().withGzippedResponsesDisabled().build()
+			.newJSONDocumentManager().read(testUri);
+		assertNull(testInterceptor.contentEncoding, "When a DatabaseClient is constructed with gzipped responses " +
+			"disabled, the Accept-Encoding header added automatically by OkHttp should be removed before the request " +
+			"is sent to MarkLogic. This prevents MarkLogic from gzipping the response, which is indicated by the " +
+			"HTTP response not having a 'Content-Encoding' header.");
+	}
+
+	/**
+	 * Used to capture the value of the Content-Encoding response header.
+	 */
+	private static class TestInterceptor implements Interceptor {
+
+		String contentEncoding;
+
+		@NotNull
+		@Override
+		public Response intercept(@NotNull Chain chain) throws IOException {
+			Response response = chain.proceed(chain.request());
+			contentEncoding = response.header("Content-Encoding");
+			return response;
+		}
+	}
+}


### PR DESCRIPTION
DatabaseClientFactory also supports multiple configurators now. This was essential for testing this new story, but it also aligns with what a user would expect a method named "add" to do (as opposed to "set"). `clearConfigurators` was also added both for testing purposes and so a user could remove all the configurators in case one or more should no longer be used. 