### PR TITLE
Bumping Jackson dependencies to latest

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -6370,7 +6370,7 @@ License Text (http://spdx.org/licenses/Apache-2.0)
 Made available under the Apache License 2.0. See Appendix for full text.
 
 Source materials are available for download at: https://github.com/FasterXML/jackson-annotations
-Jackson Annotations 2.14.1
+Jackson Annotations 2.15.2
 Attribution Statements
 http://wiki.fasterxml.com/JacksonHome
 
@@ -6403,7 +6403,7 @@ License Text (http://www.apache.org/licenses/LICENSE-2.0.txt)
 Made available under the Apache License 2.0. See Appendix for full text.
 
 Source materials are available for download at: https://github.com/FasterXML/jackson-core
-Jackson Core 2.14.1
+Jackson Core 2.15.2
 Attribution Statements
 http://wiki.fasterxml.com/JacksonHome
 
@@ -6450,7 +6450,7 @@ License Text (http://www.apache.org/licenses/LICENSE-2.0.txt)
 Made available under the Apache License 2.0. See Appendix for full text.
 
 Source materials are available for download at: https://github.com/FasterXML/jackson-databind
-Jackson Databind 2.14.1
+Jackson Databind 2.15.2
 Attribution Statements
 http://wiki.fasterxml.com/JacksonHome
 
@@ -6468,7 +6468,7 @@ License Text (http://www.apache.org/licenses/LICENSE-2.0.txt)
 Made available under the Apache License 2.0. See Appendix for full text.
 
 Source materials are available for download at: https://github.com/FasterXML/jackson-databind
-Jackson Dataformat CSV 2.10.3
+Jackson Dataformat CSV 2.15.2
 Attribution Statements
 https://github.com/FasterXML/jackson-dataformat-csv
 

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 	api 'com.squareup.okhttp3:okhttp:4.11.0'
 	api 'io.github.rburgst:okhttp-digest:2.7'
 	api 'org.slf4j:slf4j-api:1.7.36'
-	api 'com.fasterxml.jackson.core:jackson-databind:2.14.3'
+	api 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
 
 	// hsqldb < 2.7 has a High CVE - https://nvd.nist.gov/vuln/detail/CVE-2022-41853 .
 	// And hsqldb 2.6+ requires Java 11+. So this is ignored, along with the associated test,

--- a/marklogic-client-api-functionaltests/build.gradle
+++ b/marklogic-client-api-functionaltests/build.gradle
@@ -25,8 +25,8 @@ dependencies {
   implementation 'commons-io:commons-io:2.11.0'
 	implementation 'com.squareup.okio:okio:3.4.0'
   implementation 'com.squareup.okhttp3:okhttp:4.11.0'
-  implementation 'com.fasterxml.jackson.core:jackson-core:2.14.3'
-  implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.3'
+  implementation 'com.fasterxml.jackson.core:jackson-core:2.15.2'
+  implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
   implementation "org.jdom:jdom2:2.0.6.1"
   implementation "com.marklogic:ml-app-deployer:4.5.2"
 

--- a/marklogic-client-api/build.gradle
+++ b/marklogic-client-api/build.gradle
@@ -21,14 +21,14 @@ dependencies {
 	implementation 'com.squareup.okhttp3:okhttp:4.11.0'
 	implementation 'com.squareup.okhttp3:logging-interceptor:4.11.0'
 	implementation 'io.github.rburgst:okhttp-digest:2.7'
-	
+
 	implementation 'com.sun.mail:javax.mail:1.6.2'
 	implementation 'javax.ws.rs:javax.ws.rs-api:2.1.1'
 	implementation 'org.slf4j:slf4j-api:1.7.36'
-	implementation 'com.fasterxml.jackson.core:jackson-core:2.14.3'
-	implementation 'com.fasterxml.jackson.core:jackson-annotations:2.14.3'
-	implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.3'
-	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.14.3'
+	implementation 'com.fasterxml.jackson.core:jackson-core:2.15.2'
+	implementation 'com.fasterxml.jackson.core:jackson-annotations:2.15.2'
+	implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
+	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.15.2'
 
 	// Only used by extras (which some examples then depend on)
 	// Forcing codec version to avoid vulnerability with older version in httpclient
@@ -54,7 +54,7 @@ dependencies {
 	testImplementation 'com.squareup.okio:okio:3.4.0'
 	testImplementation "com.squareup.okhttp3:mockwebserver:4.11.0"
 
-	testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.14.3'
+	testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.15.2'
 	testImplementation 'ch.qos.logback:logback-classic:1.3.5'
 // schema validation issue with testImplementation 'xerces:xercesImpl:2.12.0'
 	testImplementation 'org.opengis.cite.xerces:xercesImpl-xsd11:2.12-beta-r1667115'

--- a/ml-development-tools/build.gradle
+++ b/ml-development-tools/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     compileOnly gradleApi()
     implementation project(':marklogic-client-api')
     implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.6.20'
-    implementation 'com.fasterxml.jackson.module:jackson-module-kotlin:2.14.1'
+    implementation 'com.fasterxml.jackson.module:jackson-module-kotlin:2.15.2'
     implementation 'com.networknt:json-schema-validator:1.0.76'
 
 	// Not yet migrating this project to JUnit 5. Will reconsider it once we have a reason to enhance

--- a/pom.xml
+++ b/pom.xml
@@ -70,25 +70,25 @@ It is not intended to be used to build this project.
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.14.3</version>
+      <version>2.15.2</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.14.3</version>
+      <version>2.15.2</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.14.3</version>
+      <version>2.15.2</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-csv</artifactId>
-      <version>2.14.3</version>
+      <version>2.15.2</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/test-app/build.gradle
+++ b/test-app/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 	implementation "com.marklogic:ml-javaclient-util:4.5.1"
 	implementation 'org.slf4j:slf4j-api:1.7.36'
 	implementation 'ch.qos.logback:logback-classic:1.3.5'
-	implementation "com.fasterxml.jackson.core:jackson-databind:2.14.3"
+	implementation "com.fasterxml.jackson.core:jackson-databind:2.15.2"
 	implementation 'com.squareup.okio:okio:3.4.0'
 	implementation 'com.squareup.okhttp3:okhttp:4.11.0'
 }


### PR DESCRIPTION
This should be a no-op in terms of functionality; just bumping to get the latest security fixes in Jackson.
