### PR TITLE
Bumping Gradle wrapper version

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This fixes the ml-development-tools tests that started failing when Jackson was bumped from 2.14.3 to 2.15.2. 50 tests failed with a message like this:

org.gradle.api.GradleException: Failed to create Jar file /space/Jenkins/workspace/va-client-api-regression_develop/java-client-api/ml-development-tools/build/tmp/test/work/.gradle-test-kit/caches/jars-9/ba996557e7d64c47da7a273bf722472f/jackson-core-2.15.2.jar.

I'm going to separately look into bumping the Kotlin dependencies of that project as the current ones are quite old.
