### PR TITLE
Bumped dependencies on dev-tools

### DIFF
--- a/ml-development-tools/build.gradle
+++ b/ml-development-tools/build.gradle
@@ -9,18 +9,22 @@ plugins {
 }
 
 dependencies {
-    compileOnly gradleApi()
-    implementation project(':marklogic-client-api')
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.6.20'
-    implementation 'com.fasterxml.jackson.module:jackson-module-kotlin:2.15.2'
-    implementation 'com.networknt:json-schema-validator:1.0.76'
+	compileOnly gradleApi()
+	implementation project(':marklogic-client-api')
+	// Sticking with 1.6.20 for now as that's what OkHttp 4.11.0 depends on.
+	implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.6.20'
+	implementation 'com.fasterxml.jackson.module:jackson-module-kotlin:2.15.2'
+	implementation 'com.networknt:json-schema-validator:1.0.86'
 
 	// Not yet migrating this project to JUnit 5. Will reconsider it once we have a reason to enhance
 	// this project.
 	testImplementation 'junit:junit:4.13.2'
 	testImplementation 'xmlunit:xmlunit:1.6'
 	testCompileOnly gradleTestKit()
-	testImplementation 'com.squareup.okhttp3:okhttp:4.10.0'
+
+	// Forcing usage of 3.4.0 instead of 3.2.0 to address vulnerability - https://security.snyk.io/vuln/SNYK-JAVA-COMSQUAREUPOKIO-5820002
+	testImplementation 'com.squareup.okio:okio:3.4.0'
+	testImplementation 'com.squareup.okhttp3:okhttp:4.11.0'
 }
 
 // Added to avoid problem where processResources fails because - somehow - the plugin properties file is getting
@@ -38,6 +42,7 @@ pluginBundle {
     vcsUrl = 'https://github.com/marklogic/java-client-api.git'
     tags = ['marklogic']
 }
+
 gradlePlugin {
     plugins {
         mlDevelopmentToolsPlugin {


### PR DESCRIPTION
Did not bump kotlin-stdlib though - 1.6.20 is what OkHttp 4.11.0 uses, so sticking with that for now. 