### PR TITLE
Refactored logic for determining SSL inputs

### DIFF
--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/SSLUtil.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/SSLUtil.java
@@ -15,6 +15,9 @@
  */
 package com.marklogic.client.impl;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
@@ -25,7 +28,12 @@ import java.security.NoSuchAlgorithmException;
 public interface SSLUtil {
 
 	static X509TrustManager getDefaultTrustManager() {
-		return (X509TrustManager) getDefaultTrustManagers()[0];
+		X509TrustManager trustManager = (X509TrustManager) getDefaultTrustManagers()[0];
+		Logger logger = LoggerFactory.getLogger(SSLUtil.class);
+		if (logger.isDebugEnabled() && trustManager.getAcceptedIssuers() != null) {
+			logger.debug("Count of accepted issuers in default trust manager: {}", trustManager.getAcceptedIssuers().length);
+		}
+		return trustManager;
 	}
 
 	/**

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/ssl/CheckSSLConnectionTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/ssl/CheckSSLConnectionTest.java
@@ -1,9 +1,10 @@
-package com.marklogic.client.test;
+package com.marklogic.client.test.ssl;
 
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.DatabaseClientFactory;
 import com.marklogic.client.ForbiddenUserException;
 import com.marklogic.client.MarkLogicIOException;
+import com.marklogic.client.test.Common;
 import com.marklogic.client.test.junit5.RequireSSLExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/ssl/SSLTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/ssl/SSLTest.java
@@ -13,13 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.marklogic.client.test;
+package com.marklogic.client.test.ssl;
 
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.DatabaseClientFactory.SSLHostnameVerifier;
 import com.marklogic.client.MarkLogicIOException;
 import com.marklogic.client.document.TextDocumentManager;
 import com.marklogic.client.io.StringHandle;
+import com.marklogic.client.test.Common;
 import org.junit.jupiter.api.Test;
 
 import javax.net.ssl.*;

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/ssl/TwoWaySSLTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/ssl/TwoWaySSLTest.java
@@ -1,4 +1,4 @@
-package com.marklogic.client.test;
+package com.marklogic.client.test.ssl;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.client.DatabaseClient;
@@ -8,6 +8,7 @@ import com.marklogic.client.MarkLogicIOException;
 import com.marklogic.client.document.DocumentDescriptor;
 import com.marklogic.client.eval.EvalResultIterator;
 import com.marklogic.client.io.StringHandle;
+import com.marklogic.client.test.Common;
 import com.marklogic.client.test.junit5.RequireSSLExtension;
 import com.marklogic.mgmt.ManageClient;
 import com.marklogic.mgmt.resource.appservers.ServerManager;


### PR DESCRIPTION
I was looking at this while analyzing support for 2-way SSL and I couldn't really understand what I wrote. So I refactored in the following way:

1. All construction for SSLContext/TrustManager is in buildSSLInputs.
2. There are 4 approaches, each clearly identified and implemented in its own method.
3. I moved the tests I use for verifying SSL support to a "test.ssl" package (no changes to the tests themselves).

This may actually fix a bug but I'm not certain. The bug would have been that "newCertificateAuthContext" was called before all the SSL-input logic had occurred, meaning that e.g. "default" as an sslProtocol value would not have impacted certificate authentication. 
