### PR TITLE
Added test for certificate auth with file and password

### DIFF
--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/DatabaseClientPropertySource.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/DatabaseClientPropertySource.java
@@ -290,8 +290,9 @@ public class DatabaseClientPropertySource {
 				useNewSSLContext(sslProtocol, userTrustManager);
 		}
 
-		// Approach 4 - no SSL connection is needed.
-		return new SSLInputs(null, null);
+		// Approach 4 - still return the user-defined TrustManager as that may be needed for certificate authentication,
+		// which has its own way of constructing an SSLContext from a PKCS12 file.
+		return new SSLInputs(null, userTrustManager);
 	}
 
 	private X509TrustManager getTrustManager() {


### PR DESCRIPTION
This catches the bug that I thought might have existed previous to the prior PR - it ensures that a user-defined TrustManager is used when an SSLContext is created based on a user-defined path for a PKCS12 file.
