### PR TITLE
Renamed some things in SSL tests to improve clarity

### DIFF
--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/junit5/RequireSSLExtension.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/junit5/RequireSSLExtension.java
@@ -61,9 +61,10 @@ public class RequireSSLExtension extends LoggingObject implements BeforeAllCallb
 
 	/**
 	 * @return a trust manager that accepts the public certificate associated with the certificate template created
-	 * by this class.
+	 * by this class. "secure" is meant to imply that this provides some level of security by only accepting the
+	 * one issuer, as opposed to a "trust everything" approach.
 	 */
-	public static X509TrustManager newTrustManager() {
+	public static X509TrustManager newSecureTrustManager() {
 		return new X509TrustManager() {
 			@Override
 			public void checkClientTrusted(X509Certificate[] chain, String authType) {

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/ssl/OneWaySSLTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/ssl/OneWaySSLTest.java
@@ -13,13 +13,16 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.TrustManager;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * Verifies scenarios for "one-way SSL" - i.e. the MarkLogic app server is configured with a certificate template to
+ * require an SSL connection, but the client only needs to trust the server - the client does not present its own
+ * certificate. See TwoWaySSLTest for scenarios where the client presents its own certificate which the server must
+ * trust.
+ */
 @ExtendWith(RequireSSLExtension.class)
-class CheckSSLConnectionTest {
+class OneWaySSLTest {
 
 	/**
 	 * Simple check for ensuring that an SSL connection can be made when the app server requires SSL to be used. This
@@ -59,14 +62,14 @@ class CheckSSLConnectionTest {
 	 * with the certificate template created via RequireSSLExtension.
 	 */
 	@Test
-	void customTrustManager() {
+	void trustManagerThatOnlyTrustsTheCertificateFromTheCertificateTemplate() {
 		if (Common.USE_REVERSE_PROXY_SERVER) {
 			return;
 		}
 
 		DatabaseClient client = Common.newClientBuilder()
 			.withSSLProtocol("TLSv1.2")
-			.withTrustManager(RequireSSLExtension.newTrustManager())
+			.withTrustManager(RequireSSLExtension.newSecureTrustManager())
 			.withSSLHostnameVerifier(DatabaseClientFactory.SSLHostnameVerifier.ANY)
 			.build();
 

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/ssl/TwoWaySSLTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/ssl/TwoWaySSLTest.java
@@ -105,7 +105,7 @@ public class TwoWaySSLTest {
 		DatabaseClient clientWithCert = Common.newClientBuilder()
 			.withSSLHostnameVerifier(DatabaseClientFactory.SSLHostnameVerifier.ANY)
 			.withSSLContext(createSSLContextWithClientCertificate(keyStoreFile))
-			.withTrustManager(RequireSSLExtension.newTrustManager())
+			.withTrustManager(RequireSSLExtension.newSecureTrustManager())
 			.build();
 
 		verifyTestDocumentCanBeRead(clientWithCert);
@@ -114,7 +114,7 @@ public class TwoWaySSLTest {
 		DatabaseClient clientWithoutCert = Common.newClientBuilder()
 			.withSSLHostnameVerifier(DatabaseClientFactory.SSLHostnameVerifier.ANY)
 			.withSSLProtocol("TLSv1.2")
-			.withTrustManager(RequireSSLExtension.newTrustManager())
+			.withTrustManager(RequireSSLExtension.newSecureTrustManager())
 			.build();
 
 		// The type of SSL failure varies across Java versions, so not asserting on a particular error message.
@@ -142,7 +142,7 @@ public class TwoWaySSLTest {
 		try {
 			SSLContext sslContext = createSSLContextWithClientCertificate(keyStoreFile);
 			DatabaseClient client = Common.newClientBuilder()
-				.withCertificateAuth(sslContext, RequireSSLExtension.newTrustManager())
+				.withCertificateAuth(sslContext, RequireSSLExtension.newSecureTrustManager())
 				.withSSLHostnameVerifier(DatabaseClientFactory.SSLHostnameVerifier.ANY)
 				.build();
 
@@ -166,7 +166,7 @@ public class TwoWaySSLTest {
 		try {
 			DatabaseClient client = Common.newClientBuilder()
 				.withCertificateAuth(p12File.getAbsolutePath(), KEYSTORE_PASSWORD)
-				.withTrustManager(RequireSSLExtension.newTrustManager())
+				.withTrustManager(RequireSSLExtension.newSecureTrustManager())
 				.withSSLHostnameVerifier(DatabaseClientFactory.SSLHostnameVerifier.ANY)
 				.build();
 
@@ -200,7 +200,7 @@ public class TwoWaySSLTest {
 		SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
 		sslContext.init(
 			keyManagerFactory.getKeyManagers(),
-			new X509TrustManager[]{RequireSSLExtension.newTrustManager()},
+			new X509TrustManager[]{RequireSSLExtension.newSecureTrustManager()},
 			null);
 		return sslContext;
 	}


### PR DESCRIPTION
Wanted to make the distinction between "OneWay" and "TwoWay" SSL tests. 