### PR TITLE
Removing RequiresML11

### DIFF
--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/PlanGeneratedTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/PlanGeneratedTest.java
@@ -17,13 +17,11 @@
 package com.marklogic.client.test;
 
 import com.marklogic.client.io.Format;
-import com.marklogic.client.test.junit5.RequiresML11;
 import com.marklogic.client.type.ServerExpression;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 // IMPORTANT: Do not edit. This file is generated.
-// Exception - some of these tests cannot pass on ML <= 10. Those have been modified to not run unless ML is >= 11.
 public class PlanGeneratedTest extends PlanGeneratedBase {
 
     @Test
@@ -727,7 +725,6 @@ public class PlanGeneratedTest extends PlanGeneratedBase {
     }
 
     @Test
-	@ExtendWith(RequiresML11.class)
     public void testGeoGeohashDecode1Exec() {
 		executeTester("testGeoGeohashDecode1", p.geo.geohashDecode(p.col("1")), false, "cts:box", null, null, "[-90, -180, 90, 180]", new ServerExpression[]{p.xs.string("abc")});
     }
@@ -753,7 +750,6 @@ public class PlanGeneratedTest extends PlanGeneratedBase {
     }
 
     @Test
-	@ExtendWith(RequiresML11.class)
     public void testGeoParseWkt1Exec() {
 		executeTester("testGeoParseWkt1", p.geo.parseWkt(p.col("1")), false, "cts:linestring", null, null, "LINESTRING(-112.25 47.100002,-112.3 47.100002,-112.39999 47.199997)", new ServerExpression[]{p.xs.string("LINESTRING(-112.25 47.1,-112.3 47.1,-112.4 47.2)")});
     }
@@ -1659,7 +1655,6 @@ public class PlanGeneratedTest extends PlanGeneratedBase {
     }
 
     @Test
-	@ExtendWith(RequiresML11.class)
     public void testXdmpUnquote1Exec() {
 		executeTester("testXdmpUnquote1", p.xdmp.unquote(p.col("1")), false, null, "array", Format.JSON, "[123]", new ServerExpression[]{p.xs.string("[123]")});
     }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/extra/DisableGzippedResponsesTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/extra/DisableGzippedResponsesTest.java
@@ -3,20 +3,17 @@ package com.marklogic.client.test.extra;
 import com.marklogic.client.DatabaseClientFactory;
 import com.marklogic.client.extra.okhttpclient.OkHttpClientConfigurator;
 import com.marklogic.client.test.Common;
-import com.marklogic.client.test.junit5.RequiresML11;
 import okhttp3.Interceptor;
 import okhttp3.Response;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-@ExtendWith(RequiresML11.class)
 public class DisableGzippedResponsesTest {
 
 	@AfterEach

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/ColumnInfoTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/ColumnInfoTest.java
@@ -8,17 +8,14 @@ import com.marklogic.client.row.RawPlanDefinition;
 import com.marklogic.client.row.RawQueryDSLPlan;
 import com.marklogic.client.row.RowManager;
 import com.marklogic.client.test.Common;
-import com.marklogic.client.test.junit5.RequiresML11;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.springframework.core.io.ClassPathResource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith(RequiresML11.class)
 public class ColumnInfoTest {
 
 	private RowManager rowManager;

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/ExportTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/ExportTest.java
@@ -5,11 +5,9 @@ import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.Format;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.test.Common;
-import com.marklogic.client.test.junit5.RequiresML11;
 import com.marklogic.client.type.CtsReferenceExpr;
 import com.marklogic.client.type.PlanTripleOption;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -24,7 +22,6 @@ import java.util.Map;
 public class ExportTest extends AbstractOpticUpdateTest {
 
     @Test
-	@ExtendWith(RequiresML11.class)
     public void fromDocUris() {
         verifyExportedPlanReturnsSameRowCount(
                 op.fromDocUris(op.cts.wordQuery("trumpet"), "")
@@ -43,7 +40,6 @@ public class ExportTest extends AbstractOpticUpdateTest {
     }
 
     @Test
-	@ExtendWith(RequiresML11.class)
     public void fromParam() {
         DocumentMetadataHandle metadata = new DocumentMetadataHandle();
         DocumentWriteSet writeSet = Common.client.newDocumentManager().newWriteSet();

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/FromDocDescriptorsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/FromDocDescriptorsTest.java
@@ -12,9 +12,7 @@ import com.marklogic.client.io.Format;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.row.RowRecord;
 import com.marklogic.client.test.Common;
-import com.marklogic.client.test.junit5.RequiresML11;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.List;
 import java.util.stream.Stream;
@@ -25,7 +23,6 @@ import static org.junit.jupiter.api.Assertions.*;
  * In addition to testing fromDocDescriptors, this class contains tests to verify that default collections and
  * permissions are honored correctly.
  */
-@ExtendWith(RequiresML11.class)
 public class FromDocDescriptorsTest extends AbstractOpticUpdateTest {
 
     private final static String USER_WITH_DEFAULT_COLLECTIONS_AND_PERMISSIONS = "writer-default-collections-and-permissions";

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/FromParamTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/FromParamTest.java
@@ -12,10 +12,8 @@ import com.marklogic.client.io.marker.AbstractWriteHandle;
 import com.marklogic.client.row.RawPlanDefinition;
 import com.marklogic.client.row.RowRecord;
 import com.marklogic.client.test.Common;
-import com.marklogic.client.test.junit5.RequiresML11;
 import com.marklogic.client.type.PlanParamExpr;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -28,7 +26,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * Tests various scenarios involving the {@code fromParam} accessor and the need to bind a content handle as a parameter
  * to the plan.
  */
-@ExtendWith(RequiresML11.class)
 public class FromParamTest extends AbstractOpticUpdateTest {
 
 	@Test

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/FromParamWriteTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/FromParamWriteTest.java
@@ -13,10 +13,8 @@ import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.row.RawPlanDefinition;
 import com.marklogic.client.row.RowRecord;
 import com.marklogic.client.test.Common;
-import com.marklogic.client.test.junit5.RequiresML11;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.List;
 
@@ -24,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith(RequiresML11.class)
 public class FromParamWriteTest extends AbstractOpticUpdateTest {
 
 	@Test

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/GraphQLTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/GraphQLTest.java
@@ -6,15 +6,12 @@ import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.row.RowManager;
 import com.marklogic.client.test.Common;
-import com.marklogic.client.test.junit5.RequiresML11;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith(RequiresML11.class)
 public class GraphQLTest extends AbstractOpticUpdateTest {
 
 	private final static String QUERY = "query myQuery { opticUnitTest_musician {firstName lastName}}";

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/JoinDocColsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/JoinDocColsTest.java
@@ -3,11 +3,8 @@ package com.marklogic.client.test.rows;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.client.expression.PlanBuilder;
 import com.marklogic.client.row.RowRecord;
-import com.marklogic.client.test.Common;
-import com.marklogic.client.test.junit5.RequiresML11;
 import com.marklogic.client.type.PlanColumn;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.HashMap;
 import java.util.List;
@@ -16,7 +13,6 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith(RequiresML11.class)
 public class JoinDocColsTest extends AbstractOpticUpdateTest {
 
     // 4 musician documents are expected to be in this directory via mlDeploy

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/JoinDocTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/JoinDocTest.java
@@ -5,10 +5,8 @@ import com.marklogic.client.document.JSONDocumentManager;
 import com.marklogic.client.expression.PlanBuilder;
 import com.marklogic.client.row.RowRecord;
 import com.marklogic.client.test.Common;
-import com.marklogic.client.test.junit5.RequiresML11;
 import com.marklogic.client.type.CtsReferenceExpr;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.HashMap;
 import java.util.List;
@@ -19,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * Written for bug 58069; see that description for more information.
  */
-@ExtendWith(RequiresML11.class)
 public class JoinDocTest extends AbstractOpticUpdateTest {
 
     @Test

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/LockForUpdateTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/LockForUpdateTest.java
@@ -6,16 +6,13 @@ import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.row.RowRecord;
 import com.marklogic.client.test.Common;
-import com.marklogic.client.test.junit5.RequiresML11;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith(RequiresML11.class)
 public class LockForUpdateTest extends AbstractOpticUpdateTest {
 
     @Test

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RemoveTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RemoveTest.java
@@ -11,15 +11,12 @@ import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.row.RowRecord;
 import com.marklogic.client.test.Common;
-import com.marklogic.client.test.junit5.RequiresML11;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@ExtendWith(RequiresML11.class)
 public class RemoveTest extends AbstractOpticUpdateTest {
 
     @Test

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/RowManagerTest.java
@@ -30,14 +30,12 @@ import com.marklogic.client.row.RowManager.RowSetPart;
 import com.marklogic.client.row.RowManager.RowStructure;
 import com.marklogic.client.row.RowRecord.ColumnKind;
 import com.marklogic.client.test.Common;
-import com.marklogic.client.test.junit5.RequiresML11;
 import com.marklogic.client.type.*;
 import com.marklogic.client.util.EditableNamespaceContext;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -518,7 +516,6 @@ public class RowManagerTest {
   }
 
   @Test
-  @ExtendWith(RequiresML11.class)
   public void testErrorWhileStreamingRows() {
     final String validQueryThatEventuallyThrowsAnError = "select case " +
         "when lastName = 'Davis' then fn_error(fn_qname('', 'SQL-TABLENOTFOUND'), 'Internal Server Error') end, " +
@@ -1522,7 +1519,6 @@ public class RowManagerTest {
   }
 
   @Test
-  @ExtendWith(RequiresML11.class)
   public void testFromDocUrisWithWordQuery() {
     RowManager rowMgr = Common.client.newRowManager();
     PlanBuilder p = rowMgr.newPlanBuilder();
@@ -1541,7 +1537,6 @@ public class RowManagerTest {
   }
 
   @Test
-  @ExtendWith(RequiresML11.class)
   public void testFromDocUrisWithDirectoryQuery() {
     RowManager rowMgr = Common.client.newRowManager();
     PlanBuilder p = rowMgr.newPlanBuilder();

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/TraceLabelAndOptimizeTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/TraceLabelAndOptimizeTest.java
@@ -2,10 +2,7 @@ package com.marklogic.client.test.rows;
 
 import com.marklogic.client.FailedRequestException;
 import com.marklogic.client.row.RowRecord;
-import com.marklogic.client.test.Common;
-import com.marklogic.client.test.junit5.RequiresML11;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.List;
 
@@ -16,7 +13,6 @@ import static org.junit.jupiter.api.Assertions.*;
  * verify that a particular valid value for "optimize" had the intended effect. So this test ensures that valid values
  * don't throw errors, and invalid values do not work.
  */
-@ExtendWith(RequiresML11.class)
 public class TraceLabelAndOptimizeTest extends AbstractOpticUpdateTest {
 
     @Test

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/TransformDocTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/TransformDocTest.java
@@ -9,10 +9,7 @@ import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.io.marker.AbstractWriteHandle;
 import com.marklogic.client.row.RowRecord;
-import com.marklogic.client.test.Common;
-import com.marklogic.client.test.junit5.RequiresML11;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -21,7 +18,6 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@ExtendWith(RequiresML11.class)
 public class TransformDocTest extends AbstractOpticUpdateTest {
 
     @Test

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/UnnestTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/UnnestTest.java
@@ -4,10 +4,8 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.client.expression.PlanBuilder;
 import com.marklogic.client.row.RowRecord;
-import com.marklogic.client.test.junit5.RequiresML11;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.util.StringUtils;
 
 import java.util.List;
@@ -20,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
  * Test demonstrates the primary use case for unnest, which is, for a given row, to create N rows based on a column in
  * that row containing an array with N values.
  */
-@ExtendWith(RequiresML11.class)
 public class UnnestTest extends AbstractOpticUpdateTest {
 
 	private final static String TEAM_MEMBER_NAME_COLUMN = "teamMemberName";

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/UpdateUseCasesTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/UpdateUseCasesTest.java
@@ -10,10 +10,8 @@ import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.row.RowRecord;
 import com.marklogic.client.test.Common;
-import com.marklogic.client.test.junit5.RequiresML11;
 import com.marklogic.client.type.PlanSystemColumn;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -25,7 +23,6 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Intended to capture interesting use cases, particularly those called out in the functional spec.
  */
-@ExtendWith(RequiresML11.class)
 public class UpdateUseCasesTest extends AbstractOpticUpdateTest {
 
     /**

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/ValidateDocTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/ValidateDocTest.java
@@ -26,10 +26,8 @@ import com.marklogic.client.io.Format;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.row.RowRecord;
 import com.marklogic.client.test.Common;
-import com.marklogic.client.test.junit5.RequiresML11;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -37,7 +35,6 @@ import java.util.stream.Collectors;
 import static com.marklogic.client.io.Format.XML;
 import static org.junit.jupiter.api.Assertions.*;
 
-@ExtendWith(RequiresML11.class)
 public class ValidateDocTest extends AbstractOpticUpdateTest {
 
     private Set<String> expectedUris = new HashSet<>();


### PR DESCRIPTION
Haven't really needed this since Java Client 6.0 was released, as that was associated with MarkLogic 11. We don't have any Jenkins jobs running against MarkLogic 10 either (we would do that if we do a new 5.x release). 

This simplifies using the Optic code generator by not modifying PlanGeneratedTest anymore. 