### PR TITLE
DEVEXP-563 Added geohashSubhashes to Optic plan builder

### DIFF
--- a/marklogic-client-api/src/main/java/com/marklogic/client/expression/CtsExpr.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/expression/CtsExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -3240,7 +3240,7 @@ public interface CtsExpr {
   * @return  a CtsCircleSeqExpr sequence
   */
   public CtsCircleSeqExpr circleSeq(CtsCircleExpr... items);
-
+ 
 /**
   * Constructs a sequence of CtsPeriodExpr items.
   * @param items  the CtsPeriodExpr items collected by the sequence

--- a/marklogic-client-api/src/main/java/com/marklogic/client/expression/FnExpr.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/expression/FnExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/expression/GeoExpr.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/expression/GeoExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -769,6 +769,17 @@ public interface GeoExpr {
   public ServerExpression geohashPrecisionDimensions(ServerExpression precision);
 /**
   * Given a geohash string, return the 32 subhashes.
+  *
+  * <a name="ml-server-type-geohash-subhashes"></a>
+  
+  * <p>
+  * Provides a client interface to the <a href="http://docs.marklogic.com/geo:geohash-subhashes" target="mlserverdoc">geo:geohash-subhashes</a> server function.
+  * @param hash  The geohash string, as produced from the function geo:geohash-encode.  (of <a href="{@docRoot}/doc-files/types/xs_string.html">xs:string</a>)
+  * @return  a server expression with the <a href="{@docRoot}/doc-files/types/xs_string.html">xs:string</a> server data type
+  */
+  public ServerExpression geohashSubhashes(ServerExpression hash);
+/**
+  * Given a geohash string, return the 32 subhashes.
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/geo:geohash-subhashes" target="mlserverdoc">geo:geohash-subhashes</a> server function.
   * @param hash  The geohash string, as produced from the function geo:geohash-encode.  (of <a href="{@docRoot}/doc-files/types/xs_string.html">xs:string</a>)
@@ -778,9 +789,6 @@ public interface GeoExpr {
   public ServerExpression geohashSubhashes(ServerExpression hash, String which);
 /**
   * Given a geohash string, return the 32 subhashes.
-  *
-  * <a name="ml-server-type-geohash-subhashes"></a>
-  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/geo:geohash-subhashes" target="mlserverdoc">geo:geohash-subhashes</a> server function.
   * @param hash  The geohash string, as produced from the function geo:geohash-encode.  (of <a href="{@docRoot}/doc-files/types/xs_string.html">xs:string</a>)

--- a/marklogic-client-api/src/main/java/com/marklogic/client/expression/JsonExpr.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/expression/JsonExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/expression/MapExpr.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/expression/MapExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/expression/MathExpr.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/expression/MathExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/expression/PlanBuilder.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/expression/PlanBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -603,7 +603,7 @@ public abstract class PlanBuilder implements PlanBuilderBase {
   * This function constructs document rows with rows provided by a parameter.
   * @param paramName  The paramName parameter specifies the placeholder parameter supplying the rows.
   * @param qualifier  Specifies a name for qualifying the column names.
-  * @param rowColTypes  Describes the columns with an array of JavaScript objects. It's a combinations of column, type and nullable. The 'column' is the column name, which is required. The 'type' is the optional type of the column, which can be an atomic type or the default of none. The 'nullable' is an optional boolean defaulting to false. If your rows contains only uri, doc, collections, metadata, permissions, quality and temporalCollection columns, you could simply use op.docColTypes instead.
+  * @param rowColTypes  Describes the columns with a sequence of maps. It's a combinations of column, type and nullable. The 'column' is the column name, which is required. The 'type' is the optional type of the column, which can be an atomic type or the default of none. The 'nullable' is an optional boolean defaulting to false. If your rows contains only uri, doc, collections, metadata, permissions, quality and temporalCollection columns, you could simply use op:doc-col-types instead.
   * @return  a AccessPlan object
   */
   public abstract AccessPlan fromParam(String paramName, String qualifier, PlanRowColTypesSeq rowColTypes);
@@ -611,32 +611,32 @@ public abstract class PlanBuilder implements PlanBuilderBase {
   * This function constructs document rows with rows provided by a parameter.
   * @param paramName  The paramName parameter specifies the placeholder parameter supplying the rows.
   * @param qualifier  Specifies a name for qualifying the column names.
-  * @param rowColTypes  Describes the columns with an array of JavaScript objects. It's a combinations of column, type and nullable. The 'column' is the column name, which is required. The 'type' is the optional type of the column, which can be an atomic type or the default of none. The 'nullable' is an optional boolean defaulting to false. If your rows contains only uri, doc, collections, metadata, permissions, quality and temporalCollection columns, you could simply use op.docColTypes instead.
+  * @param rowColTypes  Describes the columns with a sequence of maps. It's a combinations of column, type and nullable. The 'column' is the column name, which is required. The 'type' is the optional type of the column, which can be an atomic type or the default of none. The 'nullable' is an optional boolean defaulting to false. If your rows contains only uri, doc, collections, metadata, permissions, quality and temporalCollection columns, you could simply use op:doc-col-types instead.
   * @return  a AccessPlan object
   */
   public abstract AccessPlan fromParam(XsStringVal paramName, XsStringVal qualifier, PlanRowColTypesSeq rowColTypes);
   /**
   * This function constructs document rows from the docsDescriptors.
-  * @param docDescriptor  An array of document descriptors. Each document descriptor describes a document. A document descriptor contains a combination of uri, doc, collections, metadata, permissions, quality and temporalCollection. This is a simpler form of op.fromParam.
+  * @param docDescriptor  A map of document descriptors. Each document descriptor describes a document. A document descriptor contains a combination of uri, doc, collections, metadata, permissions, quality and temporalCollection. This is a simpler form of op:from-param.
   * @return  a AccessPlan object
   */
   public abstract AccessPlan fromDocDescriptors(PlanDocDescriptor... docDescriptor);
   /**
   * This function constructs document rows from the docsDescriptors.
-  * @param docDescriptor  An array of document descriptors. Each document descriptor describes a document. A document descriptor contains a combination of uri, doc, collections, metadata, permissions, quality and temporalCollection. This is a simpler form of op.fromParam.
+  * @param docDescriptor  A map of document descriptors. Each document descriptor describes a document. A document descriptor contains a combination of uri, doc, collections, metadata, permissions, quality and temporalCollection. This is a simpler form of op:from-param.
   * @return  a AccessPlan object
   */
   public abstract AccessPlan fromDocDescriptors(PlanDocDescriptorSeq docDescriptor);
   /**
   * This function constructs document rows from the docsDescriptors.
-  * @param docDescriptor  An array of document descriptors. Each document descriptor describes a document. A document descriptor contains a combination of uri, doc, collections, metadata, permissions, quality and temporalCollection. This is a simpler form of op.fromParam.
+  * @param docDescriptor  A map of document descriptors. Each document descriptor describes a document. A document descriptor contains a combination of uri, doc, collections, metadata, permissions, quality and temporalCollection. This is a simpler form of op:from-param.
   * @param qualifier  Specifies a name for qualifying the column names.
   * @return  a AccessPlan object
   */
   public abstract AccessPlan fromDocDescriptors(PlanDocDescriptorSeq docDescriptor, String qualifier);
   /**
   * This function constructs document rows from the docsDescriptors.
-  * @param docDescriptor  An array of document descriptors. Each document descriptor describes a document. A document descriptor contains a combination of uri, doc, collections, metadata, permissions, quality and temporalCollection. This is a simpler form of op.fromParam.
+  * @param docDescriptor  A map of document descriptors. Each document descriptor describes a document. A document descriptor contains a combination of uri, doc, collections, metadata, permissions, quality and temporalCollection. This is a simpler form of op:from-param.
   * @param qualifier  Specifies a name for qualifying the column names.
   * @return  a AccessPlan object
   */
@@ -1378,38 +1378,38 @@ public abstract class PlanBuilder implements PlanBuilderBase {
   */
   public abstract PlanFunction resolveFunction(XsQNameVal functionName, XsStringVal modulePath);
   /**
-  * Constructs a document column identifier object for columns of uri, doc, collections, metadata, permissions, quality and temporalCollection. The document column identifier object can be passed to the prototype.joinDocCols or prototype.write.
+  * Constructs a document column identifier object for columns of uri, doc, collections, metadata, permissions, quality and temporalCollection. The document column identifier object can be passed to the op:join-doc-cols or op:write.
   * @return  a PlanDocColsIdentifier object
   */
   public abstract PlanDocColsIdentifier docCols();
   /**
-  * Constructs a document column identifier object for columns of uri, doc, collections, metadata, permissions, quality and temporalCollection. The document column identifier object can be passed to the prototype.joinDocCols or prototype.write.
+  * Constructs a document column identifier object for columns of uri, doc, collections, metadata, permissions, quality and temporalCollection. The document column identifier object can be passed to the op:join-doc-cols or op:write.
   * @param qualifier  Specifies a name for qualifying the column names.
   * @return  a PlanDocColsIdentifier object
   */
   public abstract PlanDocColsIdentifier docCols(String qualifier);
   /**
-  * Constructs a document column identifier object for columns of uri, doc, collections, metadata, permissions, quality and temporalCollection. The document column identifier object can be passed to the prototype.joinDocCols or prototype.write.
+  * Constructs a document column identifier object for columns of uri, doc, collections, metadata, permissions, quality and temporalCollection. The document column identifier object can be passed to the op:join-doc-cols or op:write.
   * @param qualifier  Specifies a name for qualifying the column names.
   * @return  a PlanDocColsIdentifier object
   */
   public abstract PlanDocColsIdentifier docCols(XsStringVal qualifier);
   /**
-  * Constructs a document column identifier object for columns of uri, doc, collections, metadata, permissions, quality and temporalCollection. The document column identifier object can be passed to the prototype.joinDocCols or prototype.write.
+  * Constructs a document column identifier object for columns of uri, doc, collections, metadata, permissions, quality and temporalCollection. The document column identifier object can be passed to the op:join-doc-cols or op:write.
   * @param qualifier  Specifies a name for qualifying the column names.
-  * @param names  An array of columns names, a combination of uri, doc, collections, metadata, permissions, quality and temporalCollection.
+  * @param names  A sequence of columns names, a combination of uri, doc, collections, metadata, permissions, quality and temporalCollection.
   * @return  a PlanDocColsIdentifier object
   */
   public abstract PlanDocColsIdentifier docCols(String qualifier, String names);
   /**
-  * Constructs a document column identifier object for columns of uri, doc, collections, metadata, permissions, quality and temporalCollection. The document column identifier object can be passed to the prototype.joinDocCols or prototype.write.
+  * Constructs a document column identifier object for columns of uri, doc, collections, metadata, permissions, quality and temporalCollection. The document column identifier object can be passed to the op:join-doc-cols or op:write.
   * @param qualifier  Specifies a name for qualifying the column names.
-  * @param names  An array of columns names, a combination of uri, doc, collections, metadata, permissions, quality and temporalCollection.
+  * @param names  A sequence of columns names, a combination of uri, doc, collections, metadata, permissions, quality and temporalCollection.
   * @return  a PlanDocColsIdentifier object
   */
   public abstract PlanDocColsIdentifier docCols(XsStringVal qualifier, XsStringSeqVal names);
   /**
-  * Provides the 3rd parameter for op.fromParam for row column types.
+  * Provides the 3rd parameter for op:from-param for row column types.
   * @return  a PlanRowColTypesSeq object sequence
   */
   public abstract PlanRowColTypesSeq docColTypes();
@@ -1739,13 +1739,13 @@ public abstract class PlanBuilder implements PlanBuilderBase {
   public abstract ModifyPlan orderBy(PlanSortKeySeq keys);
 /**
   * This method prepares the specified plan for execution as an optional final step before execution.
-  * @param optimize  The optimization level, which can be 0, 1, or 2 (with 1 as the default).
+  * @param optimize  The optimization level, which can be 0, 1, or 2 (1 is mostly used).
   * @return  a PreparePlan object
   */
   public abstract PreparePlan prepare(int optimize);
 /**
   * This method prepares the specified plan for execution as an optional final step before execution.
-  * @param optimize  The optimization level, which can be 0, 1, or 2 (with 1 as the default).
+  * @param optimize  The optimization level, which can be 0, 1, or 2 (1 is mostly used).
   * @return  a PreparePlan object
   */
   public abstract PreparePlan prepare(XsIntVal optimize);
@@ -1797,33 +1797,31 @@ public abstract class PlanBuilder implements PlanBuilderBase {
   * @return  a ModifyPlan object
   */
   public abstract ModifyPlan write(PlanDocColsIdentifier docCols);
- /**
-  * This function populates the view with the uri, doc, collections, metadata, permissions, and/or quality document descriptor columns for database document values.
-  * @param cols  Supplies a document column identifier object to specify which document columns to join and their names. The names cannot conflict with existing column names.
-  * @param docIdCol  The document uri or fragment id value. This is either an op.fragmentIdCol object specifying a fragment id column or a document uri column.
+/**
+  * This function populates the view with the uri, doc, collections, metadata, permissions, and / or quality document descriptor columns for database document values.
+  * @param cols  The source column to join. This is either an op:fragment-id-col specifying a fragment id column or a op:col, op:view-col or op:schema-col that contains document uris. Joining on a fragment id is more efficient than joining on an uri column.
+  * @param docIdCol  the docIdCol  value. See {@link PlanBuilder#col(XsStringVal)}
   * @return  a ModifyPlan object
   */
- public abstract ModifyPlan joinDocCols(PlanDocColsIdentifier cols, String docIdCol);
- /**
-  * This function populates the view with the uri, doc, collections, metadata, permissions, and/or quality document descriptor columns for database document values.
-  * @param cols  Supplies a document column identifier object to specify which document columns to join and their names. The names cannot conflict with existing column names.
-  * @param docIdCol  The document uri or fragment id value. This is either an op.fragmentIdCol object specifying a fragment id column or a document uri column.
+  public abstract ModifyPlan joinDocCols(PlanDocColsIdentifier cols, String docIdCol);
+/**
+  * This function populates the view with the uri, doc, collections, metadata, permissions, and / or quality document descriptor columns for database document values.
+  * @param cols  The source column to join. This is either an op:fragment-id-col specifying a fragment id column or a op:col, op:view-col or op:schema-col that contains document uris. Joining on a fragment id is more efficient than joining on an uri column.
+  * @param docIdCol  the docIdCol  value. See {@link PlanBuilder#col(XsStringVal)}
   * @return  a ModifyPlan object
   */
   public abstract ModifyPlan joinDocCols(PlanDocColsIdentifier cols, PlanColumn docIdCol);
- /**
-  * Validates the document based on a supplied schema. This schema needs to be stored in the schema database.
-  * @param validateDocCol  Contains the document to validate.
-  * @param schemaDef  This is an object. The required 'kind' property of the schema object must be 'jsonSchema', 'schematron', or 'xmlSchema'. When 'kind' is 'jsonSchema' or 'schemtron' then a property 'schemaUri' is required.
-  *                   Property 'mode' takes 'strict', 'lax' or 'type' (refer to xdmp.validate).
+/**
+  * Validate the document based on a supplied schema. This schema needs to be stored in the schema database. Check appserver error log for validate errors.
+  * @param validateDocCol  The required 'kind' key of the schemaDef map must be 'jsonSchema', 'schematron', or 'xmlSchema'. When 'kind' is 'jsonSchema' or 'schemtron' then a key 'schemaUri' is required. Key 'mode' takes 'strict', 'lax' or 'type' (refer to xdmp:validate). See {@link PlanBuilder#col(XsStringVal)}
+  * @param schemaDef  the schemaDef  value.
   * @return  a ModifyPlan object
   */
   public abstract ModifyPlan validateDoc(String validateDocCol, PlanSchemaDef schemaDef);
- /**
-  * Validates the document based on a supplied schema. This schema needs to be stored in the schema database.
-  * @param validateDocCol  Contains the document to validate.
-  * @param schemaDef  This is an object. The required 'kind' property of the schema object must be 'jsonSchema', 'schematron', or 'xmlSchema'. When 'kind' is 'jsonSchema' or 'schemtron' then a property 'schemaUri' is required.
-  *                   Property 'mode' takes 'strict', 'lax' or 'type' (refer to xdmp.validate).
+/**
+  * Validate the document based on a supplied schema. This schema needs to be stored in the schema database. Check appserver error log for validate errors.
+  * @param validateDocCol  The required 'kind' key of the schemaDef map must be 'jsonSchema', 'schematron', or 'xmlSchema'. When 'kind' is 'jsonSchema' or 'schemtron' then a key 'schemaUri' is required. Key 'mode' takes 'strict', 'lax' or 'type' (refer to xdmp:validate). See {@link PlanBuilder#col(XsStringVal)}
+  * @param schemaDef  the schemaDef  value.
   * @return  a ModifyPlan object
   */
   public abstract ModifyPlan validateDoc(PlanColumn validateDocCol, PlanSchemaDef schemaDef);

--- a/marklogic-client-api/src/main/java/com/marklogic/client/expression/RdfExpr.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/expression/RdfExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/expression/SemExpr.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/expression/SemExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/expression/SpellExpr.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/expression/SpellExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/expression/SqlExpr.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/expression/SqlExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/expression/XdmpExpr.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/expression/XdmpExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -177,7 +177,7 @@ public interface XdmpExpr {
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/xdmp:describe" target="mlserverdoc">xdmp:describe</a> server function.
   * @param item  The item sequence whose description is returned.  (of <a href="{@docRoot}/doc-files/types/item.html">item</a>)
-  * @param maxSequenceLength  Represents the maximum number of items per sequence to print. The default is 3. () means no maximum.  (of <a href="{@docRoot}/doc-files/types/xs_unsignedInt.html">xs:unsignedInt</a>)
+  * @param maxSequenceLength  Represents the maximum number of items per sequence to print. The default is 3.  (of <a href="{@docRoot}/doc-files/types/xs_unsignedInt.html">xs:unsignedInt</a>)
   * @return  a server expression with the <a href="{@docRoot}/doc-files/types/xs_string.html">xs:string</a> server data type
   */
   public ServerExpression describe(ServerExpression item, ServerExpression maxSequenceLength);
@@ -186,8 +186,8 @@ public interface XdmpExpr {
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/xdmp:describe" target="mlserverdoc">xdmp:describe</a> server function.
   * @param item  The item sequence whose description is returned.  (of <a href="{@docRoot}/doc-files/types/item.html">item</a>)
-  * @param maxSequenceLength  Represents the maximum number of items per sequence to print. The default is 3. () means no maximum.  (of <a href="{@docRoot}/doc-files/types/xs_unsignedInt.html">xs:unsignedInt</a>)
-  * @param maxItemLength  Represents the maximum number of characters per item to print. The default is 64. The minimum is 8. () means no limit.  (of <a href="{@docRoot}/doc-files/types/xs_unsignedInt.html">xs:unsignedInt</a>)
+  * @param maxSequenceLength  Represents the maximum number of items per sequence to print. The default is 3.  (of <a href="{@docRoot}/doc-files/types/xs_unsignedInt.html">xs:unsignedInt</a>)
+  * @param maxItemLength  Represents the maximum number of characters per item to print. The default is 64. The minimum is 8.  (of <a href="{@docRoot}/doc-files/types/xs_unsignedInt.html">xs:unsignedInt</a>)
   * @return  a server expression with the <a href="{@docRoot}/doc-files/types/xs_string.html">xs:string</a> server data type
   */
   public ServerExpression describe(ServerExpression item, ServerExpression maxSequenceLength, ServerExpression maxItemLength);

--- a/marklogic-client-api/src/main/java/com/marklogic/client/expression/XsExpr.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/expression/XsExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/CtsExprImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/CtsExprImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -184,7 +184,7 @@ class CtsExprImpl implements CtsExpr {
     return new XsExprImpl.NumericCallImpl("cts", "box-west", new Object[]{ box });
   }
 
-
+  
   @Override
   public CtsCircleExpr circle(double radius, ServerExpression center) {
     return circle(xs.doubleVal(radius), center);

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/FnExprImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/FnExprImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/GeoExprImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/GeoExprImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -683,6 +683,15 @@ class GeoExprImpl implements GeoExpr {
       throw new IllegalArgumentException("precision parameter for geohashPrecisionDimensions() cannot be null");
     }
     return new XsExprImpl.DoubleSeqCallImpl("geo", "geohash-precision-dimensions", new Object[]{ precision });
+  }
+
+  
+  @Override
+  public ServerExpression geohashSubhashes(ServerExpression hash) {
+    if (hash == null) {
+      throw new IllegalArgumentException("hash parameter for geohashSubhashes() cannot be null");
+    }
+    return new XsExprImpl.StringSeqCallImpl("geo", "geohash-subhashes", new Object[]{ hash });
   }
 
   

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/JsonExprImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/JsonExprImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/MapExprImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/MapExprImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/MathExprImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/MathExprImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/PlanBuilderImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/PlanBuilderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/RdfExprImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/RdfExprImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/SemExprImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/SemExprImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/SpellExprImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/SpellExprImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/SqlExprImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/SqlExprImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/XdmpExprImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/XdmpExprImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/XsExprImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/XsExprImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/PlanGeneratedTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/PlanGeneratedTest.java
@@ -103,7 +103,7 @@ public class PlanGeneratedTest extends PlanGeneratedBase {
 
     @Test
     public void testFnAdjustDateTimeToTimezone1Exec() {
-        executeTester("testFnAdjustDateTimeToTimezone1", p.fn.adjustDateTimeToTimezone(p.col("1")), true, "xs:dateTime", null, null, "2016-01-02T02:09:08-08:00", new ServerExpression[]{ p.xs.dateTime("2016-01-02T10:09:08Z") });
+        executeTester("testFnAdjustDateTimeToTimezone1", p.fn.adjustDateTimeToTimezone(p.col("1")), true, "xs:dateTime", null, null, "2016-01-02T10:09:08Z", new ServerExpression[]{ p.xs.dateTime("2016-01-02T10:09:08Z") });
     }
 
     @Test
@@ -113,7 +113,7 @@ public class PlanGeneratedTest extends PlanGeneratedBase {
 
     @Test
     public void testFnAdjustDateToTimezone1Exec() {
-        executeTester("testFnAdjustDateToTimezone1", p.fn.adjustDateToTimezone(p.col("1")), true, "xs:date", null, null, "2016-01-02-08:00", new ServerExpression[]{ p.xs.date("2016-01-02") });
+        executeTester("testFnAdjustDateToTimezone1", p.fn.adjustDateToTimezone(p.col("1")), true, "xs:date", null, null, "2016-01-02Z", new ServerExpression[]{ p.xs.date("2016-01-02") });
     }
 
     @Test
@@ -123,7 +123,7 @@ public class PlanGeneratedTest extends PlanGeneratedBase {
 
     @Test
     public void testFnAdjustTimeToTimezone1Exec() {
-        executeTester("testFnAdjustTimeToTimezone1", p.fn.adjustTimeToTimezone(p.col("1")), true, "xs:time", null, null, "02:09:08-08:00", new ServerExpression[]{ p.xs.time("10:09:08Z") });
+        executeTester("testFnAdjustTimeToTimezone1", p.fn.adjustTimeToTimezone(p.col("1")), true, "xs:time", null, null, "10:09:08Z", new ServerExpression[]{ p.xs.time("10:09:08Z") });
     }
 
     @Test
@@ -208,17 +208,17 @@ public class PlanGeneratedTest extends PlanGeneratedBase {
 
     @Test
     public void testFnCurrentDate0Exec() {
-        executeTester("testFnCurrentDate0", p.fn.currentDate(), true, "xs:date", null, null, "2022-12-16-08:00", new ServerExpression[]{  });
+        executeTester("testFnCurrentDate0", p.fn.currentDate(), true, "xs:date", null, null, "2023-10-24Z", new ServerExpression[]{  });
     }
 
     @Test
     public void testFnCurrentDateTime0Exec() {
-        executeTester("testFnCurrentDateTime0", p.fn.currentDateTime(), true, "xs:dateTime", null, null, "2022-12-16T12:21:07.737598-08:00", new ServerExpression[]{  });
+        executeTester("testFnCurrentDateTime0", p.fn.currentDateTime(), true, "xs:dateTime", null, null, "2023-10-24T15:21:06.255777Z", new ServerExpression[]{  });
     }
 
     @Test
     public void testFnCurrentTime0Exec() {
-        executeTester("testFnCurrentTime0", p.fn.currentTime(), true, "xs:time", null, null, "12:21:07-08:00", new ServerExpression[]{  });
+        executeTester("testFnCurrentTime0", p.fn.currentTime(), true, "xs:time", null, null, "15:21:06Z", new ServerExpression[]{  });
     }
 
     @Test
@@ -348,7 +348,7 @@ public class PlanGeneratedTest extends PlanGeneratedBase {
 
     @Test
     public void testFnImplicitTimezone0Exec() {
-        executeTester("testFnImplicitTimezone0", p.fn.implicitTimezone(), true, "xs:dayTimeDuration", null, null, "-PT8H", new ServerExpression[]{  });
+        executeTester("testFnImplicitTimezone0", p.fn.implicitTimezone(), true, "xs:dayTimeDuration", null, null, "PT0S", new ServerExpression[]{  });
     }
 
     @Test
@@ -748,6 +748,12 @@ public class PlanGeneratedTest extends PlanGeneratedBase {
     }
 
     @Test
+	@ExtendWith(RequiresML11.class)
+    public void testGeoGeohashSubhashes1Exec() {
+        executeTester("testGeoGeohashSubhashes1", p.geo.geohashSubhashes(p.col("1")), false, null, null, Format.JSON, "[\"s01mtw0\", \"s01mtw1\", \"s01mtw2\", \"s01mtw3\", \"s01mtw4\", \"s01mtw5\", \"s01mtw6\", \"s01mtw7\", \"s01mtw8\", \"s01mtw9\", \"s01mtwb\", \"s01mtwc\", \"s01mtwd\", \"s01mtwe\", \"s01mtwf\", \"s01mtwg\", \"s01mtwh\", \"s01mtwj\", \"s01mtwk\", \"s01mtwm\", \"s01mtwn\", \"s01mtwp\", \"s01mtwq\", \"s01mtwr\", \"s01mtws\", \"s01mtwt\", \"s01mtwu\", \"s01mtwv\", \"s01mtww\", \"s01mtwx\", \"s01mtwy\", \"s01mtwz\"]", new ServerExpression[]{ p.xs.string("s01mtw") });
+    }
+
+    @Test
     public void testGeoGeohashSubhashes2Exec() {
         executeTester("testGeoGeohashSubhashes2", p.geo.geohashSubhashes(p.col("1"), p.col("2")), false, null, null, Format.JSON, "[\"s01mtwh\", \"s01mtwj\", \"s01mtwk\", \"s01mtwm\", \"s01mtwn\", \"s01mtwp\", \"s01mtwq\", \"s01mtwr\", \"s01mtws\", \"s01mtwt\", \"s01mtwu\", \"s01mtwv\", \"s01mtww\", \"s01mtwx\", \"s01mtwy\", \"s01mtwz\"]", new ServerExpression[]{ p.xs.string("s01mtw"), p.xs.string("S") });
     }
@@ -755,7 +761,7 @@ public class PlanGeneratedTest extends PlanGeneratedBase {
     @Test
 	@ExtendWith(RequiresML11.class)
     public void testGeoParseWkt1Exec() {
-		executeTester("testGeoParseWkt1", p.geo.parseWkt(p.col("1")), false, "cts:linestring", null, null, "LINESTRING(-112.25 47.100002,-112.3 47.100002,-112.39999 47.199997)", new ServerExpression[]{p.xs.string("LINESTRING(-112.25 47.1,-112.3 47.1,-112.4 47.2)")});
+        executeTester("testGeoParseWkt1", p.geo.parseWkt(p.col("1")), false, "cts:linestring", null, null, "LINESTRING(-112.25 47.100002,-112.3 47.100002,-112.39999 47.199997)", new ServerExpression[]{ p.xs.string("LINESTRING(-112.25 47.1,-112.3 47.1,-112.4 47.2)") });
     }
 
     @Test
@@ -1000,7 +1006,7 @@ public class PlanGeneratedTest extends PlanGeneratedBase {
 
     @Test
     public void testSemBnode0Exec() {
-        executeTester("testSemBnode0", p.sem.bnode(), true, "sem:blank", null, null, "_:bnode5979962185343367584", new ServerExpression[]{  });
+        executeTester("testSemBnode0", p.sem.bnode(), true, "sem:blank", null, null, "_:bnode801272998575329659", new ServerExpression[]{  });
     }
 
     @Test
@@ -1080,7 +1086,7 @@ public class PlanGeneratedTest extends PlanGeneratedBase {
 
     @Test
     public void testSemRandom0Exec() {
-        executeTester("testSemRandom0", p.sem.random(), true, null, null, null, "0.428380961234932", new ServerExpression[]{  });
+        executeTester("testSemRandom0", p.sem.random(), true, null, null, null, "0.996817928554708", new ServerExpression[]{  });
     }
 
     @Test
@@ -1105,12 +1111,12 @@ public class PlanGeneratedTest extends PlanGeneratedBase {
 
     @Test
     public void testSemUuid0Exec() {
-        executeTester("testSemUuid0", p.sem.uuid(), true, "sem:iri", null, null, "urn:uuid:a55ec131-c835-47c7-821e-1a10c4ad0ef1", new ServerExpression[]{  });
+        executeTester("testSemUuid0", p.sem.uuid(), true, "sem:iri", null, null, "urn:uuid:c04549cf-e759-4190-bb96-8a0efaa4fcff", new ServerExpression[]{  });
     }
 
     @Test
     public void testSemUuidString0Exec() {
-        executeTester("testSemUuidString0", p.sem.uuidString(), true, null, null, null, "3d4c4138-35e0-45ba-9444-584a3cf12b36", new ServerExpression[]{  });
+        executeTester("testSemUuidString0", p.sem.uuidString(), true, null, null, null, "32351923-7f22-4a3f-9e92-884151190ee8", new ServerExpression[]{  });
     }
 
     @Test
@@ -1245,7 +1251,7 @@ public class PlanGeneratedTest extends PlanGeneratedBase {
 
     @Test
     public void testSqlRand1Exec() {
-        executeTester("testSqlRand1", p.sql.rand(p.col("1")), true, "xs:unsignedLong", null, null, "4427752476160726433", new ServerExpression[]{ p.xs.unsignedLong(1) });
+        executeTester("testSqlRand1", p.sql.rand(p.col("1")), true, "xs:unsignedLong", null, null, "1308547733197903283", new ServerExpression[]{ p.xs.unsignedLong(1) });
     }
 
     @Test
@@ -1350,7 +1356,7 @@ public class PlanGeneratedTest extends PlanGeneratedBase {
 
     @Test
     public void testXdmpCrypt21Exec() {
-        executeTester("testXdmpCrypt21", p.xdmp.crypt2(p.col("1")), true, null, null, null, "$256$/Ma0tvPJ39.CFc0UgU1/S/$256$k8p8zL5fr.EokfeX", new ServerExpression[]{ p.xs.string("abc") });
+        executeTester("testXdmpCrypt21", p.xdmp.crypt2(p.col("1")), true, null, null, null, "$256$Byph9.Mc3xqzhgeH.IAJh/$256$nAr3j1jWo/Wf2yN7", new ServerExpression[]{ p.xs.string("abc") });
     }
 
     @Test
@@ -1550,12 +1556,12 @@ public class PlanGeneratedTest extends PlanGeneratedBase {
 
     @Test
     public void testXdmpParseDateTime2Exec() {
-        executeTester("testXdmpParseDateTime2", p.xdmp.parseDateTime(p.col("1"), p.col("2")), true, "xs:dateTime", null, null, "2016-01-06T17:13:50.873-08:00", new ServerExpression[]{ p.xs.string("[Y0001]-[M01]-[D01]T[h01]:[m01]:[s01].[f1][Z]"), p.xs.string("2016-01-06T17:13:50.873594-08:00") });
+        executeTester("testXdmpParseDateTime2", p.xdmp.parseDateTime(p.col("1"), p.col("2")), true, "xs:dateTime", null, null, "2016-01-07T01:13:50.873Z", new ServerExpression[]{ p.xs.string("[Y0001]-[M01]-[D01]T[h01]:[m01]:[s01].[f1][Z]"), p.xs.string("2016-01-06T17:13:50.873594-08:00") });
     }
 
     @Test
     public void testXdmpParseYymmdd2Exec() {
-        executeTester("testXdmpParseYymmdd2", p.xdmp.parseYymmdd(p.col("1"), p.col("2")), true, "xs:dateTime", null, null, "2016-01-06T17:13:50.873-08:00", new ServerExpression[]{ p.xs.string("yyyy-MM-ddThh:mm:ss.Sz"), p.xs.string("2016-01-06T17:13:50.873594-8.00") });
+        executeTester("testXdmpParseYymmdd2", p.xdmp.parseYymmdd(p.col("1"), p.col("2")), true, "xs:dateTime", null, null, "2016-01-07T01:13:50.873Z", new ServerExpression[]{ p.xs.string("yyyy-MM-ddThh:mm:ss.Sz"), p.xs.string("2016-01-06T17:13:50.873594-8.00") });
     }
 
     @Test
@@ -1580,12 +1586,12 @@ public class PlanGeneratedTest extends PlanGeneratedBase {
 
     @Test
     public void testXdmpRandom0Exec() {
-        executeTester("testXdmpRandom0", p.xdmp.random(), true, "xs:unsignedLong", null, null, "13118352151257417636", new ServerExpression[]{  });
+        executeTester("testXdmpRandom0", p.xdmp.random(), true, "xs:unsignedLong", null, null, "7692759001122562087", new ServerExpression[]{  });
     }
 
     @Test
     public void testXdmpRandom1Exec() {
-        executeTester("testXdmpRandom1", p.xdmp.random(p.col("1")), true, null, null, null, "1", new ServerExpression[]{ p.xs.unsignedLong(1) });
+        executeTester("testXdmpRandom1", p.xdmp.random(p.col("1")), true, null, null, null, "0", new ServerExpression[]{ p.xs.unsignedLong(1) });
     }
 
     @Test
@@ -1645,12 +1651,12 @@ public class PlanGeneratedTest extends PlanGeneratedBase {
 
     @Test
     public void testXdmpStrftime2Exec() {
-        executeTester("testXdmpStrftime2", p.xdmp.strftime(p.col("1"), p.col("2")), true, null, null, null, "Wed, 06 Jan 2016 17:13:50", new ServerExpression[]{ p.xs.string("%a, %d %b %Y %H:%M:%S"), p.xs.dateTime("2016-01-06T17:13:50.873594-08:00") });
+        executeTester("testXdmpStrftime2", p.xdmp.strftime(p.col("1"), p.col("2")), true, null, null, null, "Thu, 07 Jan 2016 01:13:50", new ServerExpression[]{ p.xs.string("%a, %d %b %Y %H:%M:%S"), p.xs.dateTime("2016-01-06T17:13:50.873594-08:00") });
     }
 
     @Test
     public void testXdmpTimestampToWallclock1Exec() {
-        executeTester("testXdmpTimestampToWallclock1", p.xdmp.timestampToWallclock(p.col("1")), true, "xs:dateTime", null, null, "1969-12-31T16:00:00.0000001", new ServerExpression[]{ p.xs.unsignedLong(1) });
+        executeTester("testXdmpTimestampToWallclock1", p.xdmp.timestampToWallclock(p.col("1")), true, "xs:dateTime", null, null, "1970-01-01T00:00:00.0000001", new ServerExpression[]{ p.xs.unsignedLong(1) });
     }
 
     @Test


### PR DESCRIPTION
This is all the code-generated stuff for DEVEXP-563. Will use a second PR for the manually-added stuff. 

Most of this is just copyright updates that were made by the code generator. 

Note that the code generator also updated PlanGeneratorTest. We have some manual mods in there so that some tests only run on MarkLogic 11, so I had to ensure those were retained. 