### PR TITLE
DEVEXP-585 Can now configure 2-way SSL

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.marklogic
-version=6.3-SNAPSHOT
+version=6.4-SNAPSHOT
 describedName=MarkLogic Java Client API
 publishUrl=file:../marklogic-java/releases
 

--- a/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClientBuilder.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClientBuilder.java
@@ -259,6 +259,48 @@ public class DatabaseClientBuilder {
 		props.put(PREFIX + "disableGzippedResponses", true);
 		return this;
 	}
+
+	/**
+	 * Enables 2-way SSL by creating an SSL context based on the given key store path.
+	 *
+	 * @param path
+	 * @return
+	 * @since 6.4.0
+	 */
+	public DatabaseClientBuilder withKeyStorePath(String path) {
+		props.put(PREFIX + "ssl.keystore.path", path);
+		return this;
+	}
+
+	/**
+	 * @param password optional password for a key store
+	 * @return
+	 * @since 6.4.0
+	 */
+	public DatabaseClientBuilder withKeyStorePassword(String password) {
+		props.put(PREFIX + "ssl.keystore.password", password);
+		return this;
+	}
+
+	/**
+	 * @param type e.g. "JKS"
+	 * @return
+	 * @since 6.4.0
+	 */
+	public DatabaseClientBuilder withKeyStoreType(String type) {
+		props.put(PREFIX + "ssl.keystore.type", type);
+		return this;
+	}
+
+	/**
+	 * @param algorithm e.g. "SunX509"
+	 * @return
+	 * @since 6.4.0
+	 */
+	public DatabaseClientBuilder withKeyStoreAlgorithm(String algorithm) {
+		props.put(PREFIX + "ssl.keystore.algorithm", algorithm);
+		return this;
+	}
 }
 
 

--- a/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClientFactory.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClientFactory.java
@@ -1299,6 +1299,10 @@ public class DatabaseClientFactory {
 	 *     a String with a value of either "any", "common", or "strict"</li>
 	 *     <li>marklogic.client.trustManager = must be an instance of {@code javax.net.ssl.X509TrustManager};
 	 *     if not specified and an SSL context is configured, an attempt will be made to use the JVM's default trust manager</li>
+	 *     <li>marklogic.client.ssl.keystore.path = must be a String; enables 2-way SSL if set; since 6.4.0.</li>
+	 *     <li>marklogic.client.ssl.keystore.password = must be a String; optional password for a key store; since 6.4.0.</li>
+	 *     <li>marklogic.client.ssl.keystore.type = must be a String; optional type for a key store, defaults to "JKS"; since 6.4.0.</li>
+	 *     <li>marklogic.client.ssl.keystore.algorithm = must be a String; optional algorithm for a key store, defaults to "SunX509"; since 6.4.0.</li>
 	 * </ol>
 	 *
 	 * @param propertySource

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/SSLUtil.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/SSLUtil.java
@@ -18,20 +18,31 @@ package com.marklogic.client.impl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.TrustManagerFactory;
-import javax.net.ssl.X509TrustManager;
+import javax.net.ssl.*;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.security.KeyManagementException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 
-public interface SSLUtil {
+/**
+ * SSL convenience methods that are stored in the "impl" package, but we may eventually want to make these officially
+ * public, particular for reuse in connectors.
+ */
+public abstract class SSLUtil {
 
-	static X509TrustManager getDefaultTrustManager() {
+	/**
+	 * @return an X509TrustManager based on the JVM's default trust manager algorithm. How this is constructed can vary
+	 * based on the JVM type and version. One common approach is for the JVM to constructs this based on its
+	 * ./jre/lib/security/cacerts file.
+	 */
+	public static X509TrustManager getDefaultTrustManager() {
 		X509TrustManager trustManager = (X509TrustManager) getDefaultTrustManagers()[0];
 		Logger logger = LoggerFactory.getLogger(SSLUtil.class);
 		if (logger.isDebugEnabled() && trustManager.getAcceptedIssuers() != null) {
-			logger.debug("Count of accepted issuers in default trust manager: {}", trustManager.getAcceptedIssuers().length);
+			logger.debug("Count of accepted issuers in default trust manager: {}",
+				trustManager.getAcceptedIssuers().length);
 		}
 		return trustManager;
 	}
@@ -40,29 +51,140 @@ public interface SSLUtil {
 	 * @return a non-empty array of TrustManager instances based on the JVM's default trust manager algorithm, with the
 	 * first trust manager guaranteed to be an instance of X509TrustManager.
 	 */
-	static TrustManager[] getDefaultTrustManagers() {
+	public static TrustManager[] getDefaultTrustManagers() {
 		final String defaultAlgorithm = TrustManagerFactory.getDefaultAlgorithm();
+		return getTrustManagers(defaultAlgorithm, null);
+	}
+
+	/**
+	 * @param trustManagerAlgorithm e.g. "SunX509".
+	 * @param optionalKeyStore      if not null, used to initialize the TrustManagerFactory constructed based on the
+	 *                              given algorithm.
+	 * @return
+	 */
+	public static TrustManager[] getTrustManagers(String trustManagerAlgorithm, KeyStore optionalKeyStore) {
 		TrustManagerFactory trustManagerFactory;
 		try {
-			trustManagerFactory = TrustManagerFactory.getInstance(defaultAlgorithm);
+			trustManagerFactory = TrustManagerFactory.getInstance(trustManagerAlgorithm);
 		} catch (NoSuchAlgorithmException e) {
-			throw new RuntimeException("Unable to obtain trust manager factory using JVM's default trust manager algorithm: " + defaultAlgorithm, e);
+			throw new RuntimeException(
+				"Unable to obtain trust manager factory using algorithm: " + trustManagerAlgorithm, e);
 		}
 
 		try {
-			trustManagerFactory.init((KeyStore) null);
+			trustManagerFactory.init(optionalKeyStore);
 		} catch (KeyStoreException e) {
-			throw new RuntimeException("Unable to initialize trust manager factory obtained using JVM's default trust manager algorithm: " + defaultAlgorithm
-				+ "; cause: " + e.getMessage(), e);
+			throw new RuntimeException(String.format(
+				"Unable to initialize trust manager factory obtained using algorithm: %s; cause: %s",
+				trustManagerAlgorithm, e.getMessage()), e);
 		}
 
 		TrustManager[] trustManagers = trustManagerFactory.getTrustManagers();
 		if (trustManagers == null || trustManagers.length == 0) {
-			throw new RuntimeException("No trust managers found using the JVM's default trust manager algorithm: " + defaultAlgorithm);
+			throw new RuntimeException("No trust managers found using algorithm: " + trustManagerAlgorithm);
 		}
 		if (!(trustManagers[0] instanceof X509TrustManager)) {
 			throw new RuntimeException("Default trust manager is not an X509TrustManager: " + trustManagers[0]);
 		}
 		return trustManagers;
+	}
+
+	/**
+	 * Captures the oft-repeated boilerplate Java code for creating an SSLContext based on a key store.
+	 *
+	 * @param keyStorePath             required path to a key store file
+	 * @param keyStorePassword         optional password, can be null
+	 * @param keyStoreType             type of key store, e.g. "JKS"
+	 * @param algorithm                key store algorithm, e.g. "SunX509"
+	 * @param sslProtocol              e.g. "TLSv1.2"
+	 * @param userProvidedTrustManager optional trust manager provided by a user; if not null, will be used to
+	 *                                 initialize the SSLContext instead of using the key store as a trust manager.
+	 * @return
+	 */
+	static SSLInputs createSSLContextFromKeyStore(String keyStorePath, char[] keyStorePassword, String keyStoreType,
+												  String algorithm, String sslProtocol,
+												  X509TrustManager userProvidedTrustManager) {
+
+		KeyStore keyStore = getKeyStore(keyStorePath, keyStorePassword, keyStoreType);
+		KeyManagerFactory keyManagerFactory = newKeyManagerFactory(keyStore, keyStorePassword, algorithm);
+		SSLContext sslContext = newSSLContext(sslProtocol);
+
+		TrustManager[] trustManagers = userProvidedTrustManager != null
+			? new X509TrustManager[]{userProvidedTrustManager}
+			: getTrustManagers(algorithm, keyStore);
+
+		try {
+			sslContext.init(keyManagerFactory.getKeyManagers(), trustManagers, null);
+		} catch (KeyManagementException ex) {
+			throw new RuntimeException("Unable to initialize SSL context", ex);
+		}
+
+		return new SSLInputs(sslContext, (X509TrustManager) trustManagers[0]);
+	}
+
+	/**
+	 * @return a Java KeyStore based on the given inputs.
+	 */
+	public static KeyStore getKeyStore(String keyStorePath, char[] keyStorePassword, String keyStoreType) {
+		KeyStore keyStore;
+		try {
+			keyStore = KeyStore.getInstance(keyStoreType);
+		} catch (KeyStoreException ex) {
+			throw new RuntimeException("Unable to get instance of key store with type: " + keyStoreType, ex);
+		}
+
+		try (InputStream inputStream = new FileInputStream(keyStorePath)) {
+			keyStore.load(inputStream, keyStorePassword);
+			return keyStore;
+		} catch (Exception ex) {
+			throw new RuntimeException("Unable to read from key store at path: " + keyStorePath, ex);
+		}
+	}
+
+	private static KeyManagerFactory newKeyManagerFactory(KeyStore keyStore, char[] keyStorePassword, String algorithm) {
+		KeyManagerFactory keyManagerFactory;
+		try {
+			keyManagerFactory = KeyManagerFactory.getInstance(algorithm);
+		} catch (NoSuchAlgorithmException ex) {
+			throw new RuntimeException("Unable to create key manager factory with algorithm: " + algorithm, ex);
+		}
+
+		try {
+			keyManagerFactory.init(keyStore, keyStorePassword);
+		} catch (Exception ex) {
+			throw new RuntimeException("Unable to initialize key manager factory", ex);
+		}
+		return keyManagerFactory;
+	}
+
+	private static SSLContext newSSLContext(String sslProtocol) {
+		try {
+			return SSLContext.getInstance(sslProtocol);
+		} catch (Exception ex) {
+			throw new RuntimeException("Unable to create SSL context using protocol: " + sslProtocol, ex);
+		}
+	}
+
+	/**
+	 * Captures the inputs needed by the Java Client for establishing an SSL connection. The need for a separate
+	 * X509TrustManager arose from the switch from Apache's HttpClient to OkHttp, where the latter needs access to a
+	 * X509TrustManager (as opposed to relying on any trust managers within an SSLContext).
+	 */
+	public static class SSLInputs {
+		private final SSLContext sslContext;
+		private final X509TrustManager trustManager;
+
+		public SSLInputs(SSLContext sslContext, X509TrustManager trustManager) {
+			this.sslContext = sslContext;
+			this.trustManager = trustManager;
+		}
+
+		public SSLContext getSslContext() {
+			return sslContext;
+		}
+
+		public X509TrustManager getTrustManager() {
+			return trustManager;
+		}
 	}
 }


### PR DESCRIPTION
Bumped the version to 6.4-SNAPSHOT as well so we can start using it in the Mule connector. 

The main value here is in TwoWaySSLTest, which can use these new properties instead of having to construct an SSLContext itself. 