### PR TITLE
DEVEXP-650 Fixing search that includes metadata values

### DIFF
--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/OkHttpServices.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/OkHttpServices.java
@@ -1627,7 +1627,7 @@ public class OkHttpServices implements RESTServices {
     }
   }
   private void addCategoryParam(RequestParameters params, Metadata category) {
-      addCategoryParam(params, category.name().toLowerCase());
+      addCategoryParam(params, category.toString().toLowerCase());
   }
   private void addCategoryParam(RequestParameters params, String category) {
     params.add("category", category);


### PR DESCRIPTION
Need to use "toString()" instead of "name()" so that "metadatavalues" is converted into "metadata-values". This works fine for reading documents but not for searching documents. 