### PR TITLE
Removing buggy usage of `execute`

### DIFF
--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/RowManagerImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/RowManagerImpl.java
@@ -215,9 +215,7 @@ public class RowManagerImpl
   @Override
   public void execute(Plan plan, Transaction transaction) {
     PlanBuilderBaseImpl.RequestPlan requestPlan = checkPlan(plan);
-    RequestParameters params = newRowsParamsBuilder(requestPlan)
-        .withOutput("execute")
-        .getRequestParameters();
+    RequestParameters params = newRowsParamsBuilder(requestPlan).getRequestParameters();
     RESTServiceResultIterator iter = submitPlan(requestPlan, params, transaction);
     if (iter != null) {
       iter.close();


### PR DESCRIPTION
Not sure why `output` was ever set to `execute` - removing it does not cause any breaks on MarkLogic 11.1, and the 11-nightly (properly) throws an error when it's included. So removing it. 