### PR TITLE
MLE-4116: Can now configure trust store

### DIFF
--- a/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClientBuilder.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClientBuilder.java
@@ -301,6 +301,49 @@ public class DatabaseClientBuilder {
 		props.put(PREFIX + "ssl.keystore.algorithm", algorithm);
 		return this;
 	}
+
+	/**
+	 * Supports constructing an {@code X509TrustManager} based on the given file path, which should point to a Java
+	 * key store or trust store.
+	 *
+	 * @param path
+	 * @return
+	 * @since 6.5.0
+	 */
+	public DatabaseClientBuilder withTrustStorePath(String path) {
+		props.put(PREFIX + "ssl.truststore.path", path);
+		return this;
+	}
+
+	/**
+	 * @param password optional password for a trust store
+	 * @return
+	 * @since 6.5.0
+	 */
+	public DatabaseClientBuilder withTrustStorePassword(String password) {
+		props.put(PREFIX + "ssl.truststore.password", password);
+		return this;
+	}
+
+	/**
+	 * @param type e.g. "JKS"
+	 * @return
+	 * @since 6.5.0
+	 */
+	public DatabaseClientBuilder withTrustStoreType(String type) {
+		props.put(PREFIX + "ssl.truststore.type", type);
+		return this;
+	}
+
+	/**
+	 * @param algorithm e.g. "SunX509"
+	 * @return
+	 * @since 6.5.0
+	 */
+	public DatabaseClientBuilder withTrustStoreAlgorithm(String algorithm) {
+		props.put(PREFIX + "ssl.truststore.algorithm", algorithm);
+		return this;
+	}
 }
 
 

--- a/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClientFactory.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClientFactory.java
@@ -1303,6 +1303,10 @@ public class DatabaseClientFactory {
 	 *     <li>marklogic.client.ssl.keystore.password = must be a String; optional password for a key store; since 6.4.0.</li>
 	 *     <li>marklogic.client.ssl.keystore.type = must be a String; optional type for a key store, defaults to "JKS"; since 6.4.0.</li>
 	 *     <li>marklogic.client.ssl.keystore.algorithm = must be a String; optional algorithm for a key store, defaults to "SunX509"; since 6.4.0.</li>
+	 *     <li>marklogic.client.ssl.truststore.path = must be a String; specifies a file path for a trust store for SSL and/or certificate authentication; since 6.5.0.</li>
+	 *     <li>marklogic.client.ssl.truststore.password = must be a String; optional password for a trust store; since 6.5.0.</li>
+	 *     <li>marklogic.client.ssl.truststore.type = must be a String; optional type for a trust store, defaults to "JKS"; since 6.5.0.</li>
+	 *     <li>marklogic.client.ssl.truststore.algorithm = must be a String; optional algorithm for a trust store, defaults to "SunX509"; since 6.5.0.</li>
 	 * </ol>
 	 *
 	 * @param propertySource

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/SSLUtil.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/SSLUtil.java
@@ -60,7 +60,7 @@ public abstract class SSLUtil {
 	 * @param trustManagerAlgorithm e.g. "SunX509".
 	 * @param optionalKeyStore      if not null, used to initialize the TrustManagerFactory constructed based on the
 	 *                              given algorithm.
-	 * @return
+	 * @return an array of at least length 1 where the first instance is an {@code X509TrustManager}
 	 */
 	public static TrustManager[] getTrustManagers(String trustManagerAlgorithm, KeyStore optionalKeyStore) {
 		TrustManagerFactory trustManagerFactory;


### PR DESCRIPTION
For SSL and/or certificate authentication. Same approach as for a keystore, just for a truststore. 

Was able to reuse and improve `TwoWaySSLTest` by modifying it to use the key store as a trust store instead of using a "trust everything" trust manager. 