### PR TITLE
Using latest 11 for Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -152,9 +152,9 @@ pipeline{
         }
       }
       steps {
-        copyRPM 'Release','11.1.0'
+        copyRPM 'Latest','11'
         setUpML '$WORKSPACE/xdmp/src/Mark*.rpm'
-        copyConvertersRPM 'Release','11.1.0'
+        copyConvertersRPM 'Latest','11'
         setUpMLConverters '$WORKSPACE/xdmp/src/Mark*Converters*.rpm'
         sh label:'deploy test app', script: '''#!/bin/bash
           export JAVA_HOME=$JAVA_HOME_DIR
@@ -200,7 +200,7 @@ pipeline{
         }
       }
       steps {
-        runAllTests('Release', '11.1.0', false)
+        runAllTests('Latest', '11', false)
         junit '**/build/**/TEST*.xml'
       }
     }
@@ -213,7 +213,7 @@ pipeline{
 				}
 			}
 			steps {
-				runAllTests('Release', '11.1.0', true)
+				runAllTests('Latest', '11', true)
 				junit '**/build/**/TEST*.xml'
 			}
     }


### PR DESCRIPTION
This is needed for the Optic Update change.

The ML 10 tests will still fail, will address that in a separate PR. 