### PR TITLE
Adding back orderBy to some Optic tests

### DIFF
--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnCtsQuery.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnCtsQuery.java
@@ -310,7 +310,8 @@ public class TestOpticOnCtsQuery extends AbstractFunctionalTest {
     ModifyPlan plan2 = p.fromLexicons(index2, "myTeam", p.fragmentIdCol("fragId2"));
 
     ModifyPlan output = plan1.joinInner(plan2)
-        .where(p.eq(p.viewCol("myCity", "city"), p.col("cityName")));
+        .where(p.eq(p.viewCol("myCity", "city"), p.col("cityName")))
+		.orderBy(p.asc(p.col("date")));
 
     JacksonHandle jacksonHandle = new JacksonHandle();
     jacksonHandle.setMimetype("application/json");
@@ -356,7 +357,8 @@ public class TestOpticOnCtsQuery extends AbstractFunctionalTest {
 
     ModifyPlan output = plan1.where(p.cts.jsonPropertyWordQuery("city", "*k", "wildcarded", "case-sensitive"))
         .joinInner(plan2)
-        .where(p.eq(p.viewCol("myCity", "city"), p.col("cityName")));
+        .where(p.eq(p.viewCol("myCity", "city"), p.col("cityName")))
+		.orderBy(p.asc(p.col("date")));
 
     JacksonHandle jacksonHandle = new JacksonHandle();
     jacksonHandle.setMimetype("application/json");

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnLexicons.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnLexicons.java
@@ -1206,8 +1206,6 @@ public class TestOpticOnLexicons extends AbstractFunctionalTest {
 	  JacksonHandle jacksonHandle = new JacksonHandle();
 	  jacksonHandle.setMimetype("application/json");
 
-	  System.out.println("PLAN: " + plan.exportAs(ObjectNode.class).toPrettyString());
-
 	  rowMgr.resultDoc(plan, jacksonHandle);
 	  JsonNode rows = jacksonHandle.get().path("rows");
 	  assertEquals(1, rows.size(), "Expected only the New Jersey row, which has a popularity of 2: " + rows.toPrettyString());

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnLiterals.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnLiterals.java
@@ -625,7 +625,8 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
             p.col("val"),
             p.col("uri"),
             p.as("nodes", p.xpath("doc", "/doc/distance/@direction")))
-        .where(p.isDefined(p.col("nodes")));
+        .where(p.isDefined(p.col("nodes")))
+		.orderBy(p.asc("id"));
 
     System.out.println(output17.exportAs(JsonNode.class).toPrettyString());
 
@@ -653,7 +654,8 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
             p.col("val"),
             p.col("uri"),
             p.as("nodes", p.xpath("doc", "/doc/location/latLonPair/(lat|long)/text()")))
-        .where(p.isDefined(p.col("nodes")));
+        .where(p.isDefined(p.col("nodes")))
+		.orderBy(p.asc("id"));
 
     JacksonHandle jacksonHandle18 = new JacksonHandle();
     jacksonHandle18.setMimetype("application/json");
@@ -712,7 +714,8 @@ public class TestOpticOnLiterals extends AbstractFunctionalTest {
             p.col("val"),
             p.col("uri"),
             p.as("nodes", p.xpath("doc", "/doc/city")))
-        .where(p.isDefined(p.col("nodes")));
+        .where(p.isDefined(p.col("nodes")))
+		.orderBy(p.asc("id"));
     JacksonHandle jacksonHandle15 = new JacksonHandle();
     jacksonHandle15.setMimetype("application/json");
     rowMgr.resultDoc(output15, jacksonHandle15);

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnTriples.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnTriples.java
@@ -452,7 +452,8 @@ public class TestOpticOnTriples extends AbstractFunctionalTest {
     ModifyPlan team_planSum = p.fromTriples(team_planSumSeq);
 
     ModifyPlan outputSum = player_planSum.joinInner(team_planSum)
-        .groupBy(null, p.sum(p.col("SumAll"), playerEffCol));
+        .groupBy(null, p.sum(p.col("SumAll"), playerEffCol))
+		.orderBy(p.desc(p.col("SumAll")));
     jacksonHandle = new JacksonHandle();
     jacksonHandle.setMimetype("application/json");
 


### PR DESCRIPTION
These were removed as part of MLE-805 (formerly bug 60065) when these tests started failing on 11-nightly due to the orderBy. I added orderBy back and ran them on 11.1.0, 11-nightly, and 12-nightly, and they all passed. 