### PR TITLE
OpticGenerator changes

### DIFF
--- a/marklogic-client-api/src/main/java/com/marklogic/client/expression/CtsExpr.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/expression/CtsExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 MarkLogic Corporation
+ * Copyright (c) 2024 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ import com.marklogic.client.type.CtsReferenceSeqExpr;
 import com.marklogic.client.type.CtsRegionExpr;
 import com.marklogic.client.type.CtsRegionSeqExpr;
 
-// IMPORTANT: Do not edit. This file is generated.
+// IMPORTANT: Do not edit. This file is generated. 
 
 // 2023-10-24 Exception: Manual changes have been made to this to expose the string constructors for cts.point and
 // cts.polygon. These changes can be removed once optic-defs.json in the xdmp repository is updated to define these
@@ -60,7 +60,7 @@ public interface CtsExpr {
   * Returns a query matching fragments committed after a specified timestamp.
   *
   * <a name="ml-server-type-after-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:after-query" target="mlserverdoc">cts:after-query</a> server function.
   * @param timestamp  A commit timestamp. Database fragments committed after this timestamp are matched.  (of <a href="{@docRoot}/doc-files/types/xs_unsignedLong.html">xs:unsignedLong</a>)
@@ -71,7 +71,7 @@ public interface CtsExpr {
   * Returns a query specifying the set difference of the matches specified by two sub-queries.
   *
   * <a name="ml-server-type-and-not-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:and-not-query" target="mlserverdoc">cts:and-not-query</a> server function.
   * @param positiveQuery  A positive query, specifying the search results filtered in.  (of <a href="{@docRoot}/doc-files/types/cts_query.html">cts:query</a>)
@@ -91,7 +91,7 @@ public interface CtsExpr {
   * Returns a query specifying the intersection of the matches specified by the sub-queries.
   *
   * <a name="ml-server-type-and-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:and-query" target="mlserverdoc">cts:and-query</a> server function.
   * @param queries  A sequence of sub-queries.  (of <a href="{@docRoot}/doc-files/types/cts_query.html">cts:query</a>)
@@ -120,7 +120,7 @@ public interface CtsExpr {
   * Returns a query matching fragments committed before or at a specified timestamp.
   *
   * <a name="ml-server-type-before-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:before-query" target="mlserverdoc">cts:before-query</a> server function.
   * @param timestamp  A commit timestamp. Database fragments committed before this timestamp are matched.  (of <a href="{@docRoot}/doc-files/types/xs_unsignedLong.html">xs:unsignedLong</a>)
@@ -131,7 +131,7 @@ public interface CtsExpr {
   * Returns a query specifying that matches to matching-query should have their search relevance scores boosted if they also match boosting-query.
   *
   * <a name="ml-server-type-boost-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:boost-query" target="mlserverdoc">cts:boost-query</a> server function.
   * @param matchingQuery  A sub-query that is used for match and scoring.  (of <a href="{@docRoot}/doc-files/types/cts_query.html">cts:query</a>)
@@ -154,7 +154,7 @@ public interface CtsExpr {
   * Returns a geospatial box value.
   *
   * <a name="ml-server-type-box"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:box" target="mlserverdoc">cts:box</a> server function.
   * @param south  The southern boundary of the box.  (of <a href="{@docRoot}/doc-files/types/xs_double.html">xs:double</a>)
@@ -168,7 +168,7 @@ public interface CtsExpr {
   * Returns a box's eastern boundary.
   *
   * <a name="ml-server-type-box-east"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:box-east" target="mlserverdoc">cts:box-east</a> server function.
   * @param box  The box.  (of <a href="{@docRoot}/doc-files/types/cts_box.html">cts:box</a>)
@@ -179,7 +179,7 @@ public interface CtsExpr {
   * Returns a box's northern boundary.
   *
   * <a name="ml-server-type-box-north"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:box-north" target="mlserverdoc">cts:box-north</a> server function.
   * @param box  The box.  (of <a href="{@docRoot}/doc-files/types/cts_box.html">cts:box</a>)
@@ -190,7 +190,7 @@ public interface CtsExpr {
   * Returns a box's southern boundary.
   *
   * <a name="ml-server-type-box-south"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:box-south" target="mlserverdoc">cts:box-south</a> server function.
   * @param box  The box.  (of <a href="{@docRoot}/doc-files/types/cts_box.html">cts:box</a>)
@@ -201,7 +201,7 @@ public interface CtsExpr {
   * Returns a box's western boundary.
   *
   * <a name="ml-server-type-box-west"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:box-west" target="mlserverdoc">cts:box-west</a> server function.
   * @param box  The box.  (of <a href="{@docRoot}/doc-files/types/cts_box.html">cts:box</a>)
@@ -221,7 +221,7 @@ public interface CtsExpr {
   * Returns a geospatial circle value.
   *
   * <a name="ml-server-type-circle"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:circle" target="mlserverdoc">cts:circle</a> server function.
   * @param radius  The radius of the circle. The units for the radius is determined at runtime by the query options (miles is currently the only option).  (of <a href="{@docRoot}/doc-files/types/xs_double.html">xs:double</a>)
@@ -233,7 +233,7 @@ public interface CtsExpr {
   * Returns a circle's center point.
   *
   * <a name="ml-server-type-circle-center"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:circle-center" target="mlserverdoc">cts:circle-center</a> server function.
   * @param circle  The circle.  (of <a href="{@docRoot}/doc-files/types/cts_circle.html">cts:circle</a>)
@@ -244,7 +244,7 @@ public interface CtsExpr {
   * Returns a circle's radius.
   *
   * <a name="ml-server-type-circle-radius"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:circle-radius" target="mlserverdoc">cts:circle-radius</a> server function.
   * @param circle  The circle.  (of <a href="{@docRoot}/doc-files/types/cts_circle.html">cts:circle</a>)
@@ -263,7 +263,7 @@ public interface CtsExpr {
   * Match documents in at least one of the specified collections. It will match both documents and properties documents in the collections with the given URIs.
   *
   * <a name="ml-server-type-collection-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:collection-query" target="mlserverdoc">cts:collection-query</a> server function.
   * @param uris  One or more collection URIs. A document matches the query if it is in at least one of these collections.  (of <a href="{@docRoot}/doc-files/types/xs_string.html">xs:string</a>)
@@ -274,7 +274,7 @@ public interface CtsExpr {
   * Creates a reference to the collection lexicon, for use as a parameter to cts:value-tuples. Since lexicons are implemented with range indexes, this function will throw an exception if the specified range index does not exist.
   *
   * <a name="ml-server-type-collection-reference"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:collection-reference" target="mlserverdoc">cts:collection-reference</a> server function.
   * @return  a server expression with the <a href="{@docRoot}/doc-files/types/cts_reference.html">cts:reference</a> server data type
@@ -311,7 +311,7 @@ public interface CtsExpr {
   * Returns a cts:query matching documents matching a TDE-view column equals to an value. Searches with the cts:column-range-query constructor require the triple index; if the triple index is not configured, then an exception is thrown.
   *
   * <a name="ml-server-type-column-range-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:column-range-query" target="mlserverdoc">cts:column-range-query</a> server function.
   * @param schema  The TDE schema name.  (of <a href="{@docRoot}/doc-files/types/xs_string.html">xs:string</a>)
@@ -403,7 +403,7 @@ public interface CtsExpr {
   * Returns a geospatial complex polygon value.
   *
   * <a name="ml-server-type-complex-polygon"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:complex-polygon" target="mlserverdoc">cts:complex-polygon</a> server function.
   * @param outer  The outer polygon.  (of <a href="{@docRoot}/doc-files/types/cts_polygon.html">cts:polygon</a>)
@@ -423,7 +423,7 @@ public interface CtsExpr {
   * Returns a query matching documents in the directories with the given URIs.
   *
   * <a name="ml-server-type-directory-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:directory-query" target="mlserverdoc">cts:directory-query</a> server function.
   * @param uris  One or more directory URIs.  (of <a href="{@docRoot}/doc-files/types/xs_string.html">xs:string</a>)
@@ -449,56 +449,16 @@ public interface CtsExpr {
   */
   public CtsQueryExpr directoryQuery(ServerExpression uris, ServerExpression depth);
 /**
-  * Returns a query matching documents of a given format.
-  * <p>
-  * Provides a client interface to the <a href="http://docs.marklogic.com/cts:document-format-query" target="mlserverdoc">cts:document-format-query</a> server function.
-  * @param format  Case insensitve one of: "json","xml","text","binary". This will result in a XDMP-ARG exception in case of an invalid format.  (of <a href="{@docRoot}/doc-files/types/xs_string.html">xs:string</a>)
-  * @return  a server expression with the <a href="{@docRoot}/doc-files/types/cts_query.html">cts:query</a> server data type
-  */
-  public CtsQueryExpr documentFormatQuery(String format);
-/**
-  * Returns a query matching documents of a given format.
-  *
-  * <a name="ml-server-type-document-format-query"></a>
-
-  * <p>
-  * Provides a client interface to the <a href="http://docs.marklogic.com/cts:document-format-query" target="mlserverdoc">cts:document-format-query</a> server function.
-  * @param format  Case insensitve one of: "json","xml","text","binary". This will result in a XDMP-ARG exception in case of an invalid format.  (of <a href="{@docRoot}/doc-files/types/xs_string.html">xs:string</a>)
-  * @return  a server expression with the <a href="{@docRoot}/doc-files/types/cts_query.html">cts:query</a> server data type
-  */
-  public CtsQueryExpr documentFormatQuery(ServerExpression format);
-/**
   * Returns a query that matches all documents where query matches any document fragment. When searching documents, document-properties, or document-locks, this function provides a convenient way to additionally constrain the search against any document fragment.
   *
   * <a name="ml-server-type-document-fragment-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:document-fragment-query" target="mlserverdoc">cts:document-fragment-query</a> server function.
   * @param query  A query to be matched against any document fragment.  (of <a href="{@docRoot}/doc-files/types/cts_query.html">cts:query</a>)
   * @return  a server expression with the <a href="{@docRoot}/doc-files/types/cts_query.html">cts:query</a> server data type
   */
   public CtsQueryExpr documentFragmentQuery(ServerExpression query);
-/**
-  * Returns a query matching documents with a given permission.
-  * <p>
-  * Provides a client interface to the <a href="http://docs.marklogic.com/cts:document-permission-query" target="mlserverdoc">cts:document-permission-query</a> server function.
-  * @param role  The role of the permission  (of <a href="{@docRoot}/doc-files/types/xs_string.html">xs:string</a>)
-  * @param capability  The capability of the permission (read, update, node-update, insert, execute)  (of <a href="{@docRoot}/doc-files/types/xs_string.html">xs:string</a>)
-  * @return  a server expression with the <a href="{@docRoot}/doc-files/types/cts_query.html">cts:query</a> server data type
-  */
-  public CtsQueryExpr documentPermissionQuery(String role, String capability);
-/**
-  * Returns a query matching documents with a given permission.
-  *
-  * <a name="ml-server-type-document-permission-query"></a>
-
-  * <p>
-  * Provides a client interface to the <a href="http://docs.marklogic.com/cts:document-permission-query" target="mlserverdoc">cts:document-permission-query</a> server function.
-  * @param role  The role of the permission  (of <a href="{@docRoot}/doc-files/types/xs_string.html">xs:string</a>)
-  * @param capability  The capability of the permission (read, update, node-update, insert, execute)  (of <a href="{@docRoot}/doc-files/types/xs_string.html">xs:string</a>)
-  * @return  a server expression with the <a href="{@docRoot}/doc-files/types/cts_query.html">cts:query</a> server data type
-  */
-  public CtsQueryExpr documentPermissionQuery(ServerExpression role, ServerExpression capability);
 /**
   * Returns a query matching documents with the given URIs. It will match both documents and properties documents with the given URIs.
   * <p>
@@ -511,32 +471,13 @@ public interface CtsExpr {
   * Returns a query matching documents with the given URIs. It will match both documents and properties documents with the given URIs.
   *
   * <a name="ml-server-type-document-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:document-query" target="mlserverdoc">cts:document-query</a> server function.
   * @param uris  One or more document URIs.  (of <a href="{@docRoot}/doc-files/types/xs_string.html">xs:string</a>)
   * @return  a server expression with the <a href="{@docRoot}/doc-files/types/cts_query.html">cts:query</a> server data type
   */
   public CtsQueryExpr documentQuery(ServerExpression uris);
-/**
-  * Returns a query matching documents with a given root element.
-  * <p>
-  * Provides a client interface to the <a href="http://docs.marklogic.com/cts:document-root-query" target="mlserverdoc">cts:document-root-query</a> server function.
-  * @param root  The root QName to query.  (of <a href="{@docRoot}/doc-files/types/xs_QName.html">xs:QName</a>)
-  * @return  a server expression with the <a href="{@docRoot}/doc-files/types/cts_query.html">cts:query</a> server data type
-  */
-  public CtsQueryExpr documentRootQuery(String root);
-/**
-  * Returns a query matching documents with a given root element.
-  *
-  * <a name="ml-server-type-document-root-query"></a>
-
-  * <p>
-  * Provides a client interface to the <a href="http://docs.marklogic.com/cts:document-root-query" target="mlserverdoc">cts:document-root-query</a> server function.
-  * @param root  The root QName to query.  (of <a href="{@docRoot}/doc-files/types/xs_QName.html">xs:QName</a>)
-  * @return  a server expression with the <a href="{@docRoot}/doc-files/types/cts_query.html">cts:query</a> server data type
-  */
-  public CtsQueryExpr documentRootQuery(ServerExpression root);
 /**
   * Returns a query matching elements by name which has specific attributes representing latitude and longitude values for a point contained within the given geographic box, circle, or polygon, or equal to the given point. Points that lie between the southern boundary and the northern boundary of a box, travelling northwards, and between the western boundary and the eastern boundary of the box, travelling eastwards, will match. Points contained within the given radius of the center point of a circle will match, using the curved distance on the surface of the Earth. Points contained within the given polygon will match, using great circle arcs over a spherical model of the Earth as edges. An error may result if the polygon is malformed in some way. Points equal to the a given point will match, taking into account the fact that longitudes converge at the poles. Using the geospatial query constructors requires a valid geospatial license key; without a valid license key, searches that include geospatial queries will throw an exception.
   * <p>
@@ -552,7 +493,7 @@ public interface CtsExpr {
   * Returns a query matching elements by name which has specific attributes representing latitude and longitude values for a point contained within the given geographic box, circle, or polygon, or equal to the given point. Points that lie between the southern boundary and the northern boundary of a box, travelling northwards, and between the western boundary and the eastern boundary of the box, travelling eastwards, will match. Points contained within the given radius of the center point of a circle will match, using the curved distance on the surface of the Earth. Points contained within the given polygon will match, using great circle arcs over a spherical model of the Earth as edges. An error may result if the polygon is malformed in some way. Points equal to the a given point will match, taking into account the fact that longitudes converge at the poles. Using the geospatial query constructors requires a valid geospatial license key; without a valid license key, searches that include geospatial queries will throw an exception.
   *
   * <a name="ml-server-type-element-attribute-pair-geospatial-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:element-attribute-pair-geospatial-query" target="mlserverdoc">cts:element-attribute-pair-geospatial-query</a> server function.
   * @param elementName  One or more parent element QNames to match. When multiple QNames are specified, the query matches if any QName matches.  (of <a href="{@docRoot}/doc-files/types/xs_QName.html">xs:QName</a>)
@@ -627,7 +568,7 @@ public interface CtsExpr {
   * Constructs a query that matches element-attributes by name with a range-index entry equal to a given value. An element attribute range index on the specified QName(s) must exist when you use this query in a search; if no such range index exists, the search throws an exception.
   *
   * <a name="ml-server-type-element-attribute-range-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:element-attribute-range-query" target="mlserverdoc">cts:element-attribute-range-query</a> server function.
   * @param elementName  One or more element QNames to match. When multiple QNames are specified, the query matches if any QName matches.  (of <a href="{@docRoot}/doc-files/types/xs_QName.html">xs:QName</a>)
@@ -700,7 +641,7 @@ public interface CtsExpr {
   * Creates a reference to an element attribute value lexicon, for use as a parameter to cts:value-tuples. Since lexicons are implemented with range indexes, this function will throw an exception if the specified range index does not exist.
   *
   * <a name="ml-server-type-element-attribute-reference"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:element-attribute-reference" target="mlserverdoc">cts:element-attribute-reference</a> server function.
   * @param element  An element QName.  (of <a href="{@docRoot}/doc-files/types/xs_QName.html">xs:QName</a>)
@@ -742,7 +683,7 @@ public interface CtsExpr {
   * Returns a query matching elements by name with attributes by name with text content equal a given phrase.
   *
   * <a name="ml-server-type-element-attribute-value-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:element-attribute-value-query" target="mlserverdoc">cts:element-attribute-value-query</a> server function.
   * @param elementName  One or more element QNames to match. When multiple QNames are specified, the query matches if any QName matches.  (of <a href="{@docRoot}/doc-files/types/xs_QName.html">xs:QName</a>)
@@ -811,7 +752,7 @@ public interface CtsExpr {
   * Returns a query matching elements by name with attributes by name with text content containing a given phrase.
   *
   * <a name="ml-server-type-element-attribute-word-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:element-attribute-word-query" target="mlserverdoc">cts:element-attribute-word-query</a> server function.
   * @param elementName  One or more element QNames to match. When multiple QNames are specified, the query matches if any QName matches.  (of <a href="{@docRoot}/doc-files/types/xs_QName.html">xs:QName</a>)
@@ -880,7 +821,7 @@ public interface CtsExpr {
   * Returns a query matching elements by name which has specific element children representing latitude and longitude values for a point contained within the given geographic box, circle, or polygon, or equal to the given point. Points that lie between the southern boundary and the northern boundary of a box, travelling northwards, and between the western boundary and the eastern boundary of the box, travelling eastwards, will match. Points contained within the given radius of the center point of a circle will match, using the curved distance on the surface of the Earth. Points contained within the given polygon will match, using great circle arcs over a spherical model of the Earth as edges. An error may result if the polygon is malformed in some way. Points equal to the a given point will match, taking into account the fact that longitudes converge at the poles. Using the geospatial query constructors requires a valid geospatial license key; without a valid license key, searches that include geospatial queries will throw an exception.
   *
   * <a name="ml-server-type-element-child-geospatial-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:element-child-geospatial-query" target="mlserverdoc">cts:element-child-geospatial-query</a> server function.
   * @param elementName  One or more parent element QNames to match. When multiple QNames are specified, the query matches if any QName matches.  (of <a href="{@docRoot}/doc-files/types/xs_QName.html">xs:QName</a>)
@@ -948,7 +889,7 @@ public interface CtsExpr {
   * Returns a query matching elements by name whose content represents a point contained within the given geographic box, circle, or polygon, or equal to the given point. Points that lie between the southern boundary and the northern boundary of a box, travelling northwards, and between the western boundary and the eastern boundary of the box, travelling eastwards, will match. Points contained within the given radius of the center point of a circle will match, using the curved distance on the surface of the Earth. Points contained within the given polygon will match, using great circle arcs over a spherical model of the Earth as edges. An error may result if the polygon is malformed in some way. Points equal to the a given point will match, taking into account the fact that longitudes converge at the poles. Using the geospatial query constructors requires a valid geospatial license key; without a valid license key, searches that include geospatial queries will throw an exception.
   *
   * <a name="ml-server-type-element-geospatial-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:element-geospatial-query" target="mlserverdoc">cts:element-geospatial-query</a> server function.
   * @param elementName  One or more element QNames to match. When multiple QNames are specified, the query matches if any QName matches.  (of <a href="{@docRoot}/doc-files/types/xs_QName.html">xs:QName</a>)
@@ -1013,7 +954,7 @@ public interface CtsExpr {
   * Returns a query matching elements by name which has specific element children representing latitude and longitude values for a point contained within the given geographic box, circle, or polygon, or equal to the given point. Points that lie between the southern boundary and the northern boundary of a box, travelling northwards, and between the western boundary and the eastern boundary of the box, travelling eastwards, will match. Points contained within the given radius of the center point of a circle will match, using the curved distance on the surface of the Earth. Points contained within the given polygon will match, using great circle arcs over a spherical model of the Earth as edges. An error may result if the polygon is malformed in some way. Points equal to the a given point will match, taking into account the fact that longitudes converge at the poles. Using the geospatial query constructors requires a valid geospatial license key; without a valid license key, searches that include geospatial queries will throw an exception.
   *
   * <a name="ml-server-type-element-pair-geospatial-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:element-pair-geospatial-query" target="mlserverdoc">cts:element-pair-geospatial-query</a> server function.
   * @param elementName  One or more parent element QNames to match. When multiple QNames are specified, the query matches if any QName matches.  (of <a href="{@docRoot}/doc-files/types/xs_QName.html">xs:QName</a>)
@@ -1086,7 +1027,7 @@ public interface CtsExpr {
   * Constructs a query that matches elements by name with the content constrained by the query given in the second parameter. Searches for matches in the specified element and all of its descendants. If the query specified in the second parameter includes any element attribute sub-queries, it will search attributes on the specified element and attributes on any descendant elements. See the second example below).
   *
   * <a name="ml-server-type-element-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:element-query" target="mlserverdoc">cts:element-query</a> server function.
   * @param elementName  One or more element QNames to match. When multiple QNames are specified, the query matches if any QName matches.  (of <a href="{@docRoot}/doc-files/types/xs_QName.html">xs:QName</a>)
@@ -1108,7 +1049,7 @@ public interface CtsExpr {
   * Constructs a query that matches elements by name with range index entry equal to a given value. Searches that use an element range query require an element range index on the specified QName(s); if no such range index exists, then an exception is thrown.
   *
   * <a name="ml-server-type-element-range-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:element-range-query" target="mlserverdoc">cts:element-range-query</a> server function.
   * @param elementName  One or more element QNames to match. When multiple QNames are specified, the query matches if any QName matches.  (of <a href="{@docRoot}/doc-files/types/xs_QName.html">xs:QName</a>)
@@ -1175,7 +1116,7 @@ public interface CtsExpr {
   * Creates a reference to an element value lexicon, for use as a parameter to cts:value-tuples, temporal:axis-create, or any other function that takes an index reference. Since lexicons are implemented with range indexes, this function will throw an exception if the specified range index does not exist.
   *
   * <a name="ml-server-type-element-reference"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:element-reference" target="mlserverdoc">cts:element-reference</a> server function.
   * @param element  An element QName.  (of <a href="{@docRoot}/doc-files/types/xs_QName.html">xs:QName</a>)
@@ -1212,7 +1153,7 @@ public interface CtsExpr {
   * Returns a query matching elements by name with text content equal a given phrase. cts:element-value-query only matches against simple elements (that is, elements that contain only text and have no element children).
   *
   * <a name="ml-server-type-element-value-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:element-value-query" target="mlserverdoc">cts:element-value-query</a> server function.
   * @param elementName  One or more element QNames to match. When multiple QNames are specified, the query matches if any QName matches.  (of <a href="{@docRoot}/doc-files/types/xs_QName.html">xs:QName</a>)
@@ -1292,7 +1233,7 @@ public interface CtsExpr {
   * Returns a query matching elements by name with text content containing a given phrase. Searches only through immediate text node children of the specified element as well as any text node children of child elements defined in the Admin Interface as element-word-query-throughs or phrase-throughs; does not search through any other children of the specified element. If neither word searches nor stemmed word searches is enabled for the target database, an XDMP-SEARCH error is thrown.
   *
   * <a name="ml-server-type-element-word-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:element-word-query" target="mlserverdoc">cts:element-word-query</a> server function.
   * @param elementName  One or more element QNames to match. When multiple QNames are specified, the query matches if any QName matches.  (of <a href="{@docRoot}/doc-files/types/xs_QName.html">xs:QName</a>)
@@ -1346,7 +1287,7 @@ public interface CtsExpr {
   * Returns a query that matches no fragments.
   *
   * <a name="ml-server-type-false-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:false-query" target="mlserverdoc">cts:false-query</a> server function.
   * @return  a server expression with the <a href="{@docRoot}/doc-files/types/cts_query.html">cts:query</a> server data type
@@ -1366,7 +1307,7 @@ public interface CtsExpr {
   * Returns a cts:query matching fields by name with a range-index entry equal to a given value. Searches with the cts:field-range-query constructor require a field range index on the specified field name(s); if there is no range index configured, then an exception is thrown.
   *
   * <a name="ml-server-type-field-range-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:field-range-query" target="mlserverdoc">cts:field-range-query</a> server function.
   * @param fieldName  One or more field names to match. When multiple field names are specified, the query matches if any field name matches.  (of <a href="{@docRoot}/doc-files/types/xs_string.html">xs:string</a>)
@@ -1433,7 +1374,7 @@ public interface CtsExpr {
   * Creates a reference to a field value lexicon, for use as a parameter to cts:value-tuples. Since lexicons are implemented with range indexes, this function will throw an exception if the specified range index does not exist.
   *
   * <a name="ml-server-type-field-reference"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:field-reference" target="mlserverdoc">cts:field-reference</a> server function.
   * @param field  A field name.  (of <a href="{@docRoot}/doc-files/types/xs_string.html">xs:string</a>)
@@ -1471,7 +1412,7 @@ public interface CtsExpr {
   * Returns a query matching text content containing a given value in the specified field. If the specified field does not exist, cts:field-value-query throws an exception. If the specified field does not have the index setting field value searches enabled, either for the database or for the specified field, then a cts:search with a cts:field-value-query throws an exception. A field is a named object that specified elements to include and exclude from a search, and can include score weights for any included elements. You create fields at the database level using the Admin Interface. For details on fields, see the chapter on "Fields Database Settings" in the Administrator's Guide.
   *
   * <a name="ml-server-type-field-value-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:field-value-query" target="mlserverdoc">cts:field-value-query</a> server function.
   * @param fieldName  One or more field names to search over. If multiple field names are supplied, the match can be in any of the specified fields (or-query semantics).  (of <a href="{@docRoot}/doc-files/types/xs_string.html">xs:string</a>)
@@ -1534,7 +1475,7 @@ public interface CtsExpr {
   * Returns a query matching fields with text content containing a given phrase. If the specified field does not exist, this function throws an exception. A field is a named object that specified elements to include and exclude from a search, and can include score weights for any included elements. You create fields at the database level using the Admin Interface. For details on fields, see the chapter on "Fields Database Settings" in the Administrator's Guide.
   *
   * <a name="ml-server-type-field-word-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:field-word-query" target="mlserverdoc">cts:field-word-query</a> server function.
   * @param fieldName  One or more field names to search over. If multiple field names are supplied, the match can be in any of the specified fields (or-query semantics).  (of <a href="{@docRoot}/doc-files/types/xs_string.html">xs:string</a>)
@@ -1596,7 +1537,7 @@ public interface CtsExpr {
   * Creates a reference to a geospatial path range index, for use as a parameter to cts:value-tuples. This function will throw an exception if the specified range index does not exist.
   *
   * <a name="ml-server-type-geospatial-path-reference"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:geospatial-path-reference" target="mlserverdoc">cts:geospatial-path-reference</a> server function.
   * @param pathExpression  A path expression.  (of <a href="{@docRoot}/doc-files/types/xs_string.html">xs:string</a>)
@@ -1653,7 +1594,7 @@ public interface CtsExpr {
   * Create a reference to a geospatial region path index, for use as a parameter to cts:geospatial-region-query and other query operations on geospatial region indexes. This function throws an exception if the specified region path index does not exist.
   *
   * <a name="ml-server-type-geospatial-region-path-reference"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:geospatial-region-path-reference" target="mlserverdoc">cts:geospatial-region-path-reference</a> server function.
   * @param pathExpression  The XPath expression specified in the index configuration.  (of <a href="{@docRoot}/doc-files/types/xs_string.html">xs:string</a>)
@@ -1784,7 +1725,7 @@ public interface CtsExpr {
   * Construct a query to match regions in documents that satisfy a specified relationship relative to other regions. For example, regions in documents that intersect with regions specified in the search criteria.
   *
   * <a name="ml-server-type-geospatial-region-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:geospatial-region-query" target="mlserverdoc">cts:geospatial-region-query</a> server function.
   * @param reference  Zero or more geospatial path region index references that identify regions in your content. To create a reference, see cts:geospatial-region-path-reference.  (of <a href="{@docRoot}/doc-files/types/cts_reference.html">cts:reference</a>)
@@ -1843,7 +1784,7 @@ public interface CtsExpr {
   * Creates a reference to the URI lexicon, for use as a parameter to cts:value-tuples. This function requires the URI lexicon to be enabled, otherwise it throws an exception. This reference returns URIs as IRIs.
   *
   * <a name="ml-server-type-iri-reference"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:iri-reference" target="mlserverdoc">cts:iri-reference</a> server function.
   * @return  a server expression with the <a href="{@docRoot}/doc-files/types/cts_reference.html">cts:reference</a> server data type
@@ -1863,7 +1804,7 @@ public interface CtsExpr {
   * Returns a query matching json properties by name which has specific children representing latitude and longitude values for a point contained within the given geographic box, circle, or polygon, or equal to the given point. Points that lie between the southern boundary and the northern boundary of a box, travelling northwards, and between the western boundary and the eastern boundary of the box, travelling eastwards, will match. Points contained within the given radius of the center point of a circle will match, using the curved distance on the surface of the Earth. Points contained within the given polygon will match, using great circle arcs over a spherical model of the Earth as edges. An error may result if the polygon is malformed in some way. Points equal to the a given point will match, taking into account the fact that longitudes converge at the poles. Using the geospatial query constructors requires a valid geospatial license key; without a valid license key, searches that include geospatial queries will throw an exception.
   *
   * <a name="ml-server-type-json-property-child-geospatial-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:json-property-child-geospatial-query" target="mlserverdoc">cts:json-property-child-geospatial-query</a> server function.
   * @param propertyName  One or more parent property names to match. When multiple names are specified, the query matches if any name matches.  (of <a href="{@docRoot}/doc-files/types/xs_string.html">xs:string</a>)
@@ -1931,7 +1872,7 @@ public interface CtsExpr {
   * Returns a query matching json properties by name whose content represents a point contained within the given geographic box, circle, or polygon, or equal to the given point. Points that lie between the southern boundary and the northern boundary of a box, travelling northwards, and between the western boundary and the eastern boundary of the box, travelling eastwards, will match. Points contained within the given radius of the center point of a circle will match, using the curved distance on the surface of the Earth. Points contained within the given polygon will match, using great circle arcs over a spherical model of the Earth as edges. An error may result if the polygon is malformed in some way. Points equal to the a given point will match, taking into account the fact that longitudes converge at the poles. Using the geospatial query constructors requires a valid geospatial license key; without a valid license key, searches that include geospatial queries will throw an exception.
   *
   * <a name="ml-server-type-json-property-geospatial-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:json-property-geospatial-query" target="mlserverdoc">cts:json-property-geospatial-query</a> server function.
   * @param propertyName  One or more json property names to match. When multiple names are specified, the query matches if any name matches.  (of <a href="{@docRoot}/doc-files/types/xs_string.html">xs:string</a>)
@@ -1996,7 +1937,7 @@ public interface CtsExpr {
   * Returns a query matching json properties by name which has specific property children representing latitude and longitude values for a point contained within the given geographic box, circle, or polygon, or equal to the given point. Points that lie between the southern boundary and the northern boundary of a box, travelling northwards, and between the western boundary and the eastern boundary of the box, travelling eastwards, will match. Points contained within the given radius of the center point of a circle will match, using the curved distance on the surface of the Earth. Points contained within the given polygon will match, using great circle arcs over a spherical model of the Earth as edges. An error may result if the polygon is malformed in some way. Points equal to the a given point will match, taking into account the fact that longitudes converge at the poles. Using the geospatial query constructors requires a valid geospatial license key; without a valid license key, searches that include geospatial queries will throw an exception.
   *
   * <a name="ml-server-type-json-property-pair-geospatial-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:json-property-pair-geospatial-query" target="mlserverdoc">cts:json-property-pair-geospatial-query</a> server function.
   * @param propertyName  One or more parent property names to match. When multiple names are specified, the query matches if any name matches.  (of <a href="{@docRoot}/doc-files/types/xs_string.html">xs:string</a>)
@@ -2070,7 +2011,7 @@ public interface CtsExpr {
   * Returns a cts:query matching JSON properties by name with a range-index entry equal to a given value. Searches with the cts:json-property-range-query constructor require a property range index on the specified names; if there is no range index configured, then an exception is thrown.
   *
   * <a name="ml-server-type-json-property-range-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:json-property-range-query" target="mlserverdoc">cts:json-property-range-query</a> server function.
   * @param propertyName  One or more property name to match. When multiple names are specified, the query matches if any name matches.  (of <a href="{@docRoot}/doc-files/types/xs_string.html">xs:string</a>)
@@ -2137,7 +2078,7 @@ public interface CtsExpr {
   * Creates a reference to a JSON property value lexicon, for use as a parameter to cts:value-tuples. Since lexicons are implemented with range indexes, this function will throw an exception if the specified range index does not exist.
   *
   * <a name="ml-server-type-json-property-reference"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:json-property-reference" target="mlserverdoc">cts:json-property-reference</a> server function.
   * @param property  A property name.  (of <a href="{@docRoot}/doc-files/types/xs_string.html">xs:string</a>)
@@ -2175,7 +2116,7 @@ public interface CtsExpr {
   * Returns a cts:query matching JSON properties by name with the content constrained by the given cts:query in the second parameter. Searches for matches in the specified property and all of its descendants.
   *
   * <a name="ml-server-type-json-property-scope-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:json-property-scope-query" target="mlserverdoc">cts:json-property-scope-query</a> server function.
   * @param propertyName  One or more property names to match. When multiple names are specified, the query matches if any name matches.  (of <a href="{@docRoot}/doc-files/types/xs_string.html">xs:string</a>)
@@ -2196,7 +2137,7 @@ public interface CtsExpr {
   * Returns a query matching JSON properties by name with value equal the given value. For arrays, the query matches if the value of any elements in the array matches the given value.
   *
   * <a name="ml-server-type-json-property-value-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:json-property-value-query" target="mlserverdoc">cts:json-property-value-query</a> server function.
   * @param propertyName  One or more property names to match. When multiple names are specified, the query matches if any name matches.  (of <a href="{@docRoot}/doc-files/types/xs_string.html">xs:string</a>)
@@ -2259,7 +2200,7 @@ public interface CtsExpr {
   * Returns a query matching JSON properties by name with text content containing a given phrase. Searches only through immediate text node children of the specified property.
   *
   * <a name="ml-server-type-json-property-word-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:json-property-word-query" target="mlserverdoc">cts:json-property-word-query</a> server function.
   * @param propertyName  One or more JSON property names to match. When multiple names are specified, the query matches if any name matches.  (of <a href="{@docRoot}/doc-files/types/xs_string.html">xs:string</a>)
@@ -2321,7 +2262,7 @@ public interface CtsExpr {
   * Returns a geospatial linestring value.
   *
   * <a name="ml-server-type-linestring"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:linestring" target="mlserverdoc">cts:linestring</a> server function.
   * @param vertices  The waypoints of the linestring, given in order. vertexes.  (of <a href="{@docRoot}/doc-files/types/xs_anyAtomicType.html">xs:anyAtomicType</a>)
@@ -2332,7 +2273,7 @@ public interface CtsExpr {
   * Returns a query that matches all documents where query matches document-locks. When searching documents or document-properties, cts:locks-fragment-query provides a convenient way to additionally constrain the search against document-locks fragments.
   *
   * <a name="ml-server-type-locks-fragment-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:locks-fragment-query" target="mlserverdoc">cts:locks-fragment-query</a> server function.
   * @param query  A query to be matched against the locks fragment.  (of <a href="{@docRoot}/doc-files/types/cts_query.html">cts:query</a>)
@@ -2351,7 +2292,7 @@ public interface CtsExpr {
   * Returns only documents before LSQT or a timestamp before LSQT for stable query results.
   *
   * <a name="ml-server-type-lsqt-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:lsqt-query" target="mlserverdoc">cts:lsqt-query</a> server function.
   * @param temporalCollection  The name of the temporal collection.  (of <a href="{@docRoot}/doc-files/types/xs_string.html">xs:string</a>)
@@ -2430,7 +2371,7 @@ public interface CtsExpr {
   * Returns a query matching all of the specified queries, where the matches occur within the specified distance from each other.
   *
   * <a name="ml-server-type-near-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:near-query" target="mlserverdoc">cts:near-query</a> server function.
   * @param queries  A sequence of queries to match.  (of <a href="{@docRoot}/doc-files/types/cts_query.html">cts:query</a>)
@@ -2501,7 +2442,7 @@ public interface CtsExpr {
   * Returns a query matching the first sub-query, where those matches do not occur within 0 distance of the other query.
   *
   * <a name="ml-server-type-not-in-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:not-in-query" target="mlserverdoc">cts:not-in-query</a> server function.
   * @param positiveQuery  A positive query, specifying the search results filtered in.  (of <a href="{@docRoot}/doc-files/types/cts_query.html">cts:query</a>)
@@ -2513,7 +2454,7 @@ public interface CtsExpr {
   * Returns a query specifying the matches not specified by its sub-query.
   *
   * <a name="ml-server-type-not-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:not-query" target="mlserverdoc">cts:not-query</a> server function.
   * @param query  A negative query, specifying the search results to filter out.  (of <a href="{@docRoot}/doc-files/types/cts_query.html">cts:query</a>)
@@ -2532,7 +2473,7 @@ public interface CtsExpr {
   * Returns a query specifying the union of the matches specified by the sub-queries.
   *
   * <a name="ml-server-type-or-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:or-query" target="mlserverdoc">cts:or-query</a> server function.
   * @param queries  A sequence of sub-queries.  (of <a href="{@docRoot}/doc-files/types/cts_query.html">cts:query</a>)
@@ -2561,7 +2502,7 @@ public interface CtsExpr {
   * Returns the part of speech for a cts:token, if any.
   *
   * <a name="ml-server-type-part-of-speech"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:part-of-speech" target="mlserverdoc">cts:part-of-speech</a> server function.
   * @param token  A token, as returned from cts:tokenize.  (of <a href="{@docRoot}/doc-files/types/xs_string.html">xs:string</a>)
@@ -2581,7 +2522,7 @@ public interface CtsExpr {
   * Returns a query matching path expressions whose content represents a point contained within the given geographic box, circle, or polygon, or equal to the given point. Points that lie between the southern boundary and the northern boundary of a box, travelling northwards, and between the western boundary and the eastern boundary of the box, travelling eastwards, will match. Points contained within the given radius of the center point of a circle will match, using the curved distance on the surface of the Earth. Points contained within the given polygon will match, using great circle arcs over a spherical model of the Earth as edges. An error may result if the polygon is malformed in some way. Points equal to the a given point will match, taking into account the fact that longitudes converge at the poles. Using the geospatial query constructors requires a valid geospatial license key; without a valid license key, searches that include geospatial queries will throw an exception.
   *
   * <a name="ml-server-type-path-geospatial-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:path-geospatial-query" target="mlserverdoc">cts:path-geospatial-query</a> server function.
   * @param pathExpression  One or more path expressions to match. When multiple path expressions are specified, the query matches if any path expression matches.  (of <a href="{@docRoot}/doc-files/types/xs_string.html">xs:string</a>)
@@ -2645,7 +2586,7 @@ public interface CtsExpr {
   * Returns a cts:query matching documents where the content addressed by an XPath expression satisfies the specified relationship (=, &lt;, &gt;, etc.) with respect to the input criteria values. A path range index must exist for each path when you perform a search.
   *
   * <a name="ml-server-type-path-range-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:path-range-query" target="mlserverdoc">cts:path-range-query</a> server function.
   * @param pathName  One or more XPath expressions that identify the content to match. When multiple paths are specified, the query matches if any path matches.  (of <a href="{@docRoot}/doc-files/types/xs_string.html">xs:string</a>)
@@ -2712,7 +2653,7 @@ public interface CtsExpr {
   * Creates a reference to a path value lexicon, for use as a parameter to cts:value-tuples. Since lexicons are implemented with range indexes, this function will throw an exception if the specified range index does not exist.
   *
   * <a name="ml-server-type-path-reference"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:path-reference" target="mlserverdoc">cts:path-reference</a> server function.
   * @param pathExpression  A path range index expression.  (of <a href="{@docRoot}/doc-files/types/xs_string.html">xs:string</a>)
@@ -2770,7 +2711,7 @@ public interface CtsExpr {
   * Creates a period value, for use as a parameter to cts:period-range-query or cts:period-compare-query.
   *
   * <a name="ml-server-type-period"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:period" target="mlserverdoc">cts:period</a> server function.
   * @param start  The dateTime value indicating start of the period.  (of <a href="{@docRoot}/doc-files/types/xs_dateTime.html">xs:dateTime</a>)
@@ -2792,7 +2733,7 @@ public interface CtsExpr {
   * Returns a cts:query matching documents that have relevant pair of period values. Searches with the cts:period-compare-query constructor require two valid names of period, if the either of the specified period does not exist, then an exception is thrown.
   *
   * <a name="ml-server-type-period-compare-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:period-compare-query" target="mlserverdoc">cts:period-compare-query</a> server function.
   * @param axis1  Name of the first axis to compare  (of <a href="{@docRoot}/doc-files/types/xs_string.html">xs:string</a>)
@@ -2836,7 +2777,7 @@ public interface CtsExpr {
   * Returns a cts:query matching axis by name with a period value with an operator. Searches with the cts:period-range-query constructor require a axis definition on the axis name; if there is no axis configured, then an exception is thrown.
   *
   * <a name="ml-server-type-period-range-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:period-range-query" target="mlserverdoc">cts:period-range-query</a> server function.
   * @param axis  One or more axis to match on.  (of <a href="{@docRoot}/doc-files/types/xs_string.html">xs:string</a>)
@@ -2906,7 +2847,7 @@ public interface CtsExpr {
   * Returns a point value.
   *
   * <a name="ml-server-type-point"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:point" target="mlserverdoc">cts:point</a> server function.
   * @param latitude  The latitude of the point.  (of <a href="{@docRoot}/doc-files/types/xs_double.html">xs:double</a>)
@@ -2918,7 +2859,7 @@ public interface CtsExpr {
   * Returns a point's latitude value.
   *
   * <a name="ml-server-type-point-latitude"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:point-latitude" target="mlserverdoc">cts:point-latitude</a> server function.
   * @param point  The point.  (of <a href="{@docRoot}/doc-files/types/cts_point.html">cts:point</a>)
@@ -2929,7 +2870,7 @@ public interface CtsExpr {
   * Returns a point's longitude value.
   *
   * <a name="ml-server-type-point-longitude"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:point-longitude" target="mlserverdoc">cts:point-longitude</a> server function.
   * @param point  The point.  (of <a href="{@docRoot}/doc-files/types/cts_point.html">cts:point</a>)
@@ -2940,7 +2881,7 @@ public interface CtsExpr {
   * Returns a geospatial polygon value.
   *
   * <a name="ml-server-type-polygon"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:polygon" target="mlserverdoc">cts:polygon</a> server function.
   * @param vertices  The vertices of the polygon, given in order. No edge may cover more than 180 degrees of either latitude or longitude. The polygon as a whole may not encompass both poles. These constraints are necessary to ensure an unambiguous interpretation of the polygon. There must be at least three vertices. The first vertex should be identical to the last vertex to close the polygon. vertexes.  (of <a href="{@docRoot}/doc-files/types/cts_point.html">cts:point</a>)
@@ -2957,7 +2898,7 @@ public interface CtsExpr {
   * Returns a query that matches all documents where query matches document-properties. When searching documents or document-locks, this query type provides a convenient way to additionally constrain the search against document-properties fragments.
   *
   * <a name="ml-server-type-properties-fragment-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:properties-fragment-query" target="mlserverdoc">cts:properties-fragment-query</a> server function.
   * @param query  A query to be matched against the properties fragment.  (of <a href="{@docRoot}/doc-files/types/cts_query.html">cts:query</a>)
@@ -2978,7 +2919,7 @@ public interface CtsExpr {
   * Returns a cts:query matching specified nodes with a range-index entry compared to a given value. Searches with the cts:range-query constructor require a range index; if there is no range index configured, then an exception is thrown.
   *
   * <a name="ml-server-type-range-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:range-query" target="mlserverdoc">cts:range-query</a> server function.
   * @param index  One or more range index references. When multiple indexes are specified, the query matches if any index matches.  (of <a href="{@docRoot}/doc-files/types/cts_reference.html">cts:reference</a>)
@@ -3037,7 +2978,7 @@ public interface CtsExpr {
   * Returns the stem(s) for a word.
   *
   * <a name="ml-server-type-stem"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:stem" target="mlserverdoc">cts:stem</a> server function.
   * @param text  A word or phrase to stem.  (of <a href="{@docRoot}/doc-files/types/xs_string.html">xs:string</a>)
@@ -3086,7 +3027,7 @@ public interface CtsExpr {
   * Tokenizes text into words, punctuation, and spaces. Returns output in the type cts:token, which has subtypes cts:word, cts:punctuation, and cts:space, all of which are subtypes of xs:string.
   *
   * <a name="ml-server-type-tokenize"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:tokenize" target="mlserverdoc">cts:tokenize</a> server function.
   * @param text  A word or phrase to tokenize.  (of <a href="{@docRoot}/doc-files/types/xs_string.html">xs:string</a>)
@@ -3145,7 +3086,7 @@ public interface CtsExpr {
   * Returns a cts:query matching triples with a triple index entry equal to the given values. Searches with the cts:triple-range-query constructor require the triple index; if the triple index is not configured, then an exception is thrown.
   *
   * <a name="ml-server-type-triple-range-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:triple-range-query" target="mlserverdoc">cts:triple-range-query</a> server function.
   * @param subject  The subjects to look up. When multiple values are specified, the query matches if any value matches. When the empty sequence is specified, then triples with any subject are matched.  (of <a href="{@docRoot}/doc-files/types/xs_anyAtomicType.html">xs:anyAtomicType</a>)
@@ -3230,7 +3171,7 @@ public interface CtsExpr {
   * Returns a query that matches all fragments.
   *
   * <a name="ml-server-type-true-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:true-query" target="mlserverdoc">cts:true-query</a> server function.
   * @return  a server expression with the <a href="{@docRoot}/doc-files/types/cts_query.html">cts:query</a> server data type
@@ -3240,7 +3181,7 @@ public interface CtsExpr {
   * Creates a reference to the URI lexicon, for use as a parameter to cts:value-tuples. This function requires the URI lexicon to be enabled, otherwise it throws an exception.
   *
   * <a name="ml-server-type-uri-reference"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:uri-reference" target="mlserverdoc">cts:uri-reference</a> server function.
   * @return  a server expression with the <a href="{@docRoot}/doc-files/types/cts_reference.html">cts:reference</a> server data type
@@ -3258,7 +3199,7 @@ public interface CtsExpr {
   * Returns a query matching text content containing a given phrase.
   *
   * <a name="ml-server-type-word-query"></a>
-
+  
   * <p>
   * Provides a client interface to the <a href="http://docs.marklogic.com/cts:word-query" target="mlserverdoc">cts:word-query</a> server function.
   * @param text  Some words or phrases to match. When multiple strings are specified, the query matches if any string matches.  (of <a href="{@docRoot}/doc-files/types/xs_string.html">xs:string</a>)
@@ -3309,49 +3250,49 @@ public interface CtsExpr {
   * @return  a CtsBoxSeqExpr sequence
   */
   public CtsBoxSeqExpr boxSeq(CtsBoxExpr... items);
-
+ 
 /**
   * Constructs a sequence of CtsCircleExpr items.
   * @param items  the CtsCircleExpr items collected by the sequence
   * @return  a CtsCircleSeqExpr sequence
   */
   public CtsCircleSeqExpr circleSeq(CtsCircleExpr... items);
-
+ 
 /**
   * Constructs a sequence of CtsPeriodExpr items.
   * @param items  the CtsPeriodExpr items collected by the sequence
   * @return  a CtsPeriodSeqExpr sequence
   */
   public CtsPeriodSeqExpr periodSeq(CtsPeriodExpr... items);
-
+ 
 /**
   * Constructs a sequence of CtsPointExpr items.
   * @param items  the CtsPointExpr items collected by the sequence
   * @return  a CtsPointSeqExpr sequence
   */
   public CtsPointSeqExpr pointSeq(CtsPointExpr... items);
-
+ 
 /**
   * Constructs a sequence of CtsPolygonExpr items.
   * @param items  the CtsPolygonExpr items collected by the sequence
   * @return  a CtsPolygonSeqExpr sequence
   */
   public CtsPolygonSeqExpr polygonSeq(CtsPolygonExpr... items);
-
+ 
 /**
   * Constructs a sequence of CtsQueryExpr items.
   * @param items  the CtsQueryExpr items collected by the sequence
   * @return  a CtsQuerySeqExpr sequence
   */
   public CtsQuerySeqExpr querySeq(CtsQueryExpr... items);
-
+ 
 /**
   * Constructs a sequence of CtsReferenceExpr items.
   * @param items  the CtsReferenceExpr items collected by the sequence
   * @return  a CtsReferenceSeqExpr sequence
   */
   public CtsReferenceSeqExpr referenceSeq(CtsReferenceExpr... items);
-
+ 
 /**
   * Constructs a sequence of CtsRegionExpr items.
   * @param items  the CtsRegionExpr items collected by the sequence

--- a/marklogic-client-api/src/main/java/com/marklogic/client/expression/PlanBuilder.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/expression/PlanBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 MarkLogic Corporation
+ * Copyright (c) 2024 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -226,6 +226,188 @@ public abstract class PlanBuilder implements PlanBuilderBase {
   * @return  a server expression with the <a href="{@docRoot}/doc-files/types/xs_numeric.html">xs:numeric</a> server data type
   */
   public abstract ServerExpression subtract(ServerExpression left, ServerExpression right);
+  /**
+  * Add an error-handler to the Optic Pipeline to catch Optic Update runtime errors. The runtime errors are added in the errors column. If no error occurred the value of the error column is null. When added, the error-handler should be the last operator before op:result.
+  * @param action  The Optic Plan. You can either use the XQuery =&gt; chaining operator or specify the variable that captures the return value from the previous operation.
+  * @return  a ModifyPlan object
+  */
+  public abstract ModifyPlan onError(String action);
+  /**
+  * Add an error-handler to the Optic Pipeline to catch Optic Update runtime errors. The runtime errors are added in the errors column. If no error occurred the value of the error column is null. When added, the error-handler should be the last operator before op:result.
+  * @param action  The Optic Plan. You can either use the XQuery =&gt; chaining operator or specify the variable that captures the return value from the previous operation.
+  * @return  a ModifyPlan object
+  */
+  public abstract ModifyPlan onError(XsStringVal action);
+  /**
+  * Add an error-handler to the Optic Pipeline to catch Optic Update runtime errors. The runtime errors are added in the errors column. If no error occurred the value of the error column is null. When added, the error-handler should be the last operator before op:result.
+  * @param action  The Optic Plan. You can either use the XQuery =&gt; chaining operator or specify the variable that captures the return value from the previous operation.
+  * @param errorColumn  Valid options are: "fail" - stop procesisng and "continue" - add an error to the error column and continue processing. See {@link PlanBuilder#col(XsStringVal)}
+  * @return  a ModifyPlan object
+  */
+  public abstract ModifyPlan onError(String action, String errorColumn);
+  /**
+  * Add an error-handler to the Optic Pipeline to catch Optic Update runtime errors. The runtime errors are added in the errors column. If no error occurred the value of the error column is null. When added, the error-handler should be the last operator before op:result.
+  * @param action  The Optic Plan. You can either use the XQuery =&gt; chaining operator or specify the variable that captures the return value from the previous operation.
+  * @param errorColumn  Valid options are: "fail" - stop procesisng and "continue" - add an error to the error column and continue processing. See {@link PlanBuilder#col(XsStringVal)}
+  * @return  a ModifyPlan object
+  */
+  public abstract ModifyPlan onError(XsStringVal action, PlanExprCol errorColumn);
+  /**
+  * Builds a patch operation including a sequence of inserts, replaces, replace-inserts and deletes.
+  * @param docColumn  The Optic Plan. You can either use the XQuery =&gt; chaining operator or specify the variable that captures the return value from the previous operation. See {@link PlanBuilder#col(XsStringVal)}
+  * @param patchDef  The document column which need to be patched.
+  * @return  a ModifyPlan object
+  */
+  public abstract ModifyPlan patch(String docColumn, PlanPatchBuilderPlan patchDef);
+  /**
+  * Builds a patch operation including a sequence of inserts, replaces, replace-inserts and deletes.
+  * @param docColumn  The Optic Plan. You can either use the XQuery =&gt; chaining operator or specify the variable that captures the return value from the previous operation. See {@link PlanBuilder#col(XsStringVal)}
+  * @param patchDef  The document column which need to be patched.
+  * @return  a ModifyPlan object
+  */
+  public abstract ModifyPlan patch(PlanExprCol docColumn, PlanPatchBuilderPlan patchDef);
+  /**
+  * Create a patch builder which can be used to chain patch operations.
+  * @param contextPath  The context path to patch.
+  * @return  a PlanPatchBuilderPlan object
+  */
+  public abstract PlanPatchBuilderPlan patchBuilder(String contextPath);
+  /**
+  * Create a patch builder which can be used to chain patch operations.
+  * @param contextPath  The context path to patch.
+  * @return  a PlanPatchBuilderPlan object
+  */
+  public abstract PlanPatchBuilderPlan patchBuilder(XsStringVal contextPath);
+  /**
+  * Create a patch builder which can be used to chain patch operations.
+  * @param contextPath  The context path to patch.
+  * @param namespaces  Namespaces prefix (key) and uri (value).
+  * @return  a PlanPatchBuilderPlan object
+  */
+  public abstract PlanPatchBuilderPlan patchBuilder(String contextPath, Map<String,String>[] namespaces);
+  /**
+  * Create a patch builder which can be used to chain patch operations.
+  * @param contextPath  The context path to patch.
+  * @param namespaces  Namespaces prefix (key) and uri (value).
+  * @return  a PlanPatchBuilderPlan object
+  */
+  public abstract PlanPatchBuilderPlan patchBuilder(XsStringVal contextPath, Map<String,String>[] namespaces);
+  /**
+  * Insert a new node after another node.
+  * @param path  The Patch Builder Plan. You can either use the XQuery =&gt; chaining operator or specify the variable that captures the return value from the previous operation.
+  * @param node  The path to insert the node after.
+  * @return  a PlanPatchBuilderPlan object
+  */
+  public abstract PlanPatchBuilderPlan insertAfter(String path, Node node);
+  /**
+  * Insert a new node after another node.
+  * @param path  The Patch Builder Plan. You can either use the XQuery =&gt; chaining operator or specify the variable that captures the return value from the previous operation.
+  * @param node  The path to insert the node after.
+  * @return  a PlanPatchBuilderPlan object
+  */
+  public abstract PlanPatchBuilderPlan insertAfter(XsStringVal path, Node node);
+  /**
+  * Insert a new node before another node.
+  * @param path  The Patch Builder Plan. You can either use the XQuery =&gt; chaining operator or specify the variable that captures the return value from the previous operation.
+  * @param node  The path to insert the node before.
+  * @return  a PlanPatchBuilderPlan object
+  */
+  public abstract PlanPatchBuilderPlan insertBefore(String path, Node node);
+  /**
+  * Insert a new node before another node.
+  * @param path  The Patch Builder Plan. You can either use the XQuery =&gt; chaining operator or specify the variable that captures the return value from the previous operation.
+  * @param node  The path to insert the node before.
+  * @return  a PlanPatchBuilderPlan object
+  */
+  public abstract PlanPatchBuilderPlan insertBefore(XsStringVal path, Node node);
+  /**
+  * Insert a node as child.
+  * @param path  The Patch Builder Plan. You can either use the XQuery =&gt; chaining operator or specify the variable that captures the return value from the previous operation.
+  * @param node  The path to insert the child.
+  * @return  a PlanPatchBuilderPlan object
+  */
+  public abstract PlanPatchBuilderPlan insertChild(String path, Node node);
+  /**
+  * Insert a node as child.
+  * @param path  The Patch Builder Plan. You can either use the XQuery =&gt; chaining operator or specify the variable that captures the return value from the previous operation.
+  * @param node  The path to insert the child.
+  * @return  a PlanPatchBuilderPlan object
+  */
+  public abstract PlanPatchBuilderPlan insertChild(XsStringVal path, Node node);
+  /**
+  * This method is specific for JSON and inserts a key/value pair to an object.
+  * @param path  The Patch Builder Plan. You can either use the XQuery =&gt; chaining operator or specify the variable that captures the return value from the previous operation.
+  * @param key  The path which returns an JSON Object.
+  * @param node  The key to insert.
+  * @return  a PlanPatchBuilderPlan object
+  */
+  public abstract PlanPatchBuilderPlan insertNamedChild(String path, String key, Node node);
+  /**
+  * This method is specific for JSON and inserts a key/value pair to an object.
+  * @param path  The Patch Builder Plan. You can either use the XQuery =&gt; chaining operator or specify the variable that captures the return value from the previous operation.
+  * @param key  The path which returns an JSON Object.
+  * @param node  The key to insert.
+  * @return  a PlanPatchBuilderPlan object
+  */
+  public abstract PlanPatchBuilderPlan insertNamedChild(XsStringVal path, XsStringVal key, Node node);
+  /**
+  * This method deletes a document from the database. If the document does not exist, this method does not throw an error. Delete a node.
+  * @param path  If this column is not specified then it assumes a column 'uri' is present. This can be a string of the uri column name or an op:col. Use op:view-col or op:schema-col if you need to identify columns in the two views that have the same column name. This can also be a map object specify the uri column name.
+  * @return  a PlanPatchBuilderPlan object
+  */
+  public abstract PlanPatchBuilderPlan remove(String path);
+  /**
+  * This method deletes a document from the database. If the document does not exist, this method does not throw an error. Delete a node.
+  * @param path  If this column is not specified then it assumes a column 'uri' is present. This can be a string of the uri column name or an op:col. Use op:view-col or op:schema-col if you need to identify columns in the two views that have the same column name. This can also be a map object specify the uri column name.
+  * @return  a PlanPatchBuilderPlan object
+  */
+  public abstract PlanPatchBuilderPlan remove(XsStringVal path);
+  /**
+  * Replace a node with another node.
+  * @param path  The Patch Builder Plan. You can either use the XQuery =&gt; chaining operator or specify the variable that captures the return value from the previous operation.
+  * @param node  The path to replace.
+  * @return  a PlanPatchBuilderPlan object
+  */
+  public abstract PlanPatchBuilderPlan replace(String path, Node node);
+  /**
+  * Replace a node with another node.
+  * @param path  The Patch Builder Plan. You can either use the XQuery =&gt; chaining operator or specify the variable that captures the return value from the previous operation.
+  * @param node  The path to replace.
+  * @return  a PlanPatchBuilderPlan object
+  */
+  public abstract PlanPatchBuilderPlan replace(XsStringVal path, Node node);
+  /**
+  * Replace a child if it exist, or insert if it does not exist.
+  * @param parentPath  The Patch Builder Plan. You can either use the XQuery =&gt; chaining operator or specify the variable that captures the return value from the previous operation.
+  * @param pathToReplace  The parent path to insert/replace.
+  * @return  a PlanPatchBuilderPlan object
+  */
+  public abstract PlanPatchBuilderPlan replaceInsertChild(String parentPath, String pathToReplace);
+  /**
+  * Replace a child if it exist, or insert if it does not exist.
+  * @param parentPath  The Patch Builder Plan. You can either use the XQuery =&gt; chaining operator or specify the variable that captures the return value from the previous operation.
+  * @param pathToReplace  The parent path to insert/replace.
+  * @return  a PlanPatchBuilderPlan object
+  */
+  public abstract PlanPatchBuilderPlan replaceInsertChild(XsStringVal parentPath, XsStringVal pathToReplace);
+  /**
+  * Replace a child if it exist, or insert if it does not exist.
+  * @param parentPath  The Patch Builder Plan. You can either use the XQuery =&gt; chaining operator or specify the variable that captures the return value from the previous operation.
+  * @param pathToReplace  The parent path to insert/replace.
+  * @param node  The path to insert/replace which is relative to parent-path.
+  * @return  a PlanPatchBuilderPlan object
+  */
+  public abstract PlanPatchBuilderPlan replaceInsertChild(String parentPath, String pathToReplace, Node node);
+  /**
+  * Replace a child if it exist, or insert if it does not exist.
+  * @param parentPath  The Patch Builder Plan. You can either use the XQuery =&gt; chaining operator or specify the variable that captures the return value from the previous operation.
+  * @param pathToReplace  The parent path to insert/replace.
+  * @param node  The path to insert/replace which is relative to parent-path.
+  * @return  a PlanPatchBuilderPlan object
+  */
+  public abstract PlanPatchBuilderPlan replaceInsertChild(XsStringVal parentPath, XsStringVal pathToReplace, Node node);
+  public abstract PlanPatchBuilderPlan replaceValue(String path, Item value);
+  public abstract PlanPatchBuilderPlan replaceValue(XsStringVal path, Item value);
   /**
   * This function creates a placeholder for a literal value in an expression or as the offset or max for a limit. The op:result function throws in an error if the binding parameter does not specify a literal value for the parameter.
   * <p>
@@ -1587,22 +1769,6 @@ public abstract class PlanBuilder implements PlanBuilderBase {
   * @return  a ModifyPlan object
   */
   public abstract ModifyPlan joinDocUri(PlanColumn uriCol, PlanColumn fragmentIdCol);
-/**
-  * This method adds an uri column and a document column to rows based on an existing source column having a value of a document uri (which can be used to read other documents) or a fragment id (which can be used to read the source documents for rows). If the fragment id column is null in the row, the row is dropped from the rowset. 
-  * @param docCol  The document column to add to the rows. This can be a string or a column, op:col, op:view-col or op:schema-col, specifying the name of the new column that should have the document as its value. See {@link PlanBuilder#col(XsStringVal)}
-  * @param uriCol  The uri column to add to the rows. This can be a string or a column, op:col, op:view-col or op:schema-col, specifying the name of the new column that should have the document uri as its value. See {@link PlanBuilder#col(XsStringVal)}
-  * @param sourceCol  The document uri or fragment id value. This is either an op:fragment-id-col specifying a fragment id column or a document uri column as xs:string or as a column using op:col, op:view-col or op:schema-col. Joining on a fragment id is more efficient than joining on a uri column. See {@link PlanBuilder#col(XsStringVal)}
-  * @return  a ModifyPlan object
-  */
-  public abstract ModifyPlan joinDocAndUri(String docCol, String uriCol, String sourceCol);
-/**
-  * This method adds an uri column and a document column to rows based on an existing source column having a value of a document uri (which can be used to read other documents) or a fragment id (which can be used to read the source documents for rows). If the fragment id column is null in the row, the row is dropped from the rowset. 
-  * @param docCol  The document column to add to the rows. This can be a string or a column, op:col, op:view-col or op:schema-col, specifying the name of the new column that should have the document as its value. See {@link PlanBuilder#col(XsStringVal)}
-  * @param uriCol  The uri column to add to the rows. This can be a string or a column, op:col, op:view-col or op:schema-col, specifying the name of the new column that should have the document uri as its value. See {@link PlanBuilder#col(XsStringVal)}
-  * @param sourceCol  The document uri or fragment id value. This is either an op:fragment-id-col specifying a fragment id column or a document uri column as xs:string or as a column using op:col, op:view-col or op:schema-col. Joining on a fragment id is more efficient than joining on a uri column. See {@link PlanBuilder#col(XsStringVal)}
-  * @return  a ModifyPlan object
-  */
-  public abstract ModifyPlan joinDocAndUri(PlanColumn docCol, PlanColumn uriCol, PlanColumn sourceCol);
 /**
   * This method returns all rows from multiple tables where the join condition is met. In the output row set, each row concatenates one left row and one right row for each match between the keys in the left and right row sets. 
   * @param right  The row set from the right view.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/CtsExprImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/CtsExprImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 MarkLogic Corporation
+ * Copyright (c) 2024 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,7 +63,7 @@ class CtsExprImpl implements CtsExpr {
   CtsExprImpl() {
   }
 
-
+    
   @Override
   public CtsQueryExpr afterQuery(ServerExpression timestamp) {
     if (timestamp == null) {
@@ -72,7 +72,7 @@ class CtsExprImpl implements CtsExpr {
     return new QueryCallImpl("cts", "after-query", new Object[]{ timestamp });
   }
 
-
+  
   @Override
   public CtsQueryExpr andNotQuery(ServerExpression positiveQuery, ServerExpression negativeQuery) {
     if (positiveQuery == null) {
@@ -84,31 +84,31 @@ class CtsExprImpl implements CtsExpr {
     return new QueryCallImpl("cts", "and-not-query", new Object[]{ positiveQuery, negativeQuery });
   }
 
-
+  
   @Override
   public CtsQueryExpr andQuery(CtsQueryExpr... queries) {
     return andQuery(new QuerySeqListImpl(queries));
   }
 
-
+  
   @Override
   public CtsQueryExpr andQuery(ServerExpression queries) {
     return new QueryCallImpl("cts", "and-query", new Object[]{ queries });
   }
 
-
+  
   @Override
   public CtsQueryExpr andQuery(ServerExpression queries, String options) {
     return andQuery(queries, (options == null) ? (XsStringVal) null : xs.string(options));
   }
 
-
+  
   @Override
   public CtsQueryExpr andQuery(ServerExpression queries, XsStringSeqVal options) {
     return new QueryCallImpl("cts", "and-query", new Object[]{ queries, options });
   }
 
-
+  
   @Override
   public CtsQueryExpr beforeQuery(ServerExpression timestamp) {
     if (timestamp == null) {
@@ -117,7 +117,7 @@ class CtsExprImpl implements CtsExpr {
     return new QueryCallImpl("cts", "before-query", new Object[]{ timestamp });
   }
 
-
+  
   @Override
   public CtsQueryExpr boostQuery(ServerExpression matchingQuery, ServerExpression boostingQuery) {
     if (matchingQuery == null) {
@@ -129,13 +129,13 @@ class CtsExprImpl implements CtsExpr {
     return new QueryCallImpl("cts", "boost-query", new Object[]{ matchingQuery, boostingQuery });
   }
 
-
+  
   @Override
   public CtsBoxExpr box(double south, double west, double north, double east) {
     return box(xs.doubleVal(south), xs.doubleVal(west), xs.doubleVal(north), xs.doubleVal(east));
   }
 
-
+  
   @Override
   public CtsBoxExpr box(ServerExpression south, ServerExpression west, ServerExpression north, ServerExpression east) {
     if (south == null) {
@@ -153,7 +153,7 @@ class CtsExprImpl implements CtsExpr {
     return new BoxCallImpl("cts", "box", new Object[]{ south, west, north, east });
   }
 
-
+  
   @Override
   public ServerExpression boxEast(ServerExpression box) {
     if (box == null) {
@@ -162,7 +162,7 @@ class CtsExprImpl implements CtsExpr {
     return new XsExprImpl.NumericCallImpl("cts", "box-east", new Object[]{ box });
   }
 
-
+  
   @Override
   public ServerExpression boxNorth(ServerExpression box) {
     if (box == null) {
@@ -171,7 +171,7 @@ class CtsExprImpl implements CtsExpr {
     return new XsExprImpl.NumericCallImpl("cts", "box-north", new Object[]{ box });
   }
 
-
+  
   @Override
   public ServerExpression boxSouth(ServerExpression box) {
     if (box == null) {
@@ -180,7 +180,7 @@ class CtsExprImpl implements CtsExpr {
     return new XsExprImpl.NumericCallImpl("cts", "box-south", new Object[]{ box });
   }
 
-
+  
   @Override
   public ServerExpression boxWest(ServerExpression box) {
     if (box == null) {
@@ -189,13 +189,13 @@ class CtsExprImpl implements CtsExpr {
     return new XsExprImpl.NumericCallImpl("cts", "box-west", new Object[]{ box });
   }
 
-
+  
   @Override
   public CtsCircleExpr circle(double radius, ServerExpression center) {
     return circle(xs.doubleVal(radius), center);
   }
 
-
+  
   @Override
   public CtsCircleExpr circle(ServerExpression radius, ServerExpression center) {
     if (radius == null) {
@@ -207,7 +207,7 @@ class CtsExprImpl implements CtsExpr {
     return new CircleCallImpl("cts", "circle", new Object[]{ radius, center });
   }
 
-
+  
   @Override
   public CtsPointExpr circleCenter(ServerExpression circle) {
     if (circle == null) {
@@ -216,7 +216,7 @@ class CtsExprImpl implements CtsExpr {
     return new PointCallImpl("cts", "circle-center", new Object[]{ circle });
   }
 
-
+  
   @Override
   public ServerExpression circleRadius(ServerExpression circle) {
     if (circle == null) {
@@ -225,43 +225,43 @@ class CtsExprImpl implements CtsExpr {
     return new XsExprImpl.NumericCallImpl("cts", "circle-radius", new Object[]{ circle });
   }
 
-
+  
   @Override
   public CtsQueryExpr collectionQuery(String uris) {
     return collectionQuery((uris == null) ? (XsStringVal) null : xs.string(uris));
   }
 
-
+  
   @Override
   public CtsQueryExpr collectionQuery(ServerExpression uris) {
     return new QueryCallImpl("cts", "collection-query", new Object[]{ uris });
   }
 
-
+  
   @Override
   public CtsReferenceExpr collectionReference() {
     return new ReferenceCallImpl("cts", "collection-reference", new Object[]{  });
   }
 
-
+  
   @Override
   public CtsReferenceExpr collectionReference(String options) {
     return collectionReference((options == null) ? (XsStringVal) null : xs.string(options));
   }
 
-
+  
   @Override
   public CtsReferenceExpr collectionReference(ServerExpression options) {
     return new ReferenceCallImpl("cts", "collection-reference", new Object[]{ options });
   }
 
-
+  
   @Override
   public CtsQueryExpr columnRangeQuery(String schema, String view, String column, String value) {
     return columnRangeQuery((schema == null) ? (XsStringVal) null : xs.string(schema), (view == null) ? (XsStringVal) null : xs.string(view), (column == null) ? (XsStringVal) null : xs.string(column), (value == null) ? (XsAnyAtomicTypeVal) null : xs.string(value));
   }
 
-
+  
   @Override
   public CtsQueryExpr columnRangeQuery(ServerExpression schema, ServerExpression view, ServerExpression column, ServerExpression value) {
     if (schema == null) {
@@ -276,13 +276,13 @@ class CtsExprImpl implements CtsExpr {
     return new QueryCallImpl("cts", "column-range-query", new Object[]{ schema, view, column, value });
   }
 
-
+  
   @Override
   public CtsQueryExpr columnRangeQuery(String schema, String view, String column, String value, String operator) {
     return columnRangeQuery((schema == null) ? (XsStringVal) null : xs.string(schema), (view == null) ? (XsStringVal) null : xs.string(view), (column == null) ? (XsStringVal) null : xs.string(column), (value == null) ? (XsAnyAtomicTypeVal) null : xs.string(value), (operator == null) ? (XsStringVal) null : xs.string(operator));
   }
 
-
+  
   @Override
   public CtsQueryExpr columnRangeQuery(ServerExpression schema, ServerExpression view, ServerExpression column, ServerExpression value, ServerExpression operator) {
     if (schema == null) {
@@ -297,13 +297,13 @@ class CtsExprImpl implements CtsExpr {
     return new QueryCallImpl("cts", "column-range-query", new Object[]{ schema, view, column, value, operator });
   }
 
-
+  
   @Override
   public CtsQueryExpr columnRangeQuery(String schema, String view, String column, String value, String operator, String... options) {
     return columnRangeQuery((schema == null) ? (XsStringVal) null : xs.string(schema), (view == null) ? (XsStringVal) null : xs.string(view), (column == null) ? (XsStringVal) null : xs.string(column), (value == null) ? (XsAnyAtomicTypeVal) null : xs.string(value), (operator == null) ? (XsStringVal) null : xs.string(operator), (options == null) ? (XsStringVal) null : xs.stringSeq(options));
   }
 
-
+  
   @Override
   public CtsQueryExpr columnRangeQuery(ServerExpression schema, ServerExpression view, ServerExpression column, ServerExpression value, ServerExpression operator, ServerExpression options) {
     if (schema == null) {
@@ -318,13 +318,13 @@ class CtsExprImpl implements CtsExpr {
     return new QueryCallImpl("cts", "column-range-query", new Object[]{ schema, view, column, value, operator, options });
   }
 
-
+  
   @Override
   public CtsQueryExpr columnRangeQuery(String schema, String view, String column, String value, String operator, String options, double weight) {
     return columnRangeQuery((schema == null) ? (XsStringVal) null : xs.string(schema), (view == null) ? (XsStringVal) null : xs.string(view), (column == null) ? (XsStringVal) null : xs.string(column), (value == null) ? (XsAnyAtomicTypeVal) null : xs.string(value), (operator == null) ? (XsStringVal) null : xs.string(operator), (options == null) ? (XsStringVal) null : xs.string(options), xs.doubleVal(weight));
   }
 
-
+  
   @Override
   public CtsQueryExpr columnRangeQuery(ServerExpression schema, ServerExpression view, ServerExpression column, ServerExpression value, ServerExpression operator, ServerExpression options, ServerExpression weight) {
     if (schema == null) {
@@ -339,7 +339,7 @@ class CtsExprImpl implements CtsExpr {
     return new QueryCallImpl("cts", "column-range-query", new Object[]{ schema, view, column, value, operator, options, weight });
   }
 
-
+  
   @Override
   public CtsPolygonExpr complexPolygon(ServerExpression outer, ServerExpression inner) {
     if (outer == null) {
@@ -348,46 +348,31 @@ class CtsExprImpl implements CtsExpr {
     return new PolygonCallImpl("cts", "complex-polygon", new Object[]{ outer, inner });
   }
 
-
+  
   @Override
   public CtsQueryExpr directoryQuery(String uris) {
     return directoryQuery((uris == null) ? (XsStringVal) null : xs.string(uris));
   }
 
-
+  
   @Override
   public CtsQueryExpr directoryQuery(ServerExpression uris) {
     return new QueryCallImpl("cts", "directory-query", new Object[]{ uris });
   }
 
-
+  
   @Override
   public CtsQueryExpr directoryQuery(String uris, String depth) {
     return directoryQuery((uris == null) ? (XsStringVal) null : xs.string(uris), (depth == null) ? (XsStringVal) null : xs.string(depth));
   }
 
-
+  
   @Override
   public CtsQueryExpr directoryQuery(ServerExpression uris, ServerExpression depth) {
     return new QueryCallImpl("cts", "directory-query", new Object[]{ uris, depth });
   }
 
-
-  @Override
-  public CtsQueryExpr documentFormatQuery(String format) {
-    return documentFormatQuery((format == null) ? (XsStringVal) null : xs.string(format));
-  }
-
-
-  @Override
-  public CtsQueryExpr documentFormatQuery(ServerExpression format) {
-    if (format == null) {
-      throw new IllegalArgumentException("format parameter for documentFormatQuery() cannot be null");
-    }
-    return new QueryCallImpl("cts", "document-format-query", new Object[]{ format });
-  }
-
-
+  
   @Override
   public CtsQueryExpr documentFragmentQuery(ServerExpression query) {
     if (query == null) {
@@ -396,94 +381,61 @@ class CtsExprImpl implements CtsExpr {
     return new QueryCallImpl("cts", "document-fragment-query", new Object[]{ query });
   }
 
-
-  @Override
-  public CtsQueryExpr documentPermissionQuery(String role, String capability) {
-    return documentPermissionQuery((role == null) ? (XsStringVal) null : xs.string(role), (capability == null) ? (XsStringVal) null : xs.string(capability));
-  }
-
-
-  @Override
-  public CtsQueryExpr documentPermissionQuery(ServerExpression role, ServerExpression capability) {
-    if (role == null) {
-      throw new IllegalArgumentException("role parameter for documentPermissionQuery() cannot be null");
-    }
-    if (capability == null) {
-      throw new IllegalArgumentException("capability parameter for documentPermissionQuery() cannot be null");
-    }
-    return new QueryCallImpl("cts", "document-permission-query", new Object[]{ role, capability });
-  }
-
-
+  
   @Override
   public CtsQueryExpr documentQuery(String uris) {
     return documentQuery((uris == null) ? (XsStringVal) null : xs.string(uris));
   }
 
-
+  
   @Override
   public CtsQueryExpr documentQuery(ServerExpression uris) {
     return new QueryCallImpl("cts", "document-query", new Object[]{ uris });
   }
 
-
-  @Override
-  public CtsQueryExpr documentRootQuery(String root) {
-    return documentRootQuery((root == null) ? (XsQNameVal) null : xs.QName(root));
-  }
-
-
-  @Override
-  public CtsQueryExpr documentRootQuery(ServerExpression root) {
-    if (root == null) {
-      throw new IllegalArgumentException("root parameter for documentRootQuery() cannot be null");
-    }
-    return new QueryCallImpl("cts", "document-root-query", new Object[]{ root });
-  }
-
-
+  
   @Override
   public CtsQueryExpr elementAttributePairGeospatialQuery(String elementName, String latitudeName, String longitudeName, CtsRegionExpr... region) {
     return elementAttributePairGeospatialQuery((elementName == null) ? (XsQNameVal) null : xs.QName(elementName), (latitudeName == null) ? (XsQNameVal) null : xs.QName(latitudeName), (longitudeName == null) ? (XsQNameVal) null : xs.QName(longitudeName), new RegionSeqListImpl(region));
   }
 
-
+  
   @Override
   public CtsQueryExpr elementAttributePairGeospatialQuery(ServerExpression elementName, ServerExpression latitudeName, ServerExpression longitudeName, ServerExpression region) {
     return new QueryCallImpl("cts", "element-attribute-pair-geospatial-query", new Object[]{ elementName, latitudeName, longitudeName, region });
   }
 
-
+  
   @Override
   public CtsQueryExpr elementAttributePairGeospatialQuery(String elementName, String latitudeName, String longitudeName, ServerExpression region, String... options) {
     return elementAttributePairGeospatialQuery((elementName == null) ? (XsQNameVal) null : xs.QName(elementName), (latitudeName == null) ? (XsQNameVal) null : xs.QName(latitudeName), (longitudeName == null) ? (XsQNameVal) null : xs.QName(longitudeName), region, (options == null) ? (XsStringVal) null : xs.stringSeq(options));
   }
 
-
+  
   @Override
   public CtsQueryExpr elementAttributePairGeospatialQuery(ServerExpression elementName, ServerExpression latitudeName, ServerExpression longitudeName, ServerExpression region, ServerExpression options) {
     return new QueryCallImpl("cts", "element-attribute-pair-geospatial-query", new Object[]{ elementName, latitudeName, longitudeName, region, options });
   }
 
-
+  
   @Override
   public CtsQueryExpr elementAttributePairGeospatialQuery(String elementName, String latitudeName, String longitudeName, ServerExpression region, String options, double weight) {
     return elementAttributePairGeospatialQuery((elementName == null) ? (XsQNameVal) null : xs.QName(elementName), (latitudeName == null) ? (XsQNameVal) null : xs.QName(latitudeName), (longitudeName == null) ? (XsQNameVal) null : xs.QName(longitudeName), region, (options == null) ? (XsStringVal) null : xs.string(options), xs.doubleVal(weight));
   }
 
-
+  
   @Override
   public CtsQueryExpr elementAttributePairGeospatialQuery(ServerExpression elementName, ServerExpression latitudeName, ServerExpression longitudeName, ServerExpression region, ServerExpression options, ServerExpression weight) {
     return new QueryCallImpl("cts", "element-attribute-pair-geospatial-query", new Object[]{ elementName, latitudeName, longitudeName, region, options, weight });
   }
 
-
+  
   @Override
   public CtsQueryExpr elementAttributeRangeQuery(String elementName, String attributeName, String operator, String value) {
     return elementAttributeRangeQuery((elementName == null) ? (XsQNameVal) null : xs.QName(elementName), (attributeName == null) ? (XsQNameVal) null : xs.QName(attributeName), (operator == null) ? (XsStringVal) null : xs.string(operator), (value == null) ? (XsAnyAtomicTypeVal) null : xs.string(value));
   }
 
-
+  
   @Override
   public CtsQueryExpr elementAttributeRangeQuery(ServerExpression elementName, ServerExpression attributeName, ServerExpression operator, ServerExpression value) {
     if (operator == null) {
@@ -492,13 +444,13 @@ class CtsExprImpl implements CtsExpr {
     return new QueryCallImpl("cts", "element-attribute-range-query", new Object[]{ elementName, attributeName, operator, value });
   }
 
-
+  
   @Override
   public CtsQueryExpr elementAttributeRangeQuery(String elementName, String attributeName, String operator, String value, String... options) {
     return elementAttributeRangeQuery((elementName == null) ? (XsQNameVal) null : xs.QName(elementName), (attributeName == null) ? (XsQNameVal) null : xs.QName(attributeName), (operator == null) ? (XsStringVal) null : xs.string(operator), (value == null) ? (XsAnyAtomicTypeVal) null : xs.string(value), (options == null) ? (XsStringVal) null : xs.stringSeq(options));
   }
 
-
+  
   @Override
   public CtsQueryExpr elementAttributeRangeQuery(ServerExpression elementName, ServerExpression attributeName, ServerExpression operator, ServerExpression value, ServerExpression options) {
     if (operator == null) {
@@ -507,13 +459,13 @@ class CtsExprImpl implements CtsExpr {
     return new QueryCallImpl("cts", "element-attribute-range-query", new Object[]{ elementName, attributeName, operator, value, options });
   }
 
-
+  
   @Override
   public CtsQueryExpr elementAttributeRangeQuery(String elementName, String attributeName, String operator, String value, String options, double weight) {
     return elementAttributeRangeQuery((elementName == null) ? (XsQNameVal) null : xs.QName(elementName), (attributeName == null) ? (XsQNameVal) null : xs.QName(attributeName), (operator == null) ? (XsStringVal) null : xs.string(operator), (value == null) ? (XsAnyAtomicTypeVal) null : xs.string(value), (options == null) ? (XsStringVal) null : xs.string(options), xs.doubleVal(weight));
   }
 
-
+  
   @Override
   public CtsQueryExpr elementAttributeRangeQuery(ServerExpression elementName, ServerExpression attributeName, ServerExpression operator, ServerExpression value, ServerExpression options, ServerExpression weight) {
     if (operator == null) {
@@ -522,13 +474,13 @@ class CtsExprImpl implements CtsExpr {
     return new QueryCallImpl("cts", "element-attribute-range-query", new Object[]{ elementName, attributeName, operator, value, options, weight });
   }
 
-
+  
   @Override
   public CtsReferenceExpr elementAttributeReference(String element, String attribute) {
     return elementAttributeReference((element == null) ? (XsQNameVal) null : xs.QName(element), (attribute == null) ? (XsQNameVal) null : xs.QName(attribute));
   }
 
-
+  
   @Override
   public CtsReferenceExpr elementAttributeReference(ServerExpression element, ServerExpression attribute) {
     if (element == null) {
@@ -540,13 +492,13 @@ class CtsExprImpl implements CtsExpr {
     return new ReferenceCallImpl("cts", "element-attribute-reference", new Object[]{ element, attribute });
   }
 
-
+  
   @Override
   public CtsReferenceExpr elementAttributeReference(String element, String attribute, String options) {
     return elementAttributeReference((element == null) ? (XsQNameVal) null : xs.QName(element), (attribute == null) ? (XsQNameVal) null : xs.QName(attribute), (options == null) ? (XsStringVal) null : xs.string(options));
   }
 
-
+  
   @Override
   public CtsReferenceExpr elementAttributeReference(ServerExpression element, ServerExpression attribute, ServerExpression options) {
     if (element == null) {
@@ -558,193 +510,193 @@ class CtsExprImpl implements CtsExpr {
     return new ReferenceCallImpl("cts", "element-attribute-reference", new Object[]{ element, attribute, options });
   }
 
-
+  
   @Override
   public CtsQueryExpr elementAttributeValueQuery(String elementName, String attributeName, String text) {
     return elementAttributeValueQuery((elementName == null) ? (XsQNameVal) null : xs.QName(elementName), (attributeName == null) ? (XsQNameVal) null : xs.QName(attributeName), (text == null) ? (XsStringVal) null : xs.string(text));
   }
 
-
+  
   @Override
   public CtsQueryExpr elementAttributeValueQuery(ServerExpression elementName, ServerExpression attributeName, ServerExpression text) {
     return new QueryCallImpl("cts", "element-attribute-value-query", new Object[]{ elementName, attributeName, text });
   }
 
-
+  
   @Override
   public CtsQueryExpr elementAttributeValueQuery(String elementName, String attributeName, String text, String... options) {
     return elementAttributeValueQuery((elementName == null) ? (XsQNameVal) null : xs.QName(elementName), (attributeName == null) ? (XsQNameVal) null : xs.QName(attributeName), (text == null) ? (XsStringVal) null : xs.string(text), (options == null) ? (XsStringVal) null : xs.stringSeq(options));
   }
 
-
+  
   @Override
   public CtsQueryExpr elementAttributeValueQuery(ServerExpression elementName, ServerExpression attributeName, ServerExpression text, ServerExpression options) {
     return new QueryCallImpl("cts", "element-attribute-value-query", new Object[]{ elementName, attributeName, text, options });
   }
 
-
+  
   @Override
   public CtsQueryExpr elementAttributeValueQuery(String elementName, String attributeName, String text, String options, double weight) {
     return elementAttributeValueQuery((elementName == null) ? (XsQNameVal) null : xs.QName(elementName), (attributeName == null) ? (XsQNameVal) null : xs.QName(attributeName), (text == null) ? (XsStringVal) null : xs.string(text), (options == null) ? (XsStringVal) null : xs.string(options), xs.doubleVal(weight));
   }
 
-
+  
   @Override
   public CtsQueryExpr elementAttributeValueQuery(ServerExpression elementName, ServerExpression attributeName, ServerExpression text, ServerExpression options, ServerExpression weight) {
     return new QueryCallImpl("cts", "element-attribute-value-query", new Object[]{ elementName, attributeName, text, options, weight });
   }
 
-
+  
   @Override
   public CtsQueryExpr elementAttributeWordQuery(String elementName, String attributeName, String text) {
     return elementAttributeWordQuery((elementName == null) ? (XsQNameVal) null : xs.QName(elementName), (attributeName == null) ? (XsQNameVal) null : xs.QName(attributeName), (text == null) ? (XsStringVal) null : xs.string(text));
   }
 
-
+  
   @Override
   public CtsQueryExpr elementAttributeWordQuery(ServerExpression elementName, ServerExpression attributeName, ServerExpression text) {
     return new QueryCallImpl("cts", "element-attribute-word-query", new Object[]{ elementName, attributeName, text });
   }
 
-
+  
   @Override
   public CtsQueryExpr elementAttributeWordQuery(String elementName, String attributeName, String text, String... options) {
     return elementAttributeWordQuery((elementName == null) ? (XsQNameVal) null : xs.QName(elementName), (attributeName == null) ? (XsQNameVal) null : xs.QName(attributeName), (text == null) ? (XsStringVal) null : xs.string(text), (options == null) ? (XsStringVal) null : xs.stringSeq(options));
   }
 
-
+  
   @Override
   public CtsQueryExpr elementAttributeWordQuery(ServerExpression elementName, ServerExpression attributeName, ServerExpression text, ServerExpression options) {
     return new QueryCallImpl("cts", "element-attribute-word-query", new Object[]{ elementName, attributeName, text, options });
   }
 
-
+  
   @Override
   public CtsQueryExpr elementAttributeWordQuery(String elementName, String attributeName, String text, String options, double weight) {
     return elementAttributeWordQuery((elementName == null) ? (XsQNameVal) null : xs.QName(elementName), (attributeName == null) ? (XsQNameVal) null : xs.QName(attributeName), (text == null) ? (XsStringVal) null : xs.string(text), (options == null) ? (XsStringVal) null : xs.string(options), xs.doubleVal(weight));
   }
 
-
+  
   @Override
   public CtsQueryExpr elementAttributeWordQuery(ServerExpression elementName, ServerExpression attributeName, ServerExpression text, ServerExpression options, ServerExpression weight) {
     return new QueryCallImpl("cts", "element-attribute-word-query", new Object[]{ elementName, attributeName, text, options, weight });
   }
 
-
+  
   @Override
   public CtsQueryExpr elementChildGeospatialQuery(String elementName, String childName, CtsRegionExpr... region) {
     return elementChildGeospatialQuery((elementName == null) ? (XsQNameVal) null : xs.QName(elementName), (childName == null) ? (XsQNameVal) null : xs.QName(childName), new RegionSeqListImpl(region));
   }
 
-
+  
   @Override
   public CtsQueryExpr elementChildGeospatialQuery(ServerExpression elementName, ServerExpression childName, ServerExpression region) {
     return new QueryCallImpl("cts", "element-child-geospatial-query", new Object[]{ elementName, childName, region });
   }
 
-
+  
   @Override
   public CtsQueryExpr elementChildGeospatialQuery(String elementName, String childName, ServerExpression region, String... options) {
     return elementChildGeospatialQuery((elementName == null) ? (XsQNameVal) null : xs.QName(elementName), (childName == null) ? (XsQNameVal) null : xs.QName(childName), region, (options == null) ? (XsStringVal) null : xs.stringSeq(options));
   }
 
-
+  
   @Override
   public CtsQueryExpr elementChildGeospatialQuery(ServerExpression elementName, ServerExpression childName, ServerExpression region, ServerExpression options) {
     return new QueryCallImpl("cts", "element-child-geospatial-query", new Object[]{ elementName, childName, region, options });
   }
 
-
+  
   @Override
   public CtsQueryExpr elementChildGeospatialQuery(String elementName, String childName, ServerExpression region, String options, double weight) {
     return elementChildGeospatialQuery((elementName == null) ? (XsQNameVal) null : xs.QName(elementName), (childName == null) ? (XsQNameVal) null : xs.QName(childName), region, (options == null) ? (XsStringVal) null : xs.string(options), xs.doubleVal(weight));
   }
 
-
+  
   @Override
   public CtsQueryExpr elementChildGeospatialQuery(ServerExpression elementName, ServerExpression childName, ServerExpression region, ServerExpression options, ServerExpression weight) {
     return new QueryCallImpl("cts", "element-child-geospatial-query", new Object[]{ elementName, childName, region, options, weight });
   }
 
-
+  
   @Override
   public CtsQueryExpr elementGeospatialQuery(String elementName, CtsRegionExpr... region) {
     return elementGeospatialQuery((elementName == null) ? (XsQNameVal) null : xs.QName(elementName), new RegionSeqListImpl(region));
   }
 
-
+  
   @Override
   public CtsQueryExpr elementGeospatialQuery(ServerExpression elementName, ServerExpression region) {
     return new QueryCallImpl("cts", "element-geospatial-query", new Object[]{ elementName, region });
   }
 
-
+  
   @Override
   public CtsQueryExpr elementGeospatialQuery(String elementName, ServerExpression region, String... options) {
     return elementGeospatialQuery((elementName == null) ? (XsQNameVal) null : xs.QName(elementName), region, (options == null) ? (XsStringVal) null : xs.stringSeq(options));
   }
 
-
+  
   @Override
   public CtsQueryExpr elementGeospatialQuery(ServerExpression elementName, ServerExpression region, ServerExpression options) {
     return new QueryCallImpl("cts", "element-geospatial-query", new Object[]{ elementName, region, options });
   }
 
-
+  
   @Override
   public CtsQueryExpr elementGeospatialQuery(String elementName, ServerExpression region, String options, double weight) {
     return elementGeospatialQuery((elementName == null) ? (XsQNameVal) null : xs.QName(elementName), region, (options == null) ? (XsStringVal) null : xs.string(options), xs.doubleVal(weight));
   }
 
-
+  
   @Override
   public CtsQueryExpr elementGeospatialQuery(ServerExpression elementName, ServerExpression region, ServerExpression options, ServerExpression weight) {
     return new QueryCallImpl("cts", "element-geospatial-query", new Object[]{ elementName, region, options, weight });
   }
 
-
+  
   @Override
   public CtsQueryExpr elementPairGeospatialQuery(String elementName, String latitudeName, String longitudeName, CtsRegionExpr... region) {
     return elementPairGeospatialQuery((elementName == null) ? (XsQNameVal) null : xs.QName(elementName), (latitudeName == null) ? (XsQNameVal) null : xs.QName(latitudeName), (longitudeName == null) ? (XsQNameVal) null : xs.QName(longitudeName), new RegionSeqListImpl(region));
   }
 
-
+  
   @Override
   public CtsQueryExpr elementPairGeospatialQuery(ServerExpression elementName, ServerExpression latitudeName, ServerExpression longitudeName, ServerExpression region) {
     return new QueryCallImpl("cts", "element-pair-geospatial-query", new Object[]{ elementName, latitudeName, longitudeName, region });
   }
 
-
+  
   @Override
   public CtsQueryExpr elementPairGeospatialQuery(String elementName, String latitudeName, String longitudeName, ServerExpression region, String... options) {
     return elementPairGeospatialQuery((elementName == null) ? (XsQNameVal) null : xs.QName(elementName), (latitudeName == null) ? (XsQNameVal) null : xs.QName(latitudeName), (longitudeName == null) ? (XsQNameVal) null : xs.QName(longitudeName), region, (options == null) ? (XsStringVal) null : xs.stringSeq(options));
   }
 
-
+  
   @Override
   public CtsQueryExpr elementPairGeospatialQuery(ServerExpression elementName, ServerExpression latitudeName, ServerExpression longitudeName, ServerExpression region, ServerExpression options) {
     return new QueryCallImpl("cts", "element-pair-geospatial-query", new Object[]{ elementName, latitudeName, longitudeName, region, options });
   }
 
-
+  
   @Override
   public CtsQueryExpr elementPairGeospatialQuery(String elementName, String latitudeName, String longitudeName, ServerExpression region, String options, double weight) {
     return elementPairGeospatialQuery((elementName == null) ? (XsQNameVal) null : xs.QName(elementName), (latitudeName == null) ? (XsQNameVal) null : xs.QName(latitudeName), (longitudeName == null) ? (XsQNameVal) null : xs.QName(longitudeName), region, (options == null) ? (XsStringVal) null : xs.string(options), xs.doubleVal(weight));
   }
 
-
+  
   @Override
   public CtsQueryExpr elementPairGeospatialQuery(ServerExpression elementName, ServerExpression latitudeName, ServerExpression longitudeName, ServerExpression region, ServerExpression options, ServerExpression weight) {
     return new QueryCallImpl("cts", "element-pair-geospatial-query", new Object[]{ elementName, latitudeName, longitudeName, region, options, weight });
   }
 
-
+  
   @Override
   public CtsQueryExpr elementQuery(String elementName, ServerExpression query) {
     return elementQuery((elementName == null) ? (XsQNameVal) null : xs.QName(elementName), query);
   }
 
-
+  
   @Override
   public CtsQueryExpr elementQuery(ServerExpression elementName, ServerExpression query) {
     if (query == null) {
@@ -753,13 +705,13 @@ class CtsExprImpl implements CtsExpr {
     return new QueryCallImpl("cts", "element-query", new Object[]{ elementName, query });
   }
 
-
+  
   @Override
   public CtsQueryExpr elementRangeQuery(String elementName, String operator, String value) {
     return elementRangeQuery((elementName == null) ? (XsQNameVal) null : xs.QName(elementName), (operator == null) ? (XsStringVal) null : xs.string(operator), (value == null) ? (XsAnyAtomicTypeVal) null : xs.string(value));
   }
 
-
+  
   @Override
   public CtsQueryExpr elementRangeQuery(ServerExpression elementName, ServerExpression operator, ServerExpression value) {
     if (operator == null) {
@@ -768,13 +720,13 @@ class CtsExprImpl implements CtsExpr {
     return new QueryCallImpl("cts", "element-range-query", new Object[]{ elementName, operator, value });
   }
 
-
+  
   @Override
   public CtsQueryExpr elementRangeQuery(String elementName, String operator, String value, String... options) {
     return elementRangeQuery((elementName == null) ? (XsQNameVal) null : xs.QName(elementName), (operator == null) ? (XsStringVal) null : xs.string(operator), (value == null) ? (XsAnyAtomicTypeVal) null : xs.string(value), (options == null) ? (XsStringVal) null : xs.stringSeq(options));
   }
 
-
+  
   @Override
   public CtsQueryExpr elementRangeQuery(ServerExpression elementName, ServerExpression operator, ServerExpression value, ServerExpression options) {
     if (operator == null) {
@@ -783,13 +735,13 @@ class CtsExprImpl implements CtsExpr {
     return new QueryCallImpl("cts", "element-range-query", new Object[]{ elementName, operator, value, options });
   }
 
-
+  
   @Override
   public CtsQueryExpr elementRangeQuery(String elementName, String operator, String value, String options, double weight) {
     return elementRangeQuery((elementName == null) ? (XsQNameVal) null : xs.QName(elementName), (operator == null) ? (XsStringVal) null : xs.string(operator), (value == null) ? (XsAnyAtomicTypeVal) null : xs.string(value), (options == null) ? (XsStringVal) null : xs.string(options), xs.doubleVal(weight));
   }
 
-
+  
   @Override
   public CtsQueryExpr elementRangeQuery(ServerExpression elementName, ServerExpression operator, ServerExpression value, ServerExpression options, ServerExpression weight) {
     if (operator == null) {
@@ -798,13 +750,13 @@ class CtsExprImpl implements CtsExpr {
     return new QueryCallImpl("cts", "element-range-query", new Object[]{ elementName, operator, value, options, weight });
   }
 
-
+  
   @Override
   public CtsReferenceExpr elementReference(String element) {
     return elementReference((element == null) ? (XsQNameVal) null : xs.QName(element));
   }
 
-
+  
   @Override
   public CtsReferenceExpr elementReference(ServerExpression element) {
     if (element == null) {
@@ -813,13 +765,13 @@ class CtsExprImpl implements CtsExpr {
     return new ReferenceCallImpl("cts", "element-reference", new Object[]{ element });
   }
 
-
+  
   @Override
   public CtsReferenceExpr elementReference(String element, String options) {
     return elementReference((element == null) ? (XsQNameVal) null : xs.QName(element), (options == null) ? (XsStringVal) null : xs.string(options));
   }
 
-
+  
   @Override
   public CtsReferenceExpr elementReference(ServerExpression element, ServerExpression options) {
     if (element == null) {
@@ -828,103 +780,103 @@ class CtsExprImpl implements CtsExpr {
     return new ReferenceCallImpl("cts", "element-reference", new Object[]{ element, options });
   }
 
-
+  
   @Override
   public CtsQueryExpr elementValueQuery(String elementName) {
     return elementValueQuery((elementName == null) ? (XsQNameVal) null : xs.QName(elementName));
   }
 
-
+  
   @Override
   public CtsQueryExpr elementValueQuery(ServerExpression elementName) {
     return new QueryCallImpl("cts", "element-value-query", new Object[]{ elementName });
   }
 
-
+  
   @Override
   public CtsQueryExpr elementValueQuery(String elementName, String text) {
     return elementValueQuery((elementName == null) ? (XsQNameVal) null : xs.QName(elementName), (text == null) ? (XsStringVal) null : xs.string(text));
   }
 
-
+  
   @Override
   public CtsQueryExpr elementValueQuery(ServerExpression elementName, ServerExpression text) {
     return new QueryCallImpl("cts", "element-value-query", new Object[]{ elementName, text });
   }
 
-
+  
   @Override
   public CtsQueryExpr elementValueQuery(String elementName, String text, String... options) {
     return elementValueQuery((elementName == null) ? (XsQNameVal) null : xs.QName(elementName), (text == null) ? (XsStringVal) null : xs.string(text), (options == null) ? (XsStringVal) null : xs.stringSeq(options));
   }
 
-
+  
   @Override
   public CtsQueryExpr elementValueQuery(ServerExpression elementName, ServerExpression text, ServerExpression options) {
     return new QueryCallImpl("cts", "element-value-query", new Object[]{ elementName, text, options });
   }
 
-
+  
   @Override
   public CtsQueryExpr elementValueQuery(String elementName, String text, String options, double weight) {
     return elementValueQuery((elementName == null) ? (XsQNameVal) null : xs.QName(elementName), (text == null) ? (XsStringVal) null : xs.string(text), (options == null) ? (XsStringVal) null : xs.string(options), xs.doubleVal(weight));
   }
 
-
+  
   @Override
   public CtsQueryExpr elementValueQuery(ServerExpression elementName, ServerExpression text, ServerExpression options, ServerExpression weight) {
     return new QueryCallImpl("cts", "element-value-query", new Object[]{ elementName, text, options, weight });
   }
 
-
+  
   @Override
   public CtsQueryExpr elementWordQuery(String elementName, String text) {
     return elementWordQuery((elementName == null) ? (XsQNameVal) null : xs.QName(elementName), (text == null) ? (XsStringVal) null : xs.string(text));
   }
 
-
+  
   @Override
   public CtsQueryExpr elementWordQuery(ServerExpression elementName, ServerExpression text) {
     return new QueryCallImpl("cts", "element-word-query", new Object[]{ elementName, text });
   }
 
-
+  
   @Override
   public CtsQueryExpr elementWordQuery(String elementName, String text, String... options) {
     return elementWordQuery((elementName == null) ? (XsQNameVal) null : xs.QName(elementName), (text == null) ? (XsStringVal) null : xs.string(text), (options == null) ? (XsStringVal) null : xs.stringSeq(options));
   }
 
-
+  
   @Override
   public CtsQueryExpr elementWordQuery(ServerExpression elementName, ServerExpression text, ServerExpression options) {
     return new QueryCallImpl("cts", "element-word-query", new Object[]{ elementName, text, options });
   }
 
-
+  
   @Override
   public CtsQueryExpr elementWordQuery(String elementName, String text, String options, double weight) {
     return elementWordQuery((elementName == null) ? (XsQNameVal) null : xs.QName(elementName), (text == null) ? (XsStringVal) null : xs.string(text), (options == null) ? (XsStringVal) null : xs.string(options), xs.doubleVal(weight));
   }
 
-
+  
   @Override
   public CtsQueryExpr elementWordQuery(ServerExpression elementName, ServerExpression text, ServerExpression options, ServerExpression weight) {
     return new QueryCallImpl("cts", "element-word-query", new Object[]{ elementName, text, options, weight });
   }
 
-
+  
   @Override
   public CtsQueryExpr falseQuery() {
     return new QueryCallImpl("cts", "false-query", new Object[]{  });
   }
 
-
+  
   @Override
   public CtsQueryExpr fieldRangeQuery(String fieldName, String operator, String value) {
     return fieldRangeQuery((fieldName == null) ? (XsStringVal) null : xs.string(fieldName), (operator == null) ? (XsStringVal) null : xs.string(operator), (value == null) ? (XsAnyAtomicTypeVal) null : xs.string(value));
   }
 
-
+  
   @Override
   public CtsQueryExpr fieldRangeQuery(ServerExpression fieldName, ServerExpression operator, ServerExpression value) {
     if (operator == null) {
@@ -933,13 +885,13 @@ class CtsExprImpl implements CtsExpr {
     return new QueryCallImpl("cts", "field-range-query", new Object[]{ fieldName, operator, value });
   }
 
-
+  
   @Override
   public CtsQueryExpr fieldRangeQuery(String fieldName, String operator, String value, String... options) {
     return fieldRangeQuery((fieldName == null) ? (XsStringVal) null : xs.string(fieldName), (operator == null) ? (XsStringVal) null : xs.string(operator), (value == null) ? (XsAnyAtomicTypeVal) null : xs.string(value), (options == null) ? (XsStringVal) null : xs.stringSeq(options));
   }
 
-
+  
   @Override
   public CtsQueryExpr fieldRangeQuery(ServerExpression fieldName, ServerExpression operator, ServerExpression value, ServerExpression options) {
     if (operator == null) {
@@ -948,13 +900,13 @@ class CtsExprImpl implements CtsExpr {
     return new QueryCallImpl("cts", "field-range-query", new Object[]{ fieldName, operator, value, options });
   }
 
-
+  
   @Override
   public CtsQueryExpr fieldRangeQuery(String fieldName, String operator, String value, String options, double weight) {
     return fieldRangeQuery((fieldName == null) ? (XsStringVal) null : xs.string(fieldName), (operator == null) ? (XsStringVal) null : xs.string(operator), (value == null) ? (XsAnyAtomicTypeVal) null : xs.string(value), (options == null) ? (XsStringVal) null : xs.string(options), xs.doubleVal(weight));
   }
 
-
+  
   @Override
   public CtsQueryExpr fieldRangeQuery(ServerExpression fieldName, ServerExpression operator, ServerExpression value, ServerExpression options, ServerExpression weight) {
     if (operator == null) {
@@ -963,13 +915,13 @@ class CtsExprImpl implements CtsExpr {
     return new QueryCallImpl("cts", "field-range-query", new Object[]{ fieldName, operator, value, options, weight });
   }
 
-
+  
   @Override
   public CtsReferenceExpr fieldReference(String field) {
     return fieldReference((field == null) ? (XsStringVal) null : xs.string(field));
   }
 
-
+  
   @Override
   public CtsReferenceExpr fieldReference(ServerExpression field) {
     if (field == null) {
@@ -978,13 +930,13 @@ class CtsExprImpl implements CtsExpr {
     return new ReferenceCallImpl("cts", "field-reference", new Object[]{ field });
   }
 
-
+  
   @Override
   public CtsReferenceExpr fieldReference(String field, String options) {
     return fieldReference((field == null) ? (XsStringVal) null : xs.string(field), (options == null) ? (XsStringVal) null : xs.string(options));
   }
 
-
+  
   @Override
   public CtsReferenceExpr fieldReference(ServerExpression field, ServerExpression options) {
     if (field == null) {
@@ -993,85 +945,85 @@ class CtsExprImpl implements CtsExpr {
     return new ReferenceCallImpl("cts", "field-reference", new Object[]{ field, options });
   }
 
-
+  
   @Override
   public CtsQueryExpr fieldValueQuery(String fieldName, String text) {
     return fieldValueQuery((fieldName == null) ? (XsStringVal) null : xs.string(fieldName), (text == null) ? (XsAnyAtomicTypeVal) null : xs.string(text));
   }
 
-
+  
   @Override
   public CtsQueryExpr fieldValueQuery(ServerExpression fieldName, ServerExpression text) {
     return new QueryCallImpl("cts", "field-value-query", new Object[]{ fieldName, text });
   }
 
-
+  
   @Override
   public CtsQueryExpr fieldValueQuery(String fieldName, String text, String... options) {
     return fieldValueQuery((fieldName == null) ? (XsStringVal) null : xs.string(fieldName), (text == null) ? (XsAnyAtomicTypeVal) null : xs.string(text), (options == null) ? (XsStringVal) null : xs.stringSeq(options));
   }
 
-
+  
   @Override
   public CtsQueryExpr fieldValueQuery(ServerExpression fieldName, ServerExpression text, ServerExpression options) {
     return new QueryCallImpl("cts", "field-value-query", new Object[]{ fieldName, text, options });
   }
 
-
+  
   @Override
   public CtsQueryExpr fieldValueQuery(String fieldName, String text, String options, double weight) {
     return fieldValueQuery((fieldName == null) ? (XsStringVal) null : xs.string(fieldName), (text == null) ? (XsAnyAtomicTypeVal) null : xs.string(text), (options == null) ? (XsStringVal) null : xs.string(options), xs.doubleVal(weight));
   }
 
-
+  
   @Override
   public CtsQueryExpr fieldValueQuery(ServerExpression fieldName, ServerExpression text, ServerExpression options, ServerExpression weight) {
     return new QueryCallImpl("cts", "field-value-query", new Object[]{ fieldName, text, options, weight });
   }
 
-
+  
   @Override
   public CtsQueryExpr fieldWordQuery(String fieldName, String text) {
     return fieldWordQuery((fieldName == null) ? (XsStringVal) null : xs.string(fieldName), (text == null) ? (XsStringVal) null : xs.string(text));
   }
 
-
+  
   @Override
   public CtsQueryExpr fieldWordQuery(ServerExpression fieldName, ServerExpression text) {
     return new QueryCallImpl("cts", "field-word-query", new Object[]{ fieldName, text });
   }
 
-
+  
   @Override
   public CtsQueryExpr fieldWordQuery(String fieldName, String text, String... options) {
     return fieldWordQuery((fieldName == null) ? (XsStringVal) null : xs.string(fieldName), (text == null) ? (XsStringVal) null : xs.string(text), (options == null) ? (XsStringVal) null : xs.stringSeq(options));
   }
 
-
+  
   @Override
   public CtsQueryExpr fieldWordQuery(ServerExpression fieldName, ServerExpression text, ServerExpression options) {
     return new QueryCallImpl("cts", "field-word-query", new Object[]{ fieldName, text, options });
   }
 
-
+  
   @Override
   public CtsQueryExpr fieldWordQuery(String fieldName, String text, String options, double weight) {
     return fieldWordQuery((fieldName == null) ? (XsStringVal) null : xs.string(fieldName), (text == null) ? (XsStringVal) null : xs.string(text), (options == null) ? (XsStringVal) null : xs.string(options), xs.doubleVal(weight));
   }
 
-
+  
   @Override
   public CtsQueryExpr fieldWordQuery(ServerExpression fieldName, ServerExpression text, ServerExpression options, ServerExpression weight) {
     return new QueryCallImpl("cts", "field-word-query", new Object[]{ fieldName, text, options, weight });
   }
 
-
+  
   @Override
   public CtsReferenceExpr geospatialPathReference(String pathExpression) {
     return geospatialPathReference((pathExpression == null) ? (XsStringVal) null : xs.string(pathExpression));
   }
 
-
+  
   @Override
   public CtsReferenceExpr geospatialPathReference(ServerExpression pathExpression) {
     if (pathExpression == null) {
@@ -1080,13 +1032,13 @@ class CtsExprImpl implements CtsExpr {
     return new ReferenceCallImpl("cts", "geospatial-path-reference", new Object[]{ pathExpression });
   }
 
-
+  
   @Override
   public CtsReferenceExpr geospatialPathReference(String pathExpression, String options) {
     return geospatialPathReference((pathExpression == null) ? (XsStringVal) null : xs.string(pathExpression), (options == null) ? (XsStringVal) null : xs.string(options));
   }
 
-
+  
   @Override
   public CtsReferenceExpr geospatialPathReference(ServerExpression pathExpression, ServerExpression options) {
     if (pathExpression == null) {
@@ -1095,13 +1047,13 @@ class CtsExprImpl implements CtsExpr {
     return new ReferenceCallImpl("cts", "geospatial-path-reference", new Object[]{ pathExpression, options });
   }
 
-
+  
   @Override
   public CtsReferenceExpr geospatialPathReference(String pathExpression, String options, ServerExpression map) {
     return geospatialPathReference((pathExpression == null) ? (XsStringVal) null : xs.string(pathExpression), (options == null) ? (XsStringVal) null : xs.string(options), map);
   }
 
-
+  
   @Override
   public CtsReferenceExpr geospatialPathReference(ServerExpression pathExpression, ServerExpression options, ServerExpression map) {
     if (pathExpression == null) {
@@ -1110,13 +1062,13 @@ class CtsExprImpl implements CtsExpr {
     return new ReferenceCallImpl("cts", "geospatial-path-reference", new Object[]{ pathExpression, options, map });
   }
 
-
+  
   @Override
   public CtsReferenceExpr geospatialRegionPathReference(String pathExpression) {
     return geospatialRegionPathReference((pathExpression == null) ? (XsStringVal) null : xs.string(pathExpression));
   }
 
-
+  
   @Override
   public CtsReferenceExpr geospatialRegionPathReference(ServerExpression pathExpression) {
     if (pathExpression == null) {
@@ -1125,13 +1077,13 @@ class CtsExprImpl implements CtsExpr {
     return new ReferenceCallImpl("cts", "geospatial-region-path-reference", new Object[]{ pathExpression });
   }
 
-
+  
   @Override
   public CtsReferenceExpr geospatialRegionPathReference(String pathExpression, String options) {
     return geospatialRegionPathReference((pathExpression == null) ? (XsStringVal) null : xs.string(pathExpression), (options == null) ? (XsStringVal) null : xs.string(options));
   }
 
-
+  
   @Override
   public CtsReferenceExpr geospatialRegionPathReference(ServerExpression pathExpression, ServerExpression options) {
     if (pathExpression == null) {
@@ -1140,13 +1092,13 @@ class CtsExprImpl implements CtsExpr {
     return new ReferenceCallImpl("cts", "geospatial-region-path-reference", new Object[]{ pathExpression, options });
   }
 
-
+  
   @Override
   public CtsReferenceExpr geospatialRegionPathReference(String pathExpression, String options, ServerExpression namespaces) {
     return geospatialRegionPathReference((pathExpression == null) ? (XsStringVal) null : xs.string(pathExpression), (options == null) ? (XsStringVal) null : xs.string(options), namespaces);
   }
 
-
+  
   @Override
   public CtsReferenceExpr geospatialRegionPathReference(ServerExpression pathExpression, ServerExpression options, ServerExpression namespaces) {
     if (pathExpression == null) {
@@ -1155,13 +1107,13 @@ class CtsExprImpl implements CtsExpr {
     return new ReferenceCallImpl("cts", "geospatial-region-path-reference", new Object[]{ pathExpression, options, namespaces });
   }
 
-
+  
   @Override
   public CtsReferenceExpr geospatialRegionPathReference(String pathExpression, String options, ServerExpression namespaces, long geohashPrecision) {
     return geospatialRegionPathReference((pathExpression == null) ? (XsStringVal) null : xs.string(pathExpression), (options == null) ? (XsStringVal) null : xs.string(options), namespaces, xs.integer(geohashPrecision));
   }
 
-
+  
   @Override
   public CtsReferenceExpr geospatialRegionPathReference(ServerExpression pathExpression, ServerExpression options, ServerExpression namespaces, ServerExpression geohashPrecision) {
     if (pathExpression == null) {
@@ -1170,13 +1122,13 @@ class CtsExprImpl implements CtsExpr {
     return new ReferenceCallImpl("cts", "geospatial-region-path-reference", new Object[]{ pathExpression, options, namespaces, geohashPrecision });
   }
 
-
+  
   @Override
   public CtsReferenceExpr geospatialRegionPathReference(String pathExpression, String options, ServerExpression namespaces, long geohashPrecision, String units) {
     return geospatialRegionPathReference((pathExpression == null) ? (XsStringVal) null : xs.string(pathExpression), (options == null) ? (XsStringVal) null : xs.string(options), namespaces, xs.integer(geohashPrecision), (units == null) ? (XsStringVal) null : xs.string(units));
   }
 
-
+  
   @Override
   public CtsReferenceExpr geospatialRegionPathReference(ServerExpression pathExpression, ServerExpression options, ServerExpression namespaces, ServerExpression geohashPrecision, ServerExpression units) {
     if (pathExpression == null) {
@@ -1185,13 +1137,13 @@ class CtsExprImpl implements CtsExpr {
     return new ReferenceCallImpl("cts", "geospatial-region-path-reference", new Object[]{ pathExpression, options, namespaces, geohashPrecision, units });
   }
 
-
+  
   @Override
   public CtsReferenceExpr geospatialRegionPathReference(String pathExpression, String options, ServerExpression namespaces, long geohashPrecision, String units, String invalidValues) {
     return geospatialRegionPathReference((pathExpression == null) ? (XsStringVal) null : xs.string(pathExpression), (options == null) ? (XsStringVal) null : xs.string(options), namespaces, xs.integer(geohashPrecision), (units == null) ? (XsStringVal) null : xs.string(units), (invalidValues == null) ? (XsStringVal) null : xs.string(invalidValues));
   }
 
-
+  
   @Override
   public CtsReferenceExpr geospatialRegionPathReference(ServerExpression pathExpression, ServerExpression options, ServerExpression namespaces, ServerExpression geohashPrecision, ServerExpression units, ServerExpression invalidValues) {
     if (pathExpression == null) {
@@ -1200,13 +1152,13 @@ class CtsExprImpl implements CtsExpr {
     return new ReferenceCallImpl("cts", "geospatial-region-path-reference", new Object[]{ pathExpression, options, namespaces, geohashPrecision, units, invalidValues });
   }
 
-
+  
   @Override
   public CtsQueryExpr geospatialRegionQuery(ServerExpression reference, String operation, CtsRegionExpr... region) {
     return geospatialRegionQuery(reference, (operation == null) ? (XsStringVal) null : xs.string(operation), new RegionSeqListImpl(region));
   }
 
-
+  
   @Override
   public CtsQueryExpr geospatialRegionQuery(ServerExpression reference, ServerExpression operation, ServerExpression region) {
     if (operation == null) {
@@ -1215,13 +1167,13 @@ class CtsExprImpl implements CtsExpr {
     return new QueryCallImpl("cts", "geospatial-region-query", new Object[]{ reference, operation, region });
   }
 
-
+  
   @Override
   public CtsQueryExpr geospatialRegionQuery(ServerExpression reference, String operation, ServerExpression region, String... options) {
     return geospatialRegionQuery(reference, (operation == null) ? (XsStringVal) null : xs.string(operation), region, (options == null) ? (XsStringVal) null : xs.stringSeq(options));
   }
 
-
+  
   @Override
   public CtsQueryExpr geospatialRegionQuery(ServerExpression reference, ServerExpression operation, ServerExpression region, ServerExpression options) {
     if (operation == null) {
@@ -1230,13 +1182,13 @@ class CtsExprImpl implements CtsExpr {
     return new QueryCallImpl("cts", "geospatial-region-query", new Object[]{ reference, operation, region, options });
   }
 
-
+  
   @Override
   public CtsQueryExpr geospatialRegionQuery(ServerExpression reference, String operation, ServerExpression region, String options, double weight) {
     return geospatialRegionQuery(reference, (operation == null) ? (XsStringVal) null : xs.string(operation), region, (options == null) ? (XsStringVal) null : xs.string(options), xs.doubleVal(weight));
   }
 
-
+  
   @Override
   public CtsQueryExpr geospatialRegionQuery(ServerExpression reference, ServerExpression operation, ServerExpression region, ServerExpression options, ServerExpression weight) {
     if (operation == null) {
@@ -1245,127 +1197,127 @@ class CtsExprImpl implements CtsExpr {
     return new QueryCallImpl("cts", "geospatial-region-query", new Object[]{ reference, operation, region, options, weight });
   }
 
-
+  
   @Override
   public CtsReferenceExpr iriReference() {
     return new ReferenceCallImpl("cts", "iri-reference", new Object[]{  });
   }
 
-
+  
   @Override
   public CtsQueryExpr jsonPropertyChildGeospatialQuery(String propertyName, String childName, CtsRegionExpr... region) {
     return jsonPropertyChildGeospatialQuery((propertyName == null) ? (XsStringVal) null : xs.string(propertyName), (childName == null) ? (XsStringVal) null : xs.string(childName), new RegionSeqListImpl(region));
   }
 
-
+  
   @Override
   public CtsQueryExpr jsonPropertyChildGeospatialQuery(ServerExpression propertyName, ServerExpression childName, ServerExpression region) {
     return new QueryCallImpl("cts", "json-property-child-geospatial-query", new Object[]{ propertyName, childName, region });
   }
 
-
+  
   @Override
   public CtsQueryExpr jsonPropertyChildGeospatialQuery(String propertyName, String childName, ServerExpression region, String... options) {
     return jsonPropertyChildGeospatialQuery((propertyName == null) ? (XsStringVal) null : xs.string(propertyName), (childName == null) ? (XsStringVal) null : xs.string(childName), region, (options == null) ? (XsStringVal) null : xs.stringSeq(options));
   }
 
-
+  
   @Override
   public CtsQueryExpr jsonPropertyChildGeospatialQuery(ServerExpression propertyName, ServerExpression childName, ServerExpression region, ServerExpression options) {
     return new QueryCallImpl("cts", "json-property-child-geospatial-query", new Object[]{ propertyName, childName, region, options });
   }
 
-
+  
   @Override
   public CtsQueryExpr jsonPropertyChildGeospatialQuery(String propertyName, String childName, ServerExpression region, String options, double weight) {
     return jsonPropertyChildGeospatialQuery((propertyName == null) ? (XsStringVal) null : xs.string(propertyName), (childName == null) ? (XsStringVal) null : xs.string(childName), region, (options == null) ? (XsStringVal) null : xs.string(options), xs.doubleVal(weight));
   }
 
-
+  
   @Override
   public CtsQueryExpr jsonPropertyChildGeospatialQuery(ServerExpression propertyName, ServerExpression childName, ServerExpression region, ServerExpression options, ServerExpression weight) {
     return new QueryCallImpl("cts", "json-property-child-geospatial-query", new Object[]{ propertyName, childName, region, options, weight });
   }
 
-
+  
   @Override
   public CtsQueryExpr jsonPropertyGeospatialQuery(String propertyName, CtsRegionExpr... region) {
     return jsonPropertyGeospatialQuery((propertyName == null) ? (XsStringVal) null : xs.string(propertyName), new RegionSeqListImpl(region));
   }
 
-
+  
   @Override
   public CtsQueryExpr jsonPropertyGeospatialQuery(ServerExpression propertyName, ServerExpression region) {
     return new QueryCallImpl("cts", "json-property-geospatial-query", new Object[]{ propertyName, region });
   }
 
-
+  
   @Override
   public CtsQueryExpr jsonPropertyGeospatialQuery(String propertyName, ServerExpression region, String... options) {
     return jsonPropertyGeospatialQuery((propertyName == null) ? (XsStringVal) null : xs.string(propertyName), region, (options == null) ? (XsStringVal) null : xs.stringSeq(options));
   }
 
-
+  
   @Override
   public CtsQueryExpr jsonPropertyGeospatialQuery(ServerExpression propertyName, ServerExpression region, ServerExpression options) {
     return new QueryCallImpl("cts", "json-property-geospatial-query", new Object[]{ propertyName, region, options });
   }
 
-
+  
   @Override
   public CtsQueryExpr jsonPropertyGeospatialQuery(String propertyName, ServerExpression region, String options, double weight) {
     return jsonPropertyGeospatialQuery((propertyName == null) ? (XsStringVal) null : xs.string(propertyName), region, (options == null) ? (XsStringVal) null : xs.string(options), xs.doubleVal(weight));
   }
 
-
+  
   @Override
   public CtsQueryExpr jsonPropertyGeospatialQuery(ServerExpression propertyName, ServerExpression region, ServerExpression options, ServerExpression weight) {
     return new QueryCallImpl("cts", "json-property-geospatial-query", new Object[]{ propertyName, region, options, weight });
   }
 
-
+  
   @Override
   public CtsQueryExpr jsonPropertyPairGeospatialQuery(String propertyName, String latitudeName, String longitudeName, CtsRegionExpr... region) {
     return jsonPropertyPairGeospatialQuery((propertyName == null) ? (XsStringVal) null : xs.string(propertyName), (latitudeName == null) ? (XsStringVal) null : xs.string(latitudeName), (longitudeName == null) ? (XsStringVal) null : xs.string(longitudeName), new RegionSeqListImpl(region));
   }
 
-
+  
   @Override
   public CtsQueryExpr jsonPropertyPairGeospatialQuery(ServerExpression propertyName, ServerExpression latitudeName, ServerExpression longitudeName, ServerExpression region) {
     return new QueryCallImpl("cts", "json-property-pair-geospatial-query", new Object[]{ propertyName, latitudeName, longitudeName, region });
   }
 
-
+  
   @Override
   public CtsQueryExpr jsonPropertyPairGeospatialQuery(String propertyName, String latitudeName, String longitudeName, ServerExpression region, String... options) {
     return jsonPropertyPairGeospatialQuery((propertyName == null) ? (XsStringVal) null : xs.string(propertyName), (latitudeName == null) ? (XsStringVal) null : xs.string(latitudeName), (longitudeName == null) ? (XsStringVal) null : xs.string(longitudeName), region, (options == null) ? (XsStringVal) null : xs.stringSeq(options));
   }
 
-
+  
   @Override
   public CtsQueryExpr jsonPropertyPairGeospatialQuery(ServerExpression propertyName, ServerExpression latitudeName, ServerExpression longitudeName, ServerExpression region, ServerExpression options) {
     return new QueryCallImpl("cts", "json-property-pair-geospatial-query", new Object[]{ propertyName, latitudeName, longitudeName, region, options });
   }
 
-
+  
   @Override
   public CtsQueryExpr jsonPropertyPairGeospatialQuery(String propertyName, String latitudeName, String longitudeName, ServerExpression region, String options, double weight) {
     return jsonPropertyPairGeospatialQuery((propertyName == null) ? (XsStringVal) null : xs.string(propertyName), (latitudeName == null) ? (XsStringVal) null : xs.string(latitudeName), (longitudeName == null) ? (XsStringVal) null : xs.string(longitudeName), region, (options == null) ? (XsStringVal) null : xs.string(options), xs.doubleVal(weight));
   }
 
-
+  
   @Override
   public CtsQueryExpr jsonPropertyPairGeospatialQuery(ServerExpression propertyName, ServerExpression latitudeName, ServerExpression longitudeName, ServerExpression region, ServerExpression options, ServerExpression weight) {
     return new QueryCallImpl("cts", "json-property-pair-geospatial-query", new Object[]{ propertyName, latitudeName, longitudeName, region, options, weight });
   }
 
-
+  
   @Override
   public CtsQueryExpr jsonPropertyRangeQuery(String propertyName, String operator, String value) {
     return jsonPropertyRangeQuery((propertyName == null) ? (XsStringVal) null : xs.string(propertyName), (operator == null) ? (XsStringVal) null : xs.string(operator), (value == null) ? (XsAnyAtomicTypeVal) null : xs.string(value));
   }
 
-
+  
   @Override
   public CtsQueryExpr jsonPropertyRangeQuery(ServerExpression propertyName, ServerExpression operator, ServerExpression value) {
     if (operator == null) {
@@ -1374,13 +1326,13 @@ class CtsExprImpl implements CtsExpr {
     return new QueryCallImpl("cts", "json-property-range-query", new Object[]{ propertyName, operator, value });
   }
 
-
+  
   @Override
   public CtsQueryExpr jsonPropertyRangeQuery(String propertyName, String operator, String value, String... options) {
     return jsonPropertyRangeQuery((propertyName == null) ? (XsStringVal) null : xs.string(propertyName), (operator == null) ? (XsStringVal) null : xs.string(operator), (value == null) ? (XsAnyAtomicTypeVal) null : xs.string(value), (options == null) ? (XsStringVal) null : xs.stringSeq(options));
   }
 
-
+  
   @Override
   public CtsQueryExpr jsonPropertyRangeQuery(ServerExpression propertyName, ServerExpression operator, ServerExpression value, ServerExpression options) {
     if (operator == null) {
@@ -1389,13 +1341,13 @@ class CtsExprImpl implements CtsExpr {
     return new QueryCallImpl("cts", "json-property-range-query", new Object[]{ propertyName, operator, value, options });
   }
 
-
+  
   @Override
   public CtsQueryExpr jsonPropertyRangeQuery(String propertyName, String operator, String value, String options, double weight) {
     return jsonPropertyRangeQuery((propertyName == null) ? (XsStringVal) null : xs.string(propertyName), (operator == null) ? (XsStringVal) null : xs.string(operator), (value == null) ? (XsAnyAtomicTypeVal) null : xs.string(value), (options == null) ? (XsStringVal) null : xs.string(options), xs.doubleVal(weight));
   }
 
-
+  
   @Override
   public CtsQueryExpr jsonPropertyRangeQuery(ServerExpression propertyName, ServerExpression operator, ServerExpression value, ServerExpression options, ServerExpression weight) {
     if (operator == null) {
@@ -1404,13 +1356,13 @@ class CtsExprImpl implements CtsExpr {
     return new QueryCallImpl("cts", "json-property-range-query", new Object[]{ propertyName, operator, value, options, weight });
   }
 
-
+  
   @Override
   public CtsReferenceExpr jsonPropertyReference(String property) {
     return jsonPropertyReference((property == null) ? (XsStringVal) null : xs.string(property));
   }
 
-
+  
   @Override
   public CtsReferenceExpr jsonPropertyReference(ServerExpression property) {
     if (property == null) {
@@ -1419,13 +1371,13 @@ class CtsExprImpl implements CtsExpr {
     return new ReferenceCallImpl("cts", "json-property-reference", new Object[]{ property });
   }
 
-
+  
   @Override
   public CtsReferenceExpr jsonPropertyReference(String property, String options) {
     return jsonPropertyReference((property == null) ? (XsStringVal) null : xs.string(property), (options == null) ? (XsStringVal) null : xs.string(options));
   }
 
-
+  
   @Override
   public CtsReferenceExpr jsonPropertyReference(ServerExpression property, ServerExpression options) {
     if (property == null) {
@@ -1434,13 +1386,13 @@ class CtsExprImpl implements CtsExpr {
     return new ReferenceCallImpl("cts", "json-property-reference", new Object[]{ property, options });
   }
 
-
+  
   @Override
   public CtsQueryExpr jsonPropertyScopeQuery(String propertyName, ServerExpression query) {
     return jsonPropertyScopeQuery((propertyName == null) ? (XsStringVal) null : xs.string(propertyName), query);
   }
 
-
+  
   @Override
   public CtsQueryExpr jsonPropertyScopeQuery(ServerExpression propertyName, ServerExpression query) {
     if (query == null) {
@@ -1449,91 +1401,91 @@ class CtsExprImpl implements CtsExpr {
     return new QueryCallImpl("cts", "json-property-scope-query", new Object[]{ propertyName, query });
   }
 
-
+  
   @Override
   public CtsQueryExpr jsonPropertyValueQuery(String propertyName, String value) {
     return jsonPropertyValueQuery((propertyName == null) ? (XsStringVal) null : xs.string(propertyName), (value == null) ? (XsAnyAtomicTypeVal) null : xs.string(value));
   }
 
-
+  
   @Override
   public CtsQueryExpr jsonPropertyValueQuery(ServerExpression propertyName, ServerExpression value) {
     return new QueryCallImpl("cts", "json-property-value-query", new Object[]{ propertyName, value });
   }
 
-
+  
   @Override
   public CtsQueryExpr jsonPropertyValueQuery(String propertyName, String value, String... options) {
     return jsonPropertyValueQuery((propertyName == null) ? (XsStringVal) null : xs.string(propertyName), (value == null) ? (XsAnyAtomicTypeVal) null : xs.string(value), (options == null) ? (XsStringVal) null : xs.stringSeq(options));
   }
 
-
+  
   @Override
   public CtsQueryExpr jsonPropertyValueQuery(ServerExpression propertyName, ServerExpression value, ServerExpression options) {
     return new QueryCallImpl("cts", "json-property-value-query", new Object[]{ propertyName, value, options });
   }
 
-
+  
   @Override
   public CtsQueryExpr jsonPropertyValueQuery(String propertyName, String value, String options, double weight) {
     return jsonPropertyValueQuery((propertyName == null) ? (XsStringVal) null : xs.string(propertyName), (value == null) ? (XsAnyAtomicTypeVal) null : xs.string(value), (options == null) ? (XsStringVal) null : xs.string(options), xs.doubleVal(weight));
   }
 
-
+  
   @Override
   public CtsQueryExpr jsonPropertyValueQuery(ServerExpression propertyName, ServerExpression value, ServerExpression options, ServerExpression weight) {
     return new QueryCallImpl("cts", "json-property-value-query", new Object[]{ propertyName, value, options, weight });
   }
 
-
+  
   @Override
   public CtsQueryExpr jsonPropertyWordQuery(String propertyName, String text) {
     return jsonPropertyWordQuery((propertyName == null) ? (XsStringVal) null : xs.string(propertyName), (text == null) ? (XsStringVal) null : xs.string(text));
   }
 
-
+  
   @Override
   public CtsQueryExpr jsonPropertyWordQuery(ServerExpression propertyName, ServerExpression text) {
     return new QueryCallImpl("cts", "json-property-word-query", new Object[]{ propertyName, text });
   }
 
-
+  
   @Override
   public CtsQueryExpr jsonPropertyWordQuery(String propertyName, String text, String... options) {
     return jsonPropertyWordQuery((propertyName == null) ? (XsStringVal) null : xs.string(propertyName), (text == null) ? (XsStringVal) null : xs.string(text), (options == null) ? (XsStringVal) null : xs.stringSeq(options));
   }
 
-
+  
   @Override
   public CtsQueryExpr jsonPropertyWordQuery(ServerExpression propertyName, ServerExpression text, ServerExpression options) {
     return new QueryCallImpl("cts", "json-property-word-query", new Object[]{ propertyName, text, options });
   }
 
-
+  
   @Override
   public CtsQueryExpr jsonPropertyWordQuery(String propertyName, String text, String options, double weight) {
     return jsonPropertyWordQuery((propertyName == null) ? (XsStringVal) null : xs.string(propertyName), (text == null) ? (XsStringVal) null : xs.string(text), (options == null) ? (XsStringVal) null : xs.string(options), xs.doubleVal(weight));
   }
 
-
+  
   @Override
   public CtsQueryExpr jsonPropertyWordQuery(ServerExpression propertyName, ServerExpression text, ServerExpression options, ServerExpression weight) {
     return new QueryCallImpl("cts", "json-property-word-query", new Object[]{ propertyName, text, options, weight });
   }
 
-
+  
   @Override
   public ServerExpression linestring(String vertices) {
     return linestring((vertices == null) ? (XsAnyAtomicTypeVal) null : xs.string(vertices));
   }
 
-
+  
   @Override
   public ServerExpression linestring(ServerExpression vertices) {
     return new RegionCallImpl("cts", "linestring", new Object[]{ vertices });
   }
 
-
+  
   @Override
   public CtsQueryExpr locksFragmentQuery(ServerExpression query) {
     if (query == null) {
@@ -1542,13 +1494,13 @@ class CtsExprImpl implements CtsExpr {
     return new QueryCallImpl("cts", "locks-fragment-query", new Object[]{ query });
   }
 
-
+  
   @Override
   public CtsQueryExpr lsqtQuery(String temporalCollection) {
     return lsqtQuery((temporalCollection == null) ? (XsStringVal) null : xs.string(temporalCollection));
   }
 
-
+  
   @Override
   public CtsQueryExpr lsqtQuery(ServerExpression temporalCollection) {
     if (temporalCollection == null) {
@@ -1557,13 +1509,13 @@ class CtsExprImpl implements CtsExpr {
     return new QueryCallImpl("cts", "lsqt-query", new Object[]{ temporalCollection });
   }
 
-
+  
   @Override
   public CtsQueryExpr lsqtQuery(String temporalCollection, String timestamp) {
     return lsqtQuery((temporalCollection == null) ? (XsStringVal) null : xs.string(temporalCollection), (timestamp == null) ? (XsDateTimeVal) null : xs.dateTime(timestamp));
   }
 
-
+  
   @Override
   public CtsQueryExpr lsqtQuery(ServerExpression temporalCollection, ServerExpression timestamp) {
     if (temporalCollection == null) {
@@ -1572,13 +1524,13 @@ class CtsExprImpl implements CtsExpr {
     return new QueryCallImpl("cts", "lsqt-query", new Object[]{ temporalCollection, timestamp });
   }
 
-
+  
   @Override
   public CtsQueryExpr lsqtQuery(String temporalCollection, String timestamp, String... options) {
     return lsqtQuery((temporalCollection == null) ? (XsStringVal) null : xs.string(temporalCollection), (timestamp == null) ? (XsDateTimeVal) null : xs.dateTime(timestamp), (options == null) ? (XsStringVal) null : xs.stringSeq(options));
   }
 
-
+  
   @Override
   public CtsQueryExpr lsqtQuery(ServerExpression temporalCollection, ServerExpression timestamp, ServerExpression options) {
     if (temporalCollection == null) {
@@ -1587,13 +1539,13 @@ class CtsExprImpl implements CtsExpr {
     return new QueryCallImpl("cts", "lsqt-query", new Object[]{ temporalCollection, timestamp, options });
   }
 
-
+  
   @Override
   public CtsQueryExpr lsqtQuery(String temporalCollection, String timestamp, String options, double weight) {
     return lsqtQuery((temporalCollection == null) ? (XsStringVal) null : xs.string(temporalCollection), (timestamp == null) ? (XsDateTimeVal) null : xs.dateTime(timestamp), (options == null) ? (XsStringVal) null : xs.string(options), xs.doubleVal(weight));
   }
 
-
+  
   @Override
   public CtsQueryExpr lsqtQuery(ServerExpression temporalCollection, ServerExpression timestamp, ServerExpression options, ServerExpression weight) {
     if (temporalCollection == null) {
@@ -1602,55 +1554,55 @@ class CtsExprImpl implements CtsExpr {
     return new QueryCallImpl("cts", "lsqt-query", new Object[]{ temporalCollection, timestamp, options, weight });
   }
 
-
+  
   @Override
   public CtsQueryExpr nearQuery(CtsQueryExpr... queries) {
     return nearQuery(new QuerySeqListImpl(queries));
   }
 
-
+  
   @Override
   public CtsQueryExpr nearQuery(ServerExpression queries) {
     return new QueryCallImpl("cts", "near-query", new Object[]{ queries });
   }
 
-
+  
   @Override
   public CtsQueryExpr nearQuery(ServerExpression queries, double distance) {
     return nearQuery(queries, xs.doubleVal(distance));
   }
 
-
+  
   @Override
   public CtsQueryExpr nearQuery(ServerExpression queries, XsDoubleVal distance) {
     return new QueryCallImpl("cts", "near-query", new Object[]{ queries, distance });
   }
 
-
+  
   @Override
   public CtsQueryExpr nearQuery(ServerExpression queries, double distance, String... options) {
     return nearQuery(queries, xs.doubleVal(distance), (options == null) ? (XsStringVal) null : xs.stringSeq(options));
   }
 
-
+  
   @Override
   public CtsQueryExpr nearQuery(ServerExpression queries, ServerExpression distance, ServerExpression options) {
     return new QueryCallImpl("cts", "near-query", new Object[]{ queries, distance, options });
   }
 
-
+  
   @Override
   public CtsQueryExpr nearQuery(ServerExpression queries, double distance, String options, double weight) {
     return nearQuery(queries, xs.doubleVal(distance), (options == null) ? (XsStringVal) null : xs.string(options), xs.doubleVal(weight));
   }
 
-
+  
   @Override
   public CtsQueryExpr nearQuery(ServerExpression queries, ServerExpression distance, ServerExpression options, ServerExpression weight) {
     return new QueryCallImpl("cts", "near-query", new Object[]{ queries, distance, options, weight });
   }
 
-
+  
   @Override
   public CtsQueryExpr notInQuery(ServerExpression positiveQuery, ServerExpression negativeQuery) {
     if (positiveQuery == null) {
@@ -1662,7 +1614,7 @@ class CtsExprImpl implements CtsExpr {
     return new QueryCallImpl("cts", "not-in-query", new Object[]{ positiveQuery, negativeQuery });
   }
 
-
+  
   @Override
   public CtsQueryExpr notQuery(ServerExpression query) {
     if (query == null) {
@@ -1671,31 +1623,31 @@ class CtsExprImpl implements CtsExpr {
     return new QueryCallImpl("cts", "not-query", new Object[]{ query });
   }
 
-
+  
   @Override
   public CtsQueryExpr orQuery(CtsQueryExpr... queries) {
     return orQuery(new QuerySeqListImpl(queries));
   }
 
-
+  
   @Override
   public CtsQueryExpr orQuery(ServerExpression queries) {
     return new QueryCallImpl("cts", "or-query", new Object[]{ queries });
   }
 
-
+  
   @Override
   public CtsQueryExpr orQuery(ServerExpression queries, String options) {
     return orQuery(queries, (options == null) ? (XsStringVal) null : xs.string(options));
   }
 
-
+  
   @Override
   public CtsQueryExpr orQuery(ServerExpression queries, XsStringSeqVal options) {
     return new QueryCallImpl("cts", "or-query", new Object[]{ queries, options });
   }
 
-
+  
   @Override
   public ServerExpression partOfSpeech(ServerExpression token) {
     if (token == null) {
@@ -1704,49 +1656,49 @@ class CtsExprImpl implements CtsExpr {
     return new XsExprImpl.StringCallImpl("cts", "part-of-speech", new Object[]{ token });
   }
 
-
+  
   @Override
   public CtsQueryExpr pathGeospatialQuery(String pathExpression, CtsRegionExpr... region) {
     return pathGeospatialQuery((pathExpression == null) ? (XsStringVal) null : xs.string(pathExpression), new RegionSeqListImpl(region));
   }
 
-
+  
   @Override
   public CtsQueryExpr pathGeospatialQuery(ServerExpression pathExpression, ServerExpression region) {
     return new QueryCallImpl("cts", "path-geospatial-query", new Object[]{ pathExpression, region });
   }
 
-
+  
   @Override
   public CtsQueryExpr pathGeospatialQuery(String pathExpression, ServerExpression region, String... options) {
     return pathGeospatialQuery((pathExpression == null) ? (XsStringVal) null : xs.string(pathExpression), region, (options == null) ? (XsStringVal) null : xs.stringSeq(options));
   }
 
-
+  
   @Override
   public CtsQueryExpr pathGeospatialQuery(ServerExpression pathExpression, ServerExpression region, ServerExpression options) {
     return new QueryCallImpl("cts", "path-geospatial-query", new Object[]{ pathExpression, region, options });
   }
 
-
+  
   @Override
   public CtsQueryExpr pathGeospatialQuery(String pathExpression, ServerExpression region, String options, double weight) {
     return pathGeospatialQuery((pathExpression == null) ? (XsStringVal) null : xs.string(pathExpression), region, (options == null) ? (XsStringVal) null : xs.string(options), xs.doubleVal(weight));
   }
 
-
+  
   @Override
   public CtsQueryExpr pathGeospatialQuery(ServerExpression pathExpression, ServerExpression region, ServerExpression options, ServerExpression weight) {
     return new QueryCallImpl("cts", "path-geospatial-query", new Object[]{ pathExpression, region, options, weight });
   }
 
-
+  
   @Override
   public CtsQueryExpr pathRangeQuery(String pathName, String operator, String value) {
     return pathRangeQuery((pathName == null) ? (XsStringVal) null : xs.string(pathName), (operator == null) ? (XsStringVal) null : xs.string(operator), (value == null) ? (XsAnyAtomicTypeVal) null : xs.string(value));
   }
 
-
+  
   @Override
   public CtsQueryExpr pathRangeQuery(ServerExpression pathName, ServerExpression operator, ServerExpression value) {
     if (operator == null) {
@@ -1755,13 +1707,13 @@ class CtsExprImpl implements CtsExpr {
     return new QueryCallImpl("cts", "path-range-query", new Object[]{ pathName, operator, value });
   }
 
-
+  
   @Override
   public CtsQueryExpr pathRangeQuery(String pathName, String operator, String value, String... options) {
     return pathRangeQuery((pathName == null) ? (XsStringVal) null : xs.string(pathName), (operator == null) ? (XsStringVal) null : xs.string(operator), (value == null) ? (XsAnyAtomicTypeVal) null : xs.string(value), (options == null) ? (XsStringVal) null : xs.stringSeq(options));
   }
 
-
+  
   @Override
   public CtsQueryExpr pathRangeQuery(ServerExpression pathName, ServerExpression operator, ServerExpression value, ServerExpression options) {
     if (operator == null) {
@@ -1770,13 +1722,13 @@ class CtsExprImpl implements CtsExpr {
     return new QueryCallImpl("cts", "path-range-query", new Object[]{ pathName, operator, value, options });
   }
 
-
+  
   @Override
   public CtsQueryExpr pathRangeQuery(String pathName, String operator, String value, String options, double weight) {
     return pathRangeQuery((pathName == null) ? (XsStringVal) null : xs.string(pathName), (operator == null) ? (XsStringVal) null : xs.string(operator), (value == null) ? (XsAnyAtomicTypeVal) null : xs.string(value), (options == null) ? (XsStringVal) null : xs.string(options), xs.doubleVal(weight));
   }
 
-
+  
   @Override
   public CtsQueryExpr pathRangeQuery(ServerExpression pathName, ServerExpression operator, ServerExpression value, ServerExpression options, ServerExpression weight) {
     if (operator == null) {
@@ -1785,13 +1737,13 @@ class CtsExprImpl implements CtsExpr {
     return new QueryCallImpl("cts", "path-range-query", new Object[]{ pathName, operator, value, options, weight });
   }
 
-
+  
   @Override
   public CtsReferenceExpr pathReference(String pathExpression) {
     return pathReference((pathExpression == null) ? (XsStringVal) null : xs.string(pathExpression));
   }
 
-
+  
   @Override
   public CtsReferenceExpr pathReference(ServerExpression pathExpression) {
     if (pathExpression == null) {
@@ -1800,13 +1752,13 @@ class CtsExprImpl implements CtsExpr {
     return new ReferenceCallImpl("cts", "path-reference", new Object[]{ pathExpression });
   }
 
-
+  
   @Override
   public CtsReferenceExpr pathReference(String pathExpression, String options) {
     return pathReference((pathExpression == null) ? (XsStringVal) null : xs.string(pathExpression), (options == null) ? (XsStringVal) null : xs.string(options));
   }
 
-
+  
   @Override
   public CtsReferenceExpr pathReference(ServerExpression pathExpression, ServerExpression options) {
     if (pathExpression == null) {
@@ -1815,13 +1767,13 @@ class CtsExprImpl implements CtsExpr {
     return new ReferenceCallImpl("cts", "path-reference", new Object[]{ pathExpression, options });
   }
 
-
+  
   @Override
   public CtsReferenceExpr pathReference(String pathExpression, String options, ServerExpression map) {
     return pathReference((pathExpression == null) ? (XsStringVal) null : xs.string(pathExpression), (options == null) ? (XsStringVal) null : xs.string(options), map);
   }
 
-
+  
   @Override
   public CtsReferenceExpr pathReference(ServerExpression pathExpression, ServerExpression options, ServerExpression map) {
     if (pathExpression == null) {
@@ -1830,13 +1782,13 @@ class CtsExprImpl implements CtsExpr {
     return new ReferenceCallImpl("cts", "path-reference", new Object[]{ pathExpression, options, map });
   }
 
-
+  
   @Override
   public CtsPeriodExpr period(String start, String end) {
     return period((start == null) ? (XsDateTimeVal) null : xs.dateTime(start), (end == null) ? (XsDateTimeVal) null : xs.dateTime(end));
   }
 
-
+  
   @Override
   public CtsPeriodExpr period(ServerExpression start, ServerExpression end) {
     if (start == null) {
@@ -1848,13 +1800,13 @@ class CtsExprImpl implements CtsExpr {
     return new PeriodCallImpl("cts", "period", new Object[]{ start, end });
   }
 
-
+  
   @Override
   public CtsQueryExpr periodCompareQuery(String axis1, String operator, String axis2) {
     return periodCompareQuery((axis1 == null) ? (XsStringVal) null : xs.string(axis1), (operator == null) ? (XsStringVal) null : xs.string(operator), (axis2 == null) ? (XsStringVal) null : xs.string(axis2));
   }
 
-
+  
   @Override
   public CtsQueryExpr periodCompareQuery(ServerExpression axis1, ServerExpression operator, ServerExpression axis2) {
     if (axis1 == null) {
@@ -1869,13 +1821,13 @@ class CtsExprImpl implements CtsExpr {
     return new QueryCallImpl("cts", "period-compare-query", new Object[]{ axis1, operator, axis2 });
   }
 
-
+  
   @Override
   public CtsQueryExpr periodCompareQuery(String axis1, String operator, String axis2, String options) {
     return periodCompareQuery((axis1 == null) ? (XsStringVal) null : xs.string(axis1), (operator == null) ? (XsStringVal) null : xs.string(operator), (axis2 == null) ? (XsStringVal) null : xs.string(axis2), (options == null) ? (XsStringVal) null : xs.string(options));
   }
 
-
+  
   @Override
   public CtsQueryExpr periodCompareQuery(ServerExpression axis1, ServerExpression operator, ServerExpression axis2, ServerExpression options) {
     if (axis1 == null) {
@@ -1890,13 +1842,13 @@ class CtsExprImpl implements CtsExpr {
     return new QueryCallImpl("cts", "period-compare-query", new Object[]{ axis1, operator, axis2, options });
   }
 
-
+  
   @Override
   public CtsQueryExpr periodRangeQuery(String axis, String operator) {
     return periodRangeQuery((axis == null) ? (XsStringVal) null : xs.string(axis), (operator == null) ? (XsStringVal) null : xs.string(operator));
   }
 
-
+  
   @Override
   public CtsQueryExpr periodRangeQuery(ServerExpression axis, ServerExpression operator) {
     if (operator == null) {
@@ -1905,13 +1857,13 @@ class CtsExprImpl implements CtsExpr {
     return new QueryCallImpl("cts", "period-range-query", new Object[]{ axis, operator });
   }
 
-
+  
   @Override
   public CtsQueryExpr periodRangeQuery(String axis, String operator, CtsPeriodExpr... period) {
     return periodRangeQuery((axis == null) ? (XsStringVal) null : xs.string(axis), (operator == null) ? (XsStringVal) null : xs.string(operator), new PeriodSeqListImpl(period));
   }
 
-
+  
   @Override
   public CtsQueryExpr periodRangeQuery(ServerExpression axis, ServerExpression operator, ServerExpression period) {
     if (operator == null) {
@@ -1920,13 +1872,13 @@ class CtsExprImpl implements CtsExpr {
     return new QueryCallImpl("cts", "period-range-query", new Object[]{ axis, operator, period });
   }
 
-
+  
   @Override
   public CtsQueryExpr periodRangeQuery(String axis, String operator, ServerExpression period, String options) {
     return periodRangeQuery((axis == null) ? (XsStringVal) null : xs.string(axis), (operator == null) ? (XsStringVal) null : xs.string(operator), period, (options == null) ? (XsStringVal) null : xs.string(options));
   }
 
-
+  
   @Override
   public CtsQueryExpr periodRangeQuery(ServerExpression axis, ServerExpression operator, ServerExpression period, ServerExpression options) {
     if (operator == null) {
@@ -1935,7 +1887,7 @@ class CtsExprImpl implements CtsExpr {
     return new QueryCallImpl("cts", "period-range-query", new Object[]{ axis, operator, period, options });
   }
 
-
+  
   @Override
   public CtsPointExpr point(double latitude, double longitude) {
     return point(xs.doubleVal(latitude), xs.doubleVal(longitude));
@@ -1946,7 +1898,7 @@ class CtsExprImpl implements CtsExpr {
 		return new PointCallImpl("cts", "point", new Object[]{ xs.string(expression) });
 	}
 
-	@Override
+  @Override
   public CtsPointExpr point(ServerExpression latitude, ServerExpression longitude) {
     if (latitude == null) {
       throw new IllegalArgumentException("latitude parameter for point() cannot be null");
@@ -1957,7 +1909,7 @@ class CtsExprImpl implements CtsExpr {
     return new PointCallImpl("cts", "point", new Object[]{ latitude, longitude });
   }
 
-
+  
   @Override
   public ServerExpression pointLatitude(ServerExpression point) {
     if (point == null) {
@@ -1966,7 +1918,7 @@ class CtsExprImpl implements CtsExpr {
     return new XsExprImpl.NumericCallImpl("cts", "point-latitude", new Object[]{ point });
   }
 
-
+  
   @Override
   public ServerExpression pointLongitude(ServerExpression point) {
     if (point == null) {
@@ -1975,7 +1927,7 @@ class CtsExprImpl implements CtsExpr {
     return new XsExprImpl.NumericCallImpl("cts", "point-longitude", new Object[]{ point });
   }
 
-
+  
   @Override
   public CtsPolygonExpr polygon(ServerExpression vertices) {
     return new PolygonCallImpl("cts", "polygon", new Object[]{ vertices });
@@ -1986,7 +1938,7 @@ class CtsExprImpl implements CtsExpr {
 		return new PolygonCallImpl("cts", "polygon", new Object[]{ xs.string(expression) });
 	}
 
-	@Override
+  @Override
   public CtsQueryExpr propertiesFragmentQuery(ServerExpression query) {
     if (query == null) {
       throw new IllegalArgumentException("query parameter for propertiesFragmentQuery() cannot be null");
@@ -1994,13 +1946,13 @@ class CtsExprImpl implements CtsExpr {
     return new QueryCallImpl("cts", "properties-fragment-query", new Object[]{ query });
   }
 
-
+  
   @Override
   public CtsQueryExpr rangeQuery(ServerExpression index, String operator, String value) {
     return rangeQuery(index, (operator == null) ? (XsStringVal) null : xs.string(operator), (value == null) ? (XsAnyAtomicTypeVal) null : xs.string(value));
   }
 
-
+  
   @Override
   public CtsQueryExpr rangeQuery(ServerExpression index, ServerExpression operator, ServerExpression value) {
     if (operator == null) {
@@ -2009,13 +1961,13 @@ class CtsExprImpl implements CtsExpr {
     return new QueryCallImpl("cts", "range-query", new Object[]{ index, operator, value });
   }
 
-
+  
   @Override
   public CtsQueryExpr rangeQuery(ServerExpression index, String operator, String value, String... options) {
     return rangeQuery(index, (operator == null) ? (XsStringVal) null : xs.string(operator), (value == null) ? (XsAnyAtomicTypeVal) null : xs.string(value), (options == null) ? (XsStringVal) null : xs.stringSeq(options));
   }
 
-
+  
   @Override
   public CtsQueryExpr rangeQuery(ServerExpression index, ServerExpression operator, ServerExpression value, ServerExpression options) {
     if (operator == null) {
@@ -2024,13 +1976,13 @@ class CtsExprImpl implements CtsExpr {
     return new QueryCallImpl("cts", "range-query", new Object[]{ index, operator, value, options });
   }
 
-
+  
   @Override
   public CtsQueryExpr rangeQuery(ServerExpression index, String operator, String value, String options, double weight) {
     return rangeQuery(index, (operator == null) ? (XsStringVal) null : xs.string(operator), (value == null) ? (XsAnyAtomicTypeVal) null : xs.string(value), (options == null) ? (XsStringVal) null : xs.string(options), xs.doubleVal(weight));
   }
 
-
+  
   @Override
   public CtsQueryExpr rangeQuery(ServerExpression index, ServerExpression operator, ServerExpression value, ServerExpression options, ServerExpression weight) {
     if (operator == null) {
@@ -2039,7 +1991,7 @@ class CtsExprImpl implements CtsExpr {
     return new QueryCallImpl("cts", "range-query", new Object[]{ index, operator, value, options, weight });
   }
 
-
+  
   @Override
   public ServerExpression stem(ServerExpression text) {
     if (text == null) {
@@ -2048,13 +2000,13 @@ class CtsExprImpl implements CtsExpr {
     return new XsExprImpl.StringSeqCallImpl("cts", "stem", new Object[]{ text });
   }
 
-
+  
   @Override
   public ServerExpression stem(ServerExpression text, String language) {
     return stem(text, (language == null) ? (ServerExpression) null : xs.string(language));
   }
 
-
+  
   @Override
   public ServerExpression stem(ServerExpression text, ServerExpression language) {
     if (text == null) {
@@ -2063,13 +2015,13 @@ class CtsExprImpl implements CtsExpr {
     return new XsExprImpl.StringSeqCallImpl("cts", "stem", new Object[]{ text, language });
   }
 
-
+  
   @Override
   public ServerExpression stem(ServerExpression text, String language, String partOfSpeech) {
     return stem(text, (language == null) ? (ServerExpression) null : xs.string(language), (partOfSpeech == null) ? (ServerExpression) null : xs.string(partOfSpeech));
   }
 
-
+  
   @Override
   public ServerExpression stem(ServerExpression text, ServerExpression language, ServerExpression partOfSpeech) {
     if (text == null) {
@@ -2078,7 +2030,7 @@ class CtsExprImpl implements CtsExpr {
     return new XsExprImpl.StringSeqCallImpl("cts", "stem", new Object[]{ text, language, partOfSpeech });
   }
 
-
+  
   @Override
   public ServerExpression tokenize(ServerExpression text) {
     if (text == null) {
@@ -2087,13 +2039,13 @@ class CtsExprImpl implements CtsExpr {
     return new XsExprImpl.StringSeqCallImpl("cts", "tokenize", new Object[]{ text });
   }
 
-
+  
   @Override
   public ServerExpression tokenize(ServerExpression text, String language) {
     return tokenize(text, (language == null) ? (ServerExpression) null : xs.string(language));
   }
 
-
+  
   @Override
   public ServerExpression tokenize(ServerExpression text, ServerExpression language) {
     if (text == null) {
@@ -2102,13 +2054,13 @@ class CtsExprImpl implements CtsExpr {
     return new XsExprImpl.StringSeqCallImpl("cts", "tokenize", new Object[]{ text, language });
   }
 
-
+  
   @Override
   public ServerExpression tokenize(ServerExpression text, String language, String field) {
     return tokenize(text, (language == null) ? (ServerExpression) null : xs.string(language), (field == null) ? (ServerExpression) null : xs.string(field));
   }
 
-
+  
   @Override
   public ServerExpression tokenize(ServerExpression text, ServerExpression language, ServerExpression field) {
     if (text == null) {
@@ -2117,97 +2069,97 @@ class CtsExprImpl implements CtsExpr {
     return new XsExprImpl.StringSeqCallImpl("cts", "tokenize", new Object[]{ text, language, field });
   }
 
-
+  
   @Override
   public CtsQueryExpr tripleRangeQuery(String subject, String predicate, String object) {
     return tripleRangeQuery((subject == null) ? (XsAnyAtomicTypeVal) null : xs.string(subject), (predicate == null) ? (XsAnyAtomicTypeVal) null : xs.string(predicate), (object == null) ? (XsAnyAtomicTypeVal) null : xs.string(object));
   }
 
-
+  
   @Override
   public CtsQueryExpr tripleRangeQuery(ServerExpression subject, ServerExpression predicate, ServerExpression object) {
     return new QueryCallImpl("cts", "triple-range-query", new Object[]{ subject, predicate, object });
   }
 
-
+  
   @Override
   public CtsQueryExpr tripleRangeQuery(String subject, String predicate, String object, String operator) {
     return tripleRangeQuery((subject == null) ? (XsAnyAtomicTypeVal) null : xs.string(subject), (predicate == null) ? (XsAnyAtomicTypeVal) null : xs.string(predicate), (object == null) ? (XsAnyAtomicTypeVal) null : xs.string(object), (operator == null) ? (XsStringVal) null : xs.string(operator));
   }
 
-
+  
   @Override
   public CtsQueryExpr tripleRangeQuery(ServerExpression subject, ServerExpression predicate, ServerExpression object, ServerExpression operator) {
     return new QueryCallImpl("cts", "triple-range-query", new Object[]{ subject, predicate, object, operator });
   }
 
-
+  
   @Override
   public CtsQueryExpr tripleRangeQuery(String subject, String predicate, String object, String operator, String... options) {
     return tripleRangeQuery((subject == null) ? (XsAnyAtomicTypeVal) null : xs.string(subject), (predicate == null) ? (XsAnyAtomicTypeVal) null : xs.string(predicate), (object == null) ? (XsAnyAtomicTypeVal) null : xs.string(object), (operator == null) ? (XsStringVal) null : xs.string(operator), (options == null) ? (XsStringVal) null : xs.stringSeq(options));
   }
 
-
+  
   @Override
   public CtsQueryExpr tripleRangeQuery(ServerExpression subject, ServerExpression predicate, ServerExpression object, ServerExpression operator, ServerExpression options) {
     return new QueryCallImpl("cts", "triple-range-query", new Object[]{ subject, predicate, object, operator, options });
   }
 
-
+  
   @Override
   public CtsQueryExpr tripleRangeQuery(String subject, String predicate, String object, String operator, String options, double weight) {
     return tripleRangeQuery((subject == null) ? (XsAnyAtomicTypeVal) null : xs.string(subject), (predicate == null) ? (XsAnyAtomicTypeVal) null : xs.string(predicate), (object == null) ? (XsAnyAtomicTypeVal) null : xs.string(object), (operator == null) ? (XsStringVal) null : xs.string(operator), (options == null) ? (XsStringVal) null : xs.string(options), xs.doubleVal(weight));
   }
 
-
+  
   @Override
   public CtsQueryExpr tripleRangeQuery(ServerExpression subject, ServerExpression predicate, ServerExpression object, ServerExpression operator, ServerExpression options, ServerExpression weight) {
     return new QueryCallImpl("cts", "triple-range-query", new Object[]{ subject, predicate, object, operator, options, weight });
   }
 
-
+  
   @Override
   public CtsQueryExpr trueQuery() {
     return new QueryCallImpl("cts", "true-query", new Object[]{  });
   }
 
-
+  
   @Override
   public CtsReferenceExpr uriReference() {
     return new ReferenceCallImpl("cts", "uri-reference", new Object[]{  });
   }
 
-
+  
   @Override
   public CtsQueryExpr wordQuery(String text) {
     return wordQuery((text == null) ? (XsStringVal) null : xs.string(text));
   }
 
-
+  
   @Override
   public CtsQueryExpr wordQuery(ServerExpression text) {
     return new QueryCallImpl("cts", "word-query", new Object[]{ text });
   }
 
-
+  
   @Override
   public CtsQueryExpr wordQuery(String text, String... options) {
     return wordQuery((text == null) ? (XsStringVal) null : xs.string(text), (options == null) ? (XsStringVal) null : xs.stringSeq(options));
   }
 
-
+  
   @Override
   public CtsQueryExpr wordQuery(ServerExpression text, ServerExpression options) {
     return new QueryCallImpl("cts", "word-query", new Object[]{ text, options });
   }
 
-
+  
   @Override
   public CtsQueryExpr wordQuery(String text, String options, double weight) {
     return wordQuery((text == null) ? (XsStringVal) null : xs.string(text), (options == null) ? (XsStringVal) null : xs.string(options), xs.doubleVal(weight));
   }
 
-
+  
   @Override
   public CtsQueryExpr wordQuery(ServerExpression text, ServerExpression options, ServerExpression weight) {
     return new QueryCallImpl("cts", "word-query", new Object[]{ text, options, weight });
@@ -2232,7 +2184,7 @@ class CtsExprImpl implements CtsExpr {
       super(fnPrefix, fnName, fnArgs);
     }
   }
-
+ 
   @Override
   public CtsCircleSeqExpr circleSeq(CtsCircleExpr... items) {
     return new CircleSeqListImpl(items);
@@ -2252,7 +2204,7 @@ class CtsExprImpl implements CtsExpr {
       super(fnPrefix, fnName, fnArgs);
     }
   }
-
+ 
   @Override
   public CtsPeriodSeqExpr periodSeq(CtsPeriodExpr... items) {
     return new PeriodSeqListImpl(items);
@@ -2272,7 +2224,7 @@ class CtsExprImpl implements CtsExpr {
       super(fnPrefix, fnName, fnArgs);
     }
   }
-
+ 
   @Override
   public CtsPointSeqExpr pointSeq(CtsPointExpr... items) {
     return new PointSeqListImpl(items);
@@ -2292,7 +2244,7 @@ class CtsExprImpl implements CtsExpr {
       super(fnPrefix, fnName, fnArgs);
     }
   }
-
+ 
   @Override
   public CtsPolygonSeqExpr polygonSeq(CtsPolygonExpr... items) {
     return new PolygonSeqListImpl(items);
@@ -2312,7 +2264,7 @@ class CtsExprImpl implements CtsExpr {
       super(fnPrefix, fnName, fnArgs);
     }
   }
-
+ 
   @Override
   public CtsQuerySeqExpr querySeq(CtsQueryExpr... items) {
     return new QuerySeqListImpl(items);
@@ -2332,7 +2284,7 @@ class CtsExprImpl implements CtsExpr {
       super(fnPrefix, fnName, fnArgs);
     }
   }
-
+ 
   @Override
   public CtsReferenceSeqExpr referenceSeq(CtsReferenceExpr... items) {
     return new ReferenceSeqListImpl(items);
@@ -2352,7 +2304,7 @@ class CtsExprImpl implements CtsExpr {
       super(fnPrefix, fnName, fnArgs);
     }
   }
-
+ 
   @Override
   public CtsRegionSeqExpr regionSeq(CtsRegionExpr... items) {
     return new RegionSeqListImpl(items);

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/PlanBuilderImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/PlanBuilderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 MarkLogic Corporation
+ * Copyright (c) 2024 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -614,6 +614,81 @@ abstract class PlanBuilderImpl extends PlanBuilderBaseImpl {
 
   
   @Override
+  public PlanPatchBuilderPlan insertAfter(String path, Node node) {
+    return insertAfter((path == null) ? (XsStringVal) null : xs.string(path), node);
+  }
+
+  
+  @Override
+  public PlanPatchBuilderPlan insertAfter(XsStringVal path, Node node) {
+    if (path == null) {
+      throw new IllegalArgumentException("path parameter for insertAfter() cannot be null");
+    }
+    if (node == null) {
+      throw new IllegalArgumentException("node parameter for insertAfter() cannot be null");
+    }
+    return new PatchBuilderPlanCallImpl("op", "insert-after", new Object[]{ path, node });
+  }
+
+  
+  @Override
+  public PlanPatchBuilderPlan insertBefore(String path, Node node) {
+    return insertBefore((path == null) ? (XsStringVal) null : xs.string(path), node);
+  }
+
+  
+  @Override
+  public PlanPatchBuilderPlan insertBefore(XsStringVal path, Node node) {
+    if (path == null) {
+      throw new IllegalArgumentException("path parameter for insertBefore() cannot be null");
+    }
+    if (node == null) {
+      throw new IllegalArgumentException("node parameter for insertBefore() cannot be null");
+    }
+    return new PatchBuilderPlanCallImpl("op", "insert-before", new Object[]{ path, node });
+  }
+
+  
+  @Override
+  public PlanPatchBuilderPlan insertChild(String path, Node node) {
+    return insertChild((path == null) ? (XsStringVal) null : xs.string(path), node);
+  }
+
+  
+  @Override
+  public PlanPatchBuilderPlan insertChild(XsStringVal path, Node node) {
+    if (path == null) {
+      throw new IllegalArgumentException("path parameter for insertChild() cannot be null");
+    }
+    if (node == null) {
+      throw new IllegalArgumentException("node parameter for insertChild() cannot be null");
+    }
+    return new PatchBuilderPlanCallImpl("op", "insert-child", new Object[]{ path, node });
+  }
+
+  
+  @Override
+  public PlanPatchBuilderPlan insertNamedChild(String path, String key, Node node) {
+    return insertNamedChild((path == null) ? (XsStringVal) null : xs.string(path), (key == null) ? (XsStringVal) null : xs.string(key), node);
+  }
+
+  
+  @Override
+  public PlanPatchBuilderPlan insertNamedChild(XsStringVal path, XsStringVal key, Node node) {
+    if (path == null) {
+      throw new IllegalArgumentException("path parameter for insertNamedChild() cannot be null");
+    }
+    if (key == null) {
+      throw new IllegalArgumentException("key parameter for insertNamedChild() cannot be null");
+    }
+    if (node == null) {
+      throw new IllegalArgumentException("node parameter for insertNamedChild() cannot be null");
+    }
+    return new PatchBuilderPlanCallImpl("op", "insert-named-child", new Object[]{ path, key, node });
+  }
+
+  
+  @Override
   public ServerExpression isDefined(ServerExpression operand) {
     if (operand == null) {
       throw new IllegalArgumentException("operand parameter for isDefined() cannot be null");
@@ -857,11 +932,74 @@ abstract class PlanBuilderImpl extends PlanBuilderBaseImpl {
 
   
   @Override
+  public ModifyPlan onError(String action) {
+    return onError((action == null) ? (XsStringVal) null : xs.string(action));
+  }
+
+  
+  @Override
+  public ModifyPlan onError(XsStringVal action) {
+    if (action == null) {
+      throw new IllegalArgumentException("action parameter for onError() cannot be null");
+    }
+    return new PlanBuilderSubImpl.ModifyPlanSubImpl("op", "on-error", new Object[]{ action });
+  }
+
+  
+  @Override
+  public ModifyPlan onError(String action, String errorColumn) {
+    return onError((action == null) ? (XsStringVal) null : xs.string(action), (errorColumn == null) ? (PlanExprCol) null : exprCol(errorColumn));
+  }
+
+  
+  @Override
+  public ModifyPlan onError(XsStringVal action, PlanExprCol errorColumn) {
+    if (action == null) {
+      throw new IllegalArgumentException("action parameter for onError() cannot be null");
+    }
+    return new PlanBuilderSubImpl.ModifyPlanSubImpl("op", "on-error", new Object[]{ action, errorColumn });
+  }
+
+  
+  @Override
   public ServerExpression or(ServerExpression... left) {
     if (left == null) {
       throw new IllegalArgumentException("left parameter for or() cannot be null");
     }
     return new XsExprImpl.BooleanCallImpl("op", "or", left);
+  }
+
+  
+  @Override
+  public ModifyPlan patch(String docColumn, PlanPatchBuilderPlan patchDef) {
+    return patch((docColumn == null) ? (PlanExprCol) null : exprCol(docColumn), patchDef);
+  }
+
+  
+  @Override
+  public ModifyPlan patch(PlanExprCol docColumn, PlanPatchBuilderPlan patchDef) {
+    if (docColumn == null) {
+      throw new IllegalArgumentException("docColumn parameter for patch() cannot be null");
+    }
+    if (patchDef == null) {
+      throw new IllegalArgumentException("patchDef parameter for patch() cannot be null");
+    }
+    return new PlanBuilderSubImpl.ModifyPlanSubImpl("op", "patch", new Object[]{ docColumn, patchDef });
+  }
+
+  
+  @Override
+  public PlanPatchBuilderPlan patchBuilder(String contextPath) {
+    return patchBuilder((contextPath == null) ? (XsStringVal) null : xs.string(contextPath));
+  }
+
+  
+  @Override
+  public PlanPatchBuilderPlan patchBuilder(XsStringVal contextPath) {
+    if (contextPath == null) {
+      throw new IllegalArgumentException("contextPath parameter for patchBuilder() cannot be null");
+    }
+    return new PatchBuilderPlanCallImpl("op", "patch-builder", new Object[]{ contextPath });
   }
 
   
@@ -910,6 +1048,96 @@ abstract class PlanBuilderImpl extends PlanBuilderBaseImpl {
       throw new IllegalArgumentException("value parameter for prop() cannot be null");
     }
     return new JsonPropertyCallImpl("op", "prop", new Object[]{ key, value });
+  }
+
+  
+  @Override
+  public PlanPatchBuilderPlan remove(String path) {
+    return remove((path == null) ? (XsStringVal) null : xs.string(path));
+  }
+
+  
+  @Override
+  public PlanPatchBuilderPlan remove(XsStringVal path) {
+    if (path == null) {
+      throw new IllegalArgumentException("path parameter for remove() cannot be null");
+    }
+    return new PatchBuilderPlanCallImpl("op", "remove", new Object[]{ path });
+  }
+
+  
+  @Override
+  public PlanPatchBuilderPlan replace(String path, Node node) {
+    return replace((path == null) ? (XsStringVal) null : xs.string(path), node);
+  }
+
+  
+  @Override
+  public PlanPatchBuilderPlan replace(XsStringVal path, Node node) {
+    if (path == null) {
+      throw new IllegalArgumentException("path parameter for replace() cannot be null");
+    }
+    if (node == null) {
+      throw new IllegalArgumentException("node parameter for replace() cannot be null");
+    }
+    return new PatchBuilderPlanCallImpl("op", "replace", new Object[]{ path, node });
+  }
+
+  
+  @Override
+  public PlanPatchBuilderPlan replaceInsertChild(String parentPath, String pathToReplace) {
+    return replaceInsertChild((parentPath == null) ? (XsStringVal) null : xs.string(parentPath), (pathToReplace == null) ? (XsStringVal) null : xs.string(pathToReplace));
+  }
+
+  
+  @Override
+  public PlanPatchBuilderPlan replaceInsertChild(XsStringVal parentPath, XsStringVal pathToReplace) {
+    if (parentPath == null) {
+      throw new IllegalArgumentException("parentPath parameter for replaceInsertChild() cannot be null");
+    }
+    if (pathToReplace == null) {
+      throw new IllegalArgumentException("pathToReplace parameter for replaceInsertChild() cannot be null");
+    }
+    return new PatchBuilderPlanCallImpl("op", "replace-insert-child", new Object[]{ parentPath, pathToReplace });
+  }
+
+  
+  @Override
+  public PlanPatchBuilderPlan replaceInsertChild(String parentPath, String pathToReplace, Node node) {
+    return replaceInsertChild((parentPath == null) ? (XsStringVal) null : xs.string(parentPath), (pathToReplace == null) ? (XsStringVal) null : xs.string(pathToReplace), node);
+  }
+
+  
+  @Override
+  public PlanPatchBuilderPlan replaceInsertChild(XsStringVal parentPath, XsStringVal pathToReplace, Node node) {
+    if (parentPath == null) {
+      throw new IllegalArgumentException("parentPath parameter for replaceInsertChild() cannot be null");
+    }
+    if (pathToReplace == null) {
+      throw new IllegalArgumentException("pathToReplace parameter for replaceInsertChild() cannot be null");
+    }
+    if (node == null) {
+      throw new IllegalArgumentException("node parameter for replaceInsertChild() cannot be null");
+    }
+    return new PatchBuilderPlanCallImpl("op", "replace-insert-child", new Object[]{ parentPath, pathToReplace, node });
+  }
+
+  
+  @Override
+  public PlanPatchBuilderPlan replaceValue(String path, Item value) {
+    return replaceValue((path == null) ? (XsStringVal) null : xs.string(path), value);
+  }
+
+  
+  @Override
+  public PlanPatchBuilderPlan replaceValue(XsStringVal path, Item value) {
+    if (path == null) {
+      throw new IllegalArgumentException("path parameter for replaceValue() cannot be null");
+    }
+    if (value == null) {
+      throw new IllegalArgumentException("value parameter for replaceValue() cannot be null");
+    }
+    return new PatchBuilderPlanCallImpl("op", "replace-value", new Object[]{ path, value });
   }
 
   
@@ -1602,6 +1830,27 @@ abstract class PlanBuilderImpl extends PlanBuilderBaseImpl {
   }
 
   
+  static class PatchBuilderPlanSeqListImpl extends PlanSeqListImpl implements PlanPatchBuilderPlanSeq {
+    PatchBuilderPlanSeqListImpl(Object[] items) {
+      super(items);
+    }
+  }
+
+  
+  static class PatchBuilderPlanSeqCallImpl extends PlanCallImpl implements PlanPatchBuilderPlanSeq {
+    PatchBuilderPlanSeqCallImpl(String fnPrefix, String fnName, Object[] fnArgs) {
+      super(fnPrefix, fnName, fnArgs);
+    }
+  }
+
+  
+  static class PatchBuilderPlanCallImpl extends PlanCallImpl implements PlanPatchBuilderPlan {
+    PatchBuilderPlanCallImpl(String fnPrefix, String fnName, Object[] fnArgs) {
+      super(fnPrefix, fnName, fnArgs);
+    }
+  }
+
+  
   static class RowColTypesSeqListImpl extends PlanSeqListImpl implements PlanRowColTypesSeq {
     RowColTypesSeqListImpl(Object[] items) {
       super(items);
@@ -1927,27 +2176,6 @@ abstract class PlanBuilderImpl extends PlanBuilderBaseImpl {
       throw new IllegalArgumentException("sourceCol parameter for joinDoc() cannot be null");
     }
     return new PlanBuilderSubImpl.ModifyPlanSubImpl(this, "op", "join-doc", new Object[]{ docCol, sourceCol });
-  }
-
-    
-  @Override
-  public ModifyPlan joinDocAndUri(String docCol, String uriCol, String sourceCol) {
-    return joinDocAndUri((docCol == null) ? (PlanColumn) null : col(docCol), (uriCol == null) ? (PlanColumn) null : col(uriCol), (sourceCol == null) ? (PlanColumn) null : col(sourceCol));
-  }
-
-    
-  @Override
-  public ModifyPlan joinDocAndUri(PlanColumn docCol, PlanColumn uriCol, PlanColumn sourceCol) {
-    if (docCol == null) {
-      throw new IllegalArgumentException("docCol parameter for joinDocAndUri() cannot be null");
-    }
-    if (uriCol == null) {
-      throw new IllegalArgumentException("uriCol parameter for joinDocAndUri() cannot be null");
-    }
-    if (sourceCol == null) {
-      throw new IllegalArgumentException("sourceCol parameter for joinDocAndUri() cannot be null");
-    }
-    return new PlanBuilderSubImpl.ModifyPlanSubImpl(this, "op", "join-doc-and-uri", new Object[]{ docCol, uriCol, sourceCol });
   }
 
     

--- a/marklogic-client-api/src/main/javadoc/doc-files/types/cts_query.html
+++ b/marklogic-client-api/src/main/javadoc/doc-files/types/cts_query.html
@@ -151,257 +151,239 @@ For all server types, see the <a href="ml-server-type-tree.html">Server Expressi
 	  </tr>
 <tr class="altColor">
 	    <td class="colFirst">cts:query</td>
-	    <td class="colLast"><span class="memberNameLink">cts:document-format-query</span>(<span><a href="xs_string.html">xs:string</a> <i>format</i></span>)</td>
-	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-document-format-query">java</a></td>
-	    <td><a href="http://docs.marklogic.com/cts:document-format-query" target="mlserverdoc">server</a></td>
-	  </tr>
-<tr class="rowColor">
-	    <td class="colFirst">cts:query</td>
 	    <td class="colLast"><span class="memberNameLink">cts:document-fragment-query</span>(<span>cts:query <i>query</i></span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-document-fragment-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:document-fragment-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="altColor">
-	    <td class="colFirst">cts:query</td>
-	    <td class="colLast"><span class="memberNameLink">cts:document-permission-query</span>(<span><a href="xs_string.html">xs:string</a> <i>role</i></span>, <span><a href="xs_string.html">xs:string</a> <i>capability</i></span>)</td>
-	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-document-permission-query">java</a></td>
-	    <td><a href="http://docs.marklogic.com/cts:document-permission-query" target="mlserverdoc">server</a></td>
-	  </tr>
 <tr class="rowColor">
-	    <td class="colFirst">cts:query</td>
-	    <td class="colLast"><span class="memberNameLink">cts:document-root-query</span>(<span><a href="xs_QName.html">xs:QName</a> <i>root</i></span>)</td>
-	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-document-root-query">java</a></td>
-	    <td><a href="http://docs.marklogic.com/cts:document-root-query" target="mlserverdoc">server</a></td>
-	  </tr>
-<tr class="altColor">
 	    <td class="colFirst">cts:query</td>
 	    <td class="colLast"><span class="memberNameLink">cts:document-query</span>(<span><a href="xs_string.html">xs:string</a> <i>uris</i>*</span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-document-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:document-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="rowColor">
+<tr class="altColor">
 	    <td class="colFirst">cts:query</td>
 	    <td class="colLast"><span class="memberNameLink">cts:element-attribute-pair-geospatial-query</span>(<span><a href="xs_QName.html">xs:QName</a> <i>element-name</i>*</span>, <span><a href="xs_QName.html">xs:QName</a> <i>latitude-name</i>*</span>, <span><a href="xs_QName.html">xs:QName</a> <i>longitude-name</i>*</span>, <span><a href="cts_region.html">cts:region</a> <i>region</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>options</i>*</span>, <span><a href="xs_double.html">xs:double</a> <i>weight</i>?</span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-element-attribute-pair-geospatial-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:element-attribute-pair-geospatial-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="altColor">
+<tr class="rowColor">
 	    <td class="colFirst">cts:query</td>
 	    <td class="colLast"><span class="memberNameLink">cts:element-attribute-range-query</span>(<span><a href="xs_QName.html">xs:QName</a> <i>element-name</i>*</span>, <span><a href="xs_QName.html">xs:QName</a> <i>attribute-name</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>operator</i></span>, <span><a href="xs_anyAtomicType.html">xs:anyAtomicType</a> <i>value</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>options</i>*</span>, <span><a href="xs_double.html">xs:double</a> <i>weight</i>?</span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-element-attribute-range-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:element-attribute-range-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="rowColor">
+<tr class="altColor">
 	    <td class="colFirst">cts:query</td>
 	    <td class="colLast"><span class="memberNameLink">cts:element-attribute-value-query</span>(<span><a href="xs_QName.html">xs:QName</a> <i>element-name</i>*</span>, <span><a href="xs_QName.html">xs:QName</a> <i>attribute-name</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>text</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>options</i>*</span>, <span><a href="xs_double.html">xs:double</a> <i>weight</i>?</span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-element-attribute-value-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:element-attribute-value-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="altColor">
+<tr class="rowColor">
 	    <td class="colFirst">cts:query</td>
 	    <td class="colLast"><span class="memberNameLink">cts:element-attribute-word-query</span>(<span><a href="xs_QName.html">xs:QName</a> <i>element-name</i>*</span>, <span><a href="xs_QName.html">xs:QName</a> <i>attribute-name</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>text</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>options</i>*</span>, <span><a href="xs_double.html">xs:double</a> <i>weight</i>?</span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-element-attribute-word-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:element-attribute-word-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="rowColor">
+<tr class="altColor">
 	    <td class="colFirst">cts:query</td>
 	    <td class="colLast"><span class="memberNameLink">cts:element-child-geospatial-query</span>(<span><a href="xs_QName.html">xs:QName</a> <i>element-name</i>*</span>, <span><a href="xs_QName.html">xs:QName</a> <i>child-name</i>*</span>, <span><a href="cts_region.html">cts:region</a> <i>region</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>options</i>*</span>, <span><a href="xs_double.html">xs:double</a> <i>weight</i>?</span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-element-child-geospatial-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:element-child-geospatial-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="altColor">
+<tr class="rowColor">
 	    <td class="colFirst">cts:query</td>
 	    <td class="colLast"><span class="memberNameLink">cts:element-geospatial-query</span>(<span><a href="xs_QName.html">xs:QName</a> <i>element-name</i>*</span>, <span><a href="cts_region.html">cts:region</a> <i>region</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>options</i>*</span>, <span><a href="xs_double.html">xs:double</a> <i>weight</i>?</span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-element-geospatial-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:element-geospatial-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="rowColor">
+<tr class="altColor">
 	    <td class="colFirst">cts:query</td>
 	    <td class="colLast"><span class="memberNameLink">cts:element-pair-geospatial-query</span>(<span><a href="xs_QName.html">xs:QName</a> <i>element-name</i>*</span>, <span><a href="xs_QName.html">xs:QName</a> <i>latitude-name</i>*</span>, <span><a href="xs_QName.html">xs:QName</a> <i>longitude-name</i>*</span>, <span><a href="cts_region.html">cts:region</a> <i>region</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>options</i>*</span>, <span><a href="xs_double.html">xs:double</a> <i>weight</i>?</span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-element-pair-geospatial-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:element-pair-geospatial-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="altColor">
+<tr class="rowColor">
 	    <td class="colFirst">cts:query</td>
 	    <td class="colLast"><span class="memberNameLink">cts:element-query</span>(<span><a href="xs_QName.html">xs:QName</a> <i>element-name</i>*</span>, <span>cts:query <i>query</i></span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-element-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:element-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="rowColor">
+<tr class="altColor">
 	    <td class="colFirst">cts:query</td>
 	    <td class="colLast"><span class="memberNameLink">cts:element-range-query</span>(<span><a href="xs_QName.html">xs:QName</a> <i>element-name</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>operator</i></span>, <span><a href="xs_anyAtomicType.html">xs:anyAtomicType</a> <i>value</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>options</i>*</span>, <span><a href="xs_double.html">xs:double</a> <i>weight</i>?</span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-element-range-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:element-range-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="altColor">
+<tr class="rowColor">
 	    <td class="colFirst">cts:query</td>
 	    <td class="colLast"><span class="memberNameLink">cts:element-value-query</span>(<span><a href="xs_QName.html">xs:QName</a> <i>element-name</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>text</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>options</i>*</span>, <span><a href="xs_double.html">xs:double</a> <i>weight</i>?</span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-element-value-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:element-value-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="rowColor">
+<tr class="altColor">
 	    <td class="colFirst">cts:query</td>
 	    <td class="colLast"><span class="memberNameLink">cts:element-word-query</span>(<span><a href="xs_QName.html">xs:QName</a> <i>element-name</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>text</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>options</i>*</span>, <span><a href="xs_double.html">xs:double</a> <i>weight</i>?</span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-element-word-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:element-word-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="altColor">
+<tr class="rowColor">
 	    <td class="colFirst">cts:query</td>
 	    <td class="colLast"><span class="memberNameLink">cts:false-query</span>()</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-false-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:false-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="rowColor">
+<tr class="altColor">
 	    <td class="colFirst">cts:query</td>
 	    <td class="colLast"><span class="memberNameLink">cts:field-range-query</span>(<span><a href="xs_string.html">xs:string</a> <i>field-name</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>operator</i></span>, <span><a href="xs_anyAtomicType.html">xs:anyAtomicType</a> <i>value</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>options</i>*</span>, <span><a href="xs_double.html">xs:double</a> <i>weight</i>?</span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-field-range-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:field-range-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="altColor">
+<tr class="rowColor">
 	    <td class="colFirst">cts:query</td>
 	    <td class="colLast"><span class="memberNameLink">cts:field-value-query</span>(<span><a href="xs_string.html">xs:string</a> <i>field-name</i>*</span>, <span><a href="xs_anyAtomicType.html">xs:anyAtomicType</a> <i>text</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>options</i>*</span>, <span><a href="xs_double.html">xs:double</a> <i>weight</i>?</span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-field-value-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:field-value-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="rowColor">
+<tr class="altColor">
 	    <td class="colFirst">cts:query</td>
 	    <td class="colLast"><span class="memberNameLink">cts:field-word-query</span>(<span><a href="xs_string.html">xs:string</a> <i>field-name</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>text</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>options</i>*</span>, <span><a href="xs_double.html">xs:double</a> <i>weight</i>?</span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-field-word-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:field-word-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="altColor">
+<tr class="rowColor">
 	    <td class="colFirst">cts:query</td>
 	    <td class="colLast"><span class="memberNameLink">cts:geospatial-region-query</span>(<span><a href="cts_reference.html">cts:reference</a> <i>reference</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>operation</i></span>, <span><a href="cts_region.html">cts:region</a> <i>region</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>options</i>*</span>, <span><a href="xs_double.html">xs:double</a> <i>weight</i>?</span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-geospatial-region-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:geospatial-region-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="rowColor">
+<tr class="altColor">
 	    <td class="colFirst">cts:query</td>
 	    <td class="colLast"><span class="memberNameLink">cts:json-property-child-geospatial-query</span>(<span><a href="xs_string.html">xs:string</a> <i>property-name</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>child-name</i>*</span>, <span><a href="cts_region.html">cts:region</a> <i>region</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>options</i>*</span>, <span><a href="xs_double.html">xs:double</a> <i>weight</i>?</span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-json-property-child-geospatial-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:json-property-child-geospatial-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="altColor">
+<tr class="rowColor">
 	    <td class="colFirst">cts:query</td>
 	    <td class="colLast"><span class="memberNameLink">cts:json-property-geospatial-query</span>(<span><a href="xs_string.html">xs:string</a> <i>property-name</i>*</span>, <span><a href="cts_region.html">cts:region</a> <i>region</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>options</i>*</span>, <span><a href="xs_double.html">xs:double</a> <i>weight</i>?</span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-json-property-geospatial-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:json-property-geospatial-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="rowColor">
+<tr class="altColor">
 	    <td class="colFirst">cts:query</td>
 	    <td class="colLast"><span class="memberNameLink">cts:json-property-pair-geospatial-query</span>(<span><a href="xs_string.html">xs:string</a> <i>property-name</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>latitude-name</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>longitude-name</i>*</span>, <span><a href="cts_region.html">cts:region</a> <i>region</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>options</i>*</span>, <span><a href="xs_double.html">xs:double</a> <i>weight</i>?</span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-json-property-pair-geospatial-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:json-property-pair-geospatial-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="altColor">
+<tr class="rowColor">
 	    <td class="colFirst">cts:query</td>
 	    <td class="colLast"><span class="memberNameLink">cts:json-property-range-query</span>(<span><a href="xs_string.html">xs:string</a> <i>property-name</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>operator</i></span>, <span><a href="xs_anyAtomicType.html">xs:anyAtomicType</a> <i>value</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>options</i>*</span>, <span><a href="xs_double.html">xs:double</a> <i>weight</i>?</span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-json-property-range-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:json-property-range-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="rowColor">
+<tr class="altColor">
 	    <td class="colFirst">cts:query</td>
 	    <td class="colLast"><span class="memberNameLink">cts:json-property-scope-query</span>(<span><a href="xs_string.html">xs:string</a> <i>property-name</i>*</span>, <span>cts:query <i>query</i></span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-json-property-scope-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:json-property-scope-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="altColor">
+<tr class="rowColor">
 	    <td class="colFirst">cts:query</td>
 	    <td class="colLast"><span class="memberNameLink">cts:json-property-value-query</span>(<span><a href="xs_string.html">xs:string</a> <i>property-name</i>*</span>, <span><a href="xs_anyAtomicType.html">xs:anyAtomicType</a> <i>value</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>options</i>*</span>, <span><a href="xs_double.html">xs:double</a> <i>weight</i>?</span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-json-property-value-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:json-property-value-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="rowColor">
+<tr class="altColor">
 	    <td class="colFirst">cts:query</td>
 	    <td class="colLast"><span class="memberNameLink">cts:json-property-word-query</span>(<span><a href="xs_string.html">xs:string</a> <i>property-name</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>text</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>options</i>*</span>, <span><a href="xs_double.html">xs:double</a> <i>weight</i>?</span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-json-property-word-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:json-property-word-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="altColor">
+<tr class="rowColor">
 	    <td class="colFirst">cts:query</td>
 	    <td class="colLast"><span class="memberNameLink">cts:locks-fragment-query</span>(<span>cts:query <i>query</i></span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-locks-fragment-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:locks-fragment-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="rowColor">
+<tr class="altColor">
 	    <td class="colFirst">cts:query</td>
 	    <td class="colLast"><span class="memberNameLink">cts:lsqt-query</span>(<span><a href="xs_string.html">xs:string</a> <i>temporal-collection</i></span>, <span><a href="xs_dateTime.html">xs:dateTime</a> <i>timestamp</i>?</span>, <span><a href="xs_string.html">xs:string</a> <i>options</i>*</span>, <span><a href="xs_double.html">xs:double</a> <i>weight</i>?</span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-lsqt-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:lsqt-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="altColor">
+<tr class="rowColor">
 	    <td class="colFirst">cts:query</td>
 	    <td class="colLast"><span class="memberNameLink">cts:near-query</span>(<span>cts:query <i>queries</i>*</span>, <span><a href="xs_double.html">xs:double</a> <i>distance</i>?</span>, <span><a href="xs_string.html">xs:string</a> <i>options</i>*</span>, <span><a href="xs_double.html">xs:double</a> <i>weight</i>?</span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-near-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:near-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="rowColor">
+<tr class="altColor">
 	    <td class="colFirst">cts:query</td>
 	    <td class="colLast"><span class="memberNameLink">cts:not-in-query</span>(<span>cts:query <i>positive-query</i></span>, <span>cts:query <i>negative-query</i></span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-not-in-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:not-in-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="altColor">
+<tr class="rowColor">
 	    <td class="colFirst">cts:query</td>
 	    <td class="colLast"><span class="memberNameLink">cts:not-query</span>(<span>cts:query <i>query</i></span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-not-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:not-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="rowColor">
+<tr class="altColor">
 	    <td class="colFirst">cts:query</td>
 	    <td class="colLast"><span class="memberNameLink">cts:or-query</span>(<span>cts:query <i>queries</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>options</i>*</span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-or-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:or-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="altColor">
+<tr class="rowColor">
 	    <td class="colFirst">cts:query</td>
 	    <td class="colLast"><span class="memberNameLink">cts:path-geospatial-query</span>(<span><a href="xs_string.html">xs:string</a> <i>path-expression</i>*</span>, <span><a href="cts_region.html">cts:region</a> <i>region</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>options</i>*</span>, <span><a href="xs_double.html">xs:double</a> <i>weight</i>?</span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-path-geospatial-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:path-geospatial-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="rowColor">
+<tr class="altColor">
 	    <td class="colFirst">cts:query</td>
 	    <td class="colLast"><span class="memberNameLink">cts:path-range-query</span>(<span><a href="xs_string.html">xs:string</a> <i>path-name</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>operator</i></span>, <span><a href="xs_anyAtomicType.html">xs:anyAtomicType</a> <i>value</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>options</i>*</span>, <span><a href="xs_double.html">xs:double</a> <i>weight</i>?</span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-path-range-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:path-range-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="altColor">
+<tr class="rowColor">
 	    <td class="colFirst">cts:query</td>
 	    <td class="colLast"><span class="memberNameLink">cts:period-compare-query</span>(<span><a href="xs_string.html">xs:string</a> <i>axis-1</i></span>, <span><a href="xs_string.html">xs:string</a> <i>operator</i></span>, <span><a href="xs_string.html">xs:string</a> <i>axis-2</i></span>, <span><a href="xs_string.html">xs:string</a> <i>options</i>*</span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-period-compare-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:period-compare-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="rowColor">
+<tr class="altColor">
 	    <td class="colFirst">cts:query</td>
 	    <td class="colLast"><span class="memberNameLink">cts:period-range-query</span>(<span><a href="xs_string.html">xs:string</a> <i>axis</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>operator</i></span>, <span><a href="cts_period.html">cts:period</a> <i>period</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>options</i>*</span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-period-range-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:period-range-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="altColor">
+<tr class="rowColor">
 	    <td class="colFirst">cts:query</td>
 	    <td class="colLast"><span class="memberNameLink">cts:properties-fragment-query</span>(<span>cts:query <i>query</i></span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-properties-fragment-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:properties-fragment-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="rowColor">
+<tr class="altColor">
 	    <td class="colFirst">cts:query</td>
 	    <td class="colLast"><span class="memberNameLink">cts:range-query</span>(<span><a href="cts_reference.html">cts:reference</a> <i>index</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>operator</i></span>, <span><a href="xs_anyAtomicType.html">xs:anyAtomicType</a> <i>value</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>options</i>*</span>, <span><a href="xs_double.html">xs:double</a> <i>weight</i>?</span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-range-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:range-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="altColor">
+<tr class="rowColor">
 	    <td class="colFirst">cts:query</td>
 	    <td class="colLast"><span class="memberNameLink">cts:triple-range-query</span>(<span><a href="xs_anyAtomicType.html">xs:anyAtomicType</a> <i>subject</i>*</span>, <span><a href="xs_anyAtomicType.html">xs:anyAtomicType</a> <i>predicate</i>*</span>, <span><a href="xs_anyAtomicType.html">xs:anyAtomicType</a> <i>object</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>operator</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>options</i>*</span>, <span><a href="xs_double.html">xs:double</a> <i>weight</i>?</span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-triple-range-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:triple-range-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="rowColor">
+<tr class="altColor">
 	    <td class="colFirst">cts:query</td>
 	    <td class="colLast"><span class="memberNameLink">cts:true-query</span>()</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-true-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:true-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="altColor">
+<tr class="rowColor">
 	    <td class="colFirst">cts:query</td>
 	    <td class="colLast"><span class="memberNameLink">cts:word-query</span>(<span><a href="xs_string.html">xs:string</a> <i>text</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>options</i>*</span>, <span><a href="xs_double.html">xs:double</a> <i>weight</i>?</span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-word-query">java</a></td>

--- a/marklogic-client-api/src/main/javadoc/doc-files/types/xs_QName.html
+++ b/marklogic-client-api/src/main/javadoc/doc-files/types/xs_QName.html
@@ -29,112 +29,106 @@ For all server types, see the <a href="ml-server-type-tree.html">Server Expressi
 	  </tr>
 <tr class="altColor">
 	    <td class="colFirst"><a href="cts_query.html">cts:query</a></td>
-	    <td class="colLast"><span class="memberNameLink">cts:document-root-query</span>(<span>xs:QName <i>root</i></span>)</td>
-	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-document-root-query">java</a></td>
-	    <td><a href="http://docs.marklogic.com/cts:document-root-query" target="mlserverdoc">server</a></td>
-	  </tr>
-<tr class="rowColor">
-	    <td class="colFirst"><a href="cts_query.html">cts:query</a></td>
 	    <td class="colLast"><span class="memberNameLink">cts:element-attribute-pair-geospatial-query</span>(<span>xs:QName <i>element-name</i>*</span>, <span>xs:QName <i>latitude-name</i>*</span>, <span>xs:QName <i>longitude-name</i>*</span>, <span><a href="cts_region.html">cts:region</a> <i>region</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>options</i>*</span>, <span><a href="xs_double.html">xs:double</a> <i>weight</i>?</span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-element-attribute-pair-geospatial-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:element-attribute-pair-geospatial-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="altColor">
+<tr class="rowColor">
 	    <td class="colFirst"><a href="cts_query.html">cts:query</a></td>
 	    <td class="colLast"><span class="memberNameLink">cts:element-attribute-range-query</span>(<span>xs:QName <i>element-name</i>*</span>, <span>xs:QName <i>attribute-name</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>operator</i></span>, <span><a href="xs_anyAtomicType.html">xs:anyAtomicType</a> <i>value</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>options</i>*</span>, <span><a href="xs_double.html">xs:double</a> <i>weight</i>?</span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-element-attribute-range-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:element-attribute-range-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="rowColor">
+<tr class="altColor">
 	    <td class="colFirst"><a href="cts_query.html">cts:query</a></td>
 	    <td class="colLast"><span class="memberNameLink">cts:element-attribute-value-query</span>(<span>xs:QName <i>element-name</i>*</span>, <span>xs:QName <i>attribute-name</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>text</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>options</i>*</span>, <span><a href="xs_double.html">xs:double</a> <i>weight</i>?</span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-element-attribute-value-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:element-attribute-value-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="altColor">
+<tr class="rowColor">
 	    <td class="colFirst"><a href="cts_query.html">cts:query</a></td>
 	    <td class="colLast"><span class="memberNameLink">cts:element-attribute-word-query</span>(<span>xs:QName <i>element-name</i>*</span>, <span>xs:QName <i>attribute-name</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>text</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>options</i>*</span>, <span><a href="xs_double.html">xs:double</a> <i>weight</i>?</span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-element-attribute-word-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:element-attribute-word-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="rowColor">
+<tr class="altColor">
 	    <td class="colFirst"><a href="cts_query.html">cts:query</a></td>
 	    <td class="colLast"><span class="memberNameLink">cts:element-child-geospatial-query</span>(<span>xs:QName <i>element-name</i>*</span>, <span>xs:QName <i>child-name</i>*</span>, <span><a href="cts_region.html">cts:region</a> <i>region</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>options</i>*</span>, <span><a href="xs_double.html">xs:double</a> <i>weight</i>?</span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-element-child-geospatial-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:element-child-geospatial-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="altColor">
+<tr class="rowColor">
 	    <td class="colFirst"><a href="cts_query.html">cts:query</a></td>
 	    <td class="colLast"><span class="memberNameLink">cts:element-geospatial-query</span>(<span>xs:QName <i>element-name</i>*</span>, <span><a href="cts_region.html">cts:region</a> <i>region</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>options</i>*</span>, <span><a href="xs_double.html">xs:double</a> <i>weight</i>?</span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-element-geospatial-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:element-geospatial-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="rowColor">
+<tr class="altColor">
 	    <td class="colFirst"><a href="cts_query.html">cts:query</a></td>
 	    <td class="colLast"><span class="memberNameLink">cts:element-pair-geospatial-query</span>(<span>xs:QName <i>element-name</i>*</span>, <span>xs:QName <i>latitude-name</i>*</span>, <span>xs:QName <i>longitude-name</i>*</span>, <span><a href="cts_region.html">cts:region</a> <i>region</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>options</i>*</span>, <span><a href="xs_double.html">xs:double</a> <i>weight</i>?</span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-element-pair-geospatial-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:element-pair-geospatial-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="altColor">
+<tr class="rowColor">
 	    <td class="colFirst"><a href="cts_query.html">cts:query</a></td>
 	    <td class="colLast"><span class="memberNameLink">cts:element-query</span>(<span>xs:QName <i>element-name</i>*</span>, <span><a href="cts_query.html">cts:query</a> <i>query</i></span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-element-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:element-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="rowColor">
+<tr class="altColor">
 	    <td class="colFirst"><a href="cts_query.html">cts:query</a></td>
 	    <td class="colLast"><span class="memberNameLink">cts:element-range-query</span>(<span>xs:QName <i>element-name</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>operator</i></span>, <span><a href="xs_anyAtomicType.html">xs:anyAtomicType</a> <i>value</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>options</i>*</span>, <span><a href="xs_double.html">xs:double</a> <i>weight</i>?</span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-element-range-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:element-range-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="altColor">
+<tr class="rowColor">
 	    <td class="colFirst"><a href="cts_query.html">cts:query</a></td>
 	    <td class="colLast"><span class="memberNameLink">cts:element-value-query</span>(<span>xs:QName <i>element-name</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>text</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>options</i>*</span>, <span><a href="xs_double.html">xs:double</a> <i>weight</i>?</span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-element-value-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:element-value-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="rowColor">
+<tr class="altColor">
 	    <td class="colFirst"><a href="cts_query.html">cts:query</a></td>
 	    <td class="colLast"><span class="memberNameLink">cts:element-word-query</span>(<span>xs:QName <i>element-name</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>text</i>*</span>, <span><a href="xs_string.html">xs:string</a> <i>options</i>*</span>, <span><a href="xs_double.html">xs:double</a> <i>weight</i>?</span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-element-word-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:element-word-query" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="altColor">
+<tr class="rowColor">
 	    <td class="colFirst"><a href="cts_reference.html">cts:reference</a></td>
 	    <td class="colLast"><span class="memberNameLink">cts:element-attribute-reference</span>(<span>xs:QName <i>element</i></span>, <span>xs:QName <i>attribute</i></span>, <span><a href="xs_string.html">xs:string</a> <i>options</i>*</span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-element-attribute-reference">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:element-attribute-reference" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="rowColor">
+<tr class="altColor">
 	    <td class="colFirst"><a href="cts_reference.html">cts:reference</a></td>
 	    <td class="colLast"><span class="memberNameLink">cts:element-reference</span>(<span>xs:QName <i>element</i></span>, <span><a href="xs_string.html">xs:string</a> <i>options</i>*</span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-element-reference">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:element-reference" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="altColor">
+<tr class="rowColor">
 	    <td class="colFirst"><a href="xs_NCName.html">xs:NCName</a>?</td>
 	    <td class="colLast"><span class="memberNameLink">fn:local-name-from-QName</span>(<span>xs:QName <i>arg</i>?</span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/FnExpr.html#ml-server-type-local-name-from-QName">java</a></td>
 	    <td><a href="http://docs.marklogic.com/fn:local-name-from-QName" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="rowColor">
+<tr class="altColor">
 	    <td class="colFirst"><a href="xs_anyURI.html">xs:anyURI</a>?</td>
 	    <td class="colLast"><span class="memberNameLink">fn:namespace-uri-from-QName</span>(<span>xs:QName <i>arg</i>?</span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/FnExpr.html#ml-server-type-namespace-uri-from-QName">java</a></td>
 	    <td><a href="http://docs.marklogic.com/fn:namespace-uri-from-QName" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="altColor">
+<tr class="rowColor">
 	    <td class="colFirst"><a href="xs_NCName.html">xs:NCName</a>?</td>
 	    <td class="colLast"><span class="memberNameLink">fn:prefix-from-QName</span>(<span>xs:QName <i>arg</i>?</span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/FnExpr.html#ml-server-type-prefix-from-QName">java</a></td>
 	    <td><a href="http://docs.marklogic.com/fn:prefix-from-QName" target="mlserverdoc">server</a></td>
 	  </tr>
-<tr class="rowColor">
+<tr class="altColor">
 	    <td class="colFirst"><a href="sem_iri.html">sem:iri</a></td>
 	    <td class="colLast"><span class="memberNameLink">sem:QName-to-iri</span>(<span>xs:QName <i>arg1</i></span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/SemExpr.html#ml-server-type-QName-to-iri">java</a></td>
 	  </tr>
-<tr class="altColor">
+<tr class="rowColor">
 	    <td class="colFirst"><a href="xs_string.html">xs:string</a></td>
 	    <td class="colLast"><span class="memberNameLink">xdmp:key-from-QName</span>(<span>xs:QName <i>name</i></span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/XdmpExpr.html#ml-server-type-key-from-QName">java</a></td>

--- a/marklogic-client-api/src/main/javadoc/doc-files/types/xs_string.html
+++ b/marklogic-client-api/src/main/javadoc/doc-files/types/xs_string.html
@@ -74,18 +74,6 @@ For all server types, see the <a href="ml-server-type-tree.html">Server Expressi
 	  </tr>
 <tr class="rowColor">
 	    <td class="colFirst"><a href="cts_query.html">cts:query</a></td>
-	    <td class="colLast"><span class="memberNameLink">cts:document-format-query</span>(<span>xs:string <i>format</i></span>)</td>
-	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-document-format-query">java</a></td>
-	    <td><a href="http://docs.marklogic.com/cts:document-format-query" target="mlserverdoc">server</a></td>
-	  </tr>
-<tr class="altColor">
-	    <td class="colFirst"><a href="cts_query.html">cts:query</a></td>
-	    <td class="colLast"><span class="memberNameLink">cts:document-permission-query</span>(<span>xs:string <i>role</i></span>, <span>xs:string <i>capability</i></span>)</td>
-	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-document-permission-query">java</a></td>
-	    <td><a href="http://docs.marklogic.com/cts:document-permission-query" target="mlserverdoc">server</a></td>
-	  </tr>
-<tr class="rowColor">
-	    <td class="colFirst"><a href="cts_query.html">cts:query</a></td>
 	    <td class="colLast"><span class="memberNameLink">cts:document-query</span>(<span>xs:string <i>uris</i>*</span>)</td>
 	    <td><a href="../../com/marklogic/client/expression/CtsExpr.html#ml-server-type-document-query">java</a></td>
 	    <td><a href="http://docs.marklogic.com/cts:document-query" target="mlserverdoc">server</a></td>

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/PlanGeneratedTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/PlanGeneratedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 MarkLogic Corporation
+ * Copyright (c) 2024 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 
 package com.marklogic.client.test;
+
+import org.junit.Test;
 
 import com.marklogic.client.io.Format;
 import com.marklogic.client.test.junit5.RequiresML11;
@@ -211,17 +213,17 @@ public class PlanGeneratedTest extends PlanGeneratedBase {
 
     @Test
     public void testFnCurrentDate0Exec() {
-        executeTester("testFnCurrentDate0", p.fn.currentDate(), true, "xs:date", null, null, "2023-10-24Z", new ServerExpression[]{  });
+        executeTester("testFnCurrentDate0", p.fn.currentDate(), true, "xs:date", null, null, "2024-03-29Z", new ServerExpression[]{  });
     }
 
     @Test
     public void testFnCurrentDateTime0Exec() {
-        executeTester("testFnCurrentDateTime0", p.fn.currentDateTime(), true, "xs:dateTime", null, null, "2023-10-24T15:21:06.255777Z", new ServerExpression[]{  });
+        executeTester("testFnCurrentDateTime0", p.fn.currentDateTime(), true, "xs:dateTime", null, null, "2024-03-29T15:55:38.802425Z", new ServerExpression[]{  });
     }
 
     @Test
     public void testFnCurrentTime0Exec() {
-        executeTester("testFnCurrentTime0", p.fn.currentTime(), true, "xs:time", null, null, "15:21:06Z", new ServerExpression[]{  });
+        executeTester("testFnCurrentTime0", p.fn.currentTime(), true, "xs:time", null, null, "15:55:38Z", new ServerExpression[]{  });
     }
 
     @Test
@@ -734,7 +736,7 @@ public class PlanGeneratedTest extends PlanGeneratedBase {
     @Test
 	@ExtendWith(RequiresML11.class)
     public void testGeoGeohashDecode1Exec() {
-		executeTester("testGeoGeohashDecode1", p.geo.geohashDecode(p.col("1")), false, "cts:box", null, null, "[-90, -180, 90, 180]", new ServerExpression[]{p.xs.string("abc")});
+        executeTester("testGeoGeohashDecode1", p.geo.geohashDecode(p.col("1")), false, "cts:box", null, null, "[-90, -180, 90, 180]", new ServerExpression[]{ p.xs.string("abc") });
     }
 
     @Test
@@ -1011,7 +1013,7 @@ public class PlanGeneratedTest extends PlanGeneratedBase {
 
     @Test
     public void testSemBnode0Exec() {
-        executeTester("testSemBnode0", p.sem.bnode(), true, "sem:blank", null, null, "_:bnode801272998575329659", new ServerExpression[]{  });
+        executeTester("testSemBnode0", p.sem.bnode(), true, "sem:blank", null, null, "_:bnode17537304856629809111", new ServerExpression[]{  });
     }
 
     @Test
@@ -1091,7 +1093,7 @@ public class PlanGeneratedTest extends PlanGeneratedBase {
 
     @Test
     public void testSemRandom0Exec() {
-        executeTester("testSemRandom0", p.sem.random(), true, null, null, null, "0.996817928554708", new ServerExpression[]{  });
+        executeTester("testSemRandom0", p.sem.random(), true, null, null, null, "0.298222040655036", new ServerExpression[]{  });
     }
 
     @Test
@@ -1116,12 +1118,12 @@ public class PlanGeneratedTest extends PlanGeneratedBase {
 
     @Test
     public void testSemUuid0Exec() {
-        executeTester("testSemUuid0", p.sem.uuid(), true, "sem:iri", null, null, "urn:uuid:c04549cf-e759-4190-bb96-8a0efaa4fcff", new ServerExpression[]{  });
+        executeTester("testSemUuid0", p.sem.uuid(), true, "sem:iri", null, null, "urn:uuid:60ab3fd4-1510-4549-b288-a9425510a6e0", new ServerExpression[]{  });
     }
 
     @Test
     public void testSemUuidString0Exec() {
-        executeTester("testSemUuidString0", p.sem.uuidString(), true, null, null, null, "32351923-7f22-4a3f-9e92-884151190ee8", new ServerExpression[]{  });
+        executeTester("testSemUuidString0", p.sem.uuidString(), true, null, null, null, "34fcd935-f4c3-49cd-940e-c5b1077ed0f2", new ServerExpression[]{  });
     }
 
     @Test
@@ -1256,7 +1258,7 @@ public class PlanGeneratedTest extends PlanGeneratedBase {
 
     @Test
     public void testSqlRand1Exec() {
-        executeTester("testSqlRand1", p.sql.rand(p.col("1")), true, "xs:unsignedLong", null, null, "1308547733197903283", new ServerExpression[]{ p.xs.unsignedLong(1) });
+        executeTester("testSqlRand1", p.sql.rand(p.col("1")), true, "xs:unsignedLong", null, null, "16821889242025875046", new ServerExpression[]{ p.xs.unsignedLong(1) });
     }
 
     @Test
@@ -1361,7 +1363,7 @@ public class PlanGeneratedTest extends PlanGeneratedBase {
 
     @Test
     public void testXdmpCrypt21Exec() {
-        executeTester("testXdmpCrypt21", p.xdmp.crypt2(p.col("1")), true, null, null, null, "$256$Byph9.Mc3xqzhgeH.IAJh/$256$nAr3j1jWo/Wf2yN7", new ServerExpression[]{ p.xs.string("abc") });
+        executeTester("testXdmpCrypt21", p.xdmp.crypt2(p.col("1")), true, null, null, null, "$256$o48F43fy9v7BGQI9gmP2l/$256$3saYwHyLNg4jkPLJ", new ServerExpression[]{ p.xs.string("abc") });
     }
 
     @Test
@@ -1591,7 +1593,7 @@ public class PlanGeneratedTest extends PlanGeneratedBase {
 
     @Test
     public void testXdmpRandom0Exec() {
-        executeTester("testXdmpRandom0", p.xdmp.random(), true, "xs:unsignedLong", null, null, "7692759001122562087", new ServerExpression[]{  });
+        executeTester("testXdmpRandom0", p.xdmp.random(), true, "xs:unsignedLong", null, null, "6870814397274692798", new ServerExpression[]{  });
     }
 
     @Test
@@ -1672,7 +1674,7 @@ public class PlanGeneratedTest extends PlanGeneratedBase {
     @Test
 	@ExtendWith(RequiresML11.class)
     public void testXdmpUnquote1Exec() {
-		executeTester("testXdmpUnquote1", p.xdmp.unquote(p.col("1")), false, null, "array", Format.JSON, "[123]", new ServerExpression[]{p.xs.string("[123]")});
+        executeTester("testXdmpUnquote1", p.xdmp.unquote(p.col("1")), false, null, "array", Format.JSON, "[123]", new ServerExpression[]{ p.xs.string("[123]") });
     }
 
     @Test


### PR DESCRIPTION
1)	Several functions were removed from CtsExpr.java and CtsExprImpl.java (or not generated this time). Are these changes correct?
a.	public CtsQueryExpr documentFormatQuery(String format);
b.	public CtsQueryExpr documentFormatQuery(ServerExpression format);
c.	public CtsQueryExpr documentPermissionQuery(String role, String capability);
d.	public CtsQueryExpr documentPermissionQuery(ServerExpression role, ServerExpression capability);
e.	public CtsQueryExpr documentRootQuery(String root);
f.	public CtsQueryExpr documentRootQuery(ServerExpression root);
2)	Two functions were removed from PlanBuilderImpl.java. Are these changes correct?
a.	public ModifyPlan joinDocAndUri(String docCol, String uriCol, String sourceCol) 
b.	public ModifyPlan joinDocAndUri(PlanColumn docCol, PlanColumn uriCol, PlanColumn sourceCol)
3)	PlanBuilderImpl.java and PlanBuilder.java both have compile issues due to unresolved symbols
a.	PlanPatchBuilderPlan
b.	PlanPatchBuilderPlanSeq
c.	Node
d.	Item
