### PR TITLE
MLE-13719 Turning down some logging

### DIFF
--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/WriteBatcherImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/WriteBatcherImpl.java
@@ -185,8 +185,10 @@ public class WriteBatcherImpl
 
       initialized = true;
 
-      logger.info("threadCount={}", getThreadCount());
-      logger.info("batchSize={}", getBatchSize());
+	  if (logger.isDebugEnabled()) {
+		  logger.debug("threadCount={}", getThreadCount());
+		  logger.debug("batchSize={}", getBatchSize());
+	  }
       super.setJobStartTime();
       super.getStarted().set(true);
     }
@@ -397,7 +399,9 @@ public class WriteBatcherImpl
     List<DocumentWriteOperation> docs = new ArrayList<>();
     batchCounter.set(0);
     queue.drainTo(docs);
-    logger.info("flushing {} queued docs", docs.size());
+	if (logger.isTraceEnabled()) {
+		logger.trace("flushing {} queued docs", docs.size());
+	}
     Iterator<DocumentWriteOperation> iter = docs.iterator();
     for ( int i=0; iter.hasNext(); i++ ) {
       if ( isStopped() == true ) {


### PR DESCRIPTION
Ticket was about the "flushing queued docs" and info being way too noisy. Turned that to "trace" because it really is not important. Also turned down logging of threadCount/batchSize to the more appropriate debug level. 