### PR TITLE
MLE-13451 GenericDocumentManager now provides temporal methods

### DIFF
--- a/marklogic-client-api/src/main/java/com/marklogic/client/document/GenericDocumentManager.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/document/GenericDocumentManager.java
@@ -15,11 +15,17 @@
  */
 package com.marklogic.client.document;
 
+import com.marklogic.client.bitemporal.TemporalDocumentManager;
 import com.marklogic.client.io.marker.GenericReadHandle;
 import com.marklogic.client.io.marker.GenericWriteHandle;
 
 /**
  * A Generic Document Manager supports database operations on documents with an unknown format.
+ *
+ * As of the 6.6.0 release, this now extends {@code TemporalDocumentManager}, which has long been possible since the
+ * one implementation of this interface - {@code GenericDocumentImpl} - already implements the methods in the temporal
+ * interface.
  */
-public interface GenericDocumentManager extends DocumentManager<GenericReadHandle, GenericWriteHandle> {
+public interface GenericDocumentManager extends DocumentManager<GenericReadHandle, GenericWriteHandle>,
+	TemporalDocumentManager<GenericReadHandle, GenericWriteHandle> {
 }


### PR DESCRIPTION
This has long been possible due to the sole implementation of GenericDocumentManager already implementing TemporalDocumentManager. Exposing this makes life simpler for connectors - particularly our Spark connector - by allowing them to depend on `GenericDocumentManager` for temporal operations instead of requiring either a JSON or XML document manager. 