### PR TITLE
Fixing bug where a 'naked' properties fragment cannot be written

### DIFF
--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/datamovement/QueryBatcherJobReportTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/datamovement/QueryBatcherJobReportTest.java
@@ -37,7 +37,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -189,10 +188,9 @@ public class QueryBatcherJobReportTest extends AbstractFunctionalTest {
 	}
 
 	@Test
-	public void testNullQdef() throws IOException, InterruptedException {
+	public void testNullQdef() {
 		System.out.println("In testNullQdef method");
 		JsonNode node = null;
-		JacksonHandle jacksonHandle = null;
 
 		WriteBatcher wbatcher = dmManager.newWriteBatcher().withBatchSize(32).withThreadCount(20);
 		try {
@@ -203,19 +201,7 @@ public class QueryBatcherJobReportTest extends AbstractFunctionalTest {
 		}
 
 		try {
-			wbatcher.add("/nulldoc", jacksonHandle);
-			fail("Exception was not thrown, when it should have been");
-		} catch (IllegalArgumentException e) {
-			assertTrue(e.getMessage().equals("contentHandle must not be null"));
-		}
-
-		QueryManager queryMgr = dbClient.newQueryManager();
-		StringQueryDefinition querydef = queryMgr.newStringDefinition();
-
-		querydef = null;
-
-		try {
-			QueryBatcher batcher = dmManager.newQueryBatcher(querydef).withBatchSize(32).withThreadCount(20);
+			dmManager.newQueryBatcher((StringQueryDefinition) null).withBatchSize(32).withThreadCount(20);
 			fail("Exception was not thrown, when it should have been");
 		} catch (IllegalArgumentException e) {
 			assertTrue(e.getMessage().equals("query must not be null"));

--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/WriteBatcherImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/WriteBatcherImpl.java
@@ -207,8 +207,9 @@ public class WriteBatcherImpl
 
   @Override
   public WriteBatcher add(DocumentWriteOperation writeOperation) {
-    if ( writeOperation.getUri() == null ) throw new IllegalArgumentException("uri must not be null");
-    if ( writeOperation.getContent() == null ) throw new IllegalArgumentException("contentHandle must not be null");
+	  if (writeOperation.getUri() == null) throw new IllegalArgumentException("uri must not be null");
+	  // Prior to 6.6.1 and higher, threw an exception here if the content was null. But that was not necessary - the
+	  // v1/documents endpoint supports writing a 'naked' properties fragment with no content.
     initialize();
     requireNotStopped();
     queue.add(writeOperation);

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/WriteNakedPropertiesTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/WriteNakedPropertiesTest.java
@@ -1,0 +1,45 @@
+package com.marklogic.client.test.datamovement;
+
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.datamovement.DataMovementManager;
+import com.marklogic.client.datamovement.WriteBatcher;
+import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.client.test.Common;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.xml.namespace.QName;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class WriteNakedPropertiesTest {
+
+	@BeforeEach
+	void setup() {
+		Common.newRestAdminClient().newXMLDocumentManager().delete("/naked.xml");
+	}
+
+	@Test
+	void test() {
+		DatabaseClient client = Common.newClient();
+		DataMovementManager dmm = client.newDataMovementManager();
+		WriteBatcher writeBatcher = dmm.newWriteBatcher();
+		dmm.startJob(writeBatcher);
+
+		DocumentMetadataHandle metadata = new DocumentMetadataHandle();
+		metadata.getProperties().put(new QName("org:example", "hello"), "world");
+		writeBatcher.add("/naked.xml", metadata, null);
+		writeBatcher.flushAndWait();
+		dmm.stopJob(writeBatcher);
+
+		DatabaseClient evalClient = Common.newEvalClient();
+		String properties = evalClient.newServerEval()
+			.xquery("xdmp:document-properties('/naked.xml')").evalAs(String.class);
+		assertTrue(properties.contains("world"), "Should be able to read the 'naked' properties fragment, " +
+			"which verifies that it was written correctly, even with the content handle being null.");
+
+		String output = evalClient.newServerEval().xquery("fn:doc-available('/naked.xml')").evalAs(String.class);
+		assertEquals("false", output, "No document exists, only a properties fragment.");
+	}
+}


### PR DESCRIPTION
The check on content being null was overly restrictive, as v1/documents allows for null content. This may cause some other DMSDK test to fail, in which case that test will be modified as null content is allowable here. 