### PR TITLE
Bumping Gradle wrapper to version 8

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/marklogic-client-api/build.gradle
+++ b/marklogic-client-api/build.gradle
@@ -2,7 +2,6 @@
 
 plugins {
     id 'maven-publish'
-    id 'distribution'
 }
 
 group = 'com.marklogic'
@@ -81,7 +80,7 @@ jar {
     )
 }
 task sourcesJar(type: Jar) {
-    classifier = 'sources'
+    archiveClassifier = 'sources'
     exclude ('property', '*.xsd', '*.xjb')
     from sourceSets.main.allSource
 }
@@ -109,9 +108,9 @@ javadoc {
     }
 }
 
-task javadocJar (type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
-    from javadoc.destinationDir
+task javadocJar(type: Jar, dependsOn: javadoc) {
+	archiveClassifier = 'javadoc'
+	from javadoc.destinationDir
 }
 
 Node pomCustomizations = new NodeBuilder(). project {
@@ -176,47 +175,6 @@ publishing {
                 }
             }
             url publishUrl
-        }
-    }
-}
-
-distZip {
-    archiveFileName = "$project.name-$rootProject.version-with-dependencies.zip"
-    dependsOn javadoc
-}
-
-distributions {
-    main {
-        contents {
-            from("..") {
-                include("NOTICE.TXT")
-            }
-            from("src/main/resources") {
-                include ("Readme.txt")
-                include ("LICENSE.txt")
-            }
-            into ("example") {
-                from ("../examples/src/main/resources") {
-                    include ("data/**")
-                    include ("scripts/**")
-                    include ("Example.properties")
-                }
-                from ("../examples/src/main/resources/example") {
-                    include ("README.txt")
-                }
-                from ("../examples/src/main/java/") {
-                    include ("com/marklogic/client/example/cookbook/*.java")
-                    include ("com/marklogic/client/example/handle/*.java")
-                    include ("com/marklogic/client/example/extension/*.java")
-                }
-            }
-            into ("doc/api") {
-                from ("build/docs/javadoc")
-            }
-            into("lib") {
-                from jar
-                from(project.configurations.runtimeClasspath)
-            }
         }
     }
 }

--- a/ml-development-tools/build.gradle
+++ b/ml-development-tools/build.gradle
@@ -1,11 +1,11 @@
 // Copyright (c) 2022 MarkLogic Corporation
 
 plugins {
-    id "groovy"
-    id 'maven-publish'
-    id 'com.gradle.plugin-publish' version '1.0.0'
-    id 'java-gradle-plugin'
-    id 'org.jetbrains.kotlin.jvm'  version '1.8.22'
+	id "groovy"
+	id 'maven-publish'
+	id "com.gradle.plugin-publish" version "1.2.1"
+	id "java-gradle-plugin"
+	id 'org.jetbrains.kotlin.jvm' version '1.8.22'
 }
 
 dependencies {
@@ -27,39 +27,36 @@ dependencies {
 // Added to avoid problem where processResources fails because - somehow - the plugin properties file is getting
 // copied twice. This started occurring with the upgrade of Gradle from 6.x to 7.x.
 tasks.processResources {
-    duplicatesStrategy = "exclude"
+	duplicatesStrategy = "exclude"
 }
 
 task mlDevelopmentToolsJar(type: Jar, dependsOn: classes) {
-    archivesBaseName = 'ml-development-tools'
-}
-
-pluginBundle {
-    website = 'https://github.com/marklogic/java-client-api'
-    vcsUrl = 'https://github.com/marklogic/java-client-api.git'
-    tags = ['marklogic']
+	archivesBaseName = 'ml-development-tools'
 }
 
 gradlePlugin {
-    plugins {
-        mlDevelopmentToolsPlugin {
-            id = 'com.marklogic.ml-development-tools'
-            implementationClass = 'com.marklogic.client.tools.gradle.ToolsPlugin'
-            displayName = 'ml-development-tools MarkLogic Data Service Tools'
-            description = 'ml-development-tools plugin for developing data services on MarkLogic'
-        }
-    }
+	website = 'https://www.marklogic.com/'
+	vcsUrl = 'https://github.com/marklogic/java-client-api.git'
+	plugins {
+		mlDevelopmentToolsPlugin {
+			id = 'com.marklogic.ml-development-tools'
+			displayName = 'ml-development-tools MarkLogic Data Service Tools'
+			description = 'ml-development-tools plugin for developing data services on MarkLogic'
+			tags.set(['marklogic', 'progress'])
+			implementationClass = 'com.marklogic.client.tools.gradle.ToolsPlugin'
+		}
+	}
 }
 
 publishing {
-    publications {
-        main(MavenPublication) {
-            from components.java
-        }
-    }
-	 repositories {
+	publications {
+		main(MavenPublication) {
+			from components.java
+		}
+	}
+	repositories {
 		maven {
-			if(project.hasProperty("mavenUser")) {
+			if (project.hasProperty("mavenUser")) {
 				credentials {
 					username mavenUser
 					password mavenPassword
@@ -71,16 +68,16 @@ publishing {
 }
 
 compileKotlin {
-    kotlinOptions.jvmTarget = '1.8'
+	kotlinOptions.jvmTarget = '1.8'
 }
 compileTestKotlin {
-    kotlinOptions.jvmTarget = '1.8'
+	kotlinOptions.jvmTarget = '1.8'
 }
 
 task generateTests(type: JavaExec) {
-    classpath = sourceSets.test.runtimeClasspath
-    main = 'com.marklogic.client.test.dbfunction.FntestgenKt'
-    args = [ './src/test/', 'latest' ]
+	classpath = sourceSets.test.runtimeClasspath
+	main = 'com.marklogic.client.test.dbfunction.FntestgenKt'
+	args = ['./src/test/', 'latest']
 }
 
 // Allows running "./gradlew test" without having to remember to generate the tests first.

--- a/test-app/build.gradle
+++ b/test-app/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'com.marklogic.ml-gradle' version '4.6.1'
+	id 'com.marklogic.ml-gradle' version '4.7.0'
 	id 'java'
 	id "com.github.psxpaul.execfork" version "0.2.2"
 }


### PR DESCRIPTION
This will make supporting Java 21 easier, and also includes a few updates based on deprecated Gradle stuff. 

Also removed the "dist" stuff from marklogic-client-api. AFAICT, we have not updated nor published this zip in a long time. It seems intended for someone to download and have a local copy of the examples and javadocs. It causes issues with Gradle 8, so removing since we haven't used this in a long time. 