### PR TITLE
Fixing thread pool size test failures

### DIFF
--- a/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/QueryBatcherImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/datamovement/impl/QueryBatcherImpl.java
@@ -368,9 +368,15 @@ public class QueryBatcherImpl extends BatcherImpl implements QueryBatcher {
       throw new IllegalArgumentException("threadCount must be 1 or greater");
     }
 	if (threadPool != null) {
-		logger.info("Adjusting thread pool size from {} to {}", getThreadCount(), threadCount);
-		threadPool.setCorePoolSize(threadCount);
-		threadPool.setMaximumPoolSize(threadCount);
+		int currentThreadCount = getThreadCount();
+		logger.info("Adjusting thread pool size from {} to {}", currentThreadCount, threadCount);
+		if (threadCount >= currentThreadCount) {
+			threadPool.setMaximumPoolSize(threadCount);
+			threadPool.setCorePoolSize(threadCount);
+		} else {
+			threadPool.setCorePoolSize(threadCount);
+			threadPool.setMaximumPoolSize(threadCount);
+		}
 	} else {
 		threadCountSet = true;
 	}


### PR DESCRIPTION
Since the Jenkinsfile was mistakenly not using later Java versions correctly, this issue went undetected. The tests pass fine on Java 8, but 11 and higher require the core/max thread pool sizes to be adjusted in a specific order. 