### PR TITLE
Removing invalid JAX-RS file

### DIFF
--- a/marklogic-client-api/src/main/resources/META-INF/services/javax.ws.rs.ext.RuntimeDelegate
+++ b/marklogic-client-api/src/main/resources/META-INF/services/javax.ws.rs.ext.RuntimeDelegate
@@ -1,1 +1,0 @@
-com.marklogic.client.impl.MockRuntimeDelegate


### PR DESCRIPTION
No idea why this was ever included in src/main . Will move it to src/test if it turns out any tests expect it to exist, but that is very unlikely since `MockRuntimeDelegate` does not exist anywhere. 