### PR TITLE
Can now use search options in ML12 for BM25, Zero, and Random.

### DIFF
--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/PlanBuilderBaseImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/PlanBuilderBaseImpl.java
@@ -61,49 +61,65 @@ abstract class PlanBuilderBaseImpl extends PlanBuilder {
 
   static class PlanSearchOptionsImpl implements PlanSearchOptions {
     private PlanBuilderBaseImpl pb;
-    private XsDoubleVal qualityWeight;
+    private XsFloatVal qualityWeight;
     private ScoreMethod scoreMethod;
+	private XsDoubleVal bm25LengthWeight;
     PlanSearchOptionsImpl(PlanBuilderBaseImpl pb) {
       this.pb = pb;
     }
-    PlanSearchOptionsImpl(PlanBuilderBaseImpl pb, XsDoubleVal qualityWeight, ScoreMethod scoreMethod) {
-      this(pb);
-      this.qualityWeight = qualityWeight;
-      this.scoreMethod   = scoreMethod;
-    }
+	PlanSearchOptionsImpl(PlanBuilderBaseImpl pb, XsFloatVal qualityWeight,
+						  ScoreMethod scoreMethod, XsDoubleVal bm25LengthWeight) {
+		  this(pb);
+		  this.qualityWeight = qualityWeight;
+		  this.scoreMethod   = scoreMethod;
+		  this.bm25LengthWeight = bm25LengthWeight;
+	}
 
     @Override
-    public XsDoubleVal getQualityWeight() {
+    public XsFloatVal getQualityWeight() {
       return qualityWeight;
     }
     @Override
     public ScoreMethod getScoreMethod() {
       return scoreMethod;
     }
+	@Override
+	public XsDoubleVal getBm25LengthWeight() {
+		  return bm25LengthWeight;
+	  }
     @Override
-    public PlanSearchOptions withQualityWeight(double qualityWeight) {
-      return withQualityWeight(pb.xs.doubleVal(qualityWeight));
+    public PlanSearchOptions withQualityWeight(float qualityWeight) {
+      return withQualityWeight(pb.xs.floatVal(qualityWeight));
     }
     @Override
-    public PlanSearchOptions withQualityWeight(XsDoubleVal qualityWeight) {
-      return new PlanSearchOptionsImpl(pb, qualityWeight, getScoreMethod());
+    public PlanSearchOptions withQualityWeight(XsFloatVal qualityWeight) {
+      return new PlanSearchOptionsImpl(pb, qualityWeight, getScoreMethod(), getBm25LengthWeight());
     }
     @Override
     public PlanSearchOptions withScoreMethod(ScoreMethod scoreMethod) {
-      return new PlanSearchOptionsImpl(pb, getQualityWeight(), scoreMethod);
+      return new PlanSearchOptionsImpl(pb, getQualityWeight(), scoreMethod, getBm25LengthWeight());
     }
-    Map<String,String> makeMap() {
-      if (qualityWeight == null && scoreMethod == null) return null;
 
-      Map<String, String> map = new HashMap<String, String>();
-      if (qualityWeight != null) {
-        map.put("qualityWeight", String.valueOf(qualityWeight));
-      }
-      if (scoreMethod != null) {
-        map.put("scoreMethod", scoreMethod.name().toLowerCase());
-      }
-      return map;
-    }
+	  @Override
+	  public PlanSearchOptions withBm25LengthWeight(double bm25LengthWeight) {
+		  return new PlanSearchOptionsImpl(pb, getQualityWeight(), getScoreMethod(), pb.xs.doubleVal(bm25LengthWeight));
+	  }
+
+	  Map<String,Object> makeMap() {
+	      if (qualityWeight == null && scoreMethod == null && bm25LengthWeight == null) return null;
+
+	      Map<String, Object> map = new HashMap<>();
+    	  if (qualityWeight != null) {
+			  map.put("qualityWeight", qualityWeight);
+		  }
+		  if (scoreMethod != null) {
+			  map.put("scoreMethod", scoreMethod.name().toLowerCase());
+		  }
+		  if (bm25LengthWeight != null) {
+			  map.put("bm25LengthWeight", bm25LengthWeight);
+		  }
+		  return map;
+	}
   }
 
   static class PlanParamBase extends BaseTypeImpl.BaseCallImpl<XsValueImpl.StringValImpl> implements PlanParamExpr {

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/PlanBuilderSubImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/PlanBuilderSubImpl.java
@@ -675,7 +675,7 @@ public class PlanBuilderSubImpl extends PlanBuilderImpl {
     }
   }
 
-  static Map<String,String> makeMap(PlanSearchOptions options) {
+  static Map<String,Object> makeMap(PlanSearchOptions options) {
     if (options == null) {
       return null;
     }

--- a/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanSearchOptions.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/type/PlanSearchOptions.java
@@ -15,19 +15,34 @@
  */
 package com.marklogic.client.type;
 
-// IMPORTANT: Do not edit. This file is generated.
-
 /**
  * An option controlling the scoring and weighting of fromSearch()
  * for a row pipeline.
  */
 public interface PlanSearchOptions {
-    XsDoubleVal getQualityWeight();
+	/**
+	 * Changed in release 6.7.0 to return a float, as the server requires a float and throws an error on a double.
+	 */
+	XsFloatVal getQualityWeight();
     ScoreMethod getScoreMethod();
-    PlanSearchOptions withQualityWeight(double qualityWeight);
-    PlanSearchOptions withQualityWeight(XsDoubleVal qualityWeight);
+	/**
+	 * @since 6.7.0
+	 */
+	XsDoubleVal getBm25LengthWeight();
+	/**
+	 * Changed in release 6.7.0 to return a float, as the server requires a float and throws an error on a double.
+	 */
+    PlanSearchOptions withQualityWeight(float qualityWeight);
+	/**
+	 * Changed in release 6.7.0 to return a float, as the server requires a float and throws an error on a double.
+	 */
+    PlanSearchOptions withQualityWeight(XsFloatVal qualityWeight);
     PlanSearchOptions withScoreMethod(ScoreMethod scoreMethod);
+	/**
+	 * @since 6.7.0
+	 */
+	PlanSearchOptions withBm25LengthWeight(double bm25LengthWeight);
     enum ScoreMethod {
-        LOGTFIDF, LOGTF, SIMPLE;
+        LOGTFIDF, LOGTF, SIMPLE, BM25, ZERO, RANDOM;
     }
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/junit5/RequiresML12.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/junit5/RequiresML12.java
@@ -1,0 +1,22 @@
+package com.marklogic.client.test.junit5;
+
+import com.marklogic.client.test.Common;
+import com.marklogic.client.test.MarkLogicVersion;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class RequiresML12 implements ExecutionCondition {
+
+	private static MarkLogicVersion markLogicVersion;
+
+	@Override
+	public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+		if (markLogicVersion == null) {
+			markLogicVersion = Common.getMarkLogicVersion();
+		}
+		return markLogicVersion.getMajor() >= 12 ?
+			ConditionEvaluationResult.enabled("MarkLogic is version 12 or higher") :
+			ConditionEvaluationResult.disabled("MarkLogic is version 11 or lower");
+	}
+}

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/FromSearchWithOptionsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/FromSearchWithOptionsTest.java
@@ -1,0 +1,73 @@
+package com.marklogic.client.test.rows;
+
+import com.marklogic.client.FailedRequestException;
+import com.marklogic.client.expression.PlanBuilder;
+import com.marklogic.client.row.RowRecord;
+import com.marklogic.client.test.junit5.RequiresML12;
+import com.marklogic.client.type.PlanSearchOptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(RequiresML12.class)
+class FromSearchWithOptionsTest extends AbstractOpticUpdateTest {
+
+	@Test
+	void bm25() {
+//		Note that this does not actually test that the scoring is correct.
+//		It only tests that including the BM25 scoring option and a valid bm25LengthWeight do not cause any problems.
+		rowManager.withUpdate(false);
+		PlanSearchOptions options = op.searchOptions()
+			.withScoreMethod(PlanSearchOptions.ScoreMethod.BM25)
+			.withBm25LengthWeight(0.25);
+		List<RowRecord> rows = resultRows(
+			op.fromSearch(op.cts.wordQuery("contents"), null, null, options)
+				.offsetLimit(0, 5)
+		);
+		assertEquals(5, rows.size());
+	}
+
+	@Test
+	void badBm25LengthWeight() {
+		rowManager.withUpdate(false);
+		PlanSearchOptions options = op.searchOptions()
+			.withScoreMethod(PlanSearchOptions.ScoreMethod.BM25)
+			.withBm25LengthWeight(99);
+		PlanBuilder.ModifyPlan plan = op.fromSearch(op.cts.wordQuery("contents"), null, null, options)
+			.offsetLimit(0, 5);
+		Exception exception = assertThrows(FailedRequestException.class, () -> resultRows(plan));
+		String actualMessage = exception.getMessage();
+		assertTrue(actualMessage.contains("Server Message: XDMP-OPTION"));
+		assertTrue(actualMessage.contains("Invalid option \"bm25-length-weight"));
+	}
+
+	@Test
+	void zero() {
+		rowManager.withUpdate(false);
+		PlanSearchOptions options = op.searchOptions().withScoreMethod(PlanSearchOptions.ScoreMethod.ZERO);
+		List<RowRecord> rows = resultRows(
+			op.fromSearch(op.cts.wordQuery("contents"), null, null, options)
+				.offsetLimit(0, 5)
+		);
+		assertEquals(5, rows.size());
+		rows.forEach(row -> {
+			assertEquals(0, row.getInt("score"), "The score for every row should be 0.");
+		});
+	}
+
+	@Test
+	void qualityWeight() {
+//		Note that this does not actually test that the scoring is correct.
+//		It only tests that including a valid qualityWeight value does not cause any problems.
+		rowManager.withUpdate(false);
+		PlanSearchOptions options = op.searchOptions().withScoreMethod(PlanSearchOptions.ScoreMethod.LOGTFIDF).withQualityWeight(0.75F);
+		List<RowRecord> rows = resultRows(
+			op.fromSearch(op.cts.wordQuery("contents"), null, null, options)
+				.offsetLimit(0, 5)
+		);
+		assertEquals(5, rows.size());
+	}
+}


### PR DESCRIPTION
Also adds a setting for BM25 Length Weight.

Added a couple of tests. These tests are of limited use here, but they do verify that "bm25" and "zero" are acceptable scoring options.