### PR TITLE
MLE-15728 Now depending on Jakarta JAXB

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,61 +51,7 @@ Full documentation is available at:
 
 ## Including JAXB support 
 
-If you are using Java 11 or higher (including Java 17) and you wish to use [JAXB](https://docs.oracle.com/javase/tutorial/jaxb/intro/)
-with the client, you'll need to include JAXB API and implementation dependencies as those are no 
-longer included in Java 11 and higher.
-
-For Maven, include the following in your pom.xml file:
-
-    <dependency>
-        <groupId>javax.xml.bind</groupId>
-        <artifactId>jaxb-api</artifactId>
-        <version>2.3.1</version>
-    </dependency>
-    <dependency>
-        <groupId>org.glassfish.jaxb</groupId>
-        <artifactId>jaxb-runtime</artifactId>
-        <version>2.3.2</version>
-    </dependency>
-    <dependency>
-        <groupId>org.glassfish.jaxb</groupId>
-        <artifactId>jaxb-core</artifactId>
-        <version>2.3.0.1</version>
-    </dependency>
-
-For Gradle, include the following in your build.gradle file (this can be included in the same `dependencies` block 
-as the one that includes the marklogic-client-api dependency):
-
-    dependencies {
-        implementation "javax.xml.bind:jaxb-api:2.3.1"
-        implementation "org.glassfish.jaxb:jaxb-runtime:2.3.2"
-        implementation "org.glassfish.jaxb:jaxb-core:2.3.0.1"
-    }
-
-You are free to use any implementation of JAXB that you wish, but you need to ensure that you're using a JAXB 
-implementation that corresponds to the `javax.xml.bind` interfaces. JAXB 3.0 and 4.0 interfaces are packaged under 
-`jakarta.xml.bind`, and the Java API does not yet depend on those interfaces. 
-
-Thus, you are free to include an implementation of JAXB 3.0 or 4.0 in your project for your own use; it will not 
-affect the Java API. A caveat though is if you are trying to use different major versions of the same JAXB 
-implementation library - such as `org.glassfish.jaxb:jaxb-runtime` - then you will run into an expected dependency 
-conflict between the two versions of the library. This can be worked around by using a different implementation of 
-JAXB 3.0 or JAXB 4.0 - for example:
-
-    dependencies {
-        // JAXB 2 dependencies required by Java Client
-        implementation "javax.xml.bind:jaxb-api:2.3.1"
-        implementation "org.glassfish.jaxb:jaxb-runtime:2.3.2"
-        implementation "org.glassfish.jaxb:jaxb-core:2.3.0.1"
-        
-        // JAXB 4 dependencies required by other application code
-        implementation "jakarta.xml.bind:jakarta.xml.bind-api:4.0.0"
-        implementation "com.sun.xml.bind:jaxb-impl:4.0.1"
-    }
-
-The client will soon be updated to use the newer `jakarta.xml.bind` interfaces. Until then, the above approach
-or one similar to it will allow for both the old and new JAXB interfaces and implementations to exist together in the
-same classpath.
+TODO, Need to rewrite this for Java Client 7.0.0.
 
 ## Support
 

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -5,11 +5,6 @@ plugins {
 }
 
 dependencies {
-	if (JavaVersion.current().isJava9Compatible()) {
-		implementation 'javax.xml.bind:jaxb-api:2.3.1'
-		implementation 'org.glassfish.jaxb:jaxb-runtime:2.3.2'
-		implementation 'org.glassfish.jaxb:jaxb-core:2.3.0.1'
-	}
 	implementation project(':marklogic-client-api')
 
 	// Forcing usage of 3.4.0 instead of 3.2.0 to address vulnerability - https://security.snyk.io/vuln/SNYK-JAVA-COMSQUAREUPOKIO-5820002

--- a/examples/src/main/java/com/marklogic/client/example/cookbook/AllCookbookExamples.java
+++ b/examples/src/main/java/com/marklogic/client/example/cookbook/AllCookbookExamples.java
@@ -17,7 +17,7 @@ package com.marklogic.client.example.cookbook;
 
 import java.io.IOException;
 
-import javax.xml.bind.JAXBException;
+import jakarta.xml.bind.JAXBException;
 import javax.xml.xpath.XPathExpressionException;
 
 import com.marklogic.client.FailedRequestException;

--- a/examples/src/main/java/com/marklogic/client/example/cookbook/JAXBDocument.java
+++ b/examples/src/main/java/com/marklogic/client/example/cookbook/JAXBDocument.java
@@ -17,9 +17,9 @@ package com.marklogic.client.example.cookbook;
 
 import java.io.IOException;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.DatabaseClientFactory;

--- a/examples/src/main/java/com/marklogic/client/example/cookbook/datamovement/DatabaseClientSingleton.java
+++ b/examples/src/main/java/com/marklogic/client/example/cookbook/datamovement/DatabaseClientSingleton.java
@@ -19,7 +19,7 @@ import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.HashMap;
 
-import javax.xml.bind.JAXBException;
+import jakarta.xml.bind.JAXBException;
 
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.DatabaseClientFactory;

--- a/examples/src/main/java/com/marklogic/client/example/cookbook/datamovement/WriteandReadPOJOs.java
+++ b/examples/src/main/java/com/marklogic/client/example/cookbook/datamovement/WriteandReadPOJOs.java
@@ -15,8 +15,8 @@
  */
 package com.marklogic.client.example.cookbook.datamovement;
 
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,7 +53,7 @@ public class WriteandReadPOJOs {
 
   /**
    * A sample class which we will be using in order to demonstrate
-   * reading and writing large number of POJOs 
+   * reading and writing large number of POJOs
    */
   @XmlRootElement
   public static class ProductDetails {
@@ -136,7 +136,7 @@ public class WriteandReadPOJOs {
     // Create a query definition in order to use it with QueryBatcher
     StructuredQueryDefinition query = new StructuredQueryBuilder().collection("products-collection1");
 
-    // Create a QueryBatcher in order to retrieve bulk POJOs 
+    // Create a QueryBatcher in order to retrieve bulk POJOs
     // from the database matching the query definition
     QueryBatcher queryBatcher = moveMgr.newQueryBatcher(query)
       .withBatchSize(batchSize)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.marklogic
-version=6.7-SNAPSHOT
+version=7.0-SNAPSHOT
 describedName=MarkLogic Java Client API
 publishUrl=file:../marklogic-java/releases
 

--- a/marklogic-client-api-functionaltests/build.gradle
+++ b/marklogic-client-api-functionaltests/build.gradle
@@ -27,13 +27,7 @@ dependencies {
   implementation 'com.fasterxml.jackson.core:jackson-core:2.15.3'
   implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.3'
   implementation "org.jdom:jdom2:2.0.6.1"
-  implementation "com.marklogic:ml-app-deployer:4.6.1"
-
-	if (JavaVersion.current().isJava9Compatible()) {
-		implementation 'javax.xml.bind:jaxb-api:2.3.1'
-		implementation 'org.glassfish.jaxb:jaxb-runtime:2.3.8'
-		implementation 'org.glassfish.jaxb:jaxb-core:2.3.0.1'
-	}
+  implementation "com.marklogic:ml-app-deployer:4.7.0"
 
   testImplementation 'ch.qos.logback:logback-classic:1.3.14'
 	testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkWriteSample1.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestBulkWriteSample1.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
 import org.skyscreamer.jsonassert.JSONAssert;
 
-import javax.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBContext;
 import javax.xml.transform.Source;
 import javax.xml.transform.dom.DOMSource;
 import java.io.*;

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestMetadata.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestMetadata.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
 import org.skyscreamer.jsonassert.JSONAssert;
 
-import javax.xml.bind.JAXBException;
+import jakarta.xml.bind.JAXBException;
 import javax.xml.namespace.QName;
 import java.io.File;
 import java.io.FileInputStream;

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/BasicJavaClientREST.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/BasicJavaClientREST.java
@@ -46,8 +46,8 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.BasicResponseHandler;
 import org.apache.http.impl.client.DefaultHttpClient;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/Product.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/Product.java
@@ -16,7 +16,7 @@
 
 package com.marklogic.client.functionaltest;
 
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement
 public class Product

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBiTempMetaValues.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBiTempMetaValues.java
@@ -35,7 +35,7 @@ import com.marklogic.client.query.StructuredQueryBuilder.TemporalOperator;
 import com.marklogic.client.query.StructuredQueryDefinition;
 import org.junit.jupiter.api.*;
 
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 import javax.xml.datatype.DatatypeFactory;
 import java.util.Calendar;
 

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBiTemporal.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBiTemporal.java
@@ -42,7 +42,7 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.ls.DOMImplementationLS;
 
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.File;
 import java.util.*;

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestSandBox.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestSandBox.java
@@ -47,7 +47,7 @@ import org.junit.jupiter.api.*;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;

--- a/marklogic-client-api/build.gradle
+++ b/marklogic-client-api/build.gradle
@@ -1,7 +1,8 @@
 // Copyright (c) 2022 MarkLogic Corporation
 
 plugins {
-    id 'maven-publish'
+	id 'java-library'
+	id 'maven-publish'
 }
 
 group = 'com.marklogic'
@@ -9,11 +10,12 @@ group = 'com.marklogic'
 description = "The official MarkLogic Java client API."
 
 dependencies {
-	if (JavaVersion.current().isJava9Compatible()) {
-		implementation 'javax.xml.bind:jaxb-api:2.3.1'
-		implementation 'org.glassfish.jaxb:jaxb-runtime:2.3.8'
-		implementation 'org.glassfish.jaxb:jaxb-core:2.3.0.1'
-	}
+	// With 7.0.0, now using the Jakarta JAXB APIs instead of the JAVAX JAXB APIs that were bundled in Java 8.
+	// To ease support for Java 8, we are depending on version 3.x of the Jakarta JAXB APIs as those only require Java 8,
+	// whereas the 4.x version requires Java 11 or higher.
+	api "jakarta.xml.bind:jakarta.xml.bind-api:3.0.1"
+	implementation "org.glassfish.jaxb:jaxb-runtime:3.0.2"
+	implementation "org.glassfish.jaxb:jaxb-core:3.0.2"
 
 	implementation 'com.squareup.okhttp3:okhttp:4.12.0'
 	implementation 'com.squareup.okhttp3:logging-interceptor:4.12.0'
@@ -43,7 +45,7 @@ dependencies {
 
 	// Allows talking to the Manage API. It depends on the Java Client itself, which will usually be a slightly older
 	// version, but that should not have any impact on the tests.
-	testImplementation "com.marklogic:ml-app-deployer:4.6.1"
+	testImplementation "com.marklogic:ml-app-deployer:4.7.0"
 
 	// Starting with mockito 5.x, Java 11 is required, so sticking with 4.x as we have to support Java 8.
 	testImplementation "org.mockito:mockito-core:4.11.0"
@@ -52,7 +54,7 @@ dependencies {
 
 	testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.15.3'
 	testImplementation 'ch.qos.logback:logback-classic:1.3.14'
-// schema validation issue with testImplementation 'xerces:xercesImpl:2.12.0'
+	// schema validation issue with testImplementation 'xerces:xercesImpl:2.12.0'
 	testImplementation 'org.opengis.cite.xerces:xercesImpl-xsd11:2.12-beta-r1667115'
 	testImplementation 'org.apache.commons:commons-lang3:3.14.0'
 	testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
@@ -203,4 +205,12 @@ task debugCloudAuth(type: JavaExec) {
 	main = 'com.marklogic.client.test.MarkLogicCloudAuthenticationDebugger'
 	classpath = sourceSets.test.runtimeClasspath
 	args = [cloudHost, cloudKey, cloudBasePath]
+}
+
+task runXmlSmokeTests(type: Test) {
+	description = "Run a bunch of XML-related tests for smoke-testing on a particular JVM"
+	include "com/marklogic/client/test/BufferableHandleTest.class"
+	include "com/marklogic/client/test/EvalTest.class"
+	include "com/marklogic/client/test/HandleAsTest.class"
+	include "com/marklogic/client/test/JAXBHandleTest.class"
 }

--- a/marklogic-client-api/src/main/java/com/marklogic/client/bitemporal/TemporalDescriptor.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/bitemporal/TemporalDescriptor.java
@@ -16,7 +16,7 @@
 package com.marklogic.client.bitemporal;
 
 import com.marklogic.client.document.DocumentDescriptor;
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 
 public interface TemporalDescriptor extends DocumentDescriptor {
   /**

--- a/marklogic-client-api/src/main/java/com/marklogic/client/bitemporal/TemporalDocumentManager.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/bitemporal/TemporalDocumentManager.java
@@ -18,7 +18,7 @@ package com.marklogic.client.bitemporal;
 
 import java.util.Calendar;
 
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 import javax.xml.datatype.Duration;
 
 import com.marklogic.client.*;

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/DocumentManagerImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/DocumentManagerImpl.java
@@ -18,7 +18,7 @@ package com.marklogic.client.impl;
 import java.nio.charset.CharsetEncoder;
 import java.util.*;
 
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 import javax.xml.datatype.Duration;
 
 import com.marklogic.client.query.SearchQueryDefinition;

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/DocumentMetadataPatchBuilderImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/DocumentMetadataPatchBuilderImpl.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import java.util.Set;
 
 import javax.xml.XMLConstants;
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/OkHttpServices.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/OkHttpServices.java
@@ -70,7 +70,7 @@ import javax.mail.MessagingException;
 import javax.mail.internet.MimeMultipart;
 import javax.mail.util.ByteArrayDataSource;
 import javax.net.ssl.*;
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 import java.io.ByteArrayInputStream;
 import java.io.Closeable;
 import java.io.File;

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/TuplesBuilder.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/TuplesBuilder.java
@@ -22,11 +22,11 @@ import com.marklogic.client.query.ValuesMetrics;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 /**
  * A TuplesBuilder parses a set of tuple results.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/ValueConverter.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/ValueConverter.java
@@ -25,7 +25,7 @@ import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 import javax.xml.datatype.Duration;
 
 /**
@@ -641,7 +641,7 @@ public class ValueConverter {
     }
     return instantPattern;
   }
-  
+
   static public <I> String[] convert(I[] in, Function<I, String> converter) {
       if (in == null) return null;
       String[] out = new String[in.length];

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/ValuesBuilder.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/ValuesBuilder.java
@@ -17,11 +17,11 @@ package com.marklogic.client.impl;
 
 import java.util.ArrayList;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 import com.marklogic.client.query.AggregateResult;
 import com.marklogic.client.query.CountedDistinctValue;

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/ValuesListBuilder.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/ValuesListBuilder.java
@@ -19,10 +19,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 /**
  * A ValuesListBuilder parses list of value results.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/ValuesMetricImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/ValuesMetricImpl.java
@@ -17,7 +17,7 @@ package com.marklogic.client.impl;
 
 import java.util.Calendar;
 
-import javax.xml.bind.annotation.XmlValue;
+import jakarta.xml.bind.annotation.XmlValue;
 import javax.xml.datatype.Duration;
 
 /**

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/ValuesMetricsImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/ValuesMetricsImpl.java
@@ -15,7 +15,7 @@
  */
 package com.marklogic.client.impl;
 
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElement;
 
 import com.marklogic.client.impl.ValuesBuilder.Values;
 import com.marklogic.client.query.ValuesMetrics;

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/XsValueImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/XsValueImpl.java
@@ -21,7 +21,7 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 import javax.xml.datatype.DatatypeConstants;
 import javax.xml.datatype.Duration;
 import javax.xml.datatype.XMLGregorianCalendar;

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/JAXBHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/JAXBHandle.java
@@ -26,10 +26,10 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.Unmarshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.Unmarshaller;
 
 import com.marklogic.client.io.marker.*;
 import org.slf4j.Logger;

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/QueryOptionsListHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/QueryOptionsListHandle.java
@@ -21,10 +21,10 @@ import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.Unmarshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.Unmarshaller;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/TuplesHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/TuplesHandle.java
@@ -22,9 +22,9 @@ import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/ValuesHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/ValuesHandle.java
@@ -22,9 +22,9 @@ import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/ValuesListHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/ValuesListHandle.java
@@ -20,9 +20,9 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/AggregateResult.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/AggregateResult.java
@@ -17,8 +17,8 @@ package com.marklogic.client.query;
 
 import com.marklogic.client.impl.ValueConverter;
 
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlValue;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlValue;
 
 /**
  * A CountedDistinctValue is a value that includes a frequency.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/CountedDistinctValue.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/CountedDistinctValue.java
@@ -17,8 +17,8 @@ package com.marklogic.client.query;
 
 import com.marklogic.client.impl.ValueConverter;
 
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlValue;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlValue;
 
 /**
  * A CountedDistinctValue is a value that includes a frequency.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/QueryOptionsListBuilder.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/QueryOptionsListBuilder.java
@@ -15,10 +15,10 @@
  */
 package com.marklogic.client.query;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/StructuredQueryBuilder.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/StructuredQueryBuilder.java
@@ -26,7 +26,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import javax.xml.XMLConstants;
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/Tuple.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/Tuple.java
@@ -17,8 +17,8 @@ package com.marklogic.client.query;
 
 import com.marklogic.client.impl.TuplesBuilder;
 
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/marklogic-client-api/src/main/java/com/marklogic/client/query/TypedDistinctValue.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/query/TypedDistinctValue.java
@@ -17,8 +17,8 @@ package com.marklogic.client.query;
 
 import com.marklogic.client.impl.ValueConverter;
 
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlValue;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlValue;
 
 /**
  * A TypedDistinctValue is a value that includes a type.

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/BinaryDocumentTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/BinaryDocumentTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 import java.io.File;
 import java.io.IOException;
 import java.util.Random;

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/BitemporalTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/BitemporalTest.java
@@ -30,7 +30,7 @@ import com.marklogic.client.query.StructuredQueryBuilder.TemporalOperator;
 import org.junit.jupiter.api.*;
 import org.w3c.dom.Document;
 
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 import java.util.Calendar;
 import java.util.Random;
 

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/BufferableHandleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/BufferableHandleTest.java
@@ -29,8 +29,8 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.xml.sax.SAXException;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.IOException;

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/BulkReadWriteTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/BulkReadWriteTest.java
@@ -27,7 +27,7 @@ import com.marklogic.client.query.QueryManager.QueryView;
 import org.junit.jupiter.api.*;
 import org.w3c.dom.Document;
 
-import javax.xml.bind.JAXBException;
+import jakarta.xml.bind.JAXBException;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.net.URLEncoder;

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/City.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/City.java
@@ -18,7 +18,7 @@ package com.marklogic.client.test;
 import com.marklogic.client.pojo.annotation.*;
 import com.marklogic.client.pojo.annotation.PathIndexProperty.ScalarType;
 
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement
 public class City {

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/ClosingHandlesTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/ClosingHandlesTest.java
@@ -23,7 +23,7 @@ import com.marklogic.client.io.*;
 import com.marklogic.client.io.marker.AbstractReadHandle;
 import org.junit.jupiter.api.Test;
 
-import javax.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBContext;
 import java.io.ByteArrayInputStream;
 import java.io.Closeable;
 import java.io.IOException;

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/EvalTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/EvalTest.java
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.parsers.DocumentBuilderFactory;

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/HandleAsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/HandleAsTest.java
@@ -39,8 +39,8 @@ import org.w3c.dom.Element;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/JAXBHandleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/JAXBHandleTest.java
@@ -23,8 +23,8 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/QueryOptionsManagerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/QueryOptionsManagerTest.java
@@ -31,7 +31,7 @@ import org.w3c.dom.Element;
 import org.w3c.dom.ls.DOMImplementationLS;
 import org.xml.sax.SAXException;
 
-import javax.xml.bind.JAXBException;
+import jakarta.xml.bind.JAXBException;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/LegalHoldsTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/LegalHoldsTest.java
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/JAXBDocumentTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/cookbook/JAXBDocumentTest.java
@@ -18,7 +18,7 @@ package com.marklogic.client.test.example.cookbook;
 import com.marklogic.client.example.cookbook.JAXBDocument;
 import org.junit.jupiter.api.Test;
 
-import javax.xml.bind.JAXBException;
+import jakarta.xml.bind.JAXBException;
 import java.io.IOException;
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/util/Refers.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/util/Refers.java
@@ -15,7 +15,7 @@
  */
 package com.marklogic.client.test.util;
 
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.List;
 import java.util.Map;
 

--- a/ml-development-tools/build.gradle
+++ b/ml-development-tools/build.gradle
@@ -15,12 +15,6 @@ dependencies {
 	implementation 'com.fasterxml.jackson.module:jackson-module-kotlin:2.15.3'
 	implementation 'com.networknt:json-schema-validator:1.0.88'
 
-	if (JavaVersion.current().isJava9Compatible()) {
-		implementation 'javax.xml.bind:jaxb-api:2.3.1'
-		implementation 'org.glassfish.jaxb:jaxb-runtime:2.3.8'
-		implementation 'org.glassfish.jaxb:jaxb-core:2.3.0.1'
-	}
-
 	// Not yet migrating this project to JUnit 5. Will reconsider it once we have a reason to enhance
 	// this project.
 	testImplementation 'junit:junit:4.13.2'

--- a/ml-development-tools/src/test/kotlin/com/marklogic/client/test/dbfunction/fntestgen.kt
+++ b/ml-development-tools/src/test/kotlin/com/marklogic/client/test/dbfunction/fntestgen.kt
@@ -46,7 +46,7 @@ enum class TestVariant {
 }
 fun getAtomicMappingImports(): String {
   return """
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 import javax.xml.datatype.DatatypeFactory;
 import java.time.format.DateTimeFormatter;
 import java.util.regex.Pattern;
@@ -1852,7 +1852,7 @@ import java.io.Reader;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.stream.Stream;
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 import java.lang.reflect.Array;
 
 $extraImports

--- a/pom.xml
+++ b/pom.xml
@@ -14,21 +14,21 @@ It is not intended to be used to build this project.
   <version>6.3.0</version>
   <dependencies>
     <dependency>
-      <groupId>javax.xml.bind</groupId>
+      <groupId>jakarta.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>
-      <version>2.3.1</version>
+      <version>3.0.1</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jaxb</groupId>
       <artifactId>jaxb-runtime</artifactId>
-      <version>2.3.8</version>
+      <version>3.0.2</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jaxb</groupId>
       <artifactId>jaxb-core</artifactId>
-      <version>2.3.0.1</version>
+      <version>3.0.2</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Will update the README later with instructions on how to force the client to use Jakarta 4.x instead of Jakarta 3.x. 

No real functional changes here, just changing from `javax.xml` to `jakarta.xml`. But it's a breaking change due to JAXB APIs being present in the public API of classes like `JAXBHandle`. 