### PR TITLE
MLE-15748 Using jakarta.mail instead of javax.mail

### DIFF
--- a/marklogic-client-api/build.gradle
+++ b/marklogic-client-api/build.gradle
@@ -21,7 +21,10 @@ dependencies {
 	implementation 'com.squareup.okhttp3:logging-interceptor:4.12.0'
 	implementation 'io.github.rburgst:okhttp-digest:2.7'
 
-	implementation 'com.sun.mail:javax.mail:1.6.2'
+	// https://eclipse-ee4j.github.io/angus-mail/ recommends using these two separate dependencies.
+	implementation "jakarta.mail:jakarta.mail-api:2.1.3"
+	implementation "org.eclipse.angus:angus-mail:2.0.3"
+
 	implementation 'javax.ws.rs:javax.ws.rs-api:2.1.1'
 	implementation 'org.slf4j:slf4j-api:1.7.36'
 	implementation 'com.fasterxml.jackson.core:jackson-core:2.15.3'

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/OkHttpServices.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/OkHttpServices.java
@@ -64,11 +64,11 @@ import okio.Source;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.mail.BodyPart;
-import javax.mail.Header;
-import javax.mail.MessagingException;
-import javax.mail.internet.MimeMultipart;
-import javax.mail.util.ByteArrayDataSource;
+import jakarta.mail.BodyPart;
+import jakarta.mail.Header;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMultipart;
+import jakarta.mail.util.ByteArrayDataSource;
 import javax.net.ssl.*;
 import jakarta.xml.bind.DatatypeConverter;
 import java.io.ByteArrayInputStream;
@@ -98,6 +98,14 @@ import java.util.stream.Stream;
 
 @SuppressWarnings({ "unchecked", "rawtypes" })
 public class OkHttpServices implements RESTServices {
+
+	static {
+		// Added in 7.0.0. Instructs jakarta-mail to allow UTF-8 in header names in multipart responses.
+		if (System.getProperty("mail.mime.allowutf8") == null) {
+			System.setProperty("mail.mime.allowutf8", "true");
+		}
+	}
+
   static final private Logger logger = LoggerFactory.getLogger(OkHttpServices.class);
 
   static final public String OKHTTP_LOGGINGINTERCEPTOR_LEVEL = "com.marklogic.client.okhttp.httplogginginterceptor.level";

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/document/ReadDocumentPageTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/document/ReadDocumentPageTest.java
@@ -8,7 +8,6 @@ import com.marklogic.client.document.DocumentPage;
 import com.marklogic.client.document.DocumentRecord;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.test.Common;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -17,7 +16,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ReadDocumentPageTest {
 
 	@Test
-	@Disabled("For MLE-15748. Using to refactor multipart reading first.")
 	void test() {
 		Common.deleteUrisWithPattern("/aaa-page/*");
 


### PR DESCRIPTION
This allows for setting `mail.mime.allowutf8` as a system property to work - that is, URIs can now contain UTF-8 characters instead of just US-ASCII. 

There is likely one more fix to make here. I ran all the Spark connector tests, and one test failed that involved hitting v1/rows. Going to debug that further and fix in a separate PR. 