### PR TITLE
Bumped Jackson dependencies to 2.17.2

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -76,7 +76,7 @@ Made available under the Apache License 2.0. See Appendix for full text.
 
 Source materials are available for download at: https://github.com/apache/commons-lang
 
-Jackson Annotations 2.15.3
+Jackson Annotations 2.17.2
 Attribution Statements
 http://wiki.fasterxml.com/JacksonHome
 
@@ -86,7 +86,7 @@ Copyright ©2009 FasterXML, LLC
 License Text (http://spdx.org/licenses/Apache-2.0)
 Made available under the Apache License 2.0. See Appendix for full text.
 
-Jackson Core 2.15.3
+Jackson Core 2.17.2
 Attribution Statements
 http://wiki.fasterxml.com/JacksonHome
 
@@ -98,7 +98,7 @@ Made available under the Apache License 2.0. See Appendix for full text.
 
 Source materials are available for download at: https://github.com/FasterXML/jackson-core
 
-Jackson Databind 2.15.3
+Jackson Databind 2.17.2
 Attribution Statements
 http://wiki.fasterxml.com/JacksonHome
 
@@ -116,7 +116,7 @@ License Text (http://www.apache.org/licenses/LICENSE-2.0.txt)
 Made available under the Apache License 2.0. See Appendix for full text.
 
 Source materials are available for download at: https://github.com/FasterXML/jackson-databind
-Jackson Dataformat CSV 2.15.3
+Jackson Dataformat CSV 2.17.2
 Attribution Statements
 https://github.com/FasterXML/jackson-dataformat-csv
 

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -16,7 +16,7 @@ dependencies {
 	api 'com.squareup.okhttp3:okhttp:4.11.0'
 	api 'io.github.rburgst:okhttp-digest:2.7'
 	api 'org.slf4j:slf4j-api:1.7.36'
-	api 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
+	api "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
 
 	// hsqldb < 2.7 has a High CVE - https://nvd.nist.gov/vuln/detail/CVE-2022-41853 .
 	// And hsqldb 2.6+ requires Java 11+. So this is ignored, along with the associated test,

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,8 @@ version=7.0-SNAPSHOT
 describedName=MarkLogic Java Client API
 publishUrl=file:../marklogic-java/releases
 
+jacksonVersion=2.17.2
+
 # Defined at this level so that they can be set as system properties and used by the marklogic-client-api and test-app
 # project
 mlHost=localhost

--- a/marklogic-client-api-functionaltests/build.gradle
+++ b/marklogic-client-api-functionaltests/build.gradle
@@ -24,10 +24,12 @@ dependencies {
   implementation 'org.slf4j:slf4j-api:1.7.36'
   implementation 'commons-io:commons-io:2.11.0'
   implementation 'com.squareup.okhttp3:okhttp:4.12.0'
-  implementation 'com.fasterxml.jackson.core:jackson-core:2.15.3'
-  implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.3'
+  implementation "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
+  implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
   implementation "org.jdom:jdom2:2.0.6.1"
-  implementation "com.marklogic:ml-app-deployer:4.7.0"
+  implementation ("com.marklogic:ml-app-deployer:4.8.0") {
+		exclude module: "marklogic-client-api"
+	}
 
   testImplementation 'ch.qos.logback:logback-classic:1.3.14'
 	testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'

--- a/marklogic-client-api/build.gradle
+++ b/marklogic-client-api/build.gradle
@@ -27,10 +27,10 @@ dependencies {
 
 	implementation 'javax.ws.rs:javax.ws.rs-api:2.1.1'
 	implementation 'org.slf4j:slf4j-api:1.7.36'
-	implementation 'com.fasterxml.jackson.core:jackson-core:2.15.3'
-	implementation 'com.fasterxml.jackson.core:jackson-annotations:2.15.3'
-	implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.3'
-	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.15.3'
+	implementation "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
+	implementation "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
+	implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
+	implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-csv:${jacksonVersion}"
 
 	// Only used by extras (which some examples then depend on)
 	// Forcing codec version to avoid vulnerability with older version in httpclient
@@ -46,16 +46,17 @@ dependencies {
 	testImplementation 'org.xmlunit:xmlunit-legacy:2.9.1'
 	testImplementation project(':examples')
 
-	// Allows talking to the Manage API. It depends on the Java Client itself, which will usually be a slightly older
-	// version, but that should not have any impact on the tests.
-	testImplementation "com.marklogic:ml-app-deployer:4.7.0"
+	// Allows talking to the Manage API.
+	testImplementation ("com.marklogic:ml-app-deployer:4.8.0") {
+		exclude module: "marklogic-client-api"
+	}
 
 	// Starting with mockito 5.x, Java 11 is required, so sticking with 4.x as we have to support Java 8.
 	testImplementation "org.mockito:mockito-core:4.11.0"
 	testImplementation "org.mockito:mockito-inline:4.11.0"
 	testImplementation "com.squareup.okhttp3:mockwebserver:4.12.0"
 
-	testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.15.3'
+	testImplementation "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:${jacksonVersion}"
 	testImplementation 'ch.qos.logback:logback-classic:1.3.14'
 	// schema validation issue with testImplementation 'xerces:xercesImpl:2.12.0'
 	testImplementation 'org.opengis.cite.xerces:xercesImpl-xsd11:2.12-beta-r1667115'

--- a/ml-development-tools/build.gradle
+++ b/ml-development-tools/build.gradle
@@ -12,7 +12,7 @@ dependencies {
 	compileOnly gradleApi()
 	implementation project(':marklogic-client-api')
 	implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.8.22'
-	implementation 'com.fasterxml.jackson.module:jackson-module-kotlin:2.15.3'
+	implementation "com.fasterxml.jackson.module:jackson-module-kotlin:${jacksonVersion}"
 	implementation 'com.networknt:json-schema-validator:1.0.88'
 
 	// Not yet migrating this project to JUnit 5. Will reconsider it once we have a reason to enhance

--- a/pom.xml
+++ b/pom.xml
@@ -70,25 +70,25 @@ It is not intended to be used to build this project.
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.15.2</version>
+      <version>2.17.2</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.15.2</version>
+      <version>2.17.2</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.15.2</version>
+      <version>2.17.2</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-csv</artifactId>
-      <version>2.15.2</version>
+      <version>2.17.2</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/test-app/build.gradle
+++ b/test-app/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'com.marklogic.ml-gradle' version '4.7.0'
+	id 'com.marklogic.ml-gradle' version '4.8.0'
 	id 'java'
 	id "com.github.psxpaul.execfork" version "0.2.2"
 }
@@ -7,10 +7,10 @@ plugins {
 dependencies {
 	implementation "io.undertow:undertow-core:2.2.24.Final"
 	implementation "io.undertow:undertow-servlet:2.2.24.Final"
-	implementation "com.marklogic:ml-javaclient-util:4.6.0"
+	implementation "com.marklogic:ml-javaclient-util:4.8.0"
 	implementation 'org.slf4j:slf4j-api:1.7.36'
 	implementation 'ch.qos.logback:logback-classic:1.3.14'
-	implementation "com.fasterxml.jackson.core:jackson-databind:2.15.3"
+	implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
 	implementation 'com.squareup.okhttp3:okhttp:4.12.0'
 }
 


### PR DESCRIPTION
This is the latest version. We'll still ignore them in the Spark connector so we defer to whatever version Spark uses.

Not expecting any issues, assuming no breaking changes from Jackson 2.15 to 2.17. 
