### PR TITLE
Bumping slf4j-api to 2.0.16

### DIFF
--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -13,9 +13,9 @@ dependencies {
 	// The 'api' configuration is used so that the test configuration in marklogic-client-api doesn't have to declare
 	// all of these dependencies. This library project won't otherwise be depended on by anything else as it's not
 	// setup for publishing.
-	api 'com.squareup.okhttp3:okhttp:4.11.0'
+	api 'com.squareup.okhttp3:okhttp:4.12.0'
 	api 'io.github.rburgst:okhttp-digest:2.7'
-	api 'org.slf4j:slf4j-api:1.7.36'
+	api 'org.slf4j:slf4j-api:2.0.16'
 	api "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
 
 	// hsqldb < 2.7 has a High CVE - https://nvd.nist.gov/vuln/detail/CVE-2022-41853 .

--- a/marklogic-client-api/build.gradle
+++ b/marklogic-client-api/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 	implementation "com.sun.mail:jakarta.mail:2.0.1"
 
 	implementation 'javax.ws.rs:javax.ws.rs-api:2.1.1'
-	implementation 'org.slf4j:slf4j-api:1.7.36'
+	implementation 'org.slf4j:slf4j-api:2.0.16'
 	implementation "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
 	implementation "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
 	implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"

--- a/test-app/build.gradle
+++ b/test-app/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 	implementation "io.undertow:undertow-core:2.2.32.Final"
 	implementation "io.undertow:undertow-servlet:2.2.32.Final"
 	implementation "com.marklogic:ml-javaclient-util:4.8.0"
-	implementation 'org.slf4j:slf4j-api:1.7.36'
+	implementation 'org.slf4j:slf4j-api:2.0.16'
 	implementation 'ch.qos.logback:logback-classic:1.3.14'
 	implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
 	implementation 'com.squareup.okhttp3:okhttp:4.12.0'


### PR DESCRIPTION
This may be the root cause of the logging issue I'm running into with Flux - at least according to https://www.slf4j.org/codes.html#StaticLoggerBinder , as I verified that slf4j-api 1.x is sneaking onto the classpath. This should otherwise be a no-op for all of the Java Client, it doesn't care what version of slf4j-api it's using.
