### PR TITLE
MLE-19222 Eval/invoke now stream results

### DIFF
--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/IoUtil.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/IoUtil.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.client.impl;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+public interface IoUtil {
+
+	/**
+	 * Tossing this commonly used logic here so that it can be reused. Can be removed when we drop Java 8 support, as
+	 * Java 9+ has a "readAllBytes" method.
+	 */
+	static byte[] streamToBytes(InputStream stream) throws IOException {
+		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+		byte[] b = new byte[8192];
+		int len = 0;
+		while ((len = stream.read(b)) != -1) {
+			buffer.write(b, 0, len);
+		}
+		buffer.flush();
+		return buffer.toByteArray();
+	}
+}

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/PartIterator.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/PartIterator.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.client.impl.okhttp;
+
+import com.marklogic.client.MarkLogicIOException;
+import com.marklogic.client.impl.IoUtil;
+import jakarta.activation.DataHandler;
+import jakarta.mail.BodyPart;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeBodyPart;
+import jakarta.mail.util.ByteArrayDataSource;
+import okhttp3.Headers;
+import okhttp3.MultipartReader;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Iterator;
+
+/**
+ * Adapts the iterator over the OkHttp MultipartReader to conform to the Iterator that is required by
+ * OkHttpEvalResultIterator. By converting each MultipartReader.Part into a jakarta.mail.BodyPart, we can reuse
+ * all the existing plumbing that depends on jakarta.mail.BodyPart.
+ * <p>
+ * Added to resolve MLE-19222, where eval/invoke results are not being streamed but rather were all being read into
+ * memory, leading to OutOfMemoryErrors.
+ */
+public class PartIterator implements Iterator<BodyPart> {
+
+	private final MultipartReader reader;
+	private BodyPart nextBodyPart;
+
+	public PartIterator(MultipartReader reader) {
+		this.reader = reader;
+		readNextPart();
+	}
+
+	@Override
+	public boolean hasNext() {
+		return nextBodyPart != null;
+	}
+
+	@Override
+	public BodyPart next() {
+		BodyPart partToReturn = nextBodyPart;
+		readNextPart();
+		return partToReturn;
+	}
+
+	private void readNextPart() {
+		try {
+			// See http://okhttp.foofun.cn/4.x/okhttp/okhttp3/-multipart-reader/ for more info on the OkHttp
+			// MultipartReader. This was actually requested many moons ago by one of the original Java Client
+			// developers - https://github.com/square/okhttp/issues/3394.
+			MultipartReader.Part nextPart = reader.nextPart();
+			this.nextBodyPart = nextPart != null ? convertPartToBodyPart(nextPart) : null;
+		} catch (Exception e) {
+			throw new MarkLogicIOException(e);
+		}
+	}
+
+	private static BodyPart convertPartToBodyPart(MultipartReader.Part part) throws IOException, MessagingException {
+		MimeBodyPart bodyPart = new MimeBodyPart();
+
+		try {
+			try (InputStream inputStream = part.body().inputStream()) {
+				byte[] bytes = IoUtil.streamToBytes(inputStream);
+				bodyPart.setDataHandler(new DataHandler(new ByteArrayDataSource(bytes, part.headers().get("Content-Type"))));
+			}
+
+			// part.headers.toMultimap() is lowercasing header names, which causes later issues.
+			Headers headers = part.headers();
+			for (String headerName : headers.names()) {
+				for (String headerValue : headers.values(headerName)) {
+					bodyPart.addHeader(headerName, headerValue);
+				}
+			}
+			return bodyPart;
+		} finally {
+			// Looking at the OkHttp source code, this does not appear necessary, as closing the InputStream above should
+			// achieve the same effect. But there is no downside to doing this, as it may be required by a future version
+			// of OkHttp.
+			part.close();
+		}
+	}
+}

--- a/marklogic-client-api/src/main/java/com/marklogic/client/io/InputStreamHandle.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/io/InputStreamHandle.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
+import com.marklogic.client.impl.IoUtil;
 import com.marklogic.client.io.marker.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,8 +45,6 @@ public class InputStreamHandle
 
   private byte[] contentBytes;
   private InputStream content;
-
-  final static private int BUFFER_SIZE = 8192;
 
   /**
    * Creates a factory to create an InputStreamHandle instance for an input stream.
@@ -186,17 +185,9 @@ public class InputStreamHandle
   public byte[] contentToBytes(InputStream content) {
     try {
       if (content == null) return null;
-
-      ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-
-      byte[] b = new byte[BUFFER_SIZE];
-      int len = 0;
-      while ((len = content.read(b)) != -1) {
-        buffer.write(b, 0, len);
-      }
+	  byte[] bytes = IoUtil.streamToBytes(content);
       content.close();
-
-      return buffer.toByteArray();
+	  return bytes;
     } catch (IOException e) {
       throw new MarkLogicIOException(e);
     }


### PR DESCRIPTION
Finally makes use of the OkHttp MultipartReader to stream body parts instead of reading them all into memory. There's no test to be added here, as the only way to verify this is to try with a sufficient amount of data to cause an OutOfMemoryError. That will be verified manually instead. The existing regression tests will suffice to ensure that eval/invoke still work properly.
