### PR TITLE
Sanity check to ensure connection is closed

### DIFF
--- a/marklogic-client-api/src/main/java/com/marklogic/client/eval/EvalResultIterator.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/eval/EvalResultIterator.java
@@ -6,15 +6,23 @@ package com.marklogic.client.eval;
 import java.io.Closeable;
 import java.util.Iterator;
 
-/** An Iterator to walk through all results returned from calls to
+/**
+ * An Iterator to walk through all results returned from calls to
  * {@link ServerEvaluationCall#eval()}.
  */
 public interface EvalResultIterator extends Iterable<EvalResult>, Iterator<EvalResult>, Closeable {
-  @Override
-  Iterator<EvalResult> iterator();
-  @Override
-  boolean hasNext();
-  @Override
-  EvalResult next();
-  void close();
+	@Override
+	Iterator<EvalResult> iterator();
+
+	@Override
+	boolean hasNext();
+
+	@Override
+	EvalResult next();
+
+	/**
+	 * As of 7.1.0, this must be called to ensure that the response is closed, as results are now
+	 * streamed from MarkLogic instead of being read entirely into memory first.
+	 */
+	void close();
 }


### PR DESCRIPTION
Also added docs to ensure clients call `close()`, which they really ought to have been doing already given the name "iterator".
