### PR TITLE
MLE-19240 Added marklogic.client.connectionString

### DIFF
--- a/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClientBuilder.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClientBuilder.java
@@ -3,6 +3,7 @@
  */
 package com.marklogic.client;
 
+import com.marklogic.client.impl.ConnectionString;
 import com.marklogic.client.impl.DatabaseClientPropertySource;
 
 import javax.net.ssl.SSLContext;
@@ -82,6 +83,24 @@ public class DatabaseClientBuilder {
 	public DatabaseClientBuilder withPort(int port) {
 		props.put(PREFIX + "port", port);
 		return this;
+	}
+
+	/**
+	 * @param connectionString of the form "username:password@host:port/optionalDatabaseName".
+	 * @since 7.1.0
+	 */
+	public DatabaseClientBuilder withConnectionString(String connectionString) {
+		ConnectionString cs = new ConnectionString(connectionString, "connection string");
+		if (!props.containsKey(PREFIX + "authType")) {
+			withAuthType("digest");
+		}
+		if (cs.getDatabase() != null && cs.getDatabase().trim().length() > 0) {
+			withDatabase(cs.getDatabase());
+		}
+		return withHost(cs.getHost())
+			.withPort(cs.getPort())
+			.withUsername(cs.getUsername())
+			.withPassword(cs.getPassword());
 	}
 
 	public DatabaseClientBuilder withBasePath(String basePath) {

--- a/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClientFactory.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClientFactory.java
@@ -1088,6 +1088,7 @@ public class DatabaseClientFactory {
 	 *     "kerberos", "certificate", or "saml"</li>
 	 *     <li>marklogic.client.username = must be a String; required for basic and digest authentication</li>
 	 *     <li>marklogic.client.password = must be a String; required for basic and digest authentication</li>
+	 *     <li>marklogic.client.connectionString = must be a String; must fit format of "username:password@host:port/optionalDatabaseName". Defaults the authentication type to "digest"; since 7.1.0.</li>
 	 *     <li>marklogic.client.certificate.file = must be a String; optional for certificate authentication</li>
 	 *     <li>marklogic.client.certificate.password = must be a String; optional for certificate authentication</li>
 	 *     <li>marklogic.client.cloud.apiKey = must be a String; required for cloud authentication</li>

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/ConnectionString.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/ConnectionString.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.client.impl;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+
+/**
+ * @since 7.1.0; copied from marklogic-spark-connector repository.
+ */
+public class ConnectionString {
+
+	private final String host;
+	private final int port;
+	private final String username;
+	private final String password;
+	private final String database;
+
+	public ConnectionString(String connectionString, String optionNameForErrorMessage) {
+		final String errorMessage = String.format(
+			"Invalid value for %s; must be username:password@host:port/optionalDatabaseName",
+			optionNameForErrorMessage
+		);
+
+		String[] parts = connectionString.split("@");
+		if (parts.length != 2) {
+			throw new IllegalArgumentException(errorMessage);
+		}
+		String[] tokens = parts[0].split(":");
+		if (tokens.length != 2) {
+			throw new IllegalArgumentException(errorMessage);
+		}
+		this.username = decodeValue(tokens[0], "username");
+		this.password = decodeValue(tokens[1], "password");
+
+		tokens = parts[1].split(":");
+		if (tokens.length != 2) {
+			throw new IllegalArgumentException(errorMessage);
+		}
+		this.host = tokens[0];
+		if (tokens[1].contains("/")) {
+			tokens = tokens[1].split("/");
+			this.port = parsePort(tokens[0], optionNameForErrorMessage);
+			this.database = tokens[1];
+		} else {
+			this.port = parsePort(tokens[1], optionNameForErrorMessage);
+			this.database = null;
+		}
+	}
+
+	private int parsePort(String value, String optionNameForErrorMessage) {
+		try {
+			return Integer.parseInt(value);
+		} catch (NumberFormatException e) {
+			throw new IllegalArgumentException(String.format(
+				"Invalid value for %s; port must be numeric, but was '%s'", optionNameForErrorMessage, value
+			));
+		}
+	}
+
+	private String decodeValue(String value, String label) {
+		try {
+			return URLDecoder.decode(value, "UTF-8");
+		} catch (UnsupportedEncodingException e) {
+			throw new IllegalArgumentException(String.format("Unable to decode '%s'; cause: %s", label, e.getMessage()));
+		}
+	}
+
+	public String getHost() {
+		return host;
+	}
+
+	public int getPort() {
+		return port;
+	}
+
+	public String getUsername() {
+		return username;
+	}
+
+	public String getPassword() {
+		return password;
+	}
+
+	public String getDatabase() {
+		return database;
+	}
+}

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/DatabaseClientPropertySource.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/DatabaseClientPropertySource.java
@@ -59,6 +59,18 @@ public class DatabaseClientPropertySource {
 				throw new IllegalArgumentException("Database must be of type String");
 			}
 		});
+		connectionPropertyHandlers.put(PREFIX + "connectionString", (bean, value) -> {
+			if (value instanceof String) {
+				ConnectionString cs = new ConnectionString((String) value, "connection string");
+				bean.setHost(cs.getHost());
+				bean.setPort(cs.getPort());
+				if (cs.getDatabase() != null && cs.getDatabase().trim().length() > 0) {
+					bean.setDatabase(cs.getDatabase());
+				}
+			} else {
+				throw new IllegalArgumentException("Connection string must be of type String");
+			}
+		});
 		connectionPropertyHandlers.put(PREFIX + "basePath", (bean, value) -> {
 			if (value instanceof String) {
 				bean.setBasePath((String) value);
@@ -125,6 +137,11 @@ public class DatabaseClientPropertySource {
 		return bean;
 	}
 
+	private ConnectionString makeConnectionString() {
+		String value = (String) propertySource.apply(PREFIX + "connectionString");
+		return value != null && value.trim().length() > 0 ? new ConnectionString(value, "connection string") : null;
+	}
+
 	private DatabaseClientFactory.SecurityContext newSecurityContext() {
 		Object securityContextValue = propertySource.apply(PREFIX + "securityContext");
 		if (securityContextValue != null) {
@@ -134,14 +151,11 @@ public class DatabaseClientPropertySource {
 			throw new IllegalArgumentException("Security context must be of type " + DatabaseClientFactory.SecurityContext.class.getName());
 		}
 
-		Object typeValue = propertySource.apply(PREFIX + "authType");
-		if (typeValue == null || !(typeValue instanceof String)) {
-			throw new IllegalArgumentException("Security context should be set, or auth type must be of type String");
-		}
-		final String authType = (String) typeValue;
+		ConnectionString connectionString = makeConnectionString();
+		final String authType = determineAuthType(connectionString);
 
 		final SSLUtil.SSLInputs sslInputs = buildSSLInputs(authType);
-		DatabaseClientFactory.SecurityContext securityContext = newSecurityContext(authType, sslInputs);
+		DatabaseClientFactory.SecurityContext securityContext = newSecurityContext(authType, connectionString, sslInputs);
 		if (sslInputs.getSslContext() != null) {
 			securityContext.withSSLContext(sslInputs.getSslContext(), sslInputs.getTrustManager());
 		}
@@ -149,12 +163,23 @@ public class DatabaseClientPropertySource {
 		return securityContext;
 	}
 
-	private DatabaseClientFactory.SecurityContext newSecurityContext(String type, SSLUtil.SSLInputs sslInputs) {
+	private String determineAuthType(ConnectionString connectionString) {
+		Object value = propertySource.apply(PREFIX + "authType");
+		if (value == null && connectionString != null) {
+			return "digest";
+		}
+		if (value == null || !(value instanceof String)) {
+			throw new IllegalArgumentException("Security context should be set, or auth type must be of type String");
+		}
+		return (String) value;
+	}
+
+	private DatabaseClientFactory.SecurityContext newSecurityContext(String type, ConnectionString connectionString, SSLUtil.SSLInputs sslInputs) {
 		switch (type.toLowerCase()) {
 			case DatabaseClientBuilder.AUTH_TYPE_BASIC:
-				return newBasicAuthContext();
+				return newBasicAuthContext(connectionString);
 			case DatabaseClientBuilder.AUTH_TYPE_DIGEST:
-				return newDigestAuthContext();
+				return newDigestAuthContext(connectionString);
 			case DatabaseClientBuilder.AUTH_TYPE_MARKLOGIC_CLOUD:
 				return newCloudAuthContext();
 			case DatabaseClientBuilder.AUTH_TYPE_KERBEROS:
@@ -194,14 +219,24 @@ public class DatabaseClientPropertySource {
 		return value != null ? (String) value : defaultValue;
 	}
 
-	private DatabaseClientFactory.SecurityContext newBasicAuthContext() {
+	private DatabaseClientFactory.SecurityContext newBasicAuthContext(ConnectionString connectionString) {
+		if (connectionString != null) {
+			return new DatabaseClientFactory.BasicAuthContext(
+				connectionString.getUsername(), connectionString.getPassword()
+			);
+		}
 		return new DatabaseClientFactory.BasicAuthContext(
 			getRequiredStringValue("username", "Must specify a username when using basic authentication."),
 			getRequiredStringValue("password", "Must specify a password when using basic authentication.")
 		);
 	}
 
-	private DatabaseClientFactory.SecurityContext newDigestAuthContext() {
+	private DatabaseClientFactory.SecurityContext newDigestAuthContext(ConnectionString connectionString) {
+		if (connectionString != null) {
+			return new DatabaseClientFactory.DigestAuthContext(
+				connectionString.getUsername(), connectionString.getPassword()
+			);
+		}
 		return new DatabaseClientFactory.DigestAuthContext(
 			getRequiredStringValue("username", "Must specify a username when using digest authentication."),
 			getRequiredStringValue("password", "Must specify a password when using digest authentication.")


### PR DESCRIPTION
Intent is to support this in places the upcoming query pipeline kit and other apps that want to create a client via properties.

Going to remove this support in the Spark connector next and reuse this.
