### PR TITLE
Few more null checks from Polaris

### DIFF
--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/OkHttpServices.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/OkHttpServices.java
@@ -673,7 +673,8 @@ public class OkHttpServices implements RESTServices {
 			closeResponse(response);
 		}
 
-		handleBase.receiveContent((reqlog != null) ? reqlog.copyContent(entity) : entity);
+		Object content = reqlog != null ? reqlog.copyContent(entity) : entity;
+		handleBase.receiveContent(content);
 
 		return true;
 	}
@@ -1915,8 +1916,7 @@ public class OkHttpServices implements RESTServices {
 				throw new UnsupportedOperationException("Only XML and JSON search results are possible.");
 		}
 
-		String mimetype = searchFormat != null ? searchFormat.getDefaultMimetype() : null;
-
+		String mimetype = searchFormat.getDefaultMimetype();
 		OkHttpSearchRequest request = generateSearchRequest(reqlog, queryDef, mimetype, transaction, null, params, forestName);
 		Response response = request.getResponse();
 		if (response == null) return null;
@@ -3005,8 +3005,7 @@ public class OkHttpServices implements RESTServices {
 
 		updateDescriptor(outputBase, response.headers());
 		if (as != null) {
-			outputBase.receiveContent(makeResult(reqlog, "read", "resource",
-				response, as));
+			outputBase.receiveContent(makeResult(reqlog, "read", "resource", response, as));
 		} else {
 			closeResponse(response);
 		}
@@ -3091,8 +3090,7 @@ public class OkHttpServices implements RESTServices {
 			ResponseStatus.OK_OR_CREATED_OR_NO_CONTENT);
 
 		if (as != null) {
-			outputBase.receiveContent(makeResult(reqlog, "write", "resource",
-				response, as));
+			outputBase.receiveContent(makeResult(reqlog, "write", "resource", response, as));
 		} else {
 			closeResponse(response);
 		}
@@ -3172,7 +3170,6 @@ public class OkHttpServices implements RESTServices {
 
 		if (as != null) {
 			Object content = makeResult(reqlog, "write", "resource", response, as);
-			Objects.requireNonNull(content);
 			outputBase.receiveContent(content);
 		} else {
 			closeResponse(response);
@@ -3261,8 +3258,8 @@ public class OkHttpServices implements RESTServices {
 		}
 
 		if (as != null) {
-			outputBase.receiveContent(makeResult(reqlog, operation, "resource",
-				response, as));
+			Object content = makeResult(reqlog, operation, "resource", response, as);
+			outputBase.receiveContent(content);
 		} else {
 			closeResponse(response);
 		}
@@ -3345,8 +3342,8 @@ public class OkHttpServices implements RESTServices {
 			ResponseStatus.OK_OR_CREATED_OR_NO_CONTENT);
 
 		if (as != null) {
-			outputBase.receiveContent(makeResult(reqlog, "apply", "resource",
-				response, as));
+			Object content = makeResult(reqlog, "apply", "resource", response, as);
+			outputBase.receiveContent(content);
 		} else {
 			closeResponse(response);
 		}
@@ -3651,10 +3648,10 @@ public class OkHttpServices implements RESTServices {
 						value = "null";
 						type = "null-node()";
 					} else if (valueObject instanceof JacksonHandle || valueObject instanceof JacksonParserHandle) {
-						JsonNode jsonNode = null;
+						JsonNode jsonNode;
 						if (valueObject instanceof JacksonHandle) {
 							jsonNode = ((JacksonHandle) valueObject).get();
-						} else if (valueObject instanceof JacksonParserHandle) {
+						} else {
 							JsonParser jsonParser = ((JacksonParserHandle) valueObject).get();
 							Objects.requireNonNull(jsonParser);
 							jsonNode = jsonParser.readValueAs(JsonNode.class);
@@ -3990,8 +3987,7 @@ public class OkHttpServices implements RESTServices {
 			ResponseStatus.OK_OR_NO_CONTENT);
 
 		if (as != null) {
-			outputBase.receiveContent(makeResult(reqlog, "delete", "resource",
-				response, as));
+			outputBase.receiveContent(makeResult(reqlog, "delete", "resource", response, as));
 		} else {
 			closeResponse(response);
 		}

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/QueryManagerImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/QueryManagerImpl.java
@@ -5,6 +5,7 @@ package com.marklogic.client.impl;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import javax.xml.namespace.QName;
 
@@ -296,6 +297,7 @@ public class QueryManagerImpl
   public <T extends QueryOptionsListReadHandle> T optionsList(T optionsHandle, Transaction transaction) {
     @SuppressWarnings("rawtypes")
     HandleImplementation optionsBase = HandleAccessor.checkHandle(optionsHandle, "optionslist");
+	  Objects.requireNonNull(optionsBase);
 
     Format optionsFormat = optionsBase.getFormat();
     switch(optionsFormat) {

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/QueryOptionsManagerImpl.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/QueryOptionsManagerImpl.java
@@ -15,6 +15,8 @@ import com.marklogic.client.io.marker.QueryOptionsListReadHandle;
 import com.marklogic.client.io.marker.QueryOptionsReadHandle;
 import com.marklogic.client.io.marker.QueryOptionsWriteHandle;
 
+import java.util.Objects;
+
 public class QueryOptionsManagerImpl
   extends AbstractLoggingManager
   implements QueryOptionsManager
@@ -168,6 +170,7 @@ public class QueryOptionsManagerImpl
   public <T extends QueryOptionsListReadHandle> T optionsList(T optionsHandle)
     throws ForbiddenUserException, FailedRequestException {
     HandleImplementation optionsBase = HandleAccessor.checkHandle(optionsHandle, "optionslist");
+	  Objects.requireNonNull(optionsBase);
 
     Format optionsFormat = optionsBase.getFormat();
     switch(optionsFormat) {


### PR DESCRIPTION
Polaris was complaining about `null` being sent to the `receiveContent` method, but that needs to happen in at least one scenario - to trigger the "skipped" functionality on a QueryBatcher. So we'll need to ignore those warnings in Polaris.
