### PR TITLE
Fixing WriteHostBatcherTest

### DIFF
--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/ExportToWriterListenerTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/ExportToWriterListenerTest.java
@@ -137,11 +137,6 @@ public class ExportToWriterListenerTest extends BasicJavaClientREST {
   @AfterAll
   public static void tearDownAfterClass() throws Exception {
     associateRESTServerWithDB(server, "Documents");
-    for (int i = 0; i < hostNames.length; i++) {
-      System.out.println(dbName + "-" + (i + 1));
-      detachForest(dbName, dbName + "-" + (i + 1));
-      deleteForest(dbName + "-" + (i + 1));
-    }
     deleteDB(dbName);
 
     // Delete the output file

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/QBFailover.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/QBFailover.java
@@ -210,15 +210,6 @@ public class QBFailover extends BasicJavaClientREST {
 		// Perform the setup on multiple nodes only.
 		if (hostNames.length > 1) {
 			associateRESTServerWithDB(server, "Documents");
-			for (int i = 0; i < hostNames.length; i++) {
-				System.out.println(dbName + "-" + (i + 1));
-				detachForest(dbName, dbName + "-" + (i + 1));
-				if (i != 0) {
-					removeReplica(dbName + "-" + (i + 1));
-					deleteForest(dbName + "-" + (i + 1) + "-replica");
-				}
-				deleteForest(dbName + "-" + (i + 1));
-			}
 			deleteDB(dbName);
 		} else {
 			System.out.println("Test skipped -  tearDownAfterClass");

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/StringQueryHostBatcherTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/StringQueryHostBatcherTest.java
@@ -3,11 +3,30 @@
  */
 package com.marklogic.client.datamovement.functionaltests;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.admin.ExtensionMetadata;
+import com.marklogic.client.admin.ServerConfigurationManager;
+import com.marklogic.client.admin.TransformExtensionsManager;
+import com.marklogic.client.datamovement.*;
+import com.marklogic.client.document.JSONDocumentManager;
+import com.marklogic.client.document.ServerTransform;
+import com.marklogic.client.expression.CtsQueryBuilder;
+import com.marklogic.client.functionaltest.BasicJavaClientREST;
+import com.marklogic.client.io.*;
+import com.marklogic.client.query.*;
+import com.marklogic.client.query.StructuredQueryBuilder.Operator;
+import com.marklogic.client.type.CtsQueryExpr;
+import com.marklogic.client.util.EditableNamespaceContext;
+import org.junit.jupiter.api.*;
+import org.w3c.dom.DOMException;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
 
+import javax.xml.namespace.QName;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.TransformerException;
+import javax.xml.xpath.XPathExpressionException;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -16,42 +35,7 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import javax.xml.namespace.QName;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.TransformerException;
-import javax.xml.xpath.XPathExpressionException;
-
-import com.marklogic.client.expression.CtsQueryBuilder;
-import com.marklogic.client.query.*;
-import com.marklogic.client.type.CtsQueryExpr;
-import com.marklogic.client.util.EditableNamespaceContext;
-import org.junit.jupiter.api.*;
-import org.w3c.dom.DOMException;
-import org.w3c.dom.Document;
-import org.xml.sax.SAXException;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.marklogic.client.DatabaseClient;
-import com.marklogic.client.admin.ExtensionMetadata;
-import com.marklogic.client.admin.ServerConfigurationManager;
-import com.marklogic.client.admin.TransformExtensionsManager;
-import com.marklogic.client.datamovement.DataMovementManager;
-import com.marklogic.client.datamovement.Forest;
-import com.marklogic.client.datamovement.HostAvailabilityListener;
-import com.marklogic.client.datamovement.JobTicket;
-import com.marklogic.client.datamovement.ProgressListener;
-import com.marklogic.client.datamovement.QueryBatcher;
-import com.marklogic.client.datamovement.WriteBatcher;
-import com.marklogic.client.document.JSONDocumentManager;
-import com.marklogic.client.document.ServerTransform;
-import com.marklogic.client.functionaltest.BasicJavaClientREST;
-import com.marklogic.client.io.DOMHandle;
-import com.marklogic.client.io.FileHandle;
-import com.marklogic.client.io.Format;
-import com.marklogic.client.io.InputStreamHandle;
-import com.marklogic.client.io.JacksonHandle;
-import com.marklogic.client.io.StringHandle;
-import com.marklogic.client.query.StructuredQueryBuilder.Operator;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author ageorge Purpose : Test String Queries - On multiple documents using
@@ -123,10 +107,7 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
     associateRESTServerWithDB(restServerName, "Documents");
     deleteRESTUser("eval-user");
     deleteUserRole("test-eval");
-    detachForest(dbName, fNames[0]);
-
     deleteDB(dbName);
-    deleteForest(fNames[0]);
   }
 
   @BeforeEach
@@ -1516,7 +1497,6 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
       deleteForest(testMultipleForest[0]);
       deleteForest(testMultipleForest[1]);
       deleteForest(testMultipleForest[2]);
-      Thread.sleep(10000);
     }
   }
 
@@ -1626,16 +1606,8 @@ public class StringQueryHostBatcherTest extends BasicJavaClientREST {
       System.out.print(e.getMessage());
       fail("testBatchClientLookupTimeout method failed");
     } finally {
-      // Associate back the original DB.
-      try {
         associateRESTServerWithDB(restServerName, dbName);
-      } catch (Exception e) {
-        e.printStackTrace();
-      }
-      detachForest(testMultipleDB, testMultipleForest[0]);
       deleteDB(testMultipleDB);
-      deleteForest(testMultipleForest[0]);
-      Thread.sleep(10000);
     }
   }
 

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/TestSplitters.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/TestSplitters.java
@@ -63,8 +63,6 @@ public class TestSplitters  extends BasicJavaClientREST {
     public static void testCleanUp() throws Exception {
         associateRESTServerWithDB(getRestServerName(), "Documents");
         deleteDB(dbName);
-        deleteForest(fNames[0]);
-        System.out.println("Running clear script");
     }
 
     @Test

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/UrisToWriterListenerFuncTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/UrisToWriterListenerFuncTest.java
@@ -76,10 +76,7 @@ public class UrisToWriterListenerFuncTest extends BasicJavaClientREST {
     associateRESTServerWithDB(restServerName, "Documents");
     deleteRESTUser("eval-user");
     deleteUserRole("test-eval");
-    detachForest(dbName, fNames[0]);
-
     deleteDB(dbName);
-    deleteForest(fNames[0]);
   }
 
   @AfterEach

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/WBFailover.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/WBFailover.java
@@ -182,15 +182,6 @@ public class WBFailover extends BasicJavaClientREST {
 		// Perform the setup on multiple nodes only.
 		if (hostNames.length > 1) {
 			associateRESTServerWithDB(server, "Documents");
-			for (int i = 0; i < hostNames.length; i++) {
-				System.out.println(dbName + "-" + (i + 1));
-				detachForest(dbName, dbName + "-" + (i + 1));
-				if (i != 0) {
-					removeReplica(dbName + "-" + (i + 1));
-					deleteForest(dbName + "-" + (i + 1) + "-replica");
-				}
-				deleteForest(dbName + "-" + (i + 1));
-			}
 			deleteDB(dbName);
 		} else {
 			System.out.println("Test skipped -  tearDownAfterClass");

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/WriteBatcherJobReportTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/WriteBatcherJobReportTest.java
@@ -127,12 +127,6 @@ public class WriteBatcherJobReportTest extends BasicJavaClientREST {
 	@AfterAll
 	public static void tearDownAfterClass() throws Exception {
 		associateRESTServerWithDB(server, "Documents");
-		for (int i = 0; i < hostNames.length; i++) {
-			System.out.println(dbName + "-" + (i + 1));
-			detachForest(dbName, dbName + "-" + (i + 1));
-			deleteForest(dbName + "-" + (i + 1));
-		}
-
 		deleteDB(dbName);
 	}
 

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/WriteHostBatcherTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/WriteHostBatcherTest.java
@@ -81,7 +81,7 @@ public class WriteHostBatcherTest extends BasicJavaClientREST {
 	private static JsonNode jsonNode;
 	private static JobTicket writeTicket;
 	private static JobTicket testBatchJobTicket;
-	private static int forestCount = 1;
+	private static final int forestCount = 3;
 
 	@BeforeAll
 	public static void setUpBeforeClass() throws Exception {
@@ -94,18 +94,9 @@ public class WriteHostBatcherTest extends BasicJavaClientREST {
 		hostNames = getHosts();
 
 		createDB(dbName);
-		Thread.currentThread().sleep(500L);
-		//Ensure db has atleast one forest
-		createForestonHost(dbName + "-" + forestCount, dbName, hostNames[0]);
-		forestCount++;
-		for (String forestHost : hostNames) {
-			for(int i = 0; i < new Random().nextInt(3); i++) {
-				createForestonHost(dbName + "-" + forestCount, dbName, forestHost);
-				forestCount++;
-			}
-			Thread.currentThread().sleep(500L);
+		for (int i = 1; i <= forestCount; i++) {
+			createForest(dbName + "-" + i, dbName);
 		}
-		// Create App Server if needed.
 		createRESTServerWithDB(server, port);
 		assocRESTServer(server, dbName, port);
 		if (IsSecurityEnabled()) {
@@ -151,12 +142,6 @@ public class WriteHostBatcherTest extends BasicJavaClientREST {
 	@AfterAll
 	public static void tearDownAfterClass() throws Exception {
 		associateRESTServerWithDB(server, "Documents");
-		for (int i = 0; i < forestCount -1 ; i++) {
-			System.out.println(dbName + "-" + (i + 1));
-			detachForest(dbName, dbName + "-" + (i + 1));
-			deleteForest(dbName + "-" + (i + 1));
-		}
-
 		deleteDB(dbName);
 	}
 
@@ -476,17 +461,17 @@ public class WriteHostBatcherTest extends BasicJavaClientREST {
 
 		ihb3.flushAndWait();
 		System.out.println("Size is " + dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue());
-		assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 4);
+		assertEquals(4, dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue());
 
 		DocumentMetadataHandle mHandle2 = readMetadataFromDocument(dbClient, "/doc/reader_xml", "XML");
 		assertEquals(1, mHandle2.getQuality());
 		assertEquals("Sample Collection 1", mHandle2.getCollections().iterator().next());
-		assertTrue(mHandle2.getCollections().size() == 1);
+		assertEquals(1, mHandle2.getCollections().size());
 
 		DocumentMetadataHandle mHandle3 = readMetadataFromDocument(dbClient, "/doc/jackson", "XML");
 		assertEquals(0, mHandle3.getQuality());
 		assertEquals("Sample Collection 2", mHandle3.getCollections().iterator().next());
-		assertTrue(mHandle3.getCollections().size() == 1);
+		assertEquals(1, mHandle3.getCollections().size());
 
 		assertTrue(uriExists(successBatch.toString(), "/doc/string"));
 
@@ -942,7 +927,7 @@ public class WriteHostBatcherTest extends BasicJavaClientREST {
 	}
 
 	@Test
-	public void testflushAsync() throws Exception {
+	public void testflushAsync() {
 		System.out.println("In testflushAsync method");
 
 		final String query1 = "fn:count(fn:doc())";
@@ -976,51 +961,48 @@ public class WriteHostBatcherTest extends BasicJavaClientREST {
 	}
 
 	@Test
-	public void testInsertoReadOnlyForest() throws Exception {
-		System.out.println("In testInsertoReadOnlyForest method");
+	public void testInsertoReadOnlyForest() {
+		try {
+			Map<String, String> properties = new HashMap<>();
+			properties.put("updates-allowed", "read-only");
+			for (int i = 1; i <= forestCount; i++) {
+				changeProperty(properties, "/manage/v2/forests/" + dbName + "-" + i + "/properties");
+			}
+			final String query1 = "fn:count(fn:doc())";
 
-		Map<String, String> properties = new HashMap<>();
-		properties.put("updates-allowed", "read-only");
-		for (int i = 0; i < forestCount; i++)
-			changeProperty(properties, "/manage/v2/forests/" + dbName + "-" + (i + 1) + "/properties");
-		final String query1 = "fn:count(fn:doc())";
+			final AtomicInteger successCount = new AtomicInteger(0);
 
-		final AtomicInteger successCount = new AtomicInteger(0);
+			final AtomicBoolean failState = new AtomicBoolean(false);
+			final AtomicInteger failCount = new AtomicInteger(0);
 
-		final AtomicBoolean failState = new AtomicBoolean(false);
-		final AtomicInteger failCount = new AtomicInteger(0);
+			WriteBatcher ihb2 = dmManager.newWriteBatcher();
+			ihb2.withBatchSize(25);
+			ihb2.onBatchSuccess(batch -> {
+				successCount.addAndGet(batch.getItems().length);
+			}).onBatchFailure((batch, throwable) -> {
+				failState.set(true);
+				failCount.addAndGet(batch.getItems().length);
+			});
 
-		for (int i = 0; i < forestCount; i++)
-			changeProperty(properties, "/manage/v2/forests/" + dbName + "-" + (i + 1) + "/properties");
+			dmManager.startJob(ihb2);
+			for (int j = 0; j < 20; j++) {
+				String uri = "/local/json-" + j;
+				ihb2.addAs(uri, stringHandle);
+			}
 
-		WriteBatcher ihb2 = dmManager.newWriteBatcher();
-		ihb2.withBatchSize(25);
-		ihb2.onBatchSuccess(batch -> {
+			ihb2.flushAndWait();
 
-			successCount.addAndGet(batch.getItems().length);
-		}).onBatchFailure((batch, throwable) -> {
-			failState.set(true);
-			failCount.addAndGet(batch.getItems().length);
-		});
-
-		dmManager.startJob(ihb2);
-		for (int j = 0; j < 20; j++) {
-			String uri = "/local/json-" + j;
-			ihb2.addAs(uri, stringHandle);
+			assertEquals(0, dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue());
+			assertTrue(failState.get());
+			assertEquals(0, successCount.intValue());
+			assertEquals(20, failCount.intValue());
+		} finally {
+			Map<String, String> properties = new HashMap<>();
+			properties.put("updates-allowed", "all");
+			for (int i = 1; i <= forestCount; i++) {
+				changeProperty(properties, "/manage/v2/forests/" + dbName + "-" + i + "/properties");
+			}
 		}
-
-		ihb2.flushAndWait();
-
-		properties.put("updates-allowed", "all");
-		for (int i = 0; i < forestCount; i++)
-			changeProperty(properties, "/manage/v2/forests/" + dbName + "-" + (i + 1) + "/properties");
-
-		assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 0);
-
-		assertTrue(failState.get());
-
-		assertTrue(successCount.intValue() == 0);
-		assertTrue(failCount.intValue() == 20);
 	}
 
 	@Test
@@ -1065,10 +1047,10 @@ public class WriteHostBatcherTest extends BasicJavaClientREST {
 		System.out.println("Success : " + successCount.intValue());
 		System.out.println("Count : " + dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue());
 
-		assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 0);
+		assertEquals(0, dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue());
 		assertTrue(failState.get());
 
-		assertTrue(failCount.intValue() == 20);
+		assertEquals(20, failCount.intValue());
 	}
 
 	@Test
@@ -1851,7 +1833,7 @@ public class WriteHostBatcherTest extends BasicJavaClientREST {
 	}
 
 	@Test
-	public void testEmptyFlush() throws Exception {
+	public void testEmptyFlush() {
 		System.out.println("In testEmptyFlush method");
 
 		WriteBatcher ihb2 = dmManager.newWriteBatcher();
@@ -1875,7 +1857,7 @@ public class WriteHostBatcherTest extends BasicJavaClientREST {
 		ihb2.add("/new", fileHandle);
 		dmManager.stopJob(job);
 		final String query1 = "fn:count(fn:doc())";
-		assertTrue(dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue() == 0);
+		assertEquals(0, dbClient.newServerEval().xquery(query1).eval().next().getNumber().intValue());
 	}
 
 	@Test

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/BulkIOCallersFnTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/BulkIOCallersFnTest.java
@@ -340,9 +340,7 @@ public class BulkIOCallersFnTest extends BasicJavaClientREST {
         associateRESTServerWithModuleDB(restServerName, "Modules");
 
         deleteDB(dbName);
-        deleteForest(fNames[0]);
         deleteDB(dbNameMod);
-        deleteForest(fNamesMod[0]);
         deleteDB("TestDynamicIngest-modules");
         deleteForest("TestDynamicIngest-modules-1");
         // release client

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ConnectedRESTQA.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ConnectedRESTQA.java
@@ -99,16 +99,20 @@ public abstract class ConnectedRESTQA {
 	}
 
 	public static void assocRESTServer(String restServerName, String dbName, int restPort) {
-		ObjectNode request = objectMapper.createObjectNode();
-		request.putObject("rest-api")
-			.put("name", restServerName)
-			.put("database", dbName)
-			.put("port", restPort);
-
 		ManageClient client = newManageClient();
-		new RestApiManager(client).createRestApi(restServerName, request.toString());
-		if (IsSecurityEnabled()) {
-			enableSecurityOnRESTServer(restServerName);
+		if (new ServerManager(client).exists(restServerName)) {
+			associateRESTServerWithDB(restServerName, dbName);
+		} else {
+			ObjectNode request = objectMapper.createObjectNode();
+			request.putObject("rest-api")
+				.put("name", restServerName)
+				.put("database", dbName)
+				.put("port", restPort);
+
+			new RestApiManager(client).createRestApi(restServerName, request.toString());
+			if (IsSecurityEnabled()) {
+				enableSecurityOnRESTServer(restServerName);
+			}
 		}
 	}
 
@@ -317,12 +321,6 @@ public abstract class ConnectedRESTQA {
 
 	public static void tearDownJavaRESTServer(String dbName, String[] fNames, String restServerName) {
 		associateRESTServerWithDB(restServerName, "Documents");
-		for (int i = 0; i < fNames.length; i++) {
-			detachForest(dbName, fNames[i]);
-		}
-		for (int i = 0; i < fNames.length; i++) {
-			deleteForest(fNames[i]);
-		}
 		deleteDB(dbName);
 	}
 

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBiTempMetaValues.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBiTempMetaValues.java
@@ -124,12 +124,7 @@ public class TestBiTempMetaValues extends BasicJavaClientREST {
         temporalCollectionName);
     ConnectedRESTQA.deleteElementRangeIndexTemporalCollection(dbName,
         bulktemporalCollectionName);
-    /*ConnectedRESTQA.deleteElementRangeIndexTemporalAxis(dbName,
-        axisValidName);
-    ConnectedRESTQA.deleteElementRangeIndexTemporalAxis(dbName,
-        axisSystemName);*/
     deleteDB(schemadbName);
-    deleteForest(schemafNames[0]);
   }
 
   @AfterEach

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBiTemporal.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBiTemporal.java
@@ -115,21 +115,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
     cleanupRESTServer(dbName, fNames);
     deleteRESTUser("eval-user");
     deleteUserRole("test-eval");
-
-    // Temporal collection needs to be delete before temporal axis associated
-    // with it can be deleted
-    /*ConnectedRESTQA.deleteElementRangeIndexTemporalCollection("Documents",
-        temporalLsqtCollectionName);
-    ConnectedRESTQA.deleteElementRangeIndexTemporalCollection("Documents",
-        temporalCollectionName);
-    ConnectedRESTQA.deleteElementRangeIndexTemporalCollection("Documents",
-        bulktemporalCollectionName);
-    ConnectedRESTQA.deleteElementRangeIndexTemporalAxis("Documents",
-        axisValidName);
-    ConnectedRESTQA.deleteElementRangeIndexTemporalAxis("Documents",
-        axisSystemName);*/
     deleteDB(schemadbName);
-    deleteForest(schemafNames[0]);
   }
 
   @BeforeEach

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientKerberosFromFile.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientKerberosFromFile.java
@@ -1048,8 +1048,6 @@ public class TestDatabaseClientKerberosFromFile extends BasicJavaClientREST {
     }
 
     deleteDB(UberdbName);
-    deleteForest(UberfNames[0]);
-    // release client
     clientUber.release();
   }
 

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientWithKerberos.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientWithKerberos.java
@@ -1001,8 +1001,6 @@ public class TestDatabaseClientWithKerberos extends BasicJavaClientREST {
     }
 
     deleteDB(UberdbName);
-    deleteForest(UberfNames[0]);
-    // release client
     clientUber.release();
   }
 


### PR DESCRIPTION
And also improved tear down methods - deleting the database via the ManageClient defaults to deleting all forests and replicas.
