### PR TITLE
MLE-21476 Deprecates MarkLogicCloudAuthContext

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ mlPassword=admin
 # Whether tests should run with the expectation that they'll use a basePath and talk to a reverse proxy server
 testUseReverseProxyServer=false
 
-# For testing cloud-based authentication; define in gradle-local.properties with valid values for a MarkLogic Cloud instance
+# For testing cloud-based authentication; define in gradle-local.properties with valid values for a Progress Data Cloud instance
 cloudHost=
 cloudKey=
 cloudBasePath=

--- a/marklogic-client-api/build.gradle
+++ b/marklogic-client-api/build.gradle
@@ -202,7 +202,7 @@ task testRows(type: Test) {
 }
 
 task debugCloudAuth(type: JavaExec) {
-	description = "Test program for manual testing of cloud-based authentication against a MarkLogic Cloud instance"
+	description = "Test program for manual testing of cloud-based authentication against a Progress Data Cloud instance"
 	main = 'com.marklogic.client.test.MarkLogicCloudAuthenticationDebugger'
 	classpath = sourceSets.test.runtimeClasspath
 	args = [cloudHost, cloudKey, cloudBasePath]

--- a/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClientFactory.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/DatabaseClientFactory.java
@@ -350,26 +350,88 @@ public class DatabaseClientFactory {
 
 	/**
 	 * @since 6.1.0
+	 * @deprecated as of 7.2.0; use {@code ProgressDataCloudAuthContext} instead. Will be removed in 8.0.0.
 	 */
-	public static class MarkLogicCloudAuthContext extends AuthContext {
+	@Deprecated
+	public static class MarkLogicCloudAuthContext extends ProgressDataCloudAuthContext {
+
+		/**
+		 * @param apiKey user's API key for accessing Progress Data Cloud
+		 */
+		public MarkLogicCloudAuthContext(String apiKey) {
+			super(apiKey);
+		}
+
+		/**
+		 * @param apiKey user's API key for accessing Progress Data Cloud
+		 * @param tokenDuration length in minutes until the generated access token expires
+		 * @since 6.3.0
+		 */
+		public MarkLogicCloudAuthContext(String apiKey, Integer tokenDuration) {
+			super(apiKey, tokenDuration);
+		}
+
+		/**
+		 * Only intended to be used in the scenario that the token endpoint of "/token" and the grant type of "apikey"
+		 * are not the intended values.
+		 *
+		 * @param apiKey user's API key for accessing Progress Data Cloud
+		 * @param tokenEndpoint for overriding the default token endpoint if necessary
+		 * @param grantType for overriding the default grant type if necessary
+		 */
+		public MarkLogicCloudAuthContext(String apiKey, String tokenEndpoint, String grantType) {
+			super(apiKey, tokenEndpoint, grantType);
+		}
+
+		/**
+		 * Only intended to be used in the scenario that the token endpoint of "/token" and the grant type of "apikey"
+		 * are not the intended values.
+		 *
+		 * @param apiKey user's API key for accessing Progress Data Cloud
+		 * @param tokenEndpoint for overriding the default token endpoint if necessary
+		 * @param grantType for overriding the default grant type if necessary
+		 * @param tokenDuration length in minutes until the generated access token expires
+		 * @since 6.3.0
+		 */
+		public MarkLogicCloudAuthContext(String apiKey, String tokenEndpoint, String grantType, Integer tokenDuration) {
+			super(apiKey, tokenEndpoint, grantType, tokenDuration);
+		}
+
+		@Override
+		public MarkLogicCloudAuthContext withSSLContext(SSLContext context, X509TrustManager trustManager) {
+			this.sslContext = context;
+			this.trustManager = trustManager;
+			return this;
+		}
+
+		@Override
+		public MarkLogicCloudAuthContext withSSLHostnameVerifier(SSLHostnameVerifier verifier) {
+			this.sslVerifier = verifier;
+			return this;
+		}
+	}
+
+	/**
+	 * @since 7.2.0 Use this instead of the now-deprecated {@code MarkLogicCloudAuthContext}
+	 */
+	public static class ProgressDataCloudAuthContext extends AuthContext {
 		private String tokenEndpoint;
 		private String grantType;
 		private String apiKey;
 		private Integer tokenDuration;
 
 		/**
-		 * @param apiKey user's API key for accessing MarkLogic Cloud
+		 * @param apiKey user's API key for accessing Progress Data Cloud
 		 */
-		public MarkLogicCloudAuthContext(String apiKey) {
+		public ProgressDataCloudAuthContext(String apiKey) {
 			this(apiKey, null);
 		}
 
 		/**
-		 * @param apiKey user's API key for accessing MarkLogic Cloud
+		 * @param apiKey user's API key for accessing Progress Data Cloud
 		 * @param tokenDuration length in minutes until the generated access token expires
-		 * @since 6.3.0
 		 */
-		public MarkLogicCloudAuthContext(String apiKey, Integer tokenDuration) {
+		public ProgressDataCloudAuthContext(String apiKey, Integer tokenDuration) {
 			this(apiKey, "/token", "apikey", tokenDuration);
 		}
 
@@ -377,11 +439,11 @@ public class DatabaseClientFactory {
 		 * Only intended to be used in the scenario that the token endpoint of "/token" and the grant type of "apikey"
 		 * are not the intended values.
 		 *
-		 * @param apiKey user's API key for accessing MarkLogic Cloud
+		 * @param apiKey user's API key for accessing Progress Data Cloud
 		 * @param tokenEndpoint for overriding the default token endpoint if necessary
 		 * @param grantType for overriding the default grant type if necessary
 		 */
-		public MarkLogicCloudAuthContext(String apiKey, String tokenEndpoint, String grantType) {
+		public ProgressDataCloudAuthContext(String apiKey, String tokenEndpoint, String grantType) {
 			this(apiKey, tokenEndpoint, grantType, null);
 		}
 
@@ -389,13 +451,12 @@ public class DatabaseClientFactory {
 		 * Only intended to be used in the scenario that the token endpoint of "/token" and the grant type of "apikey"
 		 * are not the intended values.
 		 *
-		 * @param apiKey user's API key for accessing MarkLogic Cloud
+		 * @param apiKey user's API key for accessing Progress Data Cloud
 		 * @param tokenEndpoint for overriding the default token endpoint if necessary
 		 * @param grantType for overriding the default grant type if necessary
 		 * @param tokenDuration length in minutes until the generated access token expires
-		 * @since 6.3.0
 		 */
-		public MarkLogicCloudAuthContext(String apiKey, String tokenEndpoint, String grantType, Integer tokenDuration) {
+		public ProgressDataCloudAuthContext(String apiKey, String tokenEndpoint, String grantType, Integer tokenDuration) {
 			this.apiKey = apiKey;
 			this.tokenEndpoint = tokenEndpoint;
 			this.grantType = grantType;
@@ -414,23 +475,19 @@ public class DatabaseClientFactory {
 			return apiKey;
 		}
 
-		/**
-		 * @return
-		 * @since 6.3.0
-		 */
 		public Integer getTokenDuration() {
 			return tokenDuration;
 		}
 
 		@Override
-		public MarkLogicCloudAuthContext withSSLContext(SSLContext context, X509TrustManager trustManager) {
+		public ProgressDataCloudAuthContext withSSLContext(SSLContext context, X509TrustManager trustManager) {
 			this.sslContext = context;
 			this.trustManager = trustManager;
 			return this;
 		}
 
 		@Override
-		public MarkLogicCloudAuthContext withSSLHostnameVerifier(SSLHostnameVerifier verifier) {
+		public ProgressDataCloudAuthContext withSSLHostnameVerifier(SSLHostnameVerifier verifier) {
 			this.sslVerifier = verifier;
 			return this;
 		}
@@ -1277,10 +1334,10 @@ public class DatabaseClientFactory {
                                          DatabaseClient.ConnectionType connectionType) {
       RESTServices services = new OkHttpServices();
 	  // As of 6.1.0, the following optimization is made as it's guaranteed that if the user is connecting to a
-	  // MarkLogic Cloud instance, then port 443 will be used. Every path for constructing a DatabaseClient goes through
+	  // Progress Data Cloud instance, then port 443 will be used. Every path for constructing a DatabaseClient goes through
 	  // this method, ensuring that this optimization will always be applied, and thus freeing the user from having to
-	  // worry about what port to configure when using MarkLogic Cloud.
-	  if (securityContext instanceof MarkLogicCloudAuthContext) {
+	  // worry about what port to configure when using Progress Data Cloud.
+	  if (securityContext instanceof MarkLogicCloudAuthContext || securityContext instanceof ProgressDataCloudAuthContext) {
 		  port = 443;
 	  }
       services.connect(host, port, basePath, database, securityContext);

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/DatabaseClientPropertySource.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/DatabaseClientPropertySource.java
@@ -259,7 +259,7 @@ public class DatabaseClientPropertySource {
 				throw new IllegalArgumentException("Cloud token duration must be numeric");
 			}
 		}
-		return new DatabaseClientFactory.MarkLogicCloudAuthContext(apiKey, duration);
+		return new DatabaseClientFactory.ProgressDataCloudAuthContext(apiKey, duration);
 	}
 
 	private DatabaseClientFactory.SecurityContext newCertificateAuthContext(SSLUtil.SSLInputs sslInputs, String sslProtocol) {
@@ -315,7 +315,7 @@ public class DatabaseClientPropertySource {
 	 * Uses the given propertySource to construct the inputs pertaining to constructing an SSLContext and an
 	 * X509TrustManager.
 	 *
-	 * @param authType used for applying "default" as the SSL protocol for MarkLogic cloud authentication in
+	 * @param authType used for applying "default" as the SSL protocol for Progress Data Cloud authentication in
 	 *                 case the user does not define their own SSLContext or SSL protocol
 	 * @return
 	 */
@@ -398,8 +398,8 @@ public class DatabaseClientPropertySource {
 		if (sslProtocol != null) {
 			sslProtocol = sslProtocol.trim();
 		}
-		// For convenience for MarkLogic Cloud users, assume the JVM's default SSLContext should trust the certificate
-		// used by MarkLogic Cloud. A user can always override this default behavior by providing their own SSLContext.
+		// For convenience for Progress Data Cloud users, assume the JVM's default SSLContext should trust the certificate
+		// used by Progress Data Cloud. A user can always override this default behavior by providing their own SSLContext.
 		if ((sslProtocol == null || sslProtocol.length() == 0) && DatabaseClientBuilder.AUTH_TYPE_MARKLOGIC_CLOUD.equalsIgnoreCase(authType)) {
 			sslProtocol = "default";
 		}

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/OkHttpUtil.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/OkHttpUtil.java
@@ -54,8 +54,9 @@ public abstract class OkHttpUtil {
 		} else if (securityContext instanceof DatabaseClientFactory.CertificateAuthContext) {
 		} else if (securityContext instanceof DatabaseClientFactory.SAMLAuthContext) {
 			configureSAMLAuth((DatabaseClientFactory.SAMLAuthContext) securityContext, clientBuilder);
-		} else if (securityContext instanceof DatabaseClientFactory.MarkLogicCloudAuthContext) {
-			authenticationConfigurer = new MarkLogicCloudAuthenticationConfigurer(host);
+		} else if (securityContext instanceof DatabaseClientFactory.ProgressDataCloudAuthContext ||
+			securityContext instanceof DatabaseClientFactory.MarkLogicCloudAuthContext) {
+			authenticationConfigurer = new ProgressDataCloudAuthenticationConfigurer(host);
 		} else if (securityContext instanceof DatabaseClientFactory.OAuthContext) {
 			authenticationConfigurer = new OAuthAuthenticationConfigurer();
 		} else {

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/ProgressDataCloudAuthenticationConfigurer.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/ProgressDataCloudAuthenticationConfigurer.java
@@ -5,23 +5,23 @@ package com.marklogic.client.impl.okhttp;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.marklogic.client.DatabaseClientFactory.MarkLogicCloudAuthContext;
+import com.marklogic.client.DatabaseClientFactory;
 import okhttp3.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
-class MarkLogicCloudAuthenticationConfigurer implements AuthenticationConfigurer<MarkLogicCloudAuthContext> {
+class ProgressDataCloudAuthenticationConfigurer implements AuthenticationConfigurer<DatabaseClientFactory.ProgressDataCloudAuthContext> {
 
-	private String host;
+	private final String host;
 
-	MarkLogicCloudAuthenticationConfigurer(String host) {
+	ProgressDataCloudAuthenticationConfigurer(String host) {
 		this.host = host;
 	}
 
 	@Override
-	public void configureAuthentication(OkHttpClient.Builder clientBuilder, MarkLogicCloudAuthContext securityContext) {
+	public void configureAuthentication(OkHttpClient.Builder clientBuilder, DatabaseClientFactory.ProgressDataCloudAuthContext securityContext) {
 		final String apiKey = securityContext.getApiKey();
 		if (apiKey == null || apiKey.trim().length() < 1) {
 			throw new IllegalArgumentException("No API key provided");
@@ -38,16 +38,16 @@ class MarkLogicCloudAuthenticationConfigurer implements AuthenticationConfigurer
 	}
 
 	/**
-	 * Knows how to call the "/token" endpoint in MarkLogic Cloud to generate a new token based on the
+	 * Knows how to call the "/token" endpoint in Progress Data Cloud to generate a new token based on the
 	 * user-provided API key.
 	 */
 	static class DefaultTokenGenerator implements TokenGenerator {
 
 		private final static Logger logger = LoggerFactory.getLogger(DefaultTokenGenerator.class);
-		private String host;
-		private MarkLogicCloudAuthContext securityContext;
+		private final String host;
+		private final DatabaseClientFactory.ProgressDataCloudAuthContext securityContext;
 
-		public DefaultTokenGenerator(String host, MarkLogicCloudAuthContext securityContext) {
+		public DefaultTokenGenerator(String host, DatabaseClientFactory.ProgressDataCloudAuthContext securityContext) {
 			this.host = host;
 			this.securityContext = securityContext;
 		}
@@ -65,7 +65,7 @@ class MarkLogicCloudAuthenticationConfigurer implements AuthenticationConfigurer
 			final HttpUrl tokenUrl = buildTokenUrl();
 			OkHttpClient.Builder clientBuilder = OkHttpUtil.newClientBuilder();
 			// Current assumption is that the SSL config provided for connecting to MarkLogic should also be applicable
-			// for connecting to MarkLogic Cloud's "/token" endpoint.
+			// for connecting to Progress Data Cloud's "/token" endpoint.
 			OkHttpUtil.configureSocketFactory(clientBuilder, securityContext.getSSLContext(), securityContext.getTrustManager());
 			OkHttpUtil.configureHostnameVerifier(clientBuilder, securityContext.getSSLHostnameVerifier());
 
@@ -89,7 +89,7 @@ class MarkLogicCloudAuthenticationConfigurer implements AuthenticationConfigurer
 		}
 
 		protected HttpUrl buildTokenUrl() {
-			// For the near future, it's guaranteed that https and 443 will be required for connecting to MarkLogic Cloud,
+			// For the near future, it's guaranteed that https and 443 will be required for connecting to Progress Data Cloud,
 			// so providing the ability to customize this would be misleading.
 			HttpUrl.Builder builder = new HttpUrl.Builder()
 				.scheme("https")
@@ -134,7 +134,7 @@ class MarkLogicCloudAuthenticationConfigurer implements AuthenticationConfigurer
 
 		private final static Logger logger = LoggerFactory.getLogger(TokenAuthenticationInterceptor.class);
 
-		private TokenGenerator tokenGenerator;
+		private final TokenGenerator tokenGenerator;
 		private String token;
 
 		public TokenAuthenticationInterceptor(TokenGenerator tokenGenerator) {

--- a/marklogic-client-api/src/test/java/com/marklogic/client/impl/DatabaseClientPropertySourceTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/impl/DatabaseClientPropertySourceTest.java
@@ -81,9 +81,9 @@ public class DatabaseClientPropertySourceTest {
 		bean = buildBean();
 
 		assertEquals("/my/path", bean.getBasePath());
-		assertTrue(bean.getSecurityContext() instanceof DatabaseClientFactory.MarkLogicCloudAuthContext);
+		assertTrue(bean.getSecurityContext() instanceof DatabaseClientFactory.ProgressDataCloudAuthContext);
 
-		DatabaseClientFactory.MarkLogicCloudAuthContext context = (DatabaseClientFactory.MarkLogicCloudAuthContext) bean.getSecurityContext();
+		DatabaseClientFactory.ProgressDataCloudAuthContext context = (DatabaseClientFactory.ProgressDataCloudAuthContext) bean.getSecurityContext();
 		assertEquals("abc123", context.getApiKey());
 
 		assertNotNull(context.getSSLContext(), "If cloud is chosen with no SSL protocol or context, the default JVM " +

--- a/marklogic-client-api/src/test/java/com/marklogic/client/impl/okhttp/ProgressDataCloudAuthenticationConfigurerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/impl/okhttp/ProgressDataCloudAuthenticationConfigurerTest.java
@@ -10,15 +10,15 @@ import javax.net.ssl.SSLContext;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * Since we don't yet have a reliable way to test against a MarkLogic cloud instance, including some small unit tests
+ * Since we don't yet have a reliable way to test against a Progress Data Cloud instance, including some small unit tests
  * to ensure that certain things are built as expected.
  */
-public class MarkLogicCloudAuthenticationConfigurerTest {
+public class ProgressDataCloudAuthenticationConfigurerTest {
 
 	@Test
 	void buildTokenUrl() throws Exception {
-		MarkLogicCloudAuthenticationConfigurer.DefaultTokenGenerator client = new MarkLogicCloudAuthenticationConfigurer.DefaultTokenGenerator("somehost",
-			new DatabaseClientFactory.MarkLogicCloudAuthContext("doesnt-matter")
+		ProgressDataCloudAuthenticationConfigurer.DefaultTokenGenerator client = new ProgressDataCloudAuthenticationConfigurer.DefaultTokenGenerator("somehost",
+			new DatabaseClientFactory.ProgressDataCloudAuthContext("doesnt-matter")
 				.withSSLContext(SSLContext.getDefault(), null)
 		);
 
@@ -32,8 +32,8 @@ public class MarkLogicCloudAuthenticationConfigurerTest {
 	 */
 	@Test
 	void buildTokenUrlWithCustomTokenPath() throws Exception {
-		MarkLogicCloudAuthenticationConfigurer.DefaultTokenGenerator client = new MarkLogicCloudAuthenticationConfigurer.DefaultTokenGenerator("otherhost",
-			new DatabaseClientFactory.MarkLogicCloudAuthContext("doesnt-matter", "/customToken", "doesnt-matter")
+		ProgressDataCloudAuthenticationConfigurer.DefaultTokenGenerator client = new ProgressDataCloudAuthenticationConfigurer.DefaultTokenGenerator("otherhost",
+			new DatabaseClientFactory.ProgressDataCloudAuthContext("doesnt-matter", "/customToken", "doesnt-matter")
 				.withSSLContext(SSLContext.getDefault(), null)
 		);
 
@@ -44,8 +44,8 @@ public class MarkLogicCloudAuthenticationConfigurerTest {
 	@Test
 	void buildTokenUrlWithDuration() throws Exception {
 		Integer duration = 10;
-		MarkLogicCloudAuthenticationConfigurer.DefaultTokenGenerator client = new MarkLogicCloudAuthenticationConfigurer.DefaultTokenGenerator("somehost",
-			new DatabaseClientFactory.MarkLogicCloudAuthContext("doesnt-matter", duration)
+		ProgressDataCloudAuthenticationConfigurer.DefaultTokenGenerator client = new ProgressDataCloudAuthenticationConfigurer.DefaultTokenGenerator("somehost",
+			new DatabaseClientFactory.ProgressDataCloudAuthContext("doesnt-matter", duration)
 				.withSSLContext(SSLContext.getDefault(), null)
 		);
 
@@ -56,8 +56,8 @@ public class MarkLogicCloudAuthenticationConfigurerTest {
 	@Test
 	void buildTokenUrlWithDurationAndCustomPath() throws Exception {
 		Integer duration = 10;
-		MarkLogicCloudAuthenticationConfigurer.DefaultTokenGenerator client = new MarkLogicCloudAuthenticationConfigurer.DefaultTokenGenerator("somehost",
-			new DatabaseClientFactory.MarkLogicCloudAuthContext("doesnt-matter", "/customToken", "doesnt-matter", duration)
+		ProgressDataCloudAuthenticationConfigurer.DefaultTokenGenerator client = new ProgressDataCloudAuthenticationConfigurer.DefaultTokenGenerator("somehost",
+			new DatabaseClientFactory.ProgressDataCloudAuthContext("doesnt-matter", "/customToken", "doesnt-matter", duration)
 				.withSSLContext(SSLContext.getDefault(), null)
 		);
 
@@ -67,8 +67,8 @@ public class MarkLogicCloudAuthenticationConfigurerTest {
 
 	@Test
 	void newFormBody() {
-		FormBody body = new MarkLogicCloudAuthenticationConfigurer.DefaultTokenGenerator("host-doesnt-matter",
-			new DatabaseClientFactory.MarkLogicCloudAuthContext("myKey"))
+		FormBody body = new ProgressDataCloudAuthenticationConfigurer.DefaultTokenGenerator("host-doesnt-matter",
+			new DatabaseClientFactory.ProgressDataCloudAuthContext("myKey"))
 							.newFormBody();
 		assertEquals("grant_type", body.name(0));
 		assertEquals("apikey", body.value(0));
@@ -82,8 +82,8 @@ public class MarkLogicCloudAuthenticationConfigurerTest {
 	 */
 	@Test
 	void newFormBodyWithOverrides() {
-		FormBody body = new MarkLogicCloudAuthenticationConfigurer.DefaultTokenGenerator("host-doesnt-matter",
-			new DatabaseClientFactory.MarkLogicCloudAuthContext("myKey", "doesnt-matter", "custom-grant-type"))
+		FormBody body = new ProgressDataCloudAuthenticationConfigurer.DefaultTokenGenerator("host-doesnt-matter",
+			new DatabaseClientFactory.ProgressDataCloudAuthContext("myKey", "doesnt-matter", "custom-grant-type"))
 							.newFormBody();
 		assertEquals("grant_type", body.name(0));
 		assertEquals("custom-grant-type", body.value(0));

--- a/marklogic-client-api/src/test/java/com/marklogic/client/impl/okhttp/TokenAuthenticationInterceptorTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/impl/okhttp/TokenAuthenticationInterceptorTest.java
@@ -31,8 +31,8 @@ public class TokenAuthenticationInterceptorTest extends LoggingObject {
 		mockWebServer = new MockWebServer();
 		fakeTokenGenerator = new FakeTokenGenerator();
 
-		MarkLogicCloudAuthenticationConfigurer.TokenAuthenticationInterceptor interceptor =
-			new MarkLogicCloudAuthenticationConfigurer.TokenAuthenticationInterceptor(fakeTokenGenerator);
+		ProgressDataCloudAuthenticationConfigurer.TokenAuthenticationInterceptor interceptor =
+			new ProgressDataCloudAuthenticationConfigurer.TokenAuthenticationInterceptor(fakeTokenGenerator);
 		assertEquals(1, fakeTokenGenerator.timesInvoked,
 			"When the interceptor is created, it should immediately generate a token so that when multiple threads " +
 				"are using the DatabaseClient, they will all use the same token.");
@@ -137,7 +137,7 @@ public class TokenAuthenticationInterceptorTest extends LoggingObject {
 	 * Fake token generator that allows us to assert on how many times it's invoked, which ensures that new tokens are
 	 * or are not being generated when required.
 	 */
-	private static class FakeTokenGenerator implements MarkLogicCloudAuthenticationConfigurer.TokenGenerator {
+	private static class FakeTokenGenerator implements ProgressDataCloudAuthenticationConfigurer.TokenGenerator {
 		int timesInvoked;
 
 		@Override

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/DatabaseClientBuilderTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/DatabaseClientBuilderTest.java
@@ -225,8 +225,8 @@ public class DatabaseClientBuilderTest {
 			.withCloudAuth("my-key", "/my/path")
 			.buildBean();
 
-		DatabaseClientFactory.MarkLogicCloudAuthContext context =
-			(DatabaseClientFactory.MarkLogicCloudAuthContext) bean.getSecurityContext();
+		DatabaseClientFactory.ProgressDataCloudAuthContext context =
+			(DatabaseClientFactory.ProgressDataCloudAuthContext) bean.getSecurityContext();
 		assertEquals("my-key", context.getApiKey());
 		assertEquals("/my/path", bean.getBasePath());
 
@@ -243,8 +243,8 @@ public class DatabaseClientBuilderTest {
 	@Test
 	void cloudWithDuration() {
 		bean = Common.newClientBuilder().withCloudAuth("abc123", "/my/path", 10).buildBean();
-		DatabaseClientFactory.MarkLogicCloudAuthContext context =
-			(DatabaseClientFactory.MarkLogicCloudAuthContext) bean.getSecurityContext();
+		DatabaseClientFactory.ProgressDataCloudAuthContext context =
+			(DatabaseClientFactory.ProgressDataCloudAuthContext) bean.getSecurityContext();
 		assertEquals("abc123", context.getApiKey());
 		assertEquals("/my/path", bean.getBasePath());
 		assertEquals(10, context.getTokenDuration());

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/MarkLogicCloudAuthenticationDebugger.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/MarkLogicCloudAuthenticationDebugger.java
@@ -9,10 +9,10 @@ import com.marklogic.client.DatabaseClientFactory;
 import com.marklogic.client.io.JacksonHandle;
 
 /**
- * We don't yet have a way to run tests against a MarkLogic Cloud instance. In the meantime, this program and its
+ * We don't yet have a way to run tests against a Progress Data Cloud instance. In the meantime, this program and its
  * related Gradle task can be used for easy manual testing.
  *
- * For local testing against the ReverseProxyServer in the test-app project, which emulates MarkLogic Cloud, use
+ * For local testing against the ReverseProxyServer in the test-app project, which emulates Progress Data Cloud, use
  * "localhost" as the cloud host, "username:password" (often "admin:the admin password") as the apiKey, and
  * "local/manage" as the basePath.
  */

--- a/test-app/README.md
+++ b/test-app/README.md
@@ -9,7 +9,7 @@ To deploy it, run this from the root directory of this repository:
 
 This project also includes a Gradle task for running a reverse proxy server using [Undertow](https://undertow.io/). 
 This is intended to support testing the use of a "base path" parameter with the Java Client and to also do a reasonable
-job of emulating how MarkLogic Cloud works. 
+job of emulating how Progress Data Cloud works. 
 
 Note - the reverse proxy server only supports basic authentication, not digest authentication. Thus, you need to ensure
 that any MarkLogic app server that you proxy requests to supports either "digestbasic" or "basic" for authentication. 
@@ -22,7 +22,7 @@ To run the server, run the following:
 By default, this will listen on port 8020 and proxy requests based on the mapping that it logs when the server is 
 started up.
 
-To emulate how MarkLogic Cloud works, run the following (you can use `runBlock` as an abbreviation, Gradle will figure 
+To emulate how Progress Data Cloud works, run the following (you can use `runBlock` as an abbreviation, Gradle will figure 
 out what you mean):
 
     sudo ./gradlew runBlock -PrpsHttpsPort=443

--- a/test-app/src/main/java/com/marklogic/client/test/ReverseProxyServer.java
+++ b/test-app/src/main/java/com/marklogic/client/test/ReverseProxyServer.java
@@ -50,7 +50,7 @@ import java.util.concurrent.TimeUnit;
  * authentication is required by MarkLogic. But you'll need to ensure that any MarkLogic app server you proxy is using
  * either basic or digestbasic authentication.
  * <p>
- * As of 2023-01-26, this can now emulate MarkLogic Cloud. It exposes a "/token" endpoint that proxies to port 8022,
+ * As of 2023-01-26, this can now emulate Progress Data Cloud. It exposes a "/token" endpoint that proxies to port 8022,
  * which this server listens to as well (currently hardcoded). A fake access token is returned. Subsequent requests
  * convert that fake access token into a basic authentication value that is included in the proxied request to
  * MarkLogic.
@@ -67,7 +67,7 @@ public class ReverseProxyServer {
 	 * 3) the port for this server; 4) the port for the secure (HTTPS) server. For current use cases though, including
 	 * Jenkins, localhost should suffice for both hostnames and 8020 should suffice as the port.
 	 * <p>
-	 * If you wish to enable a secure server on port 443 - i.e. you're looking to emulate MarkLogic Cloud - you'll
+	 * If you wish to enable a secure server on port 443 - i.e. you're looking to emulate Progress Data Cloud - you'll
 	 * need to run this program as root. Check the build.gradle file for this project to see an example of how to do
 	 * that via Gradle.
 	 *
@@ -129,7 +129,7 @@ public class ReverseProxyServer {
 		mapping.put("/mlxprs/rest", new URI(String.format("http://%s:8055", markLogicHost)));
 		mapping.put("/mlxprs/test", new URI(String.format("http://%s:8054", markLogicHost)));
 
-		// Emulate MarkLogic Cloud "/token" requests by mapping to the handler defined below that can respond to
+		// Emulate Progress Data Cloud "/token" requests by mapping to the handler defined below that can respond to
 		// these requests in a suitable fashion for manual testing.
 		mapping.put("/token", new URI(String.format("http://%s:8022", serverHost)));
 
@@ -166,7 +166,7 @@ public class ReverseProxyServer {
 	}
 
 	/**
-	 * This emulates how MarkLogic Cloud works with a twist - it expects the user's API key to match the pattern
+	 * This emulates how Progress Data Cloud works with a twist - it expects the user's API key to match the pattern
 	 * "username:password". It then generates a basic authentication value for this username/password and returns that
 	 * as the access token. The replaceFakeMarkLogicCloudHeaderIfNecessary method in ReverseProxyClient will then
 	 * replace this fake access token with an appropriate basic authentication header value.
@@ -175,7 +175,7 @@ public class ReverseProxyServer {
 	 */
 	private void handleMarkLogicCloudTokenRequest(HttpServerExchange exchange) {
 		try {
-			logger.info("Emulating MarkLogic Cloud and handling /token request");
+			logger.info("Emulating Progress Data Cloud and handling /token request");
 			FormData formData = FormParserFactory.builder().build().createParser(exchange).parseBlocking();
 			String apiKey = formData.getFirst("key").getValue();
 			String[] tokens = apiKey.split(":");
@@ -184,7 +184,7 @@ public class ReverseProxyServer {
 			exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/json");
 			exchange.getResponseSender().send(response.toPrettyString());
 		} catch (Exception ex) {
-			System.err.println("Unable to process MarkLogic Cloud token request: " + ex.getMessage());
+			System.err.println("Unable to process Progress Data Cloud token request: " + ex.getMessage());
 		}
 	}
 
@@ -274,7 +274,7 @@ public class ReverseProxyServer {
 		}
 
 		/**
-		 * Checks to see if the request has the fake MarkLogic Cloud authentication token in it, which is inserted
+		 * Checks to see if the request has the fake Progress Data Cloud authentication token in it, which is inserted
 		 * by the "/token" handler. If so, that token is replaced with a basic authentication value, which requires that
 		 * the MarkLogic server use basic or digestbasic authentication.
 		 *
@@ -285,7 +285,7 @@ public class ReverseProxyServer {
 			final String fakeBearerIndicator = "BEARER " + FAKE_ACCESS_TOKEN_INDICATOR;
 			if (auth != null && auth.toUpperCase().startsWith(fakeBearerIndicator)) {
 				String basicAuthValue = auth.substring(fakeBearerIndicator.length());
-				logger.info("Replacing fake MarkLogic Cloud Authorization header with a basic Authorization header: " + basicAuthValue);
+				logger.info("Replacing fake Progress Data Cloud Authorization header with a basic Authorization header: " + basicAuthValue);
 				exchange.getRequestHeaders().put(Headers.AUTHORIZATION, basicAuthValue);
 			}
 		}


### PR DESCRIPTION
Deprecates the MarkLogicCloudAuthContext class in favor of ProgressDataCloudAuthContext.

This change reflects the rebranding of MarkLogic Cloud to Progress Data Cloud and ensures that the client API aligns with the updated naming convention.
The deprecated class will be removed in a future release.
