### PR TITLE
MLE-22657 Excluding beanutils from example project

### DIFF
--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -19,6 +19,10 @@ dependencies {
 	api 'org.dom4j:dom4j:2.1.4'
 	api 'com.google.code.gson:gson:2.10.1'
 	api 'net.sourceforge.htmlcleaner:htmlcleaner:2.29'
-	api 'com.opencsv:opencsv:5.11.1'
+	api ('com.opencsv:opencsv:5.11.2') {
+		// Excluding this due to a security vulnerability, and the test for the example that uses this library
+		// passes without this on the classpath.
+		exclude module: "commons-beanutils"
+	}
 	api 'org.apache.commons:commons-lang3:3.17.0'
 }


### PR DESCRIPTION
Turns out it's not even needed by the opencsv dependency.
