### PR TITLE
MLE-23004 - Addresses Gradle 9 deprecation warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@
 buildscript {
     repositories {
         maven {
-            url "https://plugins.gradle.org/m2/"
+            url = "https://plugins.gradle.org/m2/"
         }
     }
     dependencies {

--- a/marklogic-client-api/build.gradle
+++ b/marklogic-client-api/build.gradle
@@ -170,7 +170,7 @@ publishing {
                     password mavenPassword
                 }
             }
-            url publishUrl
+            url = publishUrl
         }
     }
 }
@@ -203,7 +203,7 @@ task testRows(type: Test) {
 
 task debugCloudAuth(type: JavaExec) {
 	description = "Test program for manual testing of cloud-based authentication against a Progress Data Cloud instance"
-	main = 'com.marklogic.client.test.MarkLogicCloudAuthenticationDebugger'
+	mainClass = 'com.marklogic.client.test.MarkLogicCloudAuthenticationDebugger'
 	classpath = sourceSets.test.runtimeClasspath
 	args = [cloudHost, cloudKey, cloudBasePath]
 }

--- a/ml-development-tools/build.gradle
+++ b/ml-development-tools/build.gradle
@@ -5,13 +5,13 @@ plugins {
 	id 'maven-publish'
 	id "com.gradle.plugin-publish" version "1.2.1"
 	id "java-gradle-plugin"
-	id 'org.jetbrains.kotlin.jvm' version '1.8.22'
+	id 'org.jetbrains.kotlin.jvm' version '1.9.24'
 }
 
 dependencies {
 	compileOnly gradleApi()
 	implementation project(':marklogic-client-api')
-	implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.8.22'
+	implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.9.24'
 	implementation "com.fasterxml.jackson.module:jackson-module-kotlin:${jacksonVersion}"
 	implementation 'com.networknt:json-schema-validator:1.0.88'
 
@@ -37,7 +37,7 @@ tasks.processResources {
 
 tasks.register("mlDevelopmentToolsJar", Jar) {
 	dependsOn classes
-	archivesBaseName = 'ml-development-tools'
+	archiveBaseName = 'ml-development-tools'
 }
 
 gradlePlugin {
@@ -68,7 +68,7 @@ publishing {
 					password mavenPassword
 				}
 			}
-			url publishUrl
+			url = publishUrl
 		}
 	}
 }

--- a/test-app/build.gradle
+++ b/test-app/build.gradle
@@ -33,6 +33,6 @@ tasks.register("runBlockingReverseProxyServer", JavaExec) {
 		"or any value less than 1024, you will need to use sudo to run this - e.g. " +
 		"sudo ./gradlew runBlockingReverseProxyServer -PrpsHttpsPort=443 ."
 	classpath = sourceSets.main.runtimeClasspath
-	main = "com.marklogic.client.test.ReverseProxyServer"
+	mainClass = "com.marklogic.client.test.ReverseProxyServer"
 	args = [rpsMarkLogicServer, rpsProxyServer, rpsHttpPort, rpsHttpsPort, rpsCustomMappings]
 }


### PR DESCRIPTION
Updates the Gradle build configuration to resolve deprecation warnings in Gradle 9.

- Replaces deprecated assignment syntax in `build.gradle` files.
- Updates the Kotlin version and dependencies in `ml-development-tools/build.gradle`.
- Replaces deprecated `main` property with `mainClass` in task definitions.

MLE-23004