### PR TITLE
MLE-12345 Reworking how test plumbing clears a database

### DIFF
--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ConnectedRESTQA.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ConnectedRESTQA.java
@@ -30,6 +30,7 @@ import com.marklogic.mgmt.resource.security.UserManager;
 import com.marklogic.mgmt.resource.temporal.TemporalAxesManager;
 import com.marklogic.mgmt.resource.temporal.TemporalCollectionLSQTManager;
 import com.marklogic.mgmt.resource.temporal.TemporalCollectionManager;
+import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.*;
 import java.io.IOException;
@@ -317,12 +318,20 @@ public abstract class ConnectedRESTQA {
 
 	public static void clearDB(int port) {
 		try (DatabaseClient client = newDatabaseClientBuilder().withPort(port).build()) {
-			QueryManager mgr = client.newQueryManager();
-			mgr.delete(mgr.newDeleteDefinition());
+			// Trying an eval instead of a "DELETE v1/search", which leads to intermittent errors on Jenkins involving
+			// a "clear" operation on a forest failing.
+			String count = client.newServerEval()
+				.xquery("let $uris := " +
+					"	for $uri in cts:uris((), (), cts:true-query()) " +
+					"	let $_ := xdmp:document-delete($uri) " +
+					"	return $uri " +
+					"return fn:count($uris)")
+				.evalAs(String.class);
+			LoggerFactory.getLogger(ConnectedRESTQA.class).info("Cleared database, deleting {} URIs", count);
 		}
 	}
 
-	public static void tearDownJavaRESTServer(String dbName, String[] fNames, String restServerName) {
+	public static void tearDownJavaRESTServer(String dbName, String restServerName) {
 		associateRESTServerWithDB(restServerName, "Documents");
 		deleteDB(dbName);
 	}
@@ -849,11 +858,11 @@ public abstract class ConnectedRESTQA {
 	}
 
 	// Removes the database and forest from a REST server.
-	public static void cleanupRESTServer(String dbName, String[] fNames) throws Exception {
+	public static void cleanupRESTServer(String dbName) {
 		if (IsSecurityEnabled())
-			tearDownJavaRESTServer(dbName, fNames, restSslServerName);
+			tearDownJavaRESTServer(dbName, restSslServerName);
 		else
-			tearDownJavaRESTServer(dbName, fNames, restServerName);
+			tearDownJavaRESTServer(dbName, restServerName);
 	}
 
 	// Returns true or false based security (ssl) is enabled or disabled.

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestAutomatedPathRangeIndex.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestAutomatedPathRangeIndex.java
@@ -55,7 +55,7 @@ public class TestAutomatedPathRangeIndex extends BasicJavaClientREST {
   @AfterAll
   public static void tearDownAfterClass() throws Exception {
     System.out.println("In tear down");
-    cleanupRESTServer(dbName, fNames);
+    cleanupRESTServer(dbName);
   }
 
   @BeforeEach

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBiTempMetaValues.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBiTempMetaValues.java
@@ -109,7 +109,7 @@ public class TestBiTempMetaValues extends BasicJavaClientREST {
   public static void tearDownAfterClass() throws Exception {
     System.out.println("In tear down");
 
-    cleanupRESTServer(dbName, fNames);
+    cleanupRESTServer(dbName);
     deleteRESTUser("eval-bitemp-meta-user");
     deleteRESTUser("eval-readeruser");
     deleteUserRole("test-eval-bitemp");

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBiTemporal.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestBiTemporal.java
@@ -112,7 +112,7 @@ public class TestBiTemporal extends BasicJavaClientREST {
     System.out.println("In tear down");
 
     // Delete database first. Otherwise axis and collection cannot be deleted
-    cleanupRESTServer(dbName, fNames);
+    cleanupRESTServer(dbName);
     deleteRESTUser("eval-user");
     deleteUserRole("test-eval");
     deleteDB(schemadbName);

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientKerberosFromFile.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientKerberosFromFile.java
@@ -137,7 +137,7 @@ public class TestDatabaseClientKerberosFromFile extends BasicJavaClientREST {
     System.out.println("In tear down");
     deleteUserRole("test-evalKer");
     deleteRESTUser("builder");
-    tearDownJavaRESTServer(dbName, fNames, appServerName);
+    tearDownJavaRESTServer(dbName, appServerName);
   }
 
   @BeforeEach

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientWithKerberos.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientWithKerberos.java
@@ -111,7 +111,7 @@ public class TestDatabaseClientWithKerberos extends BasicJavaClientREST {
     System.out.println("In tear down");
     deleteUserRole("test-evalKer");
     deleteRESTUser("user2");
-    tearDownJavaRESTServer(dbName, fNames, appServerName);
+    tearDownJavaRESTServer(dbName, appServerName);
   }
 
   @BeforeEach

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestEvalwithRunTimeDBnTransactions.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestEvalwithRunTimeDBnTransactions.java
@@ -52,13 +52,13 @@ public class TestEvalwithRunTimeDBnTransactions extends BasicJavaClientREST {
   @AfterAll
   public static void tearDownAfterClass() throws Exception {
     System.out.println("In tear down");
-    cleanupRESTServer(dbName, fNames);
+    cleanupRESTServer(dbName);
     deleteRESTUser("eval-user");
     deleteUserRole("test-eval");
   }
 
   @BeforeEach
-  public void setUp() throws KeyManagementException, NoSuchAlgorithmException, Exception {
+  public void setUp() {
     client = getDatabaseClient("eval-user", "x", getConnType());
   }
 
@@ -198,7 +198,7 @@ public class TestEvalwithRunTimeDBnTransactions extends BasicJavaClientREST {
         t1.rollback();
         client2.release();
       }
-      cleanupRESTServer(dbNameTmp, fNamesTmp);
+      cleanupRESTServer(dbNameTmp);
       associateRESTServerWithDB(getRestServerName(), "Documents");
     }
   }


### PR DESCRIPTION
The "clear" that happens via DELETE v1/search causes intermittent failures on Jenkins.
