### PR TITLE
MLE-23146 Address compile warnings in src/main/java

### DIFF
--- a/examples/src/main/java/com/marklogic/client/example/handle/GSONHandleExample.java
+++ b/examples/src/main/java/com/marklogic/client/example/handle/GSONHandleExample.java
@@ -55,7 +55,7 @@ public class GSONHandleExample {
     String docId = "/example/"+filename;
 
     // parse the example file with GSON
-    JsonElement writeDocument = new JsonParser().parse(
+    JsonElement writeDocument = JsonParser.parseReader(
       new InputStreamReader(docStream, "UTF-8"));
 
     // write the document
@@ -99,7 +99,7 @@ public class GSONHandleExample {
     GSONHandle writeHandle = new GSONHandle();
 
     // parse the example file with GSON
-    JsonElement writeDocument = writeHandle.getParser().parse(
+    JsonElement writeDocument = JsonParser.parseReader(
       new InputStreamReader(docStream, "UTF-8"));
     writeHandle.set(writeDocument);
 

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/TestSplitters.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/TestSplitters.java
@@ -36,6 +36,7 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+@SuppressWarnings("unchecked")
 public class TestSplitters  extends BasicJavaClientREST {
     private static String dbName = "TestSplittersDB";
     private static String[] fNames = {"TestSplittersDB-1"};
@@ -1050,6 +1051,7 @@ class SplitRunnable implements Runnable {
     }
 
     @Override
+	@SuppressWarnings("unchecked")
     public void run() {
         Stream<StringHandle> contentStream = null;
         Charset cs = Charset.forName("UTF-8");

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/RowBatcherFuncTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/RowBatcherFuncTest.java
@@ -68,8 +68,8 @@ public class RowBatcherFuncTest extends AbstractFunctionalTest {
         PlanBuilder p = rowMgr.newPlanBuilder();
         PlanBuilder.ModifyPlan plan = p.fromView("opticFunctionalTest", "detail");
         rowsBatcherOfJsonObj.withBatchView(plan);
-        ArrayList<Double> exptdAmt = new ArrayList(Arrays.asList(10.01,20.02,30.03,40.04,50.05,60.06));
-        ArrayList<Double> resultAmt = new ArrayList<>();
+        List<Double> exptdAmt = Arrays.asList(10.01,20.02,30.03,40.04,50.05,60.06);
+        List<Double> resultAmt = new ArrayList<>();
 
         rowsBatcherOfJsonObj.onSuccess(e ->{
             JsonNode resDoc = e.getRowsDoc().get("rows");
@@ -117,8 +117,8 @@ public class RowBatcherFuncTest extends AbstractFunctionalTest {
                         p.col( "color")
                 );
         rowsBatcherOfJsonObj.withBatchView(plan3);
-        ArrayList<Double> exptdAmt = new ArrayList(Arrays.asList(10.01,20.02,30.03,40.04,50.05,60.06));
-        ArrayList<Double> resultAmt = new ArrayList<>();
+        List<Double> exptdAmt = Arrays.asList(10.01,20.02,30.03,40.04,50.05,60.06);
+        List<Double> resultAmt = new ArrayList<>();
 
         rowsBatcherOfJsonObj.onSuccess(e ->{
             JsonNode resDoc = e.getRowsDoc().get("rows");
@@ -168,8 +168,8 @@ public class RowBatcherFuncTest extends AbstractFunctionalTest {
                         p.as("divided", p.divide(p.col("amount"), p.multiply(p.col("amount"), p.viewCol("detail", "id"))))
                 );
         rowsBatcherOfJsonObj.withBatchView(plan3);
-        ArrayList<Double> exptdAmt = new ArrayList(Arrays.asList(11.01, 22.02, 31.03, 42.04, 51.05, 62.06));
-        ArrayList<Double> resultAmt = new ArrayList<>();
+        List<Double> exptdAmt = Arrays.asList(11.01, 22.02, 31.03, 42.04, 51.05, 62.06);
+		List<Double> resultAmt = new ArrayList<>();
 
         rowsBatcherOfJsonObj.onSuccess(e -> {
             JsonNode resDoc = e.getRowsDoc().get("rows");
@@ -259,9 +259,9 @@ public class RowBatcherFuncTest extends AbstractFunctionalTest {
         PlanBuilder p = rowMgr.newPlanBuilder();
         PlanBuilder.ModifyPlan plan = p.fromView("opticFunctionalTest", "detail");
         rowsBatcherOfJsonObj.withBatchView(plan);
-        ArrayList<Double> exptdAmt = new ArrayList(Arrays.asList(10.01,20.02,30.03,40.04,50.05,60.06));
-        ArrayList<Double> resultAmt1 = new ArrayList<>();
-        ArrayList<Double> resultAmt2 = new ArrayList<>();
+        List<Double> exptdAmt = Arrays.asList(10.01,20.02,30.03,40.04,50.05,60.06);
+		List<Double> resultAmt1 = new ArrayList<>();
+		List<Double> resultAmt2 = new ArrayList<>();
         rowsBatcherOfJsonObj.onSuccess(e ->{
             JsonNode resDoc = e.getRowsDoc().get("rows");
 
@@ -364,8 +364,8 @@ public class RowBatcherFuncTest extends AbstractFunctionalTest {
         PlanBuilder p = rowMgr.newPlanBuilder();
         PlanBuilder.ModifyPlan plan = p.fromView("opticFunctionalTest", "detail");
         rowsBatcherOfJsonObj.withBatchView(plan);
-        ArrayList<Double> exptdAmt = new ArrayList(Arrays.asList(10.01, 20.02, 30.03, 40.04, 50.05, 60.06));
-        ArrayList<Double> resultAmt1 = new ArrayList<>();
+        List<Double> exptdAmt = Arrays.asList(10.01, 20.02, 30.03, 40.04, 50.05, 60.06);
+		List<Double> resultAmt1 = new ArrayList<>();
 
         rowsBatcherOfJsonObj.onSuccess(e -> {
                 JsonNode resDoc = e.getRowsDoc().get("rows");

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestDocumentFormat.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestDocumentFormat.java
@@ -26,9 +26,7 @@ import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 
-
-
-
+@SuppressWarnings("unchecked")
 public class TestDocumentFormat extends AbstractFunctionalTest {
 
   @BeforeAll

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestDocumentMimetype.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestDocumentMimetype.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 
+@SuppressWarnings("unchecked")
 public class TestDocumentMimetype extends AbstractFunctionalTest {
 
   @Test

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestEvalJavaScript.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestEvalJavaScript.java
@@ -515,7 +515,7 @@ public class TestEvalJavaScript extends AbstractFunctionalTest {
       DocumentMetadataHandle metadataHandle = new DocumentMetadataHandle();
       metadataHandle.getPermissions().add("test-js-eval",
           Capability.UPDATE, Capability.READ, Capability.EXECUTE);
-      DocumentManager dm = moduleClient.newDocumentManager();
+      TextDocumentManager dm = moduleClient.newTextDocumentManager();
       dm.write("/data/javascriptQueries.sjs", metadataHandle, ish);
       /*DocumentBuilder db = DocumentBuilderFactory.newInstance()
           .newDocumentBuilder();*/
@@ -648,7 +648,7 @@ public class TestEvalJavaScript extends AbstractFunctionalTest {
 			  mjsString + "export default output;" :
 			  mjsString + "output";
 
-		  DocumentManager dm = moduleClient.newDocumentManager();
+		  TextDocumentManager dm = moduleClient.newTextDocumentManager();
 		  DocumentMetadataHandle metadataHandle = new DocumentMetadataHandle();
 		  metadataHandle.getPermissions().add("test-js-eval",
 				  Capability.UPDATE, Capability.READ, Capability.EXECUTE);

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestEvalXquery.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestEvalXquery.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.FailedRequestException;
 import com.marklogic.client.document.DocumentManager;
+import com.marklogic.client.document.TextDocumentManager;
 import com.marklogic.client.eval.EvalResult;
 import com.marklogic.client.eval.EvalResult.Type;
 import com.marklogic.client.eval.EvalResultIterator;
@@ -413,7 +414,7 @@ public class TestEvalXquery extends AbstractFunctionalTest {
       ish.set(inputStream);
       DocumentMetadataHandle metadataHandle = new DocumentMetadataHandle();
       metadataHandle.getPermissions().add("test-eval", Capability.UPDATE, Capability.READ, Capability.EXECUTE);
-      DocumentManager dm = moduleClient.newDocumentManager();
+      TextDocumentManager dm = moduleClient.newTextDocumentManager();
       dm.write("/data/xquery-modules-with-diff-variable-types.xqy", metadataHandle, ish);
       DocumentBuilder db = DocumentBuilderFactory.newInstance().newDocumentBuilder();
       InputSource is = new InputSource();

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticEnhancements.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticEnhancements.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.regex.Pattern;
 
 
+@SuppressWarnings("unchecked")
 public class TestOpticEnhancements extends AbstractFunctionalTest {
 
   private static Map<String, Object>[] literals1 = new HashMap[10];

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnLiterals.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnLiterals.java
@@ -31,6 +31,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+@SuppressWarnings("unchecked")
 public class TestOpticOnLiterals extends AbstractFunctionalTest {
 
   private static Map<String, Object>[] literals1 = new HashMap[5];

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnMixedViews.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestOpticOnMixedViews.java
@@ -23,7 +23,7 @@ import java.util.Map;
 /* The tests here are for sanity checks when we have plans from different sources
  * such as fromLexicons and fromtriples.
  */
-
+@SuppressWarnings("unchecked")
 public class TestOpticOnMixedViews extends AbstractFunctionalTest {
 
   @BeforeAll

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOQueryBuilderContainerQuery.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOQueryBuilderContainerQuery.java
@@ -81,6 +81,7 @@ public class TestPOJOQueryBuilderContainerQuery extends AbstractFunctionalTest {
     assertTrue( art.getInventory() > 1000);
   }
 
+	@SuppressWarnings("unchecked")
   public void loadSimplePojos(PojoRepository products)
   {
     for (int i = 1; i < 111; i++) {
@@ -133,6 +134,7 @@ public class TestPOJOQueryBuilderContainerQuery extends AbstractFunctionalTest {
   // Below scenario is to test container query builder with wild card options in
   // word query
   @Test
+  @SuppressWarnings("unchecked")
   public void testPOJOwordSearchWithContainerQueryBuilder() {
     PojoRepository<Artifact, Long> products = client.newPojoRepository(Artifact.class, Long.class);
     PojoPage<Artifact> p;
@@ -240,7 +242,8 @@ public class TestPOJOQueryBuilderContainerQuery extends AbstractFunctionalTest {
   // Below scenario is verifying and query with all pojo builder methods
 
   @Test
-  public void testPOJOWordSearchWithOptions() throws KeyManagementException, NoSuchAlgorithmException, Exception {
+  @SuppressWarnings("unchecked")
+  public void testPOJOWordSearchWithOptions() {
     PojoRepository<Artifact, Long> products = client.newPojoRepository(Artifact.class, Long.class);
     PojoPage<Artifact> p;
     this.loadSimplePojos(products);

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOQueryBuilderGeoQueries.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOQueryBuilderGeoQueries.java
@@ -79,6 +79,7 @@ public class TestPOJOQueryBuilderGeoQueries extends AbstractFunctionalTest {
     assertTrue( art.getInventory() > 1000);
   }
 
+	@SuppressWarnings("unchecked")
   public void loadSimplePojos(PojoRepository products)
   {
     for (int i = 1; i < 111; i++) {
@@ -96,6 +97,7 @@ public class TestPOJOQueryBuilderGeoQueries extends AbstractFunctionalTest {
   // This test is to verify GeoPair query works fine,
   // searching for lattitud and longitude of Reno
   @Test
+  @SuppressWarnings("unchecked")
   public void testPOJOGeoQuerySearchWithGeoPair() {
     PojoRepository<GeoSpecialArtifact, Long> products = client.newPojoRepository(GeoSpecialArtifact.class, Long.class);
     PojoPage<GeoSpecialArtifact> p;
@@ -135,6 +137,7 @@ public class TestPOJOQueryBuilderGeoQueries extends AbstractFunctionalTest {
 
   // This test is to verify GeoProperty query works fine
   @Test
+  @SuppressWarnings("unchecked")
   public void testPOJOGeoQuerySearchWithGeoProperty() {
     PojoRepository<GeoSpecialArtifact, Long> products = client.newPojoRepository(GeoSpecialArtifact.class, Long.class);
     PojoPage<GeoSpecialArtifact> p;
@@ -170,6 +173,7 @@ public class TestPOJOQueryBuilderGeoQueries extends AbstractFunctionalTest {
   // This test is to verify GeoPath query works fine,
   // searching for lattitud and longitude of Reno
   @Test
+  @SuppressWarnings("unchecked")
   public void testPOJOGeoQuerySearchWithGeoPath() {
     PojoRepository<GeoSpecialArtifact, Long> products = client.newPojoRepository(GeoSpecialArtifact.class, Long.class);
     PojoPage<GeoSpecialArtifact> p;

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOQueryBuilderValueQuery.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOQueryBuilderValueQuery.java
@@ -94,6 +94,7 @@ public class TestPOJOQueryBuilderValueQuery extends AbstractFunctionalTest {
     assertTrue( art.getInventory() > 1000);
   }
 
+	@SuppressWarnings("unchecked")
   public void loadSimplePojos(PojoRepository products) {
     for (int i = 1; i < 111; i++) {
       if (i % 2 == 0) {

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOReadWrite1.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOReadWrite1.java
@@ -472,6 +472,7 @@ public class TestPOJOReadWrite1 extends AbstractFunctionalTest {
     assertEquals( 1, p.getTotalPages());
   }
 
+	@SuppressWarnings("unchecked")
   public void loadSimplePojos(PojoRepository rangeQueryRepos) {
     for (int i = 1; i < 111; i++) {
       if (i % 2 == 0) {

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOWithStringQD.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOWithStringQD.java
@@ -84,6 +84,7 @@ public class TestPOJOWithStringQD extends AbstractFunctionalTest {
     assertNotNull( art.getInventory() > 1000);
   }
 
+  @SuppressWarnings("unchecked")
   public void loadSimplePojos(PojoRepository products)
   {
     for (int i = 1; i < 111; i++) {

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOWithStrucQD.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOWithStrucQD.java
@@ -87,6 +87,7 @@ public class TestPOJOWithStrucQD extends AbstractFunctionalTest {
     assertTrue( art.getInventory() > 1000);
   }
 
+	@SuppressWarnings("unchecked")
   public void loadSimplePojos(PojoRepository products)
   {
     for (int i = 1; i < 111; i++) {

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOwithQBEQueryDef.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPOJOwithQBEQueryDef.java
@@ -85,6 +85,7 @@ public class TestPOJOwithQBEQueryDef extends AbstractFunctionalTest {
     assertTrue( art.getInventory() > 1000);
   }
 
+	@SuppressWarnings("unchecked")
   public void loadSimplePojos(PojoRepository products)
   {
     for (int i = 1; i < 111; i++) {

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPointInTimeQuery.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestPointInTimeQuery.java
@@ -66,7 +66,7 @@ public class TestPointInTimeQuery extends AbstractFunctionalTest {
 		for (String filename : filenames) {
 			writeDocumentUsingInputStreamHandle(client, filename, "/partial-update/", "JSON");
 		}
-		DocumentManager docMgrIns = client.newJSONDocumentManager();
+		JSONDocumentManager docMgrIns = client.newJSONDocumentManager();
 		// create handle
 		JacksonHandle jacksonHandle = new JacksonHandle();
 

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestRollbackTransaction.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestRollbackTransaction.java
@@ -27,7 +27,7 @@ import java.security.NoSuchAlgorithmException;
 import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
 
-
+@SuppressWarnings("unchecked")
 public class TestRollbackTransaction extends AbstractFunctionalTest {
 
   @Test

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestSearchMultipleForests.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/TestSearchMultipleForests.java
@@ -7,6 +7,7 @@ package com.marklogic.client.fastfunctest;
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.Transaction;
 import com.marklogic.client.document.DocumentManager;
+import com.marklogic.client.document.XMLDocumentManager;
 import com.marklogic.client.io.SearchHandle;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.query.QueryManager;
@@ -25,13 +26,13 @@ public class TestSearchMultipleForests extends AbstractFunctionalTest {
   private static String[] fNames = { "java-functest-1", "java-functest-2" };
 
   @Test
-  public void testSearchMultipleForest() throws KeyManagementException, NoSuchAlgorithmException, IOException
+  public void testSearchMultipleForest()
   {
     System.out.println("Running testSearchMultipleForest");
     // connect the client
     DatabaseClient client = getDatabaseClient("rest-writer", "x", getConnType());
 
-    DocumentManager docMgr = client.newDocumentManager();
+    XMLDocumentManager docMgr = client.newXMLDocumentManager();
     StringHandle writeHandle1 = new StringHandle();
     for (int a = 1; a <= 10; a++) {
       writeHandle1.set("<root>hello</root>");

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/datamovement/ExportListenerTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/fastfunctest/datamovement/ExportListenerTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.*;
 
+import com.marklogic.client.document.JSONDocumentManager;
 import com.marklogic.client.fastfunctest.AbstractFunctionalTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -183,7 +184,7 @@ public class ExportListenerTest extends AbstractFunctionalTest {
             System.out.println("Batch Numer is " + batch.getJobBatchNumber());
             if (batch.getJobBatchNumber() == 1) {
               // Attempt to read firstName11 from database
-              DocumentManager docMgr = dbClient.newJSONDocumentManager();
+              JSONDocumentManager docMgr = dbClient.newJSONDocumentManager();
               JacksonHandle jacksonhandle = new JacksonHandle();
               docMgr.read("firstName11.json", jacksonhandle);
               JsonNode node = jacksonhandle.get();
@@ -307,7 +308,7 @@ public class ExportListenerTest extends AbstractFunctionalTest {
             System.out.println("Batch Numer is " + batch.getJobBatchNumber());
             if (batch.getJobBatchNumber() == 1) {
               // Attempt to read firstName11 from database
-              DocumentManager docMgr = dbClient.newJSONDocumentManager();
+				JSONDocumentManager docMgr = dbClient.newJSONDocumentManager();
               JacksonHandle jacksonhandle = new JacksonHandle();
               docMgr.read("firstName11.json", jacksonhandle);
               JsonNode node = jacksonhandle.get();

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/BasicJavaClientREST.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/BasicJavaClientREST.java
@@ -59,6 +59,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
    * @param type
    * @throws FileNotFoundException
    */
+  @SuppressWarnings("unchecked")
   public void writeDocumentUsingInputStreamHandle(DatabaseClient client, String filename, String uri, String type) throws FileNotFoundException
   {
     // create doc manager
@@ -92,6 +93,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
    * @param metadataHandle
    * @throws FileNotFoundException
    */
+  @SuppressWarnings("unchecked")
   public void writeDocumentUsingInputStreamHandle(DatabaseClient client, String filename, String uri, DocumentMetadataHandle metadataHandle, String type)
       throws FileNotFoundException
   {
@@ -124,6 +126,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
    * @param type
    * @return
    */
+  @SuppressWarnings("unchecked")
   public InputStreamHandle readDocumentUsingInputStreamHandle(DatabaseClient client, String uri, String type)
   {
     // create doc manager
@@ -150,7 +153,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
    * @param type
    * @return
    */
-
+  @SuppressWarnings("unchecked")
   public InputSourceHandle readDocumentUsingInputSourceHandle(DatabaseClient client, String uri, String type)
   {
     // create doc manager
@@ -177,7 +180,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
    * @param type
    * @return
    */
-
+  @SuppressWarnings("unchecked")
   public SourceHandle readDocumentUsingSourceHandle(DatabaseClient client, String uri, String type)
   {
     // create doc manager
@@ -205,6 +208,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
    * @param type
    * @throws FileNotFoundException
    */
+  @SuppressWarnings("unchecked")
   public void updateDocumentUsingInputStreamHandle(DatabaseClient client, String filename, String uri, String type) throws FileNotFoundException
   {
     // create doc manager
@@ -237,6 +241,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
    * @param type
    * @throws IOException
    */
+  @SuppressWarnings("unchecked")
   public void writeDocumentUsingBytesHandle(DatabaseClient client, String filename, String uri, String type) throws IOException
   {
     // get the content to bytes
@@ -280,6 +285,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
    * @param type
    * @throws IOException
    */
+  @SuppressWarnings("unchecked")
   public void writeDocumentUsingBytesHandle(DatabaseClient client, String filename, String uri, DocumentMetadataHandle metadataHandle, String type) throws IOException
   {
     // get the content to bytes
@@ -323,6 +329,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
    * @param type
    * @throws IOException
    */
+  @SuppressWarnings("unchecked")
   public void writeDocumentUsingStringHandle(DatabaseClient client, String filename, String uri, DocumentMetadataHandle metadataHandle, String type) throws IOException
   {
     // acquire the content
@@ -358,6 +365,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
    * @param type
    * @throws IOException
    */
+  @SuppressWarnings("unchecked")
   public void writeDocumentUsingStringHandle(DatabaseClient client, String filename, String uri, String type) throws IOException
   {
     // acquire the content
@@ -394,6 +402,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
    * @param type
    * @throws JAXBException
    */
+  @SuppressWarnings("unchecked")
   public void writeDocumentUsingJAXBHandle(DatabaseClient client, Product product, String uri, DocumentMetadataHandle metadataHandle, String type) throws JAXBException
   {
     // set jaxb context
@@ -425,6 +434,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
    * @param metadataHandle
    * @param type
    */
+  @SuppressWarnings("unchecked")
   public void writeDocumentUsingOutputStreamHandle(DatabaseClient client, final String filename, String uri, DocumentMetadataHandle metadataHandle, String type)
   {
     final int MAX_BUF = 1024;
@@ -439,6 +449,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
     OutputStreamSender sender = new OutputStreamSender() {
       // the callback receives the output stream
       @Override
+	  @SuppressWarnings("unchecked")
       public void write(OutputStream out) throws IOException {
         // acquire the content
         InputStream docStream = new FileInputStream("src/test/java/com/marklogic/client/functionaltest/data/" + filename);
@@ -462,6 +473,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
     System.out.println("Write " + docId + " to the database");
   }
 
+	@SuppressWarnings("unchecked")
   public void writeDocumentUsingOutputStreamHandle(DatabaseClient client, final String filename, String uri, String type)
   {
     final int MAX_BUF = 1024;
@@ -475,6 +487,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
     // create an anonymous class with a callback method
     OutputStreamSender sender = new OutputStreamSender() {
       // the callback receives the output stream
+	  @SuppressWarnings("unchecked")
       public void write(OutputStream out) throws IOException {
         // acquire the content
         InputStream docStream = new FileInputStream("src/test/java/com/marklogic/client/functionaltest/data/" + filename);
@@ -498,6 +511,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
     System.out.println("Write " + docId + " to the database");
   }
 
+	@SuppressWarnings("unchecked")
   public void updateDocumentUsingOutputStreamHandle(DatabaseClient client, final String filename, String uri, String type) throws FileNotFoundException
   {
     final int MAX_BUF = 1024;
@@ -511,6 +525,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
     // create an anonymous class with a callback method
     OutputStreamSender sender = new OutputStreamSender() {
       // the callback receives the output stream
+	  @SuppressWarnings("unchecked")
       public void write(OutputStream out) throws IOException {
         // acquire the content
         InputStream docStream = new FileInputStream("src/test/java/com/marklogic/client/functionaltest/data/" + filename);
@@ -547,6 +562,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
    *          : the document type (XML, Text, JSON, or Binary)
    * @throws IOException
    */
+  @SuppressWarnings("unchecked")
   public void writeDocumentReaderHandle(DatabaseClient client, String filename, String uri, String type) throws IOException
   {
     // create doc manager
@@ -580,6 +596,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
    * @param type
    * @throws IOException
    */
+  @SuppressWarnings("unchecked")
   public void updateDocumentReaderHandle(DatabaseClient client, String filename, String uri, String type) throws IOException
   {
     // create doc manager
@@ -652,6 +669,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
    * @param type
    * @return
    */
+  @SuppressWarnings("unchecked")
   public ReaderHandle readDocumentReaderHandle(DatabaseClient client, String uri, String type)
   {
     // create doc manager
@@ -678,6 +696,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
    * @param type
    * @return
    */
+  @SuppressWarnings("unchecked")
   public XMLEventReaderHandle readDocumentUsingXMLEventReaderHandle(DatabaseClient client, String uri, String type)
   {
     // create doc manager
@@ -695,6 +714,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
     return readerHandle;
   }
 
+	@SuppressWarnings("unchecked")
   public XMLStreamReaderHandle readDocumentUsingXMLStreamReaderHandle(DatabaseClient client, String uri, String type) {
     // create doc manager
     DocumentManager docMgr = null;
@@ -722,6 +742,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
    * @throws ParserConfigurationException
    * @throws SAXException
    */
+  @SuppressWarnings("unchecked")
   public void writeDocumentUsingDOMHandle(DatabaseClient client, String filename, String uri, String type) throws IOException, ParserConfigurationException, SAXException
   {
     // create doc manager
@@ -776,6 +797,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
    * @throws ParserConfigurationException
    * @throws SAXException
    */
+  @SuppressWarnings("unchecked")
   public void updateDocumentUsingDOMHandle(DatabaseClient client, String filename, String uri, String type) throws IOException, ParserConfigurationException, SAXException
   {
     // create doc manager
@@ -808,6 +830,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
    * @param type
    * @return
    */
+  @SuppressWarnings("unchecked")
   public DOMHandle readDocumentUsingDOMHandle(DatabaseClient client, String uri, String type)
   {
     // create doc manager
@@ -834,6 +857,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
    * @param type
    * @return
    */
+  @SuppressWarnings("unchecked")
   public StringHandle readDocumentUsingStringHandle(DatabaseClient client, String uri, String type)
   {
     // create doc manager
@@ -862,6 +886,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
    * @param type
    * @throws IOException
    */
+  @SuppressWarnings("unchecked")
   public void writeDocumentUsingFileHandle(DatabaseClient client, String filename, String uri, String type) throws IOException
   {
     // create doc manager
@@ -891,6 +916,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
    * @param type
    * @return
    */
+  @SuppressWarnings("unchecked")
   public FileHandle readDocumentUsingFileHandle(DatabaseClient client, String uri, String type)
   {
     // create doc manager
@@ -918,6 +944,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
    * @param type
    * @throws IOException
    */
+  @SuppressWarnings("unchecked")
   public void updateDocumentUsingFileHandle(DatabaseClient client, String filename, String uri, String type) throws IOException
   {
     // create doc manager
@@ -948,6 +975,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
    * @param type
    * @throws IOException
    */
+  @SuppressWarnings("unchecked")
   public void updateDocumentUsingStringHandle(DatabaseClient client, String filename, String uri, String type) throws IOException
   {
     // create doc manager
@@ -983,6 +1011,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
    * @param type
    * @throws IOException
    */
+  @SuppressWarnings("unchecked")
   public BytesHandle readDocumentUsingBytesHandle(DatabaseClient client, String uri, String type) throws IOException, NullPointerException
   {
     // create doc manager
@@ -1024,6 +1053,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
    * @param type
    * @throws IOException
    */
+  @SuppressWarnings("unchecked")
   public void updateDocumentUsingByteHandle(DatabaseClient client, String filename, String uri, String type) throws IOException, ParserConfigurationException, SAXException
   {
     // create doc manager
@@ -1091,6 +1121,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
    * @param type
    * @return
    */
+  @SuppressWarnings("unchecked")
   public DocumentMetadataHandle readMetadataFromDocument(DatabaseClient client, String uri, String type)
   {
     // create doc manager
@@ -1402,7 +1433,7 @@ public abstract class BasicJavaClientREST extends ConnectedRESTQA
     // get json document for expected result
     ObjectMapper mapper = new ObjectMapper();
     JsonFactory jfactory = new JsonFactory();
-    JsonParser jParser = jfactory.createJsonParser(new File("src/test/java/com/marklogic/client/functionaltest/data/" + filename));
+    JsonParser jParser = jfactory.createParser(new File("src/test/java/com/marklogic/client/functionaltest/data/" + filename));
     JsonNode expectedDoc = mapper.readTree(jParser);
     return expectedDoc;
   }

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ConnectedRESTQA.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ConnectedRESTQA.java
@@ -368,7 +368,7 @@ public abstract class ConnectedRESTQA {
 		} else {
 			if (!jnode.path(propName).isArray()) {
 				System.out.println("property is not array");
-				((ObjectNode) jnode).putAll(objNode);
+				((ObjectNode) jnode).setAll(objNode);
 			} else {
 				JsonNode member = jnode.withArray(propName);
 				if (objNode.path(propName).isArray()) {
@@ -894,7 +894,6 @@ public abstract class ConnectedRESTQA {
 	/**
 	 * Only use this in "slow" functional tests until they're converted over to fast.
 	 */
-	@Deprecated
 	public static DatabaseClient getDatabaseClientOnDatabase(String hostName, int port, String databaseName,
 			String user, String password, ConnectionType connType) {
 		return newDatabaseClientBuilder()

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientKerberosFromFile.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientKerberosFromFile.java
@@ -266,6 +266,7 @@ public class TestDatabaseClientKerberosFromFile extends BasicJavaClientREST {
     assertTrue(art.getInventory() > 1000);
   }
 
+	@SuppressWarnings("unchecked")
   public void loadSimplePojos(PojoRepository products) {
     for (int i = 1; i < 111; i++) {
       if (i % 2 == 0) {
@@ -480,6 +481,7 @@ public class TestDatabaseClientKerberosFromFile extends BasicJavaClientREST {
   // This test is to verify GeoPair query works fine,
   // searching for lattitude and longitude of Reno
   @Test
+  @SuppressWarnings("unchecked")
   public void testPOJOGeoQuerySearchWithGeoPair() {
     System.out.println("Running testPOJOGeoQuerySearchWithGeoPair method");
 
@@ -682,6 +684,7 @@ public class TestDatabaseClientKerberosFromFile extends BasicJavaClientREST {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testRollbackDeleteDocument() throws KeyManagementException, NoSuchAlgorithmException, ParserConfigurationException, SAXException, IOException
   {
     System.out.println("Running testRollbackDeleteDocument");

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientWithKerberos.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/TestDatabaseClientWithKerberos.java
@@ -220,6 +220,7 @@ public class TestDatabaseClientWithKerberos extends BasicJavaClientREST {
     assertTrue( art.getInventory() > 1000);
   }
 
+	@SuppressWarnings("unchecked")
   public void loadSimplePojos(PojoRepository products) {
     for (int i = 1; i < 111; i++) {
       if (i % 2 == 0) {
@@ -434,6 +435,7 @@ public class TestDatabaseClientWithKerberos extends BasicJavaClientREST {
   // This test is to verify GeoPair query works fine,
   // searching for lattitude and longitude of Reno
   @Test
+  @SuppressWarnings("unchecked")
   public void testPOJOGeoQuerySearchWithGeoPair() {
     System.out.println("Running testPOJOGeoQuerySearchWithGeoPair method");
     PojoRepository<GeoSpecialArtifact, Long> products = client.newPojoRepository(GeoSpecialArtifact.class, Long.class);
@@ -635,6 +637,7 @@ public class TestDatabaseClientWithKerberos extends BasicJavaClientREST {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testRollbackDeleteDocument() throws KeyManagementException, NoSuchAlgorithmException, ParserConfigurationException, SAXException, IOException
   {
     System.out.println("Running testRollbackDeleteDocument");

--- a/marklogic-client-api/src/test/java/com/marklogic/client/impl/DatabaseClientPropertySourceTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/impl/DatabaseClientPropertySourceTest.java
@@ -21,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 public class DatabaseClientPropertySourceTest {
 
-	private Map<String, Object> props;
+	private Map<String, Object> props = new HashMap<>();
 	private DatabaseClientFactory.Bean bean;
 	private static final String PREFIX = DatabaseClientBuilder.PREFIX;
 	private static final String VERIFIER_PROPERTY = PREFIX + "sslHostnameVerifier";
@@ -29,11 +29,9 @@ public class DatabaseClientPropertySourceTest {
 
 	@BeforeEach
 	void beforeEach() {
-		props = new HashMap() {{
-			put(PREFIX + "authType", "digest");
-			put(PREFIX + "username", "someuser");
-			put(PREFIX + "password", "someword");
-		}};
+		props.put(PREFIX + "authType", "digest");
+		props.put(PREFIX + "username", "someuser");
+		props.put(PREFIX + "password", "someword");
 	}
 
 	@Test
@@ -201,10 +199,8 @@ public class DatabaseClientPropertySourceTest {
 
 	@Test
 	void hostTakesPrecedence() {
-		props = new HashMap() {{
-			put(PREFIX + "host", "somehost");
-			put(PREFIX + "connectionString", "user:password@localhost:8000/Documents");
-		}};
+		props.put(PREFIX + "host", "somehost");
+		props.put(PREFIX + "connectionString", "user:password@localhost:8000/Documents");
 
 		DatabaseClientFactory.Bean bean = buildBean();
 		assertEquals("somehost", bean.getHost(), "This allows a user to use a connection string as a starting " +
@@ -213,9 +209,7 @@ public class DatabaseClientPropertySourceTest {
 	}
 
 	private void useConnectionString(String connectionString) {
-		props = new HashMap() {{
-			put(PREFIX + "connectionString", connectionString);
-		}};
+		props.put(PREFIX + "connectionString", connectionString);
 	}
 
 	private DatabaseClientFactory.Bean buildBean() {

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/BulkReadWriteTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/BulkReadWriteTest.java
@@ -18,7 +18,9 @@ import org.w3c.dom.Document;
 import jakarta.xml.bind.JAXBException;
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.nio.charset.Charset;
 import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -735,6 +737,7 @@ public class BulkReadWriteTest {
     test_issue_623_body( Common.client.newJSONDocumentManager(), uris, "[\"$0\"]" );
   }
 
+	@SuppressWarnings("unchecked")
   private void test_issue_623_body(DocumentManager docMgr, List<String> uris, String regex) {
     // test with 0 args
     boolean writeSuccess = false;
@@ -750,9 +753,14 @@ public class BulkReadWriteTest {
     assertTrue(deleteSuccess);
 
     for ( String uri : uris ) {
-      String contents = URLEncoder.encode(uri).replaceFirst(".*", regex);
+		String contents;
+		try {
+			contents = URLEncoder.encode(uri, "UTF-8").replaceFirst(".*", regex);
+		} catch (UnsupportedEncodingException e) {
+			throw new RuntimeException(e);
+		}
 
-      // test with 1 arg
+		// test with 1 arg
       docMgr.write(uri, new StringHandle(contents));
       assertEquals(contents, docMgr.read(uri).nextContent(new StringHandle()).get());
       docMgr.delete(uri);
@@ -774,16 +782,17 @@ public class BulkReadWriteTest {
 
   @Test
   // https://github.com/marklogic/java-client-api/issues/759
-  public void test_issue_759() throws Exception {
+  public void test_issue_759() {
     DocumentManager docMgr = Common.client.newDocumentManager();
     String[] uris = new String[150];
     for ( int i=0; i < 102; i++ ) {
-      String mapDocId = "/" + Integer.toString(i);
+      String mapDocId = "/" + i;
       uris[i] = mapDocId;
     }
     docMgr.read(uris);
   }
 
+	@SuppressWarnings("unchecked")
   private void verifyDeleted(DocumentManager docMgr, String uri) {
     try {
       docMgr.read(uri, new StringHandle());

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/JacksonHandleTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/JacksonHandleTest.java
@@ -46,8 +46,8 @@ public class JacksonHandleTest {
     childArray.add("item1");
     childArray.add("item2");
     ObjectNode writeRoot = mapper.createObjectNode();
-    writeRoot.put("object", childObj);
-    writeRoot.put("array",  childArray);
+    writeRoot.set("object", childObj);
+    writeRoot.set("array",  childArray);
 
     // create a handle for the JSON structure
     JacksonHandle writeHandle = new JacksonHandle(writeRoot);

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/JacksonStreamTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/JacksonStreamTest.java
@@ -4,7 +4,6 @@
 package com.marklogic.client.test;
 
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.io.SerializedString;
@@ -112,7 +111,7 @@ public class JacksonStreamTest {
     List<OrderItem> orderItems = new ArrayList<>();
     while ( parser.nextValue() != null ) {
       if ( parser.getCurrentToken() == JsonToken.START_ARRAY &&
-        "orderItems".equals(parser.getCurrentName()) )
+        "orderItems".equals(parser.currentName()) )
       {
         while ( parser.nextValue() == JsonToken.START_OBJECT ) {
           OrderItem item = getOrderItem(parser);
@@ -124,17 +123,17 @@ public class JacksonStreamTest {
     return null;
   }
 
-  private OrderItem getOrderItem(JsonParser parser) throws JsonParseException, IOException {
+  private OrderItem getOrderItem(JsonParser parser) throws IOException {
     OrderItem item = new OrderItem();
     if ( parser.getCurrentToken() != JsonToken.START_OBJECT ) {
       throw new IllegalStateException("nextValue should have been START_OBJECT but is:[" + parser.getCurrentToken() + "]");
     }
     while ( parser.nextValue() != null ) {
-      if ( "productId".equals(parser.getCurrentName()) ) {
+      if ( "productId".equals(parser.currentName()) ) {
         item.setProductId( parser.getText() );
-      } else if ( "quantity".equals(parser.getCurrentName()) ) {
+      } else if ( "quantity".equals(parser.currentName()) ) {
         item.setQuantity( parser.getIntValue() );
-      } else if ( "itemCostUSD".equals(parser.getCurrentName()) ) {
+      } else if ( "itemCostUSD".equals(parser.currentName()) ) {
         item.setItemCostUSD( parser.getFloatValue() );
       }
       if ( parser.getCurrentToken() == JsonToken.END_OBJECT ) {

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/PlanExpressionTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/PlanExpressionTest.java
@@ -34,9 +34,10 @@ public class PlanExpressionTest {
         rowMgr = null;
    }
 
+	@SuppressWarnings("unchecked")
    private RowRecord redactTest(String testName, Map<String,Object> testRow, PlanExprCol... cols) {
        PlanBuilder.ModifyPlan plan =
-               p.fromLiterals(new Map[]{testRow})
+               p.fromLiterals(testRow)
                 .bind(p.colSeq(cols));
 
        RowSet<RowRecord> rowSet = rowMgr.resultRows(plan);

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/ApplyTransformTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/ApplyTransformTest.java
@@ -167,7 +167,7 @@ public class ApplyTransformTest {
     uris.add(collection + "/test3.txt");
 
     ServerTransform transform = new ServerTransform(transformName1);
-    List skippedUris = new ArrayList<>();
+    List<String> skippedUris = new ArrayList<>();
     StringBuilder failures = new StringBuilder();
     QueryBatcher batcher = moveMgr.newQueryBatcher(uris.iterator())
       .withBatchSize(1)

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/JSONSplitterTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/JSONSplitterTest.java
@@ -33,8 +33,7 @@ public class JSONSplitterTest {
 
     @Test
     public void testJSONSplitterArray() throws Exception {
-
-        JSONSplitter splitter = JSONSplitter.makeArraySplitter();
+        JSONSplitter<StringHandle> splitter = JSONSplitter.makeArraySplitter();
         FileInputStream fileInputStream = new FileInputStream(new File(jsonArrayFile));
         Stream<StringHandle> contentStream = splitter.split(fileInputStream);
         assertNotNull(contentStream);
@@ -53,8 +52,8 @@ public class JSONSplitterTest {
     @Test
     public void testJSONSplitterObject() throws Exception {
 
-        JSONSplitter splitter = JSONSplitter.makeArraySplitter();
-        FileInputStream fileInputStream = new FileInputStream(new File(jsonObjectFile));
+        JSONSplitter<StringHandle> splitter = JSONSplitter.makeArraySplitter();
+        FileInputStream fileInputStream = new FileInputStream(jsonObjectFile);
         Stream<StringHandle> contentStream = splitter.split(fileInputStream);
         assertNotNull(contentStream);
 
@@ -72,8 +71,8 @@ public class JSONSplitterTest {
     @Test
     public void testJSONSplitterMultiArray() throws Exception {
 
-        JSONSplitter splitter = JSONSplitter.makeArraySplitter();
-        FileInputStream fileInputStream = new FileInputStream(new File(jsonMultiArrayFile));
+        JSONSplitter<StringHandle> splitter = JSONSplitter.makeArraySplitter();
+        FileInputStream fileInputStream = new FileInputStream(jsonMultiArrayFile);
         Stream<StringHandle> contentStream = splitter.split(fileInputStream);
         assertNotNull(contentStream);
 
@@ -103,8 +102,8 @@ public class JSONSplitterTest {
                 "/SystemPath/NewTestJson4_abcd.json",
                 "/SystemPath/NewTestJson5_abcd.json"
         };
-        JSONSplitter splitter = JSONSplitter.makeArraySplitter();
-        FileInputStream fileInputStream = new FileInputStream(new File(jsonArrayFile));
+        JSONSplitter<StringHandle> splitter = JSONSplitter.makeArraySplitter();
+        FileInputStream fileInputStream = new FileInputStream(jsonArrayFile);
         JSONSplitter.UriMaker uriMaker = new UriMakerTest();
         uriMaker.setInputAfter("/SystemPath/");
         uriMaker.setSplitFilename("NewTestJson");
@@ -173,8 +172,8 @@ public class JSONSplitterTest {
     @Test
     public void testJSONSplitterWriteWithInputName() throws Exception {
 
-        JSONSplitter splitter = JSONSplitter.makeArraySplitter();
-        FileInputStream fileInputStream = new FileInputStream(new File(jsonArrayFile));
+        JSONSplitter<StringHandle> splitter = JSONSplitter.makeArraySplitter();
+        FileInputStream fileInputStream = new FileInputStream(jsonArrayFile);
         Stream<DocumentWriteOperation> contentStream = splitter.splitWriteOperations(fileInputStream, "TestJson.json");
         assertNotNull(contentStream);
 
@@ -200,8 +199,8 @@ public class JSONSplitterTest {
     @Test
     public void testJSONSplitterWriteWithoutInputName() throws Exception {
 
-        JSONSplitter splitter = JSONSplitter.makeArraySplitter();
-        FileInputStream fileInputStream = new FileInputStream(new File(jsonArrayFile));
+        JSONSplitter<StringHandle> splitter = JSONSplitter.makeArraySplitter();
+        FileInputStream fileInputStream = new FileInputStream(jsonArrayFile);
         Stream<DocumentWriteOperation> contentStream = splitter.splitWriteOperations(fileInputStream);
         assertNotNull(contentStream);
 
@@ -228,8 +227,8 @@ public class JSONSplitterTest {
     public void testCustomMultiArray() throws Exception {
 
         MultiArrayVisitor visitor = new MultiArrayVisitor();
-        JSONSplitter splitter = new JSONSplitter(visitor);
-        FileInputStream fileInputStream = new FileInputStream(new File(jsonCustMultiArrayFile));
+        JSONSplitter<StringHandle> splitter = new JSONSplitter<>(visitor);
+        FileInputStream fileInputStream = new FileInputStream(jsonCustMultiArrayFile);
         Stream<StringHandle> contentStream = splitter.split(fileInputStream);
         assertNotNull(contentStream);
 
@@ -262,8 +261,8 @@ public class JSONSplitterTest {
     public void testCustomKey() throws Exception {
 
         KeyVisitor visitor = new KeyVisitor("context2");
-        JSONSplitter splitter = new JSONSplitter(visitor);
-        FileInputStream fileInputStream = new FileInputStream(new File(jsonObjectFile));
+        JSONSplitter<StringHandle> splitter = new JSONSplitter<>(visitor);
+        FileInputStream fileInputStream = new FileInputStream(jsonObjectFile);
         Stream<StringHandle> contentStream = splitter.split(fileInputStream);
         assertNotNull(contentStream);
 

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/JacksonCSVSplitterTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/JacksonCSVSplitterTest.java
@@ -61,7 +61,7 @@ public class JacksonCSVSplitterTest {
 
         for(int i=0; i<result.length; i++) {
             assertNotNull(result[i].get());
-            assertNotNull(result[i].get().fields());
+            assertNotNull(result[i].get().properties());
             for(int j=0; j<headerValues.length;j++) {
                 assertNotNull(result[i].get().findValue(headerValues[j]));
             }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/QueryBatcherTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/QueryBatcherTest.java
@@ -749,6 +749,7 @@ public class QueryBatcherTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testIssue658() throws Exception{
     QueryBatcher batcher =
       moveMgr.newQueryBatcher(new StructuredQueryBuilder().collection(qhbTestCollection))
@@ -759,7 +760,7 @@ public class QueryBatcherTest {
     AtomicInteger successCount = new AtomicInteger(0);
     AtomicReference<JobTicket> queryTicket = new AtomicReference<>(null);
 
-    Set uris = Collections.synchronizedSet(new HashSet());
+    Set<String> uris = Collections.synchronizedSet(new HashSet<>());
 
     batcher.onUrisReady(batch->{
       uris.addAll(Arrays.asList(batch.getItems()));

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/XMLSplitterTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/XMLSplitterTest.java
@@ -23,7 +23,7 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class XMLSplitterTest {
+class XMLSplitterTest {
 
     static final private String xmlFile = "src/test/resources/data" + File.separator + "pathSplitter/people.xml";
     static final private String[] expected = new String[]{
@@ -54,8 +54,8 @@ public class XMLSplitterTest {
     @Test
     public void testXMLSplitter() throws Exception {
 
-        XMLSplitter splitter = XMLSplitter.makeSplitter("http://www.marklogic.com/people/", "person");
-        FileInputStream fileInputStream = new FileInputStream(new File(xmlFile));
+        XMLSplitter<StringHandle> splitter = XMLSplitter.makeSplitter("http://www.marklogic.com/people/", "person");
+        FileInputStream fileInputStream = new FileInputStream(xmlFile);
         Stream<StringHandle> contentStream = splitter.split(fileInputStream);
         assertNotNull(contentStream);
 
@@ -79,7 +79,7 @@ public class XMLSplitterTest {
                 "president",
                 "yes");
 
-        XMLSplitter splitter = new XMLSplitter(visitor);
+        XMLSplitter<StringHandle> splitter = new XMLSplitter<>(visitor);
 
         Stream<StringHandle> contentStream = splitter.split(fileInputStream);
         assertNotNull(contentStream);
@@ -106,7 +106,7 @@ public class XMLSplitterTest {
                 "president",
                 "no");
 
-        XMLSplitter splitter = new XMLSplitter(visitor);
+        XMLSplitter<StringHandle> splitter = new XMLSplitter<>(visitor);
         XMLSplitter.UriMaker uriMaker = new UriMakerTest();
         uriMaker.setInputAfter("/SystemPath/");
         uriMaker.setSplitFilename("NewPeople");
@@ -182,7 +182,7 @@ public class XMLSplitterTest {
                 "president",
                 "no");
 
-        XMLSplitter splitter = new XMLSplitter(visitor);
+        XMLSplitter<StringHandle> splitter = new XMLSplitter<>(visitor);
 
         Stream<DocumentWriteOperation> contentStream = splitter.splitWriteOperations(fileInputStream);
         assertNotNull(contentStream);
@@ -213,7 +213,7 @@ public class XMLSplitterTest {
                 "president",
                 "no");
 
-        XMLSplitter splitter = new XMLSplitter(visitor);
+        XMLSplitter<StringHandle> splitter = new XMLSplitter<>(visitor);
 
         Stream<DocumentWriteOperation> contentStream = splitter.splitWriteOperations(fileInputStream, "TestSplitter.xml");
         assertNotNull(contentStream);

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/IOTestUtil.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/dataservices/IOTestUtil.java
@@ -74,19 +74,14 @@ public class IOTestUtil {
         writeSet.add(scriptPath, scriptMeta, new StringHandle(scriptBody));
         modMgr.write(writeSet);
     }
+
+	@SafeVarargs
     public static <T> Set<T> setOf(T... items) {
         Set<T> set = new HashSet<>();
         for (T item: items) {
             set.add(item);
         }
         return set;
-    }
-
-    static InputStream[] asInputStreamArray(String... values) {
-        InputStream[] list = new InputStream[values.length];
-        for (int i=0; i < values.length; i++)
-            list[i] = asInputStream(values[i]);
-        return list;
     }
 
     static InputStream asInputStream(String value) {

--- a/ml-development-tools/src/test/java/com/marklogic/client/test/dbfunction/positive/DescribedBundleTest.java
+++ b/ml-development-tools/src/test/java/com/marklogic/client/test/dbfunction/positive/DescribedBundleTest.java
@@ -16,7 +16,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 import static org.junit.Assert.assertTrue;
 
@@ -43,7 +42,7 @@ public class DescribedBundleTest {
 
       // the default doclet path doesn't seem to have the standard doclet from tools.jar in Java 8
       if (javaMajorVersion < 9) {
-         List<File> toolClassPath = getClassPath(ToolProvider.getSystemToolClassLoader());
+         List<File> toolClassPath = getClassPath(ClassLoader.getSystemClassLoader());
          List<File> docletClassPath = toList(fileManager.getLocation(DocumentationTool.Location.DOCLET_PATH));
          if (docletClassPath != null) {
             if (toolClassPath != null) {

--- a/ml-development-tools/src/test/kotlin/com/marklogic/client/test/dbfunction/fntestgen.kt
+++ b/ml-development-tools/src/test/kotlin/com/marklogic/client/test/dbfunction/fntestgen.kt
@@ -1854,6 +1854,7 @@ import static org.junit.Assert.fail;
 
 import com.marklogic.client.test.dbfunction.DBFunctionTestUtil;
 
+@SuppressWarnings("unchecked")
 public class $testingClass {
    $testedClass testObj = ${testedClass}.on(DBFunctionTestUtil.db);
 


### PR DESCRIPTION
Copilot got a little carried away and knocked out some issues in src/test/java too. More to come after this PR. 

Addresses unchecked and deprecation warnings by:
- Adding compiler arguments to include deprecation details.
- Removing unnecessary `finalize()` methods.
- Replacing raw types with parameterized types in test classes.
- Replacing StringBuffer with StringBuilder.
- Using isEmpty() instead of checking length > 0.
- Replacing Boolean constructor with boolean literal.
- Various other minor code improvements.