### PR TITLE
MLE-23230 Applying RetryInterceptor in test plumbing

### DIFF
--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ConnectedRESTQA.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/functionaltest/ConnectedRESTQA.java
@@ -15,7 +15,9 @@ import com.marklogic.client.DatabaseClientBuilder;
 import com.marklogic.client.DatabaseClientFactory;
 import com.marklogic.client.FailedRequestException;
 import com.marklogic.client.admin.ServerConfigurationManager;
+import com.marklogic.client.extra.okhttpclient.OkHttpClientConfigurator;
 import com.marklogic.client.impl.SSLUtil;
+import com.marklogic.client.impl.okhttp.RetryInterceptor;
 import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.DocumentMetadataHandle.Capability;
 import com.marklogic.client.query.QueryManager;
@@ -44,6 +46,12 @@ import java.util.*;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public abstract class ConnectedRESTQA {
+
+	static {
+		DatabaseClientFactory.removeConfigurators();
+		DatabaseClientFactory.addConfigurator((OkHttpClientConfigurator) client ->
+			client.addInterceptor(new RetryInterceptor(3, 1000, 2, 8000)));
+	}
 
 	private static Properties testProperties = null;
 

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/OkHttpUtil.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/OkHttpUtil.java
@@ -78,9 +78,6 @@ public abstract class OkHttpUtil {
 		OkHttpUtil.configureSocketFactory(clientBuilder, sslContext, trustManager);
 		OkHttpUtil.configureHostnameVerifier(clientBuilder, sslVerifier);
 
-		// Trying this out for all calls initially to see how the regression test piplines do.
-		clientBuilder.addInterceptor(new RetryInterceptor(3, 1000, 2, 8000));
-
 		return clientBuilder;
 	}
 

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/RetryInterceptor.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/RetryInterceptor.java
@@ -17,7 +17,7 @@ import java.net.UnknownHostException;
  * OkHttp interceptor that retries requests on certain connection failures,
  * which can be helpful when MarkLogic is temporarily unavailable during restarts.
  */
-class RetryInterceptor implements Interceptor {
+public class RetryInterceptor implements Interceptor {
 
 	private final static Logger logger = org.slf4j.LoggerFactory.getLogger(RetryInterceptor.class);
 
@@ -26,7 +26,7 @@ class RetryInterceptor implements Interceptor {
 	private final double backoffMultiplier;
 	private final long maxDelayMs;
 
-	RetryInterceptor(int maxRetries, long initialDelayMs, double backoffMultiplier, long maxDelayMs) {
+	public RetryInterceptor(int maxRetries, long initialDelayMs, double backoffMultiplier, long maxDelayMs) {
 		this.maxRetries = maxRetries;
 		this.initialDelayMs = initialDelayMs;
 		this.backoffMultiplier = backoffMultiplier;
@@ -36,14 +36,11 @@ class RetryInterceptor implements Interceptor {
 	@Override
 	public Response intercept(Chain chain) throws IOException {
 		Request request = chain.request();
-		IOException lastException = null;
 
 		for (int attempt = 0; attempt <= maxRetries; attempt++) {
 			try {
 				return chain.proceed(request);
 			} catch (IOException e) {
-				lastException = e;
-
 				if (attempt == maxRetries || !isRetryableException(e)) {
 					logger.warn("Not retryable: {}; {}", e.getClass(), e.getMessage());
 					throw e;
@@ -57,7 +54,8 @@ class RetryInterceptor implements Interceptor {
 			}
 		}
 
-		throw lastException;
+		// This should never be reached due to loop logic, but is required for compilation.
+		throw new IllegalStateException("Unexpected end of retry loop");
 	}
 
 	private boolean isRetryableException(IOException e) {

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/Common.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/Common.java
@@ -8,9 +8,12 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.DatabaseClientBuilder;
 import com.marklogic.client.DatabaseClientFactory;
+import com.marklogic.client.extra.okhttpclient.OkHttpClientConfigurator;
+import com.marklogic.client.impl.okhttp.RetryInterceptor;
 import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.mgmt.ManageClient;
 import com.marklogic.mgmt.ManageConfig;
+import okhttp3.OkHttpClient;
 import org.springframework.util.FileCopyUtils;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
@@ -28,6 +31,12 @@ import java.net.URISyntaxException;
 import java.security.cert.X509Certificate;
 
 public class Common {
+
+	static {
+		DatabaseClientFactory.removeConfigurators();
+		DatabaseClientFactory.addConfigurator((OkHttpClientConfigurator) client ->
+			client.addInterceptor(new RetryInterceptor(3, 1000, 2, 8000)));
+	}
 
 	final public static String USER = "rest-writer";
 	final public static String PASS = "x";


### PR DESCRIPTION
This avoids hardcoding it in the actual client and let's us still see the results for the tests.

Also fixed a warning from Polaris about the interceptor.
