### PR TITLE
MLE-24405 Refactor: Moved some OkHttp-specific classes

### DIFF
--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/FailedRequest.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/FailedRequest.java
@@ -11,7 +11,6 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
 import com.marklogic.client.io.Format;
-import okhttp3.MediaType;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/HTTPKerberosAuthInterceptor.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/HTTPKerberosAuthInterceptor.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2010-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
-package com.marklogic.client.impl;
+package com.marklogic.client.impl.okhttp;
 
 import java.io.IOException;
 import java.util.Map;
@@ -20,6 +20,7 @@ import javax.security.auth.login.AppConfigurationEntry;
 import javax.security.auth.login.Configuration;
 import javax.security.auth.kerberos.KerberosTicket;
 
+import com.marklogic.client.impl.SSLUtil;
 import org.ietf.jgss.GSSContext;
 import org.ietf.jgss.GSSCredential;
 import org.ietf.jgss.GSSException;

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/HTTPSamlAuthInterceptor.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/HTTPSamlAuthInterceptor.java
@@ -2,11 +2,12 @@
  * Copyright (c) 2010-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 
-package com.marklogic.client.impl;
+package com.marklogic.client.impl.okhttp;
 
 import com.marklogic.client.DatabaseClientFactory.SAMLAuthContext.AuthorizerCallback;
 import com.marklogic.client.DatabaseClientFactory.SAMLAuthContext.ExpiringSAMLAuth;
 import com.marklogic.client.DatabaseClientFactory.SAMLAuthContext.RenewerCallback;
+import com.marklogic.client.impl.RESTServices;
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -55,7 +56,7 @@ public class HTTPSamlAuthInterceptor implements Interceptor {
 		Request authenticatedRequest = chain.request().newBuilder()
 			.header(RESTServices.HEADER_AUTHORIZATION, buildSamlHeader())
 			.build();
-		
+
 		return chain.proceed(authenticatedRequest);
 	}
 

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/OkHttpUtil.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/OkHttpUtil.java
@@ -5,9 +5,6 @@ package com.marklogic.client.impl.okhttp;
 
 import com.marklogic.client.DatabaseClientFactory;
 import com.marklogic.client.extra.okhttpclient.OkHttpClientConfigurator;
-import com.marklogic.client.impl.HTTPKerberosAuthInterceptor;
-import com.marklogic.client.impl.HTTPSamlAuthInterceptor;
-import com.marklogic.client.impl.OkHttpServices;
 import com.marklogic.client.impl.SSLUtil;
 import okhttp3.*;
 
@@ -23,7 +20,6 @@ import java.security.KeyManagementException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 /**


### PR DESCRIPTION
Trying to get as many okhttp3 imports into one package as possible, with the notable exception for now of OkHttpServices.
