### PR TITLE
MLE-28583 ML12 test fixes

### DIFF
--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/PlanGeneratedTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/PlanGeneratedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2010-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 
 package com.marklogic.client.test;
@@ -1441,6 +1441,7 @@ public class PlanGeneratedTest extends PlanGeneratedBase {
         executeTester("testXdmpFormatNumber8", p.xdmp.formatNumber(p.col("1"), p.col("2"), p.col("3"), p.col("4"), p.col("5"), p.col("6"), p.col("7"), p.col("8")), false, null, null, null, "NINE", new ServerExpression[]{ p.xs.doubleVal(9), p.xs.string("W"), p.xs.string("en"), p.xs.string(""), p.xs.string(""), p.xs.string(""), p.xs.string(","), p.xs.integer(3) });
     }
 
+	@ExtendWith(RequiresML11OrLower.class)
     @Test
     public void testXdmpGetCurrentUser0Exec() {
         executeTester("testXdmpGetCurrentUser0", p.xdmp.getCurrentUser(), true, null, null, null, "admin", new ServerExpression[]{  });
@@ -1677,11 +1678,13 @@ public class PlanGeneratedTest extends PlanGeneratedBase {
 		executeTester("testXdmpUnquote1", p.xdmp.unquote(p.col("1")), false, null, "array", Format.JSON, "[123]", new ServerExpression[]{p.xs.string("[123]")});
     }
 
+	@ExtendWith(RequiresML11OrLower.class)
     @Test
     public void testXdmpUriContentType1Exec() {
         executeTester("testXdmpUriContentType1", p.xdmp.uriContentType(p.col("1")), false, null, null, null, "application/json", new ServerExpression[]{ p.xs.string("a.json") });
     }
 
+	@ExtendWith(RequiresML11OrLower.class)
     @Test
     public void testXdmpUriFormat1Exec() {
         executeTester("testXdmpUriFormat1", p.xdmp.uriFormat(p.col("1")), false, null, null, null, "json", new ServerExpression[]{ p.xs.string("a.json") });

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/AbstractOpticUpdateTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/AbstractOpticUpdateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2010-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.client.test.rows;
 
@@ -37,13 +37,15 @@ public abstract class AbstractOpticUpdateTest extends AbstractClientTest {
 
 	private final static String XML_PREAMBLE = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
 
+	protected static final String TEST_USER = "writer-no-default-permissions";
+
 	protected RowManager rowManager;
 	protected PlanBuilder op;
 	protected ObjectMapper mapper = new ObjectMapper();
 
 	@BeforeEach
 	public void setup() {
-		Common.client = Common.newClientBuilder().withUsername("writer-no-default-permissions").build();
+		Common.client = Common.newClientBuilder().withUsername(TEST_USER).build();
 		rowManager = Common.client.newRowManager().withUpdate(true);
 		op = rowManager.newPlanBuilder();
 	}

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/UpdateUseCasesTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/UpdateUseCasesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2010-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.client.test.rows;
 
@@ -153,20 +153,20 @@ public class UpdateUseCasesTest extends AbstractOpticUpdateTest {
 			.bind(op.as(
 				op.col("doc"),
 				op.jsonObject(
-					op.prop("header", op.jsonObject(op.prop("user", op.xdmp.getCurrentUser()))),
+					op.prop("header", op.jsonObject(op.prop("user", op.xs.string(op.param("currentUser"))))),
 					op.prop("body", op.col("doc"))
 				)
 			));
 
-		rowManager.execute(plan.write());
+		rowManager.execute(plan.write().bindParam("currentUser", TEST_USER));
 
 		verifyJsonDoc("/acme/1.json", doc -> {
-			assertEquals("writer-no-default-permissions", doc.get("header").get("user").asText());
+			assertEquals(TEST_USER, doc.get("header").get("user").asText());
 			assertEquals(1, doc.get("body").get("value").asInt());
 		});
 
 		verifyJsonDoc("/acme/2.json", doc -> {
-			assertEquals("writer-no-default-permissions", doc.get("header").get("user").asText());
+			assertEquals(TEST_USER, doc.get("header").get("user").asText());
 			assertEquals(2, doc.get("body").get("value").asInt());
 		});
 	}


### PR DESCRIPTION
xdmp.uriContentType and xdmp.uriFormat are no longer available in 12, the tests should only be run in 11 or lower.
Fixed how we get the user in marklogic-client-api/src/test/java/com/marklogic/client/test/rows/UpdateUseCasesTest.java as xdmp.getCurrentUser is no longer available.