### PR TITLE
MLE-30241: Apply XXE protections

### DIFF
--- a/examples/src/main/java/com/marklogic/client/example/extension/OpenCSVBatcher.java
+++ b/examples/src/main/java/com/marklogic/client/example/extension/OpenCSVBatcher.java
@@ -8,8 +8,9 @@ import java.io.Reader;
 
 import javax.xml.namespace.QName;
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
+
+import com.marklogic.client.impl.XmlFactories;
 
 import com.opencsv.exceptions.CsvValidationException;
 import org.w3c.dom.Document;
@@ -88,10 +89,7 @@ public class OpenCSVBatcher
       }
     }
 
-    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-    factory.setNamespaceAware(true);
-    factory.setValidating(false);
-    DocumentBuilder docBuilder = factory.newDocumentBuilder();
+    DocumentBuilder docBuilder = XmlFactories.getDocumentBuilderFactory().newDocumentBuilder();
 
     String path = directory + rowName;
 

--- a/examples/src/main/java/com/marklogic/client/example/extension/OpenCSVBatcher.java
+++ b/examples/src/main/java/com/marklogic/client/example/extension/OpenCSVBatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2010-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.client.example.extension;
 
@@ -10,16 +10,14 @@ import javax.xml.namespace.QName;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.ParserConfigurationException;
 
-import com.marklogic.client.impl.XmlFactories;
-
 import com.opencsv.exceptions.CsvValidationException;
+import com.marklogic.client.io.DOMHandle;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 import com.opencsv.CSVReader;
 
 import com.marklogic.client.DatabaseClient;
-import com.marklogic.client.io.DOMHandle;
 
 /**
  * An OpenCSV Batcher writes a CSV stream to the database in XML document batches.
@@ -89,7 +87,7 @@ public class OpenCSVBatcher
       }
     }
 
-    DocumentBuilder docBuilder = XmlFactories.getDocumentBuilderFactory().newDocumentBuilder();
+    DocumentBuilder docBuilder = new DOMHandle().getFactory().newDocumentBuilder();
 
     String path = directory + rowName;
 

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/extension/OpenCSVBatcherTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/extension/OpenCSVBatcherTest.java
@@ -4,7 +4,15 @@
 package com.marklogic.client.test.example.extension;
 
 import com.marklogic.client.example.extension.OpenCSVBatcherExample;
+import com.marklogic.client.impl.XmlFactories;
 import org.junit.jupiter.api.Test;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilder;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class OpenCSVBatcherTest {
 
@@ -12,5 +20,21 @@ class OpenCSVBatcherTest {
 	void testMain() throws Exception {
 		// This is a simple smoke test to ensure that the main method runs without exceptions.
 		OpenCSVBatcherExample.main(new String[0]);
+	}
+
+	@Test
+	void documentBuilderShouldRejectDoctype() throws Exception {
+		// Verifies that the DocumentBuilder produced by XmlFactories.getDocumentBuilderFactory()
+		// — the same factory now used by OpenCSVBatcher.write() — rejects DOCTYPE declarations,
+		// confirming that XXE / DTD processing is disabled (CWE-611).
+		DocumentBuilder builder = XmlFactories.getDocumentBuilderFactory().newDocumentBuilder();
+		String xmlWithDoctype =
+			"<?xml version=\"1.0\"?>" +
+			"<!DOCTYPE foo [<!ENTITY xxe SYSTEM \"file:///etc/passwd\">]>" +
+			"<foo>&xxe;</foo>";
+
+		assertThrows(SAXException.class, () ->
+			builder.parse(new ByteArrayInputStream(xmlWithDoctype.getBytes(StandardCharsets.UTF_8)))
+		);
 	}
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/example/extension/OpenCSVBatcherTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/example/extension/OpenCSVBatcherTest.java
@@ -1,10 +1,10 @@
 /*
- * Copyright (c) 2010-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2010-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.client.test.example.extension;
 
 import com.marklogic.client.example.extension.OpenCSVBatcherExample;
-import com.marklogic.client.impl.XmlFactories;
+import com.marklogic.client.io.DOMHandle;
 import org.junit.jupiter.api.Test;
 import org.xml.sax.SAXException;
 
@@ -24,14 +24,14 @@ class OpenCSVBatcherTest {
 
 	@Test
 	void documentBuilderShouldRejectDoctype() throws Exception {
-		// Verifies that the DocumentBuilder produced by XmlFactories.getDocumentBuilderFactory()
+		// Verifies that the DocumentBuilder produced by DOMHandle.getFactory()
 		// — the same factory now used by OpenCSVBatcher.write() — rejects DOCTYPE declarations,
 		// confirming that XXE / DTD processing is disabled (CWE-611).
-		DocumentBuilder builder = XmlFactories.getDocumentBuilderFactory().newDocumentBuilder();
+		DocumentBuilder builder = new DOMHandle().getFactory().newDocumentBuilder();
 		String xmlWithDoctype =
 			"<?xml version=\"1.0\"?>" +
-			"<!DOCTYPE foo [<!ENTITY xxe SYSTEM \"file:///etc/passwd\">]>" +
-			"<foo>&xxe;</foo>";
+			"<!DOCTYPE foo []>" +
+			"<foo/>";
 
 		assertThrows(SAXException.class, () ->
 			builder.parse(new ByteArrayInputStream(xmlWithDoctype.getBytes(StandardCharsets.UTF_8)))


### PR DESCRIPTION
## Summary

Fixes FIND-005 from the Java Client Security Findings Report (May 14, 2026),
tracked as MLE-30241.

`OpenCSVBatcher.write()` was creating a `DocumentBuilderFactory` via
`DocumentBuilderFactory.newInstance()` with no XXE mitigations, in contrast
to the rest of the library which consistently uses the hardened
`XmlFactories.getDocumentBuilderFactory()`. This provided an insecure
baseline to any developer who adapts or extends the example (CWE-611,
CVSS 6.1 Medium).

## Changes

### `examples/.../OpenCSVBatcher.java`
- Replaced `DocumentBuilderFactory.newInstance()` + two `set*` calls +
  `newDocumentBuilder()` with a single call to
  `XmlFactories.getDocumentBuilderFactory().newDocumentBuilder()`
- Updated imports: removed `DocumentBuilderFactory`, added `XmlFactories`

### `marklogic-client-api/.../OpenCSVBatcherTest.java`
- Added `documentBuilderShouldRejectDoctype()` test verifying that the
  `DocumentBuilder` produced by `XmlFactories.getDocumentBuilderFactory()`
  throws `SAXException` on XML containing a DOCTYPE declaration, confirming
  XXE / DTD processing is disabled

Jira Bug: https://progresssoftware.atlassian.net/browse/MLE-30241