### PR TITLE
MLE-30240: Redact auth headers from OkHttp logs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,10 +64,10 @@ The Java Client supports optional HTTP traffic logging via the system property
 
 > **Security warning:** `HEADERS` and `BODY` levels write HTTP headers and/or
 > request/response bodies to stdout, stderr, or your application logger.
-> `Authorization` header values are automatically redacted in the output, but
-> body content may include MarkLogic document data and must **never** be
-> enabled in production environments. Use these levels only during local
-> debugging sessions.
+> `Authorization` and `x-auth-token` header values are automatically redacted
+> in the output, but body content may include MarkLogic document data and must
+> **never** be enabled in production environments. Use these levels only during
+> local debugging sessions.
 
 Set the output target via `com.marklogic.client.okhttp.httplogginginterceptor.output`:
 `LOGGER` (routes to SLF4J at DEBUG level), `STDERR`, or leave unset for stdout.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,19 +55,3 @@ You can also undeploy the test application if you do not wish to keep it around 
 
 To test the `ml-development-tools` Gradle plugin, see the README.md file located at
 `ml-development-tools/src/test/example-project`.
-
-## HTTP Logging (Debugging Only)
-
-The Java Client supports optional HTTP traffic logging via the system property
-`com.marklogic.client.okhttp.httplogginginterceptor.level`. Accepted values are
-`BASIC`, `HEADERS`, `BODY`, and `NONE`.
-
-> **Security warning:** `HEADERS` and `BODY` levels write HTTP headers and/or
-> request/response bodies to stdout, stderr, or your application logger.
-> `Authorization` and `x-auth-token` header values are automatically redacted
-> in the output, but body content may include MarkLogic document data and must
-> **never** be enabled in production environments. Use these levels only during
-> local debugging sessions.
-
-Set the output target via `com.marklogic.client.okhttp.httplogginginterceptor.output`:
-`LOGGER` (routes to SLF4J at DEBUG level), `STDERR`, or leave unset for stdout.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
-To develop the Java Client and ultimately submit a pull request, you'll first need to be able to build the client and 
-run the tests locally. 
+To develop the Java Client and ultimately submit a pull request, you'll first need to be able to build the client and
+run the tests locally.
 
 Please see [this guide](.github/CONTRIBUTING.md) for information on creating and submitting a pull request.
 
@@ -11,7 +11,7 @@ To build the client locally, complete the following steps:
 4. Verify that you can build the client by running `./gradlew build -x test`
 
 "Running the tests" in the context of developing and submitting a pull request refers to running the tests found
-in the `marklogic-client-api` module. The tests for this module depend on a 
+in the `marklogic-client-api` module. The tests for this module depend on a
 [ml-gradle](https://github.com/marklogic-community/ml-gradle) application being deployed from the `test-app` module.
 This application contains a number of database and security resources that the tests depend on.
 The `./gradle.properties` file defines the connection properties for this application; these default
@@ -53,5 +53,21 @@ You can also undeploy the test application if you do not wish to keep it around 
 
     ./gradlew mlUndeploy -i -Pconfirm=true
 
-To test the `ml-development-tools` Gradle plugin, see the README.md file located at 
+To test the `ml-development-tools` Gradle plugin, see the README.md file located at
 `ml-development-tools/src/test/example-project`.
+
+## HTTP Logging (Debugging Only)
+
+The Java Client supports optional HTTP traffic logging via the system property
+`com.marklogic.client.okhttp.httplogginginterceptor.level`. Accepted values are
+`BASIC`, `HEADERS`, `BODY`, and `NONE`.
+
+> **Security warning:** `HEADERS` and `BODY` levels write HTTP headers and/or
+> request/response bodies to stdout, stderr, or your application logger.
+> `Authorization` header values are automatically redacted in the output, but
+> body content may include MarkLogic document data and must **never** be
+> enabled in production environments. Use these levels only during local
+> debugging sessions.
+
+Set the output target via `com.marklogic.client.okhttp.httplogginginterceptor.output`:
+`LOGGER` (routes to SLF4J at DEBUG level), `STDERR`, or leave unset for stdout.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/OkHttpServices.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/OkHttpServices.java
@@ -60,6 +60,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.*;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.regex.Pattern;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -78,8 +79,31 @@ public class OkHttpServices implements RESTServices {
 
 	static final private Logger logger = LoggerFactory.getLogger(OkHttpServices.class);
 
+	/**
+	 * Controls the verbosity of OkHttp HTTP traffic logging. Accepted values: {@code NONE}, {@code BASIC},
+	 * {@code HEADERS}, {@code BODY}.
+	 *
+	 * <p><strong>Security warning:</strong> {@code HEADERS} and {@code BODY} levels log HTTP request and response
+	 * headers and/or bodies, which may contain MarkLogic credentials, OAuth/SAML tokens, or sensitive document
+	 * content. These levels must <em>never</em> be enabled in production environments. {@code Authorization} header
+	 * values are automatically redacted from log output, but body content (including MarkLogic document data) is
+	 * not redacted.
+	 */
 	private static final String OKHTTP_LOGGINGINTERCEPTOR_LEVEL = "com.marklogic.client.okhttp.httplogginginterceptor.level";
+
+	/**
+	 * Controls where OkHttp log output is written. Accepted values: {@code LOGGER} (SLF4J debug logger),
+	 * {@code STDERR}, or leave unset for stdout.
+	 */
 	private static final String OKHTTP_LOGGINGINTERCEPTOR_OUTPUT = "com.marklogic.client.okhttp.httplogginginterceptor.output";
+
+	// Regex pattern used to redact sensitive HTTP header values from log output. Matches the Authorization header
+	// and x-auth-token header (case-insensitively) and replaces the entire value with [REDACTED]. The pattern
+	// intentionally uses .* (not \S+) so that multi-word values such as "Basic <token>", "Bearer <token>",
+	// "Negotiate <token>", and "Digest username=..." are fully captured. The . metacharacter does not match \n in
+	// Java by default, so the replacement never crosses line boundaries in multi-line log messages.
+	private static final Pattern SENSITIVE_HEADER_REDACTION_PATTERN = Pattern.compile("(?i)(authorization|x-auth-token):.*");
+	private static final String SENSITIVE_HEADER_REDACTION_REPLACEMENT = "$1: [REDACTED]";
 
 	private static final String DOCUMENT_URI_PREFIX = "/documents?uri=";
 
@@ -215,18 +239,24 @@ public class OkHttpServices implements RESTServices {
 
 	/**
 	 * Based on the given properties, add a network interceptor to the given OkHttpClient.Builder to log HTTP
-	 * traffic.
+	 * traffic. {@code Authorization} and {@code x-auth-token} header values are automatically redacted from all
+	 * log output so that credentials are never written to log files or stdout/stderr.
+	 *
+	 * <p><strong>Security warning:</strong> Even with header redaction, {@code BODY}-level logging writes full
+	 * HTTP request and response bodies to the log target. This may include MarkLogic document content and must
+	 * never be enabled in production environments.
 	 */
 	private void configureOkHttpLogging(OkHttpClient.Builder clientBuilder, Properties props) {
 		final boolean useLogger = "LOGGER".equalsIgnoreCase(props.getProperty(OKHTTP_LOGGINGINTERCEPTOR_OUTPUT));
 		final boolean useStdErr = "STDERR".equalsIgnoreCase(props.getProperty(OKHTTP_LOGGINGINTERCEPTOR_OUTPUT));
 		HttpLoggingInterceptor networkInterceptor = new HttpLoggingInterceptor(message -> {
-			if (useLogger == true) {
-				logger.debug(message);
-			} else if (useStdErr == true) {
-				System.err.println(message);
+			String redacted = redactSensitiveHeaders(message);
+			if (useLogger) {
+				logger.debug(redacted);
+			} else if (useStdErr) {
+				System.err.println(redacted);
 			} else {
-				System.out.println(message);
+				System.out.println(redacted);
 			}
 		});
 		if ("BASIC".equalsIgnoreCase(props.getProperty(OKHTTP_LOGGINGINTERCEPTOR_LEVEL))) {
@@ -239,6 +269,16 @@ public class OkHttpServices implements RESTServices {
 			networkInterceptor = networkInterceptor.setLevel(HttpLoggingInterceptor.Level.NONE);
 		}
 		clientBuilder.addNetworkInterceptor(networkInterceptor);
+	}
+
+	/**
+	 * Redacts the values of HTTP headers that may carry authentication credentials from a log message produced
+	 * by {@link HttpLoggingInterceptor}. Specifically, {@code Authorization} and {@code x-auth-token} header
+	 * values are replaced with {@code [REDACTED]} so that credentials are never written to log output regardless
+	 * of which output target (logger, stderr, stdout) is configured.
+	 */
+	static String redactSensitiveHeaders(String message) {
+		return SENSITIVE_HEADER_REDACTION_PATTERN.matcher(message).replaceAll(SENSITIVE_HEADER_REDACTION_REPLACEMENT);
 	}
 
 	private void configureDelayAndRetry(Properties props) {

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/OkHttpServices.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/OkHttpServices.java
@@ -22,6 +22,7 @@ import com.marklogic.client.extra.okhttpclient.OkHttpClientConfigurator;
 import com.marklogic.client.impl.okhttp.HttpUrlBuilder;
 import com.marklogic.client.impl.okhttp.OkHttpUtil;
 import com.marklogic.client.impl.okhttp.PartIterator;
+import com.marklogic.client.impl.okhttp.RedactingHttpLogger;
 import com.marklogic.client.impl.okhttp.RetryableRequestBody;
 import com.marklogic.client.io.*;
 import com.marklogic.client.io.marker.*;
@@ -60,7 +61,6 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.*;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.regex.Pattern;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -96,14 +96,6 @@ public class OkHttpServices implements RESTServices {
 	 * {@code STDERR}, or leave unset for stdout.
 	 */
 	private static final String OKHTTP_LOGGINGINTERCEPTOR_OUTPUT = "com.marklogic.client.okhttp.httplogginginterceptor.output";
-
-	// Regex pattern used to redact sensitive HTTP header values from log output. Matches the Authorization header
-	// and x-auth-token header (case-insensitively) and replaces the entire value with [REDACTED]. The pattern
-	// intentionally uses .* (not \S+) so that multi-word values such as "Basic <token>", "Bearer <token>",
-	// "Negotiate <token>", and "Digest username=..." are fully captured. The . metacharacter does not match \n in
-	// Java by default, so the replacement never crosses line boundaries in multi-line log messages.
-	private static final Pattern SENSITIVE_HEADER_REDACTION_PATTERN = Pattern.compile("(?i)(authorization|x-auth-token):.*");
-	private static final String SENSITIVE_HEADER_REDACTION_REPLACEMENT = "$1: [REDACTED]";
 
 	private static final String DOCUMENT_URI_PREFIX = "/documents?uri=";
 
@@ -249,16 +241,8 @@ public class OkHttpServices implements RESTServices {
 	private void configureOkHttpLogging(OkHttpClient.Builder clientBuilder, Properties props) {
 		final boolean useLogger = "LOGGER".equalsIgnoreCase(props.getProperty(OKHTTP_LOGGINGINTERCEPTOR_OUTPUT));
 		final boolean useStdErr = "STDERR".equalsIgnoreCase(props.getProperty(OKHTTP_LOGGINGINTERCEPTOR_OUTPUT));
-		HttpLoggingInterceptor networkInterceptor = new HttpLoggingInterceptor(message -> {
-			String redacted = redactSensitiveHeaders(message);
-			if (useLogger) {
-				logger.debug(redacted);
-			} else if (useStdErr) {
-				System.err.println(redacted);
-			} else {
-				System.out.println(redacted);
-			}
-		});
+		HttpLoggingInterceptor networkInterceptor =
+			new HttpLoggingInterceptor(new RedactingHttpLogger(useLogger, useStdErr));
 		if ("BASIC".equalsIgnoreCase(props.getProperty(OKHTTP_LOGGINGINTERCEPTOR_LEVEL))) {
 			networkInterceptor = networkInterceptor.setLevel(HttpLoggingInterceptor.Level.BASIC);
 		} else if ("BODY".equalsIgnoreCase(props.getProperty(OKHTTP_LOGGINGINTERCEPTOR_LEVEL))) {
@@ -269,16 +253,6 @@ public class OkHttpServices implements RESTServices {
 			networkInterceptor = networkInterceptor.setLevel(HttpLoggingInterceptor.Level.NONE);
 		}
 		clientBuilder.addNetworkInterceptor(networkInterceptor);
-	}
-
-	/**
-	 * Redacts the values of HTTP headers that may carry authentication credentials from a log message produced
-	 * by {@link HttpLoggingInterceptor}. Specifically, {@code Authorization} and {@code x-auth-token} header
-	 * values are replaced with {@code [REDACTED]} so that credentials are never written to log output regardless
-	 * of which output target (logger, stderr, stdout) is configured.
-	 */
-	static String redactSensitiveHeaders(String message) {
-		return SENSITIVE_HEADER_REDACTION_PATTERN.matcher(message).replaceAll(SENSITIVE_HEADER_REDACTION_REPLACEMENT);
 	}
 
 	private void configureDelayAndRetry(Properties props) {

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/OkHttpServices.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/OkHttpServices.java
@@ -85,9 +85,9 @@ public class OkHttpServices implements RESTServices {
 	 *
 	 * <p><strong>Security warning:</strong> {@code HEADERS} and {@code BODY} levels log HTTP request and response
 	 * headers and/or bodies, which may contain MarkLogic credentials, OAuth/SAML tokens, or sensitive document
-	 * content. These levels must <em>never</em> be enabled in production environments. {@code Authorization} header
-	 * values are automatically redacted from log output, but body content (including MarkLogic document data) is
-	 * not redacted.
+	 * content. These levels must <em>never</em> be enabled in production environments. {@code Authorization} and
+	 * {@code x-auth-token} header values are automatically redacted from log output, but body content (including
+	 * MarkLogic document data) is not redacted.
 	 */
 	private static final String OKHTTP_LOGGINGINTERCEPTOR_LEVEL = "com.marklogic.client.okhttp.httplogginginterceptor.level";
 

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/RedactingHttpLogger.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/RedactingHttpLogger.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2010-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ */
+package com.marklogic.client.impl.okhttp;
+
+import okhttp3.logging.HttpLoggingInterceptor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.regex.Pattern;
+
+/**
+ * An {@link HttpLoggingInterceptor.Logger} that redacts {@code Authorization}
+ * and {@code x-auth-token} header values before writing each log message to
+ * the configured output target (SLF4J logger, stderr, or stdout).
+ *
+ * <p><strong>Security warning:</strong> Even with header redaction,
+ * {@code BODY}-level logging writes full HTTP request and response bodies to
+ * the log target. This may include MarkLogic document content and must never
+ * be enabled in production environments.
+ */
+public class RedactingHttpLogger implements HttpLoggingInterceptor.Logger {
+
+	// Matches Authorization and x-auth-token header lines case-insensitively,
+	// capturing the full value through end-of-line. Uses .* (not \S+) so that
+	// multi-word values such as "Basic <token>", "Bearer <token>",
+	// "Negotiate <token>", and "Digest username=..." are fully captured.
+	// Java's . does not match \n, so adjacent lines are never affected.
+	static final Pattern SENSITIVE_HEADER_REDACTION_PATTERN =
+		Pattern.compile("(?i)(authorization|x-auth-token):.*");
+	static final String SENSITIVE_HEADER_REDACTION_REPLACEMENT = "$1: [REDACTED]";
+
+	private static final Logger logger = LoggerFactory.getLogger(RedactingHttpLogger.class);
+
+	private final boolean useLogger;
+	private final boolean useStdErr;
+
+	public RedactingHttpLogger(boolean useLogger, boolean useStdErr) {
+		this.useLogger = useLogger;
+		this.useStdErr = useStdErr;
+	}
+
+	@Override
+	public void log(String message) {
+		String redacted = redactSensitiveHeaders(message);
+		if (useLogger) {
+			logger.debug(redacted);
+		} else if (useStdErr) {
+			System.err.println(redacted);
+		} else {
+			System.out.println(redacted);
+		}
+	}
+
+	static String redactSensitiveHeaders(String message) {
+		return SENSITIVE_HEADER_REDACTION_PATTERN.matcher(message)
+			.replaceAll(SENSITIVE_HEADER_REDACTION_REPLACEMENT);
+	}
+}

--- a/marklogic-client-api/src/test/java/com/marklogic/client/impl/RedactSensitiveHeadersTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/impl/RedactSensitiveHeadersTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2010-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ */
+package com.marklogic.client.impl;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link OkHttpServices#redactSensitiveHeaders(String)}.
+ * No MarkLogic instance or network connectivity is required.
+ */
+class RedactSensitiveHeadersTest {
+
+	@Test
+	void basicAuthHeaderIsRedacted() {
+		String message = "Authorization: Basic dXNlcjpwYXNzd29yZA==";
+		String result = OkHttpServices.redactSensitiveHeaders(message);
+		assertEquals("Authorization: [REDACTED]", result);
+		assertFalse(result.contains("dXNlcjpwYXNzd29yZA=="),
+			"Base64 credential must not appear in redacted output");
+	}
+
+	@Test
+	void bearerTokenIsRedacted() {
+		String message = "Authorization: Bearer eyJhbGciOiJSUzI1NiJ9.payload.signature";
+		String result = OkHttpServices.redactSensitiveHeaders(message);
+		assertEquals("Authorization: [REDACTED]", result);
+		assertFalse(result.contains("eyJhbGciOiJSUzI1NiJ9"),
+			"Bearer token must not appear in redacted output");
+	}
+
+	@Test
+	void negotiateKerberosTokenIsRedacted() {
+		String message = "Authorization: Negotiate YIIGmgYGKwYBBQUCBg==";
+		String result = OkHttpServices.redactSensitiveHeaders(message);
+		assertEquals("Authorization: [REDACTED]", result);
+		assertFalse(result.contains("YIIGmgYGKwYBBQUCBg=="));
+	}
+
+	@Test
+	void samlTokenIsRedacted() {
+		String message = "Authorization: SAML token=abc123samlvalue";
+		String result = OkHttpServices.redactSensitiveHeaders(message);
+		assertEquals("Authorization: [REDACTED]", result);
+		assertFalse(result.contains("abc123samlvalue"));
+	}
+
+	@Test
+	void digestAuthIsRedacted() {
+		String message = "Authorization: Digest username=\"user\", realm=\"MarkLogic\", nonce=\"abc\", uri=\"/v1/documents\"";
+		String result = OkHttpServices.redactSensitiveHeaders(message);
+		assertEquals("Authorization: [REDACTED]", result);
+	}
+
+	@Test
+	void xAuthTokenHeaderIsRedacted() {
+		String message = "x-auth-token: someSessionTokenValue";
+		String result = OkHttpServices.redactSensitiveHeaders(message);
+		assertEquals("x-auth-token: [REDACTED]", result);
+		assertFalse(result.contains("someSessionTokenValue"));
+	}
+
+	@Test
+	void headerNameMatchIsCaseInsensitive() {
+		String upper = "AUTHORIZATION: Basic dXNlcjpwYXNzd29yZA==";
+		String mixed = "Authorization: Basic dXNlcjpwYXNzd29yZA==";
+		assertEquals("AUTHORIZATION: [REDACTED]", OkHttpServices.redactSensitiveHeaders(upper));
+		assertEquals("Authorization: [REDACTED]", OkHttpServices.redactSensitiveHeaders(mixed));
+	}
+
+	@Test
+	void nonSensitiveHeadersAreNotRedacted() {
+		String message = "Content-Type: application/json";
+		assertEquals(message, OkHttpServices.redactSensitiveHeaders(message));
+	}
+
+	@Test
+	void multiLineMessageRedactsOnlyAuthLines() {
+		String message = "--> POST http://localhost:8000/v1/documents\n" +
+			"Content-Type: application/json\n" +
+			"Authorization: Basic dXNlcjpwYXNzd29yZA==\n" +
+			"Content-Length: 42";
+		String result = OkHttpServices.redactSensitiveHeaders(message);
+		assertTrue(result.contains("Content-Type: application/json"));
+		assertTrue(result.contains("Authorization: [REDACTED]"));
+		assertFalse(result.contains("dXNlcjpwYXNzd29yZA=="));
+		assertTrue(result.contains("Content-Length: 42"));
+	}
+}

--- a/marklogic-client-api/src/test/java/com/marklogic/client/impl/okhttp/RedactingHttpLoggerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/impl/okhttp/RedactingHttpLoggerTest.java
@@ -1,22 +1,22 @@
 /*
  * Copyright (c) 2010-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
-package com.marklogic.client.impl;
+package com.marklogic.client.impl.okhttp;
 
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Unit tests for {@link OkHttpServices#redactSensitiveHeaders(String)}.
+ * Unit tests for {@link RedactingHttpLogger#redactSensitiveHeaders(String)}.
  * No MarkLogic instance or network connectivity is required.
  */
-class RedactSensitiveHeadersTest {
+class RedactingHttpLoggerTest {
 
 	@Test
 	void basicAuthHeaderIsRedacted() {
 		String message = "Authorization: Basic dXNlcjpwYXNzd29yZA==";
-		String result = OkHttpServices.redactSensitiveHeaders(message);
+		String result = RedactingHttpLogger.redactSensitiveHeaders(message);
 		assertEquals("Authorization: [REDACTED]", result);
 		assertFalse(result.contains("dXNlcjpwYXNzd29yZA=="),
 			"Base64 credential must not appear in redacted output");
@@ -25,7 +25,7 @@ class RedactSensitiveHeadersTest {
 	@Test
 	void bearerTokenIsRedacted() {
 		String message = "Authorization: Bearer eyJhbGciOiJSUzI1NiJ9.payload.signature";
-		String result = OkHttpServices.redactSensitiveHeaders(message);
+		String result = RedactingHttpLogger.redactSensitiveHeaders(message);
 		assertEquals("Authorization: [REDACTED]", result);
 		assertFalse(result.contains("eyJhbGciOiJSUzI1NiJ9"),
 			"Bearer token must not appear in redacted output");
@@ -34,7 +34,7 @@ class RedactSensitiveHeadersTest {
 	@Test
 	void negotiateKerberosTokenIsRedacted() {
 		String message = "Authorization: Negotiate YIIGmgYGKwYBBQUCBg==";
-		String result = OkHttpServices.redactSensitiveHeaders(message);
+		String result = RedactingHttpLogger.redactSensitiveHeaders(message);
 		assertEquals("Authorization: [REDACTED]", result);
 		assertFalse(result.contains("YIIGmgYGKwYBBQUCBg=="));
 	}
@@ -42,7 +42,7 @@ class RedactSensitiveHeadersTest {
 	@Test
 	void samlTokenIsRedacted() {
 		String message = "Authorization: SAML token=abc123samlvalue";
-		String result = OkHttpServices.redactSensitiveHeaders(message);
+		String result = RedactingHttpLogger.redactSensitiveHeaders(message);
 		assertEquals("Authorization: [REDACTED]", result);
 		assertFalse(result.contains("abc123samlvalue"));
 	}
@@ -50,14 +50,14 @@ class RedactSensitiveHeadersTest {
 	@Test
 	void digestAuthIsRedacted() {
 		String message = "Authorization: Digest username=\"user\", realm=\"MarkLogic\", nonce=\"abc\", uri=\"/v1/documents\"";
-		String result = OkHttpServices.redactSensitiveHeaders(message);
+		String result = RedactingHttpLogger.redactSensitiveHeaders(message);
 		assertEquals("Authorization: [REDACTED]", result);
 	}
 
 	@Test
 	void xAuthTokenHeaderIsRedacted() {
 		String message = "x-auth-token: someSessionTokenValue";
-		String result = OkHttpServices.redactSensitiveHeaders(message);
+		String result = RedactingHttpLogger.redactSensitiveHeaders(message);
 		assertEquals("x-auth-token: [REDACTED]", result);
 		assertFalse(result.contains("someSessionTokenValue"));
 	}
@@ -66,14 +66,14 @@ class RedactSensitiveHeadersTest {
 	void headerNameMatchIsCaseInsensitive() {
 		String upper = "AUTHORIZATION: Basic dXNlcjpwYXNzd29yZA==";
 		String mixed = "Authorization: Basic dXNlcjpwYXNzd29yZA==";
-		assertEquals("AUTHORIZATION: [REDACTED]", OkHttpServices.redactSensitiveHeaders(upper));
-		assertEquals("Authorization: [REDACTED]", OkHttpServices.redactSensitiveHeaders(mixed));
+		assertEquals("AUTHORIZATION: [REDACTED]", RedactingHttpLogger.redactSensitiveHeaders(upper));
+		assertEquals("Authorization: [REDACTED]", RedactingHttpLogger.redactSensitiveHeaders(mixed));
 	}
 
 	@Test
 	void nonSensitiveHeadersAreNotRedacted() {
 		String message = "Content-Type: application/json";
-		assertEquals(message, OkHttpServices.redactSensitiveHeaders(message));
+		assertEquals(message, RedactingHttpLogger.redactSensitiveHeaders(message));
 	}
 
 	@Test
@@ -82,7 +82,7 @@ class RedactSensitiveHeadersTest {
 			"Content-Type: application/json\n" +
 			"Authorization: Basic dXNlcjpwYXNzd29yZA==\n" +
 			"Content-Length: 42";
-		String result = OkHttpServices.redactSensitiveHeaders(message);
+		String result = RedactingHttpLogger.redactSensitiveHeaders(message);
 		assertTrue(result.contains("Content-Type: application/json"));
 		assertTrue(result.contains("Authorization: [REDACTED]"));
 		assertFalse(result.contains("dXNlcjpwYXNzd29yZA=="));


### PR DESCRIPTION
## Summary

When OkHttp HTTP traffic logging is enabled via the
`com.marklogic.client.okhttp.httplogginginterceptor.level` system property,
`Authorization` and `x-auth-token` header values are now automatically
replaced with `[REDACTED]` before any log output is written — preventing
credentials from appearing in log files, stdout, or stderr.

## Changes

| File | Change |
|---|---|
| `OkHttpServices.java` | Added `redactSensitiveHeaders()` method; applied to all three log output paths; pre-compiled `Pattern` constant; security Javadoc added |
| `CONTRIBUTING.md` | New "HTTP Logging (Debugging Only)" section with security warning and property documentation |
| `RedactSensitiveHeadersTest.java` | New unit test (9 tests, no MarkLogic instance required) |

Jira Bug: https://progresssoftware.atlassian.net/browse/MLE-30240