### PR TITLE
MLE-30237 fix serverStartStop to prevent OS command injection

### DIFF
--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/QBFailover.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/QBFailover.java
@@ -55,9 +55,10 @@ public class QBFailover extends BasicJavaClientREST {
 	private static String[] hostNames;
 	private static JobTicket ticket;
 	private static final String TEST_DIR_PREFIX = "/WriteHostBatcher-testdata/";
-	private static final Pattern HOSTNAME_PATTERN = Pattern.compile("[A-Za-z0-9._-]+");
+	// Hostname must start with alphanumeric to prevent leading-dash SSH option injection
+	private static final Pattern HOSTNAME_PATTERN = Pattern.compile("[A-Za-z0-9][A-Za-z0-9._-]*");
 	private static final ProcessStarter DEFAULT_PROCESS_STARTER =
-			(server, commandToRun) -> new ProcessBuilder("ssh", server, commandToRun).start();
+			(server, commandToRun) -> new ProcessBuilder("ssh", "--", server, commandToRun).start();
 	private static ProcessStarter processStarter = DEFAULT_PROCESS_STARTER;
 
 	@FunctionalInterface

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/QBFailover.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/QBFailover.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2010-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.client.datamovement.functionaltests;
 
@@ -55,6 +55,23 @@ public class QBFailover extends BasicJavaClientREST {
 	private static String[] hostNames;
 	private static JobTicket ticket;
 	private static final String TEST_DIR_PREFIX = "/WriteHostBatcher-testdata/";
+	private static final Pattern HOSTNAME_PATTERN = Pattern.compile("[A-Za-z0-9._-]+");
+	private static final ProcessStarter DEFAULT_PROCESS_STARTER =
+			(server, commandToRun) -> new ProcessBuilder("ssh", server, commandToRun).start();
+	private static ProcessStarter processStarter = DEFAULT_PROCESS_STARTER;
+
+	@FunctionalInterface
+	interface ProcessStarter {
+		Process start(String server, String commandToRun) throws Exception;
+	}
+
+	static void setProcessStarterForTest(ProcessStarter starter) {
+		processStarter = starter;
+	}
+
+	static void resetProcessStarterForTest() {
+		processStarter = DEFAULT_PROCESS_STARTER;
+	}
 
 	@BeforeAll
 	public static void setUpBeforeClass() throws Exception {
@@ -999,21 +1016,26 @@ public class QBFailover extends BasicJavaClientREST {
 
 	private void serverStartStop(String server, String command) throws Exception {
 		System.out.println("Preparing to " + command + " " + server);
-		String commandtoRun = null;
+		if (command == null) {
+			throw new IllegalArgumentException("Invalid command: null");
+		}
+		if (server == null || !HOSTNAME_PATTERN.matcher(server).matches()) {
+			throw new IllegalArgumentException("Suspicious hostname: " + server);
+		}
+
+		String cmd = command.toLowerCase(Locale.ROOT);
+		if (!cmd.equals("start") && !cmd.equals("stop")) {
+			throw new IllegalArgumentException("Invalid command: " + command);
+		}
+
+		String commandtoRun;
 
 		if (OS.indexOf("win") >= 0) {
-			commandtoRun = "net " + command.toLowerCase() + " MarkLogic";
+			commandtoRun = "net " + cmd + " MarkLogic";
 		} else {
-			commandtoRun = "sudo mladmin " + command.toLowerCase();
+			commandtoRun = "sudo mladmin " + cmd;
 		}
-
-		if (command.toLowerCase() != "start" && command.toLowerCase() != "stop") {
-			System.out.println("Invalid Command");
-			return;
-
-		}
-		String[] temp = { "sh", "-c", "ssh " + server + " " + commandtoRun };
-		Process proc = Runtime.getRuntime().exec(temp);
+		Process proc = processStarter.start(server, commandtoRun);
 		BufferedReader stdOut = new BufferedReader(new InputStreamReader(proc.getInputStream()));
 		BufferedReader stdError = new BufferedReader(new InputStreamReader(proc.getErrorStream()));
 		String s = null;

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/ServerStartStopSecurityTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/ServerStartStopSecurityTest.java
@@ -73,6 +73,32 @@ public class ServerStartStopSecurityTest {
 		assertEquals(0, processStartCount.get());
 	}
 
+	@Test
+	void wbServerStartStopRejectsLeadingDashHostnameBeforeProcessStart() {
+		AtomicInteger processStartCount = new AtomicInteger(0);
+		WBFailover.setProcessStarterForTest((server, commandToRun) -> {
+			processStartCount.incrementAndGet();
+			throw new AssertionError("Process creation should not be attempted for leading-dash hostname");
+		});
+
+		assertThrows(IllegalArgumentException.class,
+				() -> invokeServerStartStop(new WBFailover(), "-oProxyCommand=id", "start"));
+		assertEquals(0, processStartCount.get());
+	}
+
+	@Test
+	void qbServerStartStopRejectsLeadingDashHostnameBeforeProcessStart() {
+		AtomicInteger processStartCount = new AtomicInteger(0);
+		QBFailover.setProcessStarterForTest((server, commandToRun) -> {
+			processStartCount.incrementAndGet();
+			throw new AssertionError("Process creation should not be attempted for leading-dash hostname");
+		});
+
+		assertThrows(IllegalArgumentException.class,
+				() -> invokeServerStartStop(new QBFailover(), "-oProxyCommand=id", "start"));
+		assertEquals(0, processStartCount.get());
+	}
+
 	private void invokeServerStartStop(Object target, String server, String command) throws Throwable {
 		Method method = target.getClass().getDeclaredMethod("serverStartStop", String.class, String.class);
 		method.setAccessible(true);

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/ServerStartStopSecurityTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/ServerStartStopSecurityTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2010-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ */
+package com.marklogic.client.datamovement.functionaltests;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ServerStartStopSecurityTest {
+
+	@AfterEach
+	void resetProcessStarters() {
+		WBFailover.resetProcessStarterForTest();
+		QBFailover.resetProcessStarterForTest();
+	}
+
+	@Test
+	void wbServerStartStopRejectsSuspiciousHostnameBeforeProcessStart() {
+		AtomicInteger processStartCount = new AtomicInteger(0);
+		WBFailover.setProcessStarterForTest((server, commandToRun) -> {
+			processStartCount.incrementAndGet();
+			throw new AssertionError("Process creation should not be attempted for invalid hostname");
+		});
+
+		assertThrows(IllegalArgumentException.class,
+				() -> invokeServerStartStop(new WBFailover(), "host; echo pwned", "start"));
+		assertEquals(0, processStartCount.get());
+	}
+
+	@Test
+	void wbServerStartStopRejectsInvalidCommandBeforeProcessStart() {
+		AtomicInteger processStartCount = new AtomicInteger(0);
+		WBFailover.setProcessStarterForTest((server, commandToRun) -> {
+			processStartCount.incrementAndGet();
+			throw new AssertionError("Process creation should not be attempted for invalid command");
+		});
+
+		assertThrows(IllegalArgumentException.class,
+				() -> invokeServerStartStop(new WBFailover(), "host", "reboot"));
+		assertEquals(0, processStartCount.get());
+	}
+
+	@Test
+	void qbServerStartStopRejectsSuspiciousHostnameBeforeProcessStart() {
+		AtomicInteger processStartCount = new AtomicInteger(0);
+		QBFailover.setProcessStarterForTest((server, commandToRun) -> {
+			processStartCount.incrementAndGet();
+			throw new AssertionError("Process creation should not be attempted for invalid hostname");
+		});
+
+		assertThrows(IllegalArgumentException.class,
+				() -> invokeServerStartStop(new QBFailover(), "host; echo pwned", "start"));
+		assertEquals(0, processStartCount.get());
+	}
+
+	@Test
+	void qbServerStartStopRejectsInvalidCommandBeforeProcessStart() {
+		AtomicInteger processStartCount = new AtomicInteger(0);
+		QBFailover.setProcessStarterForTest((server, commandToRun) -> {
+			processStartCount.incrementAndGet();
+			throw new AssertionError("Process creation should not be attempted for invalid command");
+		});
+
+		assertThrows(IllegalArgumentException.class,
+				() -> invokeServerStartStop(new QBFailover(), "host", "reboot"));
+		assertEquals(0, processStartCount.get());
+	}
+
+	private void invokeServerStartStop(Object target, String server, String command) throws Throwable {
+		Method method = target.getClass().getDeclaredMethod("serverStartStop", String.class, String.class);
+		method.setAccessible(true);
+		try {
+			method.invoke(target, server, command);
+		} catch (InvocationTargetException ex) {
+			throw ex.getCause();
+		}
+	}
+}

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/WBFailover.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/WBFailover.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2010-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.client.datamovement.functionaltests;
 
@@ -31,6 +31,7 @@ public class WBFailover extends BasicJavaClientREST {
 	private static String dbName = "WBFailover";
 	private static DataMovementManager dmManager;
 	private static final String OS = System.getProperty("os.name").toLowerCase();
+	private static final Pattern HOSTNAME_PATTERN = Pattern.compile("[A-Za-z0-9._-]+");
 
 	private static DatabaseClient dbClient;
 	private static DatabaseClient evalClient;
@@ -45,6 +46,22 @@ public class WBFailover extends BasicJavaClientREST {
 	private static JobTicket writeTicket;
 	final String query1 = "fn:count(fn:doc())";
 	private static List<String> hostLists;
+	private static final ProcessStarter DEFAULT_PROCESS_STARTER =
+			(server, commandToRun) -> new ProcessBuilder("ssh", server, commandToRun).start();
+	private static ProcessStarter processStarter = DEFAULT_PROCESS_STARTER;
+
+	@FunctionalInterface
+	interface ProcessStarter {
+		Process start(String server, String commandToRun) throws Exception;
+	}
+
+	static void setProcessStarterForTest(ProcessStarter starter) {
+		processStarter = starter;
+	}
+
+	static void resetProcessStarterForTest() {
+		processStarter = DEFAULT_PROCESS_STARTER;
+	}
 
 	@BeforeAll
 	public static void setUpBeforeClass() throws Exception {
@@ -732,21 +749,26 @@ public class WBFailover extends BasicJavaClientREST {
 
 	private void serverStartStop(String server, String command) throws Exception {
 		System.out.println("Preparing to " + command + " " + server);
-		String commandtoRun = null;
+		if (command == null) {
+			throw new IllegalArgumentException("Invalid command: null");
+		}
+		if (server == null || !HOSTNAME_PATTERN.matcher(server).matches()) {
+			throw new IllegalArgumentException("Suspicious hostname: " + server);
+		}
+
+		String cmd = command.toLowerCase(Locale.ROOT);
+		if (!cmd.equals("start") && !cmd.equals("stop")) {
+			throw new IllegalArgumentException("Invalid command: " + command);
+		}
+
+		String commandtoRun;
 
 		if (OS.indexOf("win") >= 0) {
-			commandtoRun = "net " + command.toLowerCase() + " MarkLogic";
+			commandtoRun = "net " + cmd + " MarkLogic";
 		} else {
-			commandtoRun = "sudo mladmin " + command.toLowerCase();
+			commandtoRun = "sudo mladmin " + cmd;
 		}
-
-		if (command.toLowerCase() != "start" && command.toLowerCase() != "stop") {
-			System.out.println("Invalid Command");
-			return;
-
-		}
-		String[] temp = { "sh", "-c", "ssh " + server + " " + commandtoRun };
-		Process proc = Runtime.getRuntime().exec(temp);
+		Process proc = processStarter.start(server, commandtoRun);
 		BufferedReader stdOut = new BufferedReader(new InputStreamReader(proc.getInputStream()));
 		BufferedReader stdError = new BufferedReader(new InputStreamReader(proc.getErrorStream()));
 		String s = null;

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/WBFailover.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/WBFailover.java
@@ -31,7 +31,8 @@ public class WBFailover extends BasicJavaClientREST {
 	private static String dbName = "WBFailover";
 	private static DataMovementManager dmManager;
 	private static final String OS = System.getProperty("os.name").toLowerCase();
-	private static final Pattern HOSTNAME_PATTERN = Pattern.compile("[A-Za-z0-9._-]+");
+	// Hostname must start with alphanumeric to prevent leading-dash SSH option injection
+	private static final Pattern HOSTNAME_PATTERN = Pattern.compile("[A-Za-z0-9][A-Za-z0-9._-]*");
 
 	private static DatabaseClient dbClient;
 	private static DatabaseClient evalClient;
@@ -47,7 +48,7 @@ public class WBFailover extends BasicJavaClientREST {
 	final String query1 = "fn:count(fn:doc())";
 	private static List<String> hostLists;
 	private static final ProcessStarter DEFAULT_PROCESS_STARTER =
-			(server, commandToRun) -> new ProcessBuilder("ssh", server, commandToRun).start();
+			(server, commandToRun) -> new ProcessBuilder("ssh", "--", server, commandToRun).start();
 	private static ProcessStarter processStarter = DEFAULT_PROCESS_STARTER;
 
 	@FunctionalInterface


### PR DESCRIPTION
Key Security Fixes:
CWE-480 (Use of Incorrect Operator): Broken != "start" reference checks replaced with .equals("start") value checks

CWE-78 (OS Command Injection): Mitigated through:
Hostname validation [A-Za-z0-9._-]+ before any process launch
Command value validation (only "start" and "stop" allowed)
ProcessBuilder with fixed argument array instead of shell string concatenation

Test Results
New test class: ServerStartStopSecurityTest.java
All 4 security unit tests executed and passed.