### PR TITLE
MLE-30667 Added toString() override to ClientCookie

### DIFF
--- a/marklogic-client-api/src/main/java/com/marklogic/client/ClientCookie.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/ClientCookie.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2010-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.client;
 
@@ -54,5 +54,10 @@ public class ClientCookie {
 
 	public String getValue() {
 		return value;
+	}
+
+	@Override
+	public String toString() {
+		return name + "=" + value;
 	}
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/ClientCookieTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/ClientCookieTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2010-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ */
+package com.marklogic.client.test;
+
+import com.marklogic.client.ClientCookie;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ClientCookieTest {
+
+    @Test
+    void toStringReturnsNameEqualsValue() {
+        ClientCookie cookie = new ClientCookie("HostId", "abc123", Long.MAX_VALUE, "localhost", "/", false);
+        assertEquals("HostId=abc123", cookie.toString(),
+            "ClientCookie.toString() must return name=value for correct Cookie header formatting");
+    }
+
+    @Test
+    void toStringWithEmptyValue() {
+        ClientCookie cookie = new ClientCookie("SessionId", "", Long.MAX_VALUE, "localhost", "/", false);
+        assertEquals("SessionId=", cookie.toString());
+    }
+}


### PR DESCRIPTION
## Summary
Fixes a bug where `ClientCookie.toString()` returned the default `Object.toString()` value
(`com.marklogic.client.ClientCookie@<hashcode>`) instead of `name=value`. This caused
`OkHttpServices.addCookies()` to set a malformed `Cookie` request header, silently breaking
load balancer session affinity (e.g., HAProxy HostId affinity) for multi-statement transactions.
Requests could land on different backend nodes, resulting in `XDMP-NOTXN: No transaction with
identifier` errors.

## Changes
- **`ClientCookie.java`** — Added `toString()` override returning `name + "=" + value`
- **`ClientCookieTest.java`** — New unit test class with two tests covering the standard
  `name=value` format and the empty-value edge case

## Testing
- `ClientCookieTest` passes (no MarkLogic instance required)
- No existing tests broken

## Related
- Jira: [MLE-30667](https://progresssoftware.atlassian.net/browse/MLE-30667)
- GitHub Issue: #1944

[MLE-30667]: https://progresssoftware.atlassian.net/browse/MLE-30667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ