### PR TITLE
MLE-30953 MLE-30952 MLE-30968 Vulnerability fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,9 @@ subprojects {
 			resolutionStrategy {
 				// Forcing the latest commons-lang3 version to eliminate CVEs.
 				force "org.apache.commons:commons-lang3:3.20.0"
+				// Forcing the OpenTelemetry version to eliminate CVEs.
+				force "io.opentelemetry:opentelemetry-api:1.62.0"
+				force "io.opentelemetry:opentelemetry-context:1.62.0"
 			}
 		}
 	}

--- a/build.gradle
+++ b/build.gradle
@@ -18,9 +18,6 @@ subprojects {
 			resolutionStrategy {
 				// Forcing the latest commons-lang3 version to eliminate CVEs.
 				force "org.apache.commons:commons-lang3:3.20.0"
-				// Forcing the OpenTelemetry version to eliminate CVEs.
-				force "io.opentelemetry:opentelemetry-api:1.62.0"
-				force "io.opentelemetry:opentelemetry-context:1.62.0"
 			}
 		}
 	}

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ publishUrl=file:../marklogic-java/releases
 okhttpVersion=5.3.2
 
 # See https://github.com/FasterXML/jackson for more information on the Jackson libraries.
-jacksonVersion=2.21.1
+jacksonVersion=2.22.0
 
 junitVersion=6.0.3
 logbackVersion=1.5.37

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ okhttpVersion=5.3.2
 jacksonVersion=2.21.1
 
 junitVersion=6.0.3
-logbackVersion=1.5.35
+logbackVersion=1.5.37
 
 # Defined at this level so that they can be set as system properties and used by the marklogic-client-api and test-app
 # project

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ group=com.marklogic
 version=8.2-SNAPSHOT
 publishUrl=file:../marklogic-java/releases
 
-okhttpVersion=5.3.2
+okhttpVersion=5.4.0
 
 # See https://github.com/FasterXML/jackson for more information on the Jackson libraries.
 jacksonVersion=2.22.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ okhttpVersion=5.3.2
 jacksonVersion=2.21.1
 
 junitVersion=6.0.3
-logbackVersion=1.5.32
+logbackVersion=1.5.35
 
 # Defined at this level so that they can be set as system properties and used by the marklogic-client-api and test-app
 # project

--- a/ml-development-tools/build.gradle
+++ b/ml-development-tools/build.gradle
@@ -9,7 +9,7 @@ plugins {
 	id 'maven-publish'
 	id "com.gradle.plugin-publish" version "1.2.1"
 	id "java-gradle-plugin"
-	id 'org.jetbrains.kotlin.jvm' version '2.2.21'
+	id 'org.jetbrains.kotlin.jvm' version '2.4.0'
 }
 
 dependencies {
@@ -23,7 +23,7 @@ dependencies {
 	// additional work during development, though we rarely modify the code in this plugin anymore.
 	implementation "com.marklogic:marklogic-client-api:${version}"
 
-	implementation 'org.jetbrains.kotlin:kotlin-stdlib:2.2.21'
+	implementation 'org.jetbrains.kotlin:kotlin-stdlib:2.4.0'
 	implementation "com.fasterxml.jackson.module:jackson-module-kotlin:${jacksonVersion}"
 
 	// Sticking with this older version for now as the latest 1.x version introduces breaking changes.

--- a/ml-development-tools/build.gradle
+++ b/ml-development-tools/build.gradle
@@ -23,7 +23,7 @@ dependencies {
 	// additional work during development, though we rarely modify the code in this plugin anymore.
 	implementation "com.marklogic:marklogic-client-api:${version}"
 
-	implementation 'org.jetbrains.kotlin:kotlin-stdlib:2.4.0'
+	implementation 'org.jetbrains.kotlin:kotlin-stdlib:2.2.21'
 	implementation "com.fasterxml.jackson.module:jackson-module-kotlin:${jacksonVersion}"
 
 	// Sticking with this older version for now as the latest 1.x version introduces breaking changes.


### PR DESCRIPTION
https://progresssoftware.atlassian.net/browse/MLE-30953: Bumped kotlin from 2.2.21 to 2.4.0 to resolve OpenTelemetry Java v1.41.0 vuln.
https://progresssoftware.atlassian.net/browse/MLE-30952: Bumped Logback from v1.5.32 to v1.5.37
https://progresssoftware.atlassian.net/browse/MLE-30968: Bumped jacksonVersion from 2.21.1 to 2.22.0