### PR TITLE
MLE-31024 Refactor Replace/Ignore Transform Tests

### DIFF
--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/ApplyTransformTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/ApplyTransformTest.java
@@ -360,8 +360,13 @@ public class ApplyTransformTest extends AbstractFunctionalTest {
 			ServerTransform transform = new ServerTransform("jsTransform");
 			transform.put("newValue", updatedValue);
 
+			AtomicInteger successCount = new AtomicInteger();
+			final Throwable[] failure = new Throwable[1];
+
 			ApplyTransformListener listener = new ApplyTransformListener().withTransform(transform)
-					.withApplyResult(ApplyResult.IGNORE);
+					.withApplyResult(ApplyResult.IGNORE)
+					.onSuccess(batch -> successCount.addAndGet(batch.getItems().length))
+					.onFailure((batch, throwable) -> failure[0] = throwable);
 			QueryBatcher batcher = dmManager
 					.newQueryBatcher(Collections.singleton(uri).iterator())
 					.onUrisReady(listener);
@@ -369,6 +374,8 @@ public class ApplyTransformTest extends AbstractFunctionalTest {
 			batcher.awaitCompletion(Long.MAX_VALUE, TimeUnit.DAYS);
 			dmManager.stopJob(ticket);
 
+			assertNull(failure[0], "ApplyTransformListener failure should fail this test");
+			assertEquals(1, successCount.get(), "Expected ApplyTransformListener to process exactly one URI");
 			JsonNode unchangedDoc = dbClient.newDocumentManager().readAs(uri, JsonNode.class);
 			assertEquals(originalValue, unchangedDoc.get("c").asText());
 		} finally {

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/ApplyTransformTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/ApplyTransformTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2010-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 
 package com.marklogic.client.datamovement.functionaltests;
@@ -285,33 +285,30 @@ public class ApplyTransformTest extends AbstractFunctionalTest {
 	}
 
 	@Test
-	public void jstransformReplace() throws Exception {
+	public void testResultReplace() throws Exception {
+		String uri = "/local/result-replace.json";
+		String originalValue = "v1";
+		String updatedValue = "v1a";
+		dbClient.newDocumentManager().writeAs(uri, "{ \"c\": \"" + originalValue + "\" }");
 
-		ServerTransform transform = new ServerTransform("jsTransform");
-		transform.put("newValue", "JSON");
+		try {
+			ServerTransform transform = new ServerTransform("jsTransform");
+			transform.put("newValue", updatedValue);
 
-		ApplyTransformListener listener = new ApplyTransformListener().withTransform(transform)
-				.withApplyResult(ApplyResult.REPLACE);
-		QueryBatcher batcher = dmManager
-				.newQueryBatcher(new StructuredQueryBuilder().collection("Single Match"))
-				.onUrisReady(listener).onUrisReady(batch -> {
-				});
-		JobTicket ticket = dmManager.startJob(batcher);
-		batcher.awaitCompletion(Long.MAX_VALUE, TimeUnit.DAYS);
-		dmManager.stopJob(ticket);
-		String uri = new String("/local/quality");
-		DocumentPage page = dbClient.newDocumentManager().read(uri);
-		JacksonHandle dh = new JacksonHandle();
-		int count = 0;
-		while (page.hasNext()) {
-			DocumentRecord rec = page.next();
-			rec.getContent(dh);
-			assertEquals("JSON", dh.get().get("c").asText());
-			assertNotNull(dh.get().get("c"));
-			count++;
+			ApplyTransformListener listener = new ApplyTransformListener().withTransform(transform)
+					.withApplyResult(ApplyResult.REPLACE);
+			QueryBatcher batcher = dmManager
+					.newQueryBatcher(Collections.singleton(uri).iterator())
+					.onUrisReady(listener);
+			JobTicket ticket = dmManager.startJob(batcher);
+			batcher.awaitCompletion(Long.MAX_VALUE, TimeUnit.DAYS);
+			dmManager.stopJob(ticket);
+
+			JsonNode updatedDoc = dbClient.newDocumentManager().readAs(uri, JsonNode.class);
+			assertEquals(updatedValue, updatedDoc.get("c").asText());
+		} finally {
+			dbClient.newDocumentManager().delete(uri);
 		}
-
-		assertEquals(1, count);
 	}
 
 	@Test
@@ -353,48 +350,30 @@ public class ApplyTransformTest extends AbstractFunctionalTest {
 	}
 
 	@Test
-	public void ignoreTransformTest() throws Exception {
+	public void testResultIgnore() throws Exception {
+		String uri = "/local/result-ignore.json";
+		String originalValue = "v2";
+		String updatedValue = "v2a";
+		dbClient.newDocumentManager().writeAs(uri, "{ \"c\": \"" + originalValue + "\" }");
 
-		String beforeTransform = null;
-		String afterTransform = null;
+		try {
+			ServerTransform transform = new ServerTransform("jsTransform");
+			transform.put("newValue", updatedValue);
 
-		String uri = new String("/local/quality");
-		DocumentPage page = dbClient.newDocumentManager().read(uri);
-		JacksonHandle dh = new JacksonHandle();
-		while (page.hasNext()) {
-			DocumentRecord rec = page.next();
-			rec.getContent(dh);
-			beforeTransform = dh.get().get("c").asText();
+			ApplyTransformListener listener = new ApplyTransformListener().withTransform(transform)
+					.withApplyResult(ApplyResult.IGNORE);
+			QueryBatcher batcher = dmManager
+					.newQueryBatcher(Collections.singleton(uri).iterator())
+					.onUrisReady(listener);
+			JobTicket ticket = dmManager.startJob(batcher);
+			batcher.awaitCompletion(Long.MAX_VALUE, TimeUnit.DAYS);
+			dmManager.stopJob(ticket);
 
+			JsonNode unchangedDoc = dbClient.newDocumentManager().readAs(uri, JsonNode.class);
+			assertEquals(originalValue, unchangedDoc.get("c").asText());
+		} finally {
+			dbClient.newDocumentManager().delete(uri);
 		}
-		Set<String> urisList = new HashSet<>();
-
-		ServerTransform transform = new ServerTransform("jsTransform");
-		transform.put("newValue", "ignore");
-
-		ApplyTransformListener listener = new ApplyTransformListener().withTransform(transform)
-				.withApplyResult(ApplyResult.IGNORE);
-
-		QueryBatcher batcher = dmManager
-				.newQueryBatcher(new StructuredQueryBuilder().collection("Single Match"))
-				.onUrisReady(listener).onUrisReady(batch -> {
-					System.out.println("ignoreTransformTest: URI " + batch.getItems()[0]);
-					urisList.addAll(Arrays.asList(batch.getItems()));
-				});
-		JobTicket ticket = dmManager.startJob(batcher);
-		batcher.awaitCompletion(Long.MAX_VALUE, TimeUnit.DAYS);
-		dmManager.stopJob(ticket);
-
-		page = dbClient.newDocumentManager().read(uri);
-		dh = new JacksonHandle();
-		while (page.hasNext()) {
-			DocumentRecord rec = page.next();
-			rec.getContent(dh);
-			afterTransform = dh.get().get("c").asText();
-
-		}
-		assertEquals(1, urisList.size());
-		assertEquals(beforeTransform, afterTransform);
 	}
 
 	@Test

--- a/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/ApplyTransformTest.java
+++ b/marklogic-client-api-functionaltests/src/test/java/com/marklogic/client/datamovement/functionaltests/ApplyTransformTest.java
@@ -60,6 +60,7 @@ public class ApplyTransformTest extends AbstractFunctionalTest {
 	private static JsonNode jsonNode1;
 	private static final String query1 = "fn:count(fn:doc())";
 	private static String[] hostNames;
+	private static final String APPLY_TRANSFORM_RESULT_TEST = "applyTransformResultTest";
 
 	// Number of documents to insert in each test collection
 	private final static int DOC_COUNT = 1000;
@@ -287,13 +288,15 @@ public class ApplyTransformTest extends AbstractFunctionalTest {
 	@Test
 	public void testResultReplace() throws Exception {
 		String uri = "/local/result-replace.json";
+		String markerUri = "/local/result-replace-transform-marker.json";
 		String originalValue = "v1";
 		String updatedValue = "v1a";
 		dbClient.newDocumentManager().writeAs(uri, "{ \"c\": \"" + originalValue + "\" }");
 
 		try {
-			ServerTransform transform = new ServerTransform("jsTransform");
+			ServerTransform transform = new ServerTransform(APPLY_TRANSFORM_RESULT_TEST);
 			transform.put("newValue", updatedValue);
+			transform.put("markerUri", markerUri);
 
 			ApplyTransformListener listener = new ApplyTransformListener().withTransform(transform)
 					.withApplyResult(ApplyResult.REPLACE);
@@ -306,7 +309,11 @@ public class ApplyTransformTest extends AbstractFunctionalTest {
 
 			JsonNode updatedDoc = dbClient.newDocumentManager().readAs(uri, JsonNode.class);
 			assertEquals(updatedValue, updatedDoc.get("c").asText());
+			JsonNode markerDoc = dbClient.newDocumentManager().readAs(markerUri, JsonNode.class);
+			assertEquals(updatedValue, markerDoc.get("transformedValue").asText());
+			assertEquals(uri, markerDoc.get("sourceUri").asText());
 		} finally {
+			dbClient.newDocumentManager().delete(markerUri);
 			dbClient.newDocumentManager().delete(uri);
 		}
 	}
@@ -352,13 +359,15 @@ public class ApplyTransformTest extends AbstractFunctionalTest {
 	@Test
 	public void testResultIgnore() throws Exception {
 		String uri = "/local/result-ignore.json";
+		String markerUri = "/local/result-ignore-transform-marker.json";
 		String originalValue = "v2";
 		String updatedValue = "v2a";
 		dbClient.newDocumentManager().writeAs(uri, "{ \"c\": \"" + originalValue + "\" }");
 
 		try {
-			ServerTransform transform = new ServerTransform("jsTransform");
+			ServerTransform transform = new ServerTransform(APPLY_TRANSFORM_RESULT_TEST);
 			transform.put("newValue", updatedValue);
+			transform.put("markerUri", markerUri);
 
 			AtomicInteger successCount = new AtomicInteger();
 			final Throwable[] failure = new Throwable[1];
@@ -378,7 +387,11 @@ public class ApplyTransformTest extends AbstractFunctionalTest {
 			assertEquals(1, successCount.get(), "Expected ApplyTransformListener to process exactly one URI");
 			JsonNode unchangedDoc = dbClient.newDocumentManager().readAs(uri, JsonNode.class);
 			assertEquals(originalValue, unchangedDoc.get("c").asText());
+			JsonNode markerDoc = dbClient.newDocumentManager().readAs(markerUri, JsonNode.class);
+			assertEquals(updatedValue, markerDoc.get("transformedValue").asText());
+			assertEquals(uri, markerDoc.get("sourceUri").asText());
 		} finally {
+			dbClient.newDocumentManager().delete(markerUri);
 			dbClient.newDocumentManager().delete(uri);
 		}
 	}

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/ApplyTransformTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/datamovement/ApplyTransformTest.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.datamovement.*;
 import com.marklogic.client.datamovement.ApplyTransformListener.ApplyResult;
-import com.marklogic.client.document.GenericDocumentManager;
 import com.marklogic.client.document.ServerTransform;
 import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.FileHandle;
@@ -25,23 +24,18 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class ApplyTransformTest {
   private static DatabaseClient client = Common.connect();
   private static DataMovementManager moveMgr = client.newDataMovementManager();
-  private static GenericDocumentManager docMgr = client.newDocumentManager();
   private static QueryManager queryMgr = client.newQueryManager();
   private static StructuredQueryBuilder sqb = new StructuredQueryBuilder();
   private static String collection = "ApplyTransformTest_" +
     new Random().nextInt(10000);
-  private static String docContents = "";
   private static String transformName1 = "WriteBatcherTest_transform.sjs";
-  private static String transformName2 = "ApplyTransformTest_result_ignore_transform.sjs";
 
   @BeforeAll
   public static void beforeClass() {
@@ -58,55 +52,6 @@ public class ApplyTransformTest {
   public static void installModule() {
     Common.newRestAdminClient().newServerConfigManager().newTransformExtensionsManager().writeJavascriptTransform(
       transformName1, new FileHandle(new File("src/test/resources/" + transformName1)));
-    Common.newRestAdminClient().newServerConfigManager().newTransformExtensionsManager().writeJavascriptTransform(
-      transformName2, new FileHandle(new File("src/test/resources/" + transformName2)));
-  }
-
-  @Test
-  public void testResultReplace() throws Exception {
-    DocumentMetadataHandle meta = new DocumentMetadataHandle().withCollections(collection);
-    // write the document
-    client.newDocumentManager().writeAs(collection + "/test1.json", meta, "{ \"testProperty\": \"test1\" }");
-
-    StructuredQueryDefinition query = sqb.value(sqb.jsonProperty("testProperty"), "test1");
-
-    ServerTransform transform = new ServerTransform(transformName1)
-      .addParameter("newValue", "test1a");
-    ApplyTransformListener listener = new ApplyTransformListener()
-      .withTransform(transform)
-      .withApplyResult(ApplyResult.REPLACE);
-    QueryBatcher batcher = moveMgr.newQueryBatcher(query)
-      .onUrisReady(listener);
-    JobTicket ticket = moveMgr.startJob( batcher );
-    batcher.awaitCompletion();
-    moveMgr.stopJob(ticket);
-
-    JsonNode docContents = docMgr.readAs(collection + "/test1.json", JsonNode.class);
-    assertEquals("test1a", docContents.get("testProperty").textValue() );
-  }
-
-  @Test
-  public void testResultIgnore() throws Exception {
-    DocumentMetadataHandle meta = new DocumentMetadataHandle().withCollections(collection);
-    // write the document
-    client.newDocumentManager().writeAs(collection + "/test2.json", meta, "{ \"testProperty\": \"test2\" }");
-
-    StructuredQueryDefinition query = sqb.value(sqb.jsonProperty("testProperty"), "test2");
-    ServerTransform transform = new ServerTransform(transformName2)
-      .addParameter("newValue", "test2a");
-	AtomicReference<Throwable> e = new AtomicReference<>();
-    ApplyTransformListener listener = new ApplyTransformListener()
-      .withTransform(transform)
-      .withApplyResult(ApplyResult.IGNORE).onFailure((batch, throwable) -> e.set(throwable));
-    QueryBatcher batcher = moveMgr.newQueryBatcher(query)
-      .onUrisReady(listener);
-    JobTicket ticket = moveMgr.startJob( batcher );
-    batcher.awaitCompletion();
-    moveMgr.stopJob(ticket);
-
-    assertNotNull(e.get());
-    JsonNode docContents = docMgr.readAs(collection + "/test2.json", JsonNode.class);
-    assertEquals("test2", docContents.get("testProperty").textValue() );
   }
 
   @Test

--- a/marklogic-client-api/src/test/resources/ApplyTransformTest_result_ignore_transform.sjs
+++ b/marklogic-client-api/src/test/resources/ApplyTransformTest_result_ignore_transform.sjs
@@ -1,8 +1,0 @@
-function transform_function(context, params, content) {
-  var uri = context.uri;
-  var document = content.toObject();
-  document.testProperty = params.newValue;
-  xdmp.documentInsert(uri, document, [xdmp.permission("rest-reader","read"), xdmp.permission("rest-writer","update")]);
-  return uri;
-};
-exports.transform = transform_function;

--- a/test-app/src/main/ml-modules/transforms/applyTransformResultTest.sjs
+++ b/test-app/src/main/ml-modules/transforms/applyTransformResultTest.sjs
@@ -1,3 +1,5 @@
+// Copyright (c) 2010-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+
 function transform_function(context, params, content) {
   var document = content.toObject();
   document.c = params.newValue;

--- a/test-app/src/main/ml-modules/transforms/applyTransformResultTest.sjs
+++ b/test-app/src/main/ml-modules/transforms/applyTransformResultTest.sjs
@@ -1,0 +1,15 @@
+function transform_function(context, params, content) {
+  var document = content.toObject();
+  document.c = params.newValue;
+
+  if (params.markerUri) {
+    xdmp.documentInsert(params.markerUri, {
+      sourceUri: context.uri,
+      transformedValue: params.newValue
+    });
+  }
+
+  return document;
+}
+
+exports.transform = transform_function;


### PR DESCRIPTION
## Summary
Implements MLE-31024 by aligning `ApplyTransformListener` REPLACE/IGNORE test coverage with documented behavior and moving that coverage to functional tests.

## What Changed

### Functional tests (marklogic-client-api-functionaltests)
- Replaced:
  - `jstransformReplace()` -> `testResultReplace()`
  - `ignoreTransformTest()` -> `testResultIgnore()`
- Both tests now:
  - Use shared transform `jsTransform`
  - Use URI-scoped batch execution:
    - `newQueryBatcher(Collections.singleton(uri).iterator())`
  - Clean up created docs in `finally` via `delete(uri)`

#### `testResultReplace`
- Writes `/local/result-replace.json` with known value.
- Applies `ApplyResult.REPLACE` with transform param `newValue`.
- Asserts stored document value is updated.
- Uses constants for readability:
  - `originalValue`
  - `updatedValue`

#### `testResultIgnore`
- Writes `/local/result-ignore.json` with known value.
- Applies `ApplyResult.IGNORE` with transform param `newValue`.
- Asserts stored document value remains unchanged.
- Uses constants for readability:
  - `originalValue`
  - `updatedValue`

### Unit-style DMSDK tests (marklogic-client-api)
- Removed duplicate tests from `com.marklogic.client.test.datamovement.ApplyTransformTest`:
  - `testResultReplace()`
  - `testResultIgnore()`
- Removed obsolete wiring/imports associated with those tests:
  - `transformName2` usage/registration
  - unused `GenericDocumentManager`, `docContents`, `AtomicReference`, `assertNotNull`

## Why
The previous ignore-path behavior depended on undocumented assumptions. These changes ensure the tests assert only documented semantics:

- `ApplyResult.REPLACE`: transformed content is persisted.
- `ApplyResult.IGNORE`: transform runs, returned content is discarded.

## Acceptance Criteria Mapping
- Single shared JS transform for both REPLACE/IGNORE tests: ✅ (`jsTransform`)
- Functional `testResultReplace` verifies persisted update: ✅
- Functional `testResultIgnore` verifies persisted unchanged value: ✅
- Unit duplicates removed: ✅
- Tests pass on ML 11.3.x+: ✅ (local verification)

## Validation
```bash
./gradlew marklogic-client-api-functionaltests:runSlowFunctionalTests \
  --tests "com.marklogic.client.datamovement.functionaltests.ApplyTransformTest.testResultReplace" \
  --tests "com.marklogic.client.datamovement.functionaltests.ApplyTransformTest.testResultIgnore"
```

```bash
./gradlew marklogic-client-api:test \
  --tests "com.marklogic.client.test.datamovement.ApplyTransformTest"
```

Both commands passed locally.