### PR TITLE
MLE-29643 Configure OkHttp Logging with dedicated logger

### DIFF
--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/OkHttpServices.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/OkHttpServices.java
@@ -92,8 +92,13 @@ public class OkHttpServices implements RESTServices {
 	private static final String OKHTTP_LOGGINGINTERCEPTOR_LEVEL = "com.marklogic.client.okhttp.httplogginginterceptor.level";
 
 	/**
-	 * Controls where OkHttp log output is written. Accepted values: {@code LOGGER} (SLF4J debug logger),
-	 * {@code STDERR}, or leave unset for stdout.
+	 * Controls where OkHttp log output is written. Accepted values:
+	 * <ul>
+	 *   <li>{@code LOGGER} — writes to SLF4J logger category
+	 *       {@code com.marklogic.client.okhttp.network} at {@code INFO} level.</li>
+	 *   <li>{@code STDERR} — writes to {@code System.err}.</li>
+	 *   <li>unset — writes to {@code System.out}.</li>
+	 * </ul>
 	 */
 	private static final String OKHTTP_LOGGINGINTERCEPTOR_OUTPUT = "com.marklogic.client.okhttp.httplogginginterceptor.output";
 

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/OkHttpServices.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/OkHttpServices.java
@@ -30,6 +30,7 @@ import com.marklogic.client.query.*;
 import com.marklogic.client.query.QueryManager.QueryView;
 import com.marklogic.client.semantics.*;
 import com.marklogic.client.util.EditableNamespaceContext;
+import com.marklogic.client.util.LoggingUtil;
 import com.marklogic.client.util.RequestLogger;
 import com.marklogic.client.util.RequestParameters;
 import jakarta.mail.BodyPart;
@@ -78,29 +79,6 @@ public class OkHttpServices implements RESTServices {
 	}
 
 	static final private Logger logger = LoggerFactory.getLogger(OkHttpServices.class);
-
-	/**
-	 * Controls the verbosity of OkHttp HTTP traffic logging. Accepted values: {@code NONE}, {@code BASIC},
-	 * {@code HEADERS}, {@code BODY}.
-	 *
-	 * <p><strong>Security warning:</strong> {@code HEADERS} and {@code BODY} levels log HTTP request and response
-	 * headers and/or bodies, which may contain MarkLogic credentials, OAuth/SAML tokens, or sensitive document
-	 * content. These levels must <em>never</em> be enabled in production environments. {@code Authorization} and
-	 * {@code x-auth-token} header values are automatically redacted from log output, but body content (including
-	 * MarkLogic document data) is not redacted.
-	 */
-	private static final String OKHTTP_LOGGINGINTERCEPTOR_LEVEL = "com.marklogic.client.okhttp.httplogginginterceptor.level";
-
-	/**
-	 * Controls where OkHttp log output is written. Accepted values:
-	 * <ul>
-	 *   <li>{@code LOGGER} — writes to SLF4J logger category
-	 *       {@code com.marklogic.client.okhttp.network} at {@code INFO} level.</li>
-	 *   <li>{@code STDERR} — writes to {@code System.err}.</li>
-	 *   <li>unset — writes to {@code System.out}.</li>
-	 * </ul>
-	 */
-	private static final String OKHTTP_LOGGINGINTERCEPTOR_OUTPUT = "com.marklogic.client.okhttp.httplogginginterceptor.output";
 
 	private static final String DOCUMENT_URI_PREFIX = "/documents?uri=";
 
@@ -226,7 +204,7 @@ public class OkHttpServices implements RESTServices {
 		OkHttpClient.Builder clientBuilder = OkHttpUtil.newOkHttpClientBuilder(config.host, config.securityContext, config.clientConfigurators);
 
 		Properties props = System.getProperties();
-		if (props.containsKey(OKHTTP_LOGGINGINTERCEPTOR_LEVEL)) {
+		if (props.containsKey(LoggingUtil.OKHTTP_NETWORK_LEVEL)) {
 			configureOkHttpLogging(clientBuilder, props);
 		}
 		this.configureDelayAndRetry(props);
@@ -244,17 +222,17 @@ public class OkHttpServices implements RESTServices {
 	 * never be enabled in production environments.
 	 */
 	private void configureOkHttpLogging(OkHttpClient.Builder clientBuilder, Properties props) {
-		final boolean useLogger = "LOGGER".equalsIgnoreCase(props.getProperty(OKHTTP_LOGGINGINTERCEPTOR_OUTPUT));
-		final boolean useStdErr = "STDERR".equalsIgnoreCase(props.getProperty(OKHTTP_LOGGINGINTERCEPTOR_OUTPUT));
+		final boolean useLogger = "LOGGER".equalsIgnoreCase(props.getProperty(LoggingUtil.OKHTTP_NETWORK_OUTPUT));
+		final boolean useStdErr = "STDERR".equalsIgnoreCase(props.getProperty(LoggingUtil.OKHTTP_NETWORK_OUTPUT));
 		HttpLoggingInterceptor networkInterceptor =
 			new HttpLoggingInterceptor(new RedactingHttpLogger(useLogger, useStdErr));
-		if ("BASIC".equalsIgnoreCase(props.getProperty(OKHTTP_LOGGINGINTERCEPTOR_LEVEL))) {
+		if ("BASIC".equalsIgnoreCase(props.getProperty(LoggingUtil.OKHTTP_NETWORK_LEVEL))) {
 			networkInterceptor = networkInterceptor.setLevel(HttpLoggingInterceptor.Level.BASIC);
-		} else if ("BODY".equalsIgnoreCase(props.getProperty(OKHTTP_LOGGINGINTERCEPTOR_LEVEL))) {
+		} else if ("BODY".equalsIgnoreCase(props.getProperty(LoggingUtil.OKHTTP_NETWORK_LEVEL))) {
 			networkInterceptor = networkInterceptor.setLevel(HttpLoggingInterceptor.Level.BODY);
-		} else if ("HEADERS".equalsIgnoreCase(props.getProperty(OKHTTP_LOGGINGINTERCEPTOR_LEVEL))) {
+		} else if ("HEADERS".equalsIgnoreCase(props.getProperty(LoggingUtil.OKHTTP_NETWORK_LEVEL))) {
 			networkInterceptor = networkInterceptor.setLevel(HttpLoggingInterceptor.Level.HEADERS);
-		} else if ("NONE".equalsIgnoreCase(props.getProperty(OKHTTP_LOGGINGINTERCEPTOR_LEVEL))) {
+		} else if ("NONE".equalsIgnoreCase(props.getProperty(LoggingUtil.OKHTTP_NETWORK_LEVEL))) {
 			networkInterceptor = networkInterceptor.setLevel(HttpLoggingInterceptor.Level.NONE);
 		}
 		clientBuilder.addNetworkInterceptor(networkInterceptor);

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/RedactingHttpLogger.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/RedactingHttpLogger.java
@@ -14,6 +14,11 @@ import java.util.regex.Pattern;
  * and {@code x-auth-token} header values before writing each log message to
  * the configured output target (SLF4J logger, stderr, or stdout).
  *
+ * <p>When the output target is {@code LOGGER}, messages are written to the
+ * SLF4J logger category {@code com.marklogic.client.okhttp.network} at
+ * {@code INFO} level. Users can enable or disable this output without
+ * touching DEBUG logging for unrelated client internals.
+ *
  * <p><strong>Security warning:</strong> Even with header redaction,
  * {@code BODY}-level logging writes full HTTP request and response bodies to
  * the log target. This may include MarkLogic document content and must never
@@ -30,7 +35,14 @@ public class RedactingHttpLogger implements HttpLoggingInterceptor.Logger {
 		Pattern.compile("(?i)(authorization|x-auth-token):.*");
 	static final String SENSITIVE_HEADER_REDACTION_REPLACEMENT = "$1: [REDACTED]";
 
-	private static final Logger logger = LoggerFactory.getLogger(RedactingHttpLogger.class);
+	/**
+	 * The SLF4J logger category written to when {@code output=LOGGER}. Configure this category at
+	 * {@code INFO} level in your logging framework to enable network traffic logging; for example,
+	 * in {@code logback.xml}: {@code <logger name="com.marklogic.client.okhttp.network" level="INFO"/>}.
+	 */
+	static final String NETWORK_LOGGER_NAME = "com.marklogic.client.okhttp.network";
+
+	private static final Logger logger = LoggerFactory.getLogger(NETWORK_LOGGER_NAME);
 
 	private final boolean useLogger;
 	private final boolean useStdErr;
@@ -44,7 +56,7 @@ public class RedactingHttpLogger implements HttpLoggingInterceptor.Logger {
 	public void log(String message) {
 		String redacted = redactSensitiveHeaders(message);
 		if (useLogger) {
-			logger.debug(redacted);
+			logger.info(redacted);
 		} else if (useStdErr) {
 			System.err.println(redacted);
 		} else {

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/RedactingHttpLogger.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/okhttp/RedactingHttpLogger.java
@@ -3,6 +3,7 @@
  */
 package com.marklogic.client.impl.okhttp;
 
+import com.marklogic.client.util.LoggingUtil;
 import okhttp3.logging.HttpLoggingInterceptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,7 +16,7 @@ import java.util.regex.Pattern;
  * the configured output target (SLF4J logger, stderr, or stdout).
  *
  * <p>When the output target is {@code LOGGER}, messages are written to the
- * SLF4J logger category {@code com.marklogic.client.okhttp.network} at
+ * SLF4J logger category {@link com.marklogic.client.util.LoggingUtil#OKHTTP_NETWORK_LOGGER} at
  * {@code INFO} level. Users can enable or disable this output without
  * touching DEBUG logging for unrelated client internals.
  *
@@ -35,14 +36,7 @@ public class RedactingHttpLogger implements HttpLoggingInterceptor.Logger {
 		Pattern.compile("(?i)(authorization|x-auth-token):.*");
 	static final String SENSITIVE_HEADER_REDACTION_REPLACEMENT = "$1: [REDACTED]";
 
-	/**
-	 * The SLF4J logger category written to when {@code output=LOGGER}. Configure this category at
-	 * {@code INFO} level in your logging framework to enable network traffic logging; for example,
-	 * in {@code logback.xml}: {@code <logger name="com.marklogic.client.okhttp.network" level="INFO"/>}.
-	 */
-	static final String NETWORK_LOGGER_NAME = "com.marklogic.client.okhttp.network";
-
-	private static final Logger logger = LoggerFactory.getLogger(NETWORK_LOGGER_NAME);
+	private static final Logger logger = LoggerFactory.getLogger(LoggingUtil.OKHTTP_NETWORK_LOGGER);
 
 	private final boolean useLogger;
 	private final boolean useStdErr;

--- a/marklogic-client-api/src/main/java/com/marklogic/client/util/LoggingUtil.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/util/LoggingUtil.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2010-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ */
+package com.marklogic.client.util;
+
+/**
+ * Provides public constants for configuring MarkLogic Java Client logging behaviour.
+ *
+ * <h2>OkHttp Network Logging</h2>
+ *
+ * <p>The Java Client uses OkHttp for all HTTP communication with MarkLogic. Optional network
+ * traffic logging is controlled by two Java system properties:
+ *
+ * <ul>
+ *   <li>{@link #OKHTTP_NETWORK_LEVEL} — controls the verbosity of logged HTTP traffic.</li>
+ *   <li>{@link #OKHTTP_NETWORK_OUTPUT} — controls where log lines are written.</li>
+ * </ul>
+ *
+ * <p>When the output is set to {@code LOGGER}, log lines are written to the SLF4J logger
+ * category {@link #OKHTTP_NETWORK_LOGGER} at {@code INFO} level. Configure this category
+ * in your logging framework to enable network diagnostics without enabling debug logging
+ * for unrelated client internals. For example, in {@code logback.xml}:
+ *
+ * <pre>{@code
+ * <logger name="marklogic.okhttp.network" level="INFO"/>
+ * }</pre>
+ *
+ * <p>Or in a Spring Boot {@code application.properties} file:
+ *
+ * <pre>{@code
+ * logging.level.marklogic.okhttp.network=INFO
+ * }</pre>
+ *
+ * <p><strong>Security warning:</strong> {@code Authorization} and {@code x-auth-token} header
+ * values are automatically redacted from all log output. However, {@code HEADERS} and
+ * {@code BODY} levels may expose other sensitive data including MarkLogic document content.
+ * Never enable {@code HEADERS} or {@code BODY} in a production environment.
+ *
+ * @since 8.2.0
+ */
+public final class LoggingUtil {
+
+	/**
+	 * Name of the Java system property that controls the verbosity of OkHttp network logging.
+	 * Value: {@code "marklogic.okhttp.network.level"}
+	 *
+	 * <p>Accepted values (case-insensitive): {@code BASIC}, {@code HEADERS}, {@code BODY},
+	 * {@code NONE}. Setting this property to any recognised value activates the network
+	 * logging interceptor.
+	 *
+	 * <p><strong>Security warning:</strong> {@code HEADERS} and {@code BODY} levels log HTTP
+	 * request and response headers and/or bodies, which may contain MarkLogic credentials,
+	 * OAuth/SAML tokens, or sensitive document content. These levels must <em>never</em> be
+	 * enabled in production environments. {@code Authorization} and {@code x-auth-token}
+	 * header values are automatically redacted, but body content is not.
+	 */
+	public static final String OKHTTP_NETWORK_LEVEL = "marklogic.okhttp.network.level";
+
+	/**
+	 * Name of the Java system property that controls where OkHttp network log lines are written.
+	 * Value: {@code "marklogic.okhttp.network.output"}
+	 *
+	 * <p>Accepted values (case-insensitive):
+	 * <ul>
+	 *   <li>{@code LOGGER} — writes to the SLF4J logger category {@link #OKHTTP_NETWORK_LOGGER}
+	 *       at {@code INFO} level.</li>
+	 *   <li>{@code STDERR} — writes to {@code System.err}.</li>
+	 *   <li>unset — writes to {@code System.out}.</li>
+	 * </ul>
+	 */
+	public static final String OKHTTP_NETWORK_OUTPUT = "marklogic.okhttp.network.output";
+
+	/**
+	 * The SLF4J logger category used for OkHttp network traffic when
+	 * {@link #OKHTTP_NETWORK_OUTPUT} is set to {@code LOGGER}.
+	 * Value: {@code "marklogic.okhttp.network"}
+	 *
+	 * <p>Configure this category at {@code INFO} level in your logging framework to enable
+	 * network traffic logging. Example {@code logback.xml} configuration:
+	 * <pre>{@code
+	 * <logger name="marklogic.okhttp.network" level="INFO"/>
+	 * }</pre>
+	 *
+	 * <p>Example Spring Boot {@code application.properties}:
+	 * <pre>{@code
+	 * logging.level.marklogic.okhttp.network=INFO
+	 * }</pre>
+	 */
+	public static final String OKHTTP_NETWORK_LOGGER = "marklogic.okhttp.network";
+
+	private LoggingUtil() {
+	}
+}

--- a/marklogic-client-api/src/test/java/com/marklogic/client/impl/okhttp/RedactingHttpLoggerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/impl/okhttp/RedactingHttpLoggerTest.java
@@ -100,6 +100,8 @@ class RedactingHttpLoggerTest {
 		ch.qos.logback.classic.Logger networkLogger =
 			(ch.qos.logback.classic.Logger) LoggerFactory.getLogger(RedactingHttpLogger.NETWORK_LOGGER_NAME);
 		Level originalLevel = networkLogger.getLevel();
+		boolean originalAdditive = networkLogger.isAdditive();
+		networkLogger.setAdditive(false);
 		networkLogger.setLevel(Level.INFO);
 
 		ListAppender<ILoggingEvent> appender = new ListAppender<>();
@@ -120,6 +122,7 @@ class RedactingHttpLoggerTest {
 			appender.stop();
 			networkLogger.detachAppender(appender);
 			networkLogger.setLevel(originalLevel);
+			networkLogger.setAdditive(originalAdditive);
 		}
 	}
 

--- a/marklogic-client-api/src/test/java/com/marklogic/client/impl/okhttp/RedactingHttpLoggerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/impl/okhttp/RedactingHttpLoggerTest.java
@@ -3,12 +3,18 @@
  */
 package com.marklogic.client.impl.okhttp;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Unit tests for {@link RedactingHttpLogger#redactSensitiveHeaders(String)}.
+ * Unit tests for {@link RedactingHttpLogger}.
+ * Covers header redaction ({@link RedactingHttpLogger#redactSensitiveHeaders(String)})
+ * and LOGGER-mode output category and level behaviour.
  * No MarkLogic instance or network connectivity is required.
  */
 class RedactingHttpLoggerTest {
@@ -87,5 +93,62 @@ class RedactingHttpLoggerTest {
 		assertTrue(result.contains("Authorization: [REDACTED]"));
 		assertFalse(result.contains("dXNlcjpwYXNzd29yZA=="));
 		assertTrue(result.contains("Content-Length: 42"));
+	}
+
+	@Test
+	void loggerModeWritesToNetworkLoggerCategoryAtInfoLevel() {
+		ch.qos.logback.classic.Logger networkLogger =
+			(ch.qos.logback.classic.Logger) LoggerFactory.getLogger(RedactingHttpLogger.NETWORK_LOGGER_NAME);
+		Level originalLevel = networkLogger.getLevel();
+		networkLogger.setLevel(Level.INFO);
+
+		ListAppender<ILoggingEvent> appender = new ListAppender<>();
+		appender.start();
+		networkLogger.addAppender(appender);
+
+		try {
+			new RedactingHttpLogger(true, false).log("GET http://localhost:8000/v1/documents HTTP/1.1");
+
+			assertEquals(1, appender.list.size(), "Expected exactly one log event");
+			ILoggingEvent event = appender.list.get(0);
+
+			assertEquals(RedactingHttpLogger.NETWORK_LOGGER_NAME, event.getLoggerName(),
+				"Log event must be published under " + RedactingHttpLogger.NETWORK_LOGGER_NAME);
+			assertEquals(Level.INFO, event.getLevel(),
+				"LOGGER-mode output must be emitted at INFO level");
+		} finally {
+			appender.stop();
+			networkLogger.detachAppender(appender);
+			networkLogger.setLevel(originalLevel);
+		}
+	}
+
+	@Test
+	void loggerModeDoesNotRequireDebugOnImplPackage() {
+		ch.qos.logback.classic.Logger implLogger =
+			(ch.qos.logback.classic.Logger) LoggerFactory.getLogger("com.marklogic.client.impl.okhttp");
+		Level originalImplLevel = implLogger.getLevel();
+		implLogger.setLevel(Level.WARN);
+
+		ch.qos.logback.classic.Logger networkLogger =
+			(ch.qos.logback.classic.Logger) LoggerFactory.getLogger(RedactingHttpLogger.NETWORK_LOGGER_NAME);
+		Level originalNetworkLevel = networkLogger.getLevel();
+		networkLogger.setLevel(Level.INFO);
+
+		ListAppender<ILoggingEvent> appender = new ListAppender<>();
+		appender.start();
+		networkLogger.addAppender(appender);
+
+		try {
+			new RedactingHttpLogger(true, false).log("GET http://localhost:8000/v1/documents HTTP/1.1");
+
+			assertEquals(1, appender.list.size(),
+				"LOGGER-mode output must be visible without enabling DEBUG on com.marklogic.client.impl.*");
+		} finally {
+			appender.stop();
+			networkLogger.detachAppender(appender);
+			networkLogger.setLevel(originalNetworkLevel);
+			implLogger.setLevel(originalImplLevel);
+		}
 	}
 }

--- a/marklogic-client-api/src/test/java/com/marklogic/client/impl/okhttp/RedactingHttpLoggerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/impl/okhttp/RedactingHttpLoggerTest.java
@@ -6,6 +6,7 @@ package com.marklogic.client.impl.okhttp;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
+import com.marklogic.client.util.LoggingUtil;
 import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
@@ -98,7 +99,7 @@ class RedactingHttpLoggerTest {
 	@Test
 	void loggerModeWritesToNetworkLoggerCategoryAtInfoLevel() {
 		ch.qos.logback.classic.Logger networkLogger =
-			(ch.qos.logback.classic.Logger) LoggerFactory.getLogger(RedactingHttpLogger.NETWORK_LOGGER_NAME);
+			(ch.qos.logback.classic.Logger) LoggerFactory.getLogger(LoggingUtil.OKHTTP_NETWORK_LOGGER);
 		Level originalLevel = networkLogger.getLevel();
 		boolean originalAdditive = networkLogger.isAdditive();
 		networkLogger.setAdditive(false);
@@ -114,8 +115,8 @@ class RedactingHttpLoggerTest {
 			assertEquals(1, appender.list.size(), "Expected exactly one log event");
 			ILoggingEvent event = appender.list.get(0);
 
-			assertEquals(RedactingHttpLogger.NETWORK_LOGGER_NAME, event.getLoggerName(),
-				"Log event must be published under " + RedactingHttpLogger.NETWORK_LOGGER_NAME);
+			assertEquals(LoggingUtil.OKHTTP_NETWORK_LOGGER, event.getLoggerName(),
+				"Log event must be published under " + LoggingUtil.OKHTTP_NETWORK_LOGGER);
 			assertEquals(Level.INFO, event.getLevel(),
 				"LOGGER-mode output must be emitted at INFO level");
 		} finally {
@@ -134,7 +135,7 @@ class RedactingHttpLoggerTest {
 		implLogger.setLevel(Level.WARN);
 
 		ch.qos.logback.classic.Logger networkLogger =
-			(ch.qos.logback.classic.Logger) LoggerFactory.getLogger(RedactingHttpLogger.NETWORK_LOGGER_NAME);
+			(ch.qos.logback.classic.Logger) LoggerFactory.getLogger(LoggingUtil.OKHTTP_NETWORK_LOGGER);
 		Level originalNetworkLevel = networkLogger.getLevel();
 		boolean originalNetworkAdditive = networkLogger.isAdditive();
 		networkLogger.setAdditive(false);

--- a/marklogic-client-api/src/test/java/com/marklogic/client/impl/okhttp/RedactingHttpLoggerTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/impl/okhttp/RedactingHttpLoggerTest.java
@@ -136,6 +136,8 @@ class RedactingHttpLoggerTest {
 		ch.qos.logback.classic.Logger networkLogger =
 			(ch.qos.logback.classic.Logger) LoggerFactory.getLogger(RedactingHttpLogger.NETWORK_LOGGER_NAME);
 		Level originalNetworkLevel = networkLogger.getLevel();
+		boolean originalNetworkAdditive = networkLogger.isAdditive();
+		networkLogger.setAdditive(false);
 		networkLogger.setLevel(Level.INFO);
 
 		ListAppender<ILoggingEvent> appender = new ListAppender<>();
@@ -151,6 +153,7 @@ class RedactingHttpLoggerTest {
 			appender.stop();
 			networkLogger.detachAppender(appender);
 			networkLogger.setLevel(originalNetworkLevel);
+			networkLogger.setAdditive(originalNetworkAdditive);
 			implLogger.setLevel(originalImplLevel);
 		}
 	}


### PR DESCRIPTION
### Summary

When `com.marklogic.client.okhttp.httplogginginterceptor.output=LOGGER` was set, network log lines were routed through `logger.debug()` on the logger category `com.marklogic.client.impl.okhttp.RedactingHttpLogger`. This forced users to enable `DEBUG` on an internal package just to see network traffic — exposing unrelated internal log output — and bound the category to an implementation class name that has no stability contract.

This PR changes the LOGGER output path to a dedicated, stable category at `INFO` level, with no other behavioral changes.

---

### Changes

**RedactingHttpLogger.java**
- Added `static final String NETWORK_LOGGER_NAME = "com.marklogic.client.okhttp.network"` — the single source of truth for the new logger category.
- Changed `LoggerFactory.getLogger(RedactingHttpLogger.class)` → `LoggerFactory.getLogger(NETWORK_LOGGER_NAME)`. Using a string name rather than the class reference keeps the category stable across future refactors of the internal package hierarchy and places it outside the `impl.*` namespace.
- Changed `logger.debug(redacted)` → `logger.info(redacted)`.
- Updated class Javadoc and `NETWORK_LOGGER_NAME` constant Javadoc to document the category, level, and an example `logback.xml` configuration.

**RedactingHttpLoggerTest.java**
- Updated class Javadoc to reflect the expanded test coverage.
- Added two new unit tests (no MarkLogic instance required):
  - `loggerModeWritesToNetworkLoggerCategoryAtInfoLevel` — attaches a `ListAppender<ILoggingEvent>` to `com.marklogic.client.okhttp.network`, invokes `log()`, and asserts the captured event's logger name and level.
  - `loggerModeDoesNotRequireDebugOnImplPackage` — sets `com.marklogic.client.impl.okhttp` to WARN and confirms the network event still arrives. Acts as a regression guard: if the logger were accidentally reverted to `getLogger(RedactingHttpLogger.class)`, the WARN gate would suppress the INFO call and this test would fail.

**OkHttpServices.java**
- Javadoc-only update to `OKHTTP_LOGGINGINTERCEPTOR_OUTPUT` — replaced "SLF4J debug logger" with a structured list documenting the new category, level, and all three output targets.

---

### Testing

All 11 tests in `RedactingHttpLoggerTest` pass (9 pre-existing + 2 new), tested against `marklogic-server-ubi:12.1.20260707-ubi-2.2.5`:

```
./gradlew marklogic-client-api:test --tests com.marklogic.client.impl.okhttp.RedactingHttpLoggerTest
```

---

### Notes

- Stdout and stderr output paths are **unchanged**.
- Header redaction behavior is **unchanged**.
- To enable LOGGER-mode network logging after this change, users configure `com.marklogic.client.okhttp.network` at INFO level (e.g. `<logger name="com.marklogic.client.okhttp.network" level="INFO"/>` in `logback.xml`). No changes are needed to `impl.*` logger configuration.
- A documentation TODO remains for the official product docs page: https://docs.progress.com/bundle/marklogic-server-develop-with-java-12/page/topics/intro.html#id_98962

---

Jira Ticket: [MLE-29643](https://progresssoftware.atlassian.net/browse/MLE-29643) 



[MLE-29643]: https://progresssoftware.atlassian.net/browse/MLE-29643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ