### PR TITLE
MLE-31109 Bump kotlin plugin and remove kotlin.system.exitProcess

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,9 @@ subprojects {
 			resolutionStrategy {
 				// Forcing the latest commons-lang3 version to eliminate CVEs.
 				force "org.apache.commons:commons-lang3:3.20.0"
+				// Force kotlin-stdlib to the version matching the Kotlin JVM plugin, overriding the
+				// vulnerable 2.2.21 version that okhttp brings in transitively.
+				force "org.jetbrains.kotlin:kotlin-stdlib:2.4.10"
 			}
 		}
 	}

--- a/ml-development-tools/build.gradle
+++ b/ml-development-tools/build.gradle
@@ -9,7 +9,7 @@ plugins {
 	id 'maven-publish'
 	id "com.gradle.plugin-publish" version "1.2.1"
 	id "java-gradle-plugin"
-	id 'org.jetbrains.kotlin.jvm' version '2.4.0'
+	id 'org.jetbrains.kotlin.jvm' version '2.4.10'
 }
 
 dependencies {
@@ -23,7 +23,10 @@ dependencies {
 	// additional work during development, though we rarely modify the code in this plugin anymore.
 	implementation "com.marklogic:marklogic-client-api:${version}"
 
-	implementation 'org.jetbrains.kotlin:kotlin-stdlib:2.2.21'
+	// kotlin-stdlib is intentionally not declared here; the Kotlin JVM plugin (version 2.4.10)
+	// automatically adds the matching kotlin-stdlib to the compile and runtime classpath.
+	// Declaring it explicitly with an older version (e.g. to match okhttp's transitive dep)
+	// would re-introduce CVE risk.
 	implementation "com.fasterxml.jackson.module:jackson-module-kotlin:${jacksonVersion}"
 
 	// Sticking with this older version for now as the latest 1.x version introduces breaking changes.

--- a/ml-development-tools/src/main/kotlin/com/marklogic/client/tools/fnclassgen.kt
+++ b/ml-development-tools/src/main/kotlin/com/marklogic/client/tools/fnclassgen.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2010-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.client.tools
 

--- a/ml-development-tools/src/main/kotlin/com/marklogic/client/tools/fnclassgen.kt
+++ b/ml-development-tools/src/main/kotlin/com/marklogic/client/tools/fnclassgen.kt
@@ -4,13 +4,11 @@
 package com.marklogic.client.tools
 
 import com.marklogic.client.tools.proxy.Generator
-import kotlin.system.exitProcess
 
 fun main(args: Array<String>) {
   if (args.size == 2) {
     Generator().serviceBundleToJava(args[0], args[1])
   } else {
-    System.err.println("usage: fnclassgen serviceDeclarationFile javaBaseDir")
-    exitProcess(-1)
+    throw IllegalArgumentException("usage: fnclassgen serviceDeclarationFile javaBaseDir")
   }
 }

--- a/ml-development-tools/src/main/kotlin/com/marklogic/client/tools/fnmodinit.kt
+++ b/ml-development-tools/src/main/kotlin/com/marklogic/client/tools/fnmodinit.kt
@@ -4,13 +4,11 @@
 package com.marklogic.client.tools
 
 import com.marklogic.client.tools.proxy.Generator
-import kotlin.system.exitProcess
 
 fun main(args: Array<String>) {
   if (args.size == 2) {
     Generator().endpointDeclToModStubImpl(args[0], args[1])
   } else {
-    System.err.println("usage: fnmodinit endpointDeclarationFile moduleExtension")
-    exitProcess(-1)
+    throw IllegalArgumentException("usage: fnmodinit endpointDeclarationFile moduleExtension")
   }
 }

--- a/ml-development-tools/src/main/kotlin/com/marklogic/client/tools/fnmodinit.kt
+++ b/ml-development-tools/src/main/kotlin/com/marklogic/client/tools/fnmodinit.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2010-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.client.tools
 

--- a/ml-development-tools/src/test/example-project/build.gradle
+++ b/ml-development-tools/src/test/example-project/build.gradle
@@ -4,7 +4,7 @@ buildscript {
 		mavenCentral()
 	}
 	dependencies {
-		classpath "com.marklogic:ml-development-tools:8.0.0"
+		classpath "com.marklogic:ml-development-tools:8.2-SNAPSHOT"
 	}
 }
 
@@ -23,7 +23,7 @@ repositories {
 }
 
 dependencies {
-	implementation 'com.marklogic:marklogic-client-api:8.0.0'
+	implementation 'com.marklogic:marklogic-client-api:8.2-SNAPSHOT'
 }
 
 tasks.register("testFullPath", com.marklogic.client.tools.gradle.EndpointProxiesGenTask) {

--- a/ml-development-tools/src/test/example-project/build.gradle
+++ b/ml-development-tools/src/test/example-project/build.gradle
@@ -4,7 +4,7 @@ buildscript {
 		mavenCentral()
 	}
 	dependencies {
-		classpath "com.marklogic:ml-development-tools:8.2-SNAPSHOT"
+		classpath "com.marklogic:ml-development-tools:8.0.0"
 	}
 }
 
@@ -23,7 +23,7 @@ repositories {
 }
 
 dependencies {
-	implementation 'com.marklogic:marklogic-client-api:8.2-SNAPSHOT'
+	implementation 'com.marklogic:marklogic-client-api:8.0.0'
 }
 
 tasks.register("testFullPath", com.marklogic.client.tools.gradle.EndpointProxiesGenTask) {

--- a/ml-development-tools/src/test/kotlin/com/marklogic/client/test/dbfunction/fntestgen.kt
+++ b/ml-development-tools/src/test/kotlin/com/marklogic/client/test/dbfunction/fntestgen.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2010-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.client.test.dbfunction
 

--- a/ml-development-tools/src/test/kotlin/com/marklogic/client/test/dbfunction/fntestgen.kt
+++ b/ml-development-tools/src/test/kotlin/com/marklogic/client/test/dbfunction/fntestgen.kt
@@ -18,7 +18,6 @@ import java.io.File
 import java.lang.Exception
 
 import java.lang.IllegalStateException
-import kotlin.system.exitProcess
 
 const val TEST_PACKAGE = "com.marklogic.client.test.dbfunction.generated"
 
@@ -515,10 +514,7 @@ fun main(args: Array<String>) {
     when (args.size) {
         1 -> dbfTestGenerate(args[0], "latest")
         2 -> dbfTestGenerate(args[0], args[1])
-        else -> {
-            System.err.println("usage: fntestgen testDir [release]")
-            exitProcess(-1)
-        }
+        else -> throw IllegalArgumentException("usage: fntestgen testDir [release]")
     }
   } catch (e: Exception) {
     e.printStackTrace()
@@ -529,11 +525,7 @@ fun getExtensions(release: String) : List<String> {
         "release4" -> listOf("sjs", "xqy")
         "release5",
         "latest"   -> listOf("mjs", "sjs", "xqy")
-        else       -> {
-            System.err.println("unknown release: $release")
-            System.err.println("valid releases are one of release4, release5, or latest")
-            exitProcess(-1)
-        }
+        else       -> throw IllegalArgumentException("unknown release: $release; valid releases are one of release4, release5, or latest")
     }
 }
 


### PR DESCRIPTION
Bump kotlin plugin from 2.4.0 to 2.4.10
Removed imported instances of kotlin.system.exitProcess from com.squareup.okhttp3:okhttp:5.4.0 vulnerable dependency org.jetbrains.kotlin:kotlin-stdlib:2.2.21

Jira Item: https://progresssoftware.atlassian.net/browse/MLE-31109

---

**Validating the `kotlin-stdlib` CVE fix**

**1. Verify dependency resolution (no MarkLogic server needed)**

From the repo root, confirm `kotlin-stdlib` is forced to `2.4.10` across all subprojects:

```bash
./gradlew :marklogic-client-api:dependencies --configuration runtimeClasspath | grep kotlin-stdlib
./gradlew :ml-development-tools:dependencies --configuration runtimeClasspath | grep kotlin-stdlib
```

Expected output — every `kotlin-stdlib` line should show `-> 2.4.10`:
```
\--- org.jetbrains.kotlin:kotlin-stdlib:2.2.21 -> 2.4.10 (*)
```

**2. Confirm `exitProcess` is gone from the main source**

```bash
grep -r "exitProcess" ml-development-tools/src/main/
```
Expected: no results.

**3. Build the project**

```bash
./gradlew clean build -x test
```
Expected: `BUILD SUCCESSFUL`

**4. Test the plugin end-to-end via the example-project**

```bash
# Publish the snapshot artifacts to your local Maven repo
./gradlew publishToMavenLocal

# Run the plugin task in the example-project
cd ml-development-tools/src/test/example-project
../../../../../gradlew testProjectPath   # Linux/Mac
# or on Windows:
& C:\path\to\java-client-api\gradlew.bat testProjectPath
```

Expected: `BUILD SUCCESSFUL` and a generated `DynamicPricer.java` file appearing under `src/main/java/org/example/inventory/` (can be deleted afterwards — it's gitignored). 

