### PR TITLE
MLE-31642 Update noSslContext Test

### DIFF
--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/junit5/RequiresML12Dot0.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/junit5/RequiresML12Dot0.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2010-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ */
+package com.marklogic.client.test.junit5;
+
+import com.marklogic.client.test.Common;
+import com.marklogic.client.test.MarkLogicVersion;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class RequiresML12Dot0 implements ExecutionCondition {
+
+	private static MarkLogicVersion markLogicVersion;
+
+	@Override
+	public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+		if (markLogicVersion == null) {
+			markLogicVersion = Common.getMarkLogicVersion();
+		}
+		boolean supported =
+			markLogicVersion.getMajor() == 12 && markLogicVersion.getMinor() != null && markLogicVersion.getMinor() == 0;
+		return supported ?
+			ConditionEvaluationResult.enabled("MarkLogic is version 12.0.x") :
+			ConditionEvaluationResult.disabled("MarkLogic is not version 12.0.x");
+	}
+}

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/ssl/OneWaySSLTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/ssl/OneWaySSLTest.java
@@ -122,14 +122,14 @@ class OneWaySSLTest {
 		assertTrue(ex.getCause() instanceof SSLException, "Unexpected cause: " + ex.getCause());
 	}
 
-	@ExtendWith({RequiresML11OrLower.class, RequiresML12Dot1.class})
+	@ExtendWith(RequiresML11OrLower.class)
 	@Test
-	void noSslContext() {
+	void noSslContextWithMarkLogic11OrLower() {
 		DatabaseClient client = newSslClient(Map.of());
 
 		DatabaseClient.ConnectionResult result = client.checkConnection();
-		assertEquals("Forbidden", result.getErrorMessage(), "MarkLogic 11 or lower and MarkLogic 12.1 or higher is " +
-			"expected to return a 403 Forbidden when the user tries to access an HTTPS app server using HTTP.");
+		assertEquals("Forbidden", result.getErrorMessage(), "MarkLogic 11 or lower is expected to return a 403 Forbidden when the " +
+			"user tries to access an HTTPS app server using HTTP.");
 		assertEquals(403, result.getStatusCode());
 
 		ForbiddenUserException ex = assertThrows(ForbiddenUserException.class,
@@ -153,6 +153,27 @@ class OneWaySSLTest {
 			"library used by the server results in an IO exception when the client tries to connect to an " +
 			"app server that requires SSL, but the client does not use SSL. This impacts all ML 12.0.x versions as of 12.0.3. " +
 			"Actual message: " + ex.getMessage());
+	}
+
+	@ExtendWith(RequiresML12Dot1.class)
+	@Test
+	void noSslContextWithMarkLogic12Dot1OrHigher() {
+		DatabaseClient client = newSslClient(Map.of());
+
+		DatabaseClient.ConnectionResult result = client.checkConnection();
+		assertEquals("Forbidden", result.getErrorMessage(), "MarkLogic 12.1 or higher is expected to return a 403 Forbidden when the " +
+			"user tries to access an HTTPS app server using HTTP.");
+		assertEquals(403, result.getStatusCode());
+
+		ForbiddenUserException ex = assertThrows(ForbiddenUserException.class,
+			() -> client.newServerEval().javascript("fn.currentDate()").evalAs(String.class));
+
+		assertEquals(
+			"Local message: User is not allowed to apply resource at eval. Server Message: You have attempted to access an HTTPS server using HTTP.",
+			ex.getMessage(),
+			"The user should get a clear message on why the connection failed as opposed to the previous error " +
+				"message of 'Server (not a REST instance?)'."
+		);
 	}
 
 	@Test

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/ssl/OneWaySSLTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/ssl/OneWaySSLTest.java
@@ -122,14 +122,14 @@ class OneWaySSLTest {
 		assertTrue(ex.getCause() instanceof SSLException, "Unexpected cause: " + ex.getCause());
 	}
 
-	@ExtendWith(RequiresML11OrLower.class)
+	@ExtendWith({RequiresML11OrLower.class, RequiresML12Dot1.class})
 	@Test
-	void noSslContextWithMarkLogic11OrLower() {
+	void noSslContext() {
 		DatabaseClient client = newSslClient(Map.of());
 
 		DatabaseClient.ConnectionResult result = client.checkConnection();
-		assertEquals("Forbidden", result.getErrorMessage(), "MarkLogic 11 or lower is expected to return a 403 Forbidden when the " +
-			"user tries to access an HTTPS app server using HTTP.");
+		assertEquals("Forbidden", result.getErrorMessage(), "MarkLogic 11 or lower and MarkLogic 12.1 or higher is " +
+			"expected to return a 403 Forbidden when the user tries to access an HTTPS app server using HTTP.");
 		assertEquals(403, result.getStatusCode());
 
 		ForbiddenUserException ex = assertThrows(ForbiddenUserException.class,
@@ -153,27 +153,6 @@ class OneWaySSLTest {
 			"library used by the server results in an IO exception when the client tries to connect to an " +
 			"app server that requires SSL, but the client does not use SSL. This impacts all ML 12.0.x versions as of 12.0.3. " +
 			"Actual message: " + ex.getMessage());
-	}
-
-	@ExtendWith(RequiresML12Dot1.class)
-	@Test
-	void noSslContextWithMarkLogic12Dot1OrHigher() {
-		DatabaseClient client = newSslClient(Map.of());
-
-		DatabaseClient.ConnectionResult result = client.checkConnection();
-		assertEquals("Forbidden", result.getErrorMessage(), "MarkLogic 12.1 or higher is expected to return a 403 Forbidden when the " +
-			"user tries to access an HTTPS app server using HTTP.");
-		assertEquals(403, result.getStatusCode());
-
-		ForbiddenUserException ex = assertThrows(ForbiddenUserException.class,
-			() -> client.newServerEval().javascript("fn.currentDate()").evalAs(String.class));
-
-		assertEquals(
-			"Local message: User is not allowed to apply resource at eval. Server Message: You have attempted to access an HTTPS server using HTTP.",
-			ex.getMessage(),
-			"The user should get a clear message on why the connection failed as opposed to the previous error " +
-				"message of 'Server (not a REST instance?)'."
-		);
 	}
 
 	@Test

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/ssl/OneWaySSLTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/ssl/OneWaySSLTest.java
@@ -12,7 +12,6 @@ import com.marklogic.client.test.Common;
 import com.marklogic.client.test.MarkLogicVersion;
 import com.marklogic.client.test.junit5.DisabledWhenUsingReverseProxyServer;
 import com.marklogic.client.test.junit5.RequireSSLExtension;
-import com.marklogic.client.test.junit5.RequiresML11OrLower;
 import com.marklogic.client.test.junit5.RequiresML12;
 import com.marklogic.mgmt.ManageClient;
 import com.marklogic.mgmt.resource.appservers.ServerManager;
@@ -120,16 +119,25 @@ class OneWaySSLTest {
 		assertTrue(ex.getCause() instanceof SSLException, "Unexpected cause: " + ex.getCause());
 	}
 
-	@ExtendWith(RequiresML11OrLower.class)
+	/**
+	 * Verifies that MarkLogic returns a 403 Forbidden response when a plain HTTP client connects to an
+	 * app server that requires SSL. This is the expected behaviour for MarkLogic 11 and for MarkLogic 12.1+.
+	 *
+	 * <p>Note: early MarkLogic 12 builds (before 12.1) briefly changed this behaviour per MLE-17505, where
+	 * the server's openssl library would close the TCP connection abruptly instead of returning HTTP 403,
+	 * causing {@link com.marklogic.client.MarkLogicIOException} with "unexpected end of stream" to be thrown.
+	 * That change was reverted in 12.1. If this test is run against a pre-12.1 MarkLogic 12 build it will
+	 * fail because {@code checkConnection()} will throw rather than return a 403 {@code ConnectionResult}.</p>
+	 */
 	@Test
 	void noSslContext() {
 		DatabaseClient client = newSslClient(Map.of());
 
 		DatabaseClient.ConnectionResult result = client.checkConnection();
 		assertEquals("Forbidden", result.getErrorMessage(), "MarkLogic is expected to return a 403 Forbidden when the " +
-			"user tries to access an HTTPS app server using HTTP. This behavior changes in MarkLogic 12, and it may " +
-			"be considered a bit surprising with MarkLogic 11 and earlier - that is, the user probably shouldn't get " +
-			"any response back since a connection cannot be made without using SSL.");
+			"user tries to access an HTTPS app server using HTTP. If this assertion fails with a MarkLogicIOException " +
+			"containing 'unexpected end of stream', the test is likely running against a pre-12.1 MarkLogic 12 build " +
+			"that exhibited the now-reverted MLE-17505 behaviour.");
 		assertEquals(403, result.getStatusCode());
 
 		ForbiddenUserException ex = assertThrows(ForbiddenUserException.class,
@@ -141,17 +149,6 @@ class OneWaySSLTest {
 			"The user should get a clear message on why the connection failed as opposed to the previous error " +
 				"message of 'Server (not a REST instance?)'."
 		);
-	}
-
-	@ExtendWith(RequiresML12.class)
-	@Test
-	void noSslContextWithMarkLogic12() {
-		DatabaseClient client = newSslClient(Map.of());
-
-		MarkLogicIOException ex = assertThrows(MarkLogicIOException.class, () -> client.checkConnection());
-		assertTrue(ex.getMessage().contains("unexpected end of stream"), "Per MLE-17505, a change in the openssl " +
-			"library used by the server results in an IO exception when the client tries to connect to an " +
-			"app server that requires SSL, but the client does not use SSL. Actual message: " + ex.getMessage());
 	}
 
 	@Test

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/ssl/OneWaySSLTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/ssl/OneWaySSLTest.java
@@ -12,6 +12,7 @@ import com.marklogic.client.test.Common;
 import com.marklogic.client.test.MarkLogicVersion;
 import com.marklogic.client.test.junit5.DisabledWhenUsingReverseProxyServer;
 import com.marklogic.client.test.junit5.RequireSSLExtension;
+import com.marklogic.client.test.junit5.RequiresML11OrLower;
 import com.marklogic.client.test.junit5.RequiresML12;
 import com.marklogic.mgmt.ManageClient;
 import com.marklogic.mgmt.resource.appservers.ServerManager;
@@ -119,25 +120,16 @@ class OneWaySSLTest {
 		assertTrue(ex.getCause() instanceof SSLException, "Unexpected cause: " + ex.getCause());
 	}
 
-	/**
-	 * Verifies that MarkLogic returns a 403 Forbidden response when a plain HTTP client connects to an
-	 * app server that requires SSL. This is the expected behaviour for MarkLogic 11 and for MarkLogic 12.1+.
-	 *
-	 * <p>Note: early MarkLogic 12 builds (before 12.1) briefly changed this behaviour per MLE-17505, where
-	 * the server's openssl library would close the TCP connection abruptly instead of returning HTTP 403,
-	 * causing {@link com.marklogic.client.MarkLogicIOException} with "unexpected end of stream" to be thrown.
-	 * That change was reverted in 12.1. If this test is run against a pre-12.1 MarkLogic 12 build it will
-	 * fail because {@code checkConnection()} will throw rather than return a 403 {@code ConnectionResult}.</p>
-	 */
+	@ExtendWith(RequiresML11OrLower.class)
 	@Test
 	void noSslContext() {
 		DatabaseClient client = newSslClient(Map.of());
 
 		DatabaseClient.ConnectionResult result = client.checkConnection();
 		assertEquals("Forbidden", result.getErrorMessage(), "MarkLogic is expected to return a 403 Forbidden when the " +
-			"user tries to access an HTTPS app server using HTTP. If this assertion fails with a MarkLogicIOException " +
-			"containing 'unexpected end of stream', the test is likely running against a pre-12.1 MarkLogic 12 build " +
-			"that exhibited the now-reverted MLE-17505 behaviour.");
+			"user tries to access an HTTPS app server using HTTP. This behavior changes in MarkLogic 12, and it may " +
+			"be considered a bit surprising with MarkLogic 11 and earlier - that is, the user probably shouldn't get " +
+			"any response back since a connection cannot be made without using SSL.");
 		assertEquals(403, result.getStatusCode());
 
 		ForbiddenUserException ex = assertThrows(ForbiddenUserException.class,
@@ -149,6 +141,17 @@ class OneWaySSLTest {
 			"The user should get a clear message on why the connection failed as opposed to the previous error " +
 				"message of 'Server (not a REST instance?)'."
 		);
+	}
+
+	@ExtendWith(RequiresML12.class)
+	@Test
+	void noSslContextWithMarkLogic12() {
+		DatabaseClient client = newSslClient(Map.of());
+
+		MarkLogicIOException ex = assertThrows(MarkLogicIOException.class, () -> client.checkConnection());
+		assertTrue(ex.getMessage().contains("unexpected end of stream"), "Per MLE-17505, a change in the openssl " +
+			"library used by the server results in an IO exception when the client tries to connect to an " +
+			"app server that requires SSL, but the client does not use SSL. Actual message: " + ex.getMessage());
 	}
 
 	@Test

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/ssl/OneWaySSLTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/ssl/OneWaySSLTest.java
@@ -13,6 +13,8 @@ import com.marklogic.client.test.MarkLogicVersion;
 import com.marklogic.client.test.junit5.DisabledWhenUsingReverseProxyServer;
 import com.marklogic.client.test.junit5.RequireSSLExtension;
 import com.marklogic.client.test.junit5.RequiresML11OrLower;
+import com.marklogic.client.test.junit5.RequiresML12Dot0;
+import com.marklogic.client.test.junit5.RequiresML12Dot1;
 import com.marklogic.client.test.junit5.RequiresML12;
 import com.marklogic.mgmt.ManageClient;
 import com.marklogic.mgmt.resource.appservers.ServerManager;
@@ -122,14 +124,12 @@ class OneWaySSLTest {
 
 	@ExtendWith(RequiresML11OrLower.class)
 	@Test
-	void noSslContext() {
+	void noSslContextWithMarkLogic11OrLower() {
 		DatabaseClient client = newSslClient(Map.of());
 
 		DatabaseClient.ConnectionResult result = client.checkConnection();
-		assertEquals("Forbidden", result.getErrorMessage(), "MarkLogic is expected to return a 403 Forbidden when the " +
-			"user tries to access an HTTPS app server using HTTP. This behavior changes in MarkLogic 12, and it may " +
-			"be considered a bit surprising with MarkLogic 11 and earlier - that is, the user probably shouldn't get " +
-			"any response back since a connection cannot be made without using SSL.");
+		assertEquals("Forbidden", result.getErrorMessage(), "MarkLogic 11 or lower is expected to return a 403 Forbidden when the " +
+			"user tries to access an HTTPS app server using HTTP.");
 		assertEquals(403, result.getStatusCode());
 
 		ForbiddenUserException ex = assertThrows(ForbiddenUserException.class,
@@ -143,15 +143,37 @@ class OneWaySSLTest {
 		);
 	}
 
-	@ExtendWith(RequiresML12.class)
+	@ExtendWith(RequiresML12Dot0.class)
 	@Test
-	void noSslContextWithMarkLogic12() {
+	void noSslContextWithMarkLogic12Dot0() {
 		DatabaseClient client = newSslClient(Map.of());
 
 		MarkLogicIOException ex = assertThrows(MarkLogicIOException.class, () -> client.checkConnection());
 		assertTrue(ex.getMessage().contains("unexpected end of stream"), "Per MLE-17505, a change in the openssl " +
 			"library used by the server results in an IO exception when the client tries to connect to an " +
-			"app server that requires SSL, but the client does not use SSL. Actual message: " + ex.getMessage());
+			"app server that requires SSL, but the client does not use SSL. This impacts all ML 12.0.x versions as of 12.0.3. " +
+			"Actual message: " + ex.getMessage());
+	}
+
+	@ExtendWith(RequiresML12Dot1.class)
+	@Test
+	void noSslContextWithMarkLogic12Dot1OrHigher() {
+		DatabaseClient client = newSslClient(Map.of());
+
+		DatabaseClient.ConnectionResult result = client.checkConnection();
+		assertEquals("Forbidden", result.getErrorMessage(), "MarkLogic 12.1 or higher is expected to return a 403 Forbidden when the " +
+			"user tries to access an HTTPS app server using HTTP.");
+		assertEquals(403, result.getStatusCode());
+
+		ForbiddenUserException ex = assertThrows(ForbiddenUserException.class,
+			() -> client.newServerEval().javascript("fn.currentDate()").evalAs(String.class));
+
+		assertEquals(
+			"Local message: User is not allowed to apply resource at eval. Server Message: You have attempted to access an HTTPS server using HTTP.",
+			ex.getMessage(),
+			"The user should get a clear message on why the connection failed as opposed to the previous error " +
+				"message of 'Server (not a REST instance?)'."
+		);
 	}
 
 	@Test


### PR DESCRIPTION
MarkLogic 12.1 is now returning a 403 error code, like we expect, instead of closing the connection and throwing a MarkLogicIOException for ML 12.1.

- Renamed noSslContext() -> noSslContextWithMarkLogic11OrLower()
- Added RequiresML12Dot0.java to only run tests against 12.0 versions
- Renamed noSslContextWithMarkLogic12() to noSslContextWithMarkLogic12Dot0()
- noSslContextWithMarkLogic12Dot0() ExtendWith updated to new RequiresML12Dot0.class to only run against 12.0 versions
- Added noSslContextWithMarkLogic12Dot1OrHigher() for new ML 12.1 behavior

Jira Ticket: https://progresssoftware.atlassian.net/browse/MLE-31642