### PR TITLE
MLE-31642 fromLexicons Test fix

### DIFF
--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/junit5/RequiresML12Dot0OrLower.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/junit5/RequiresML12Dot0OrLower.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2010-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ */
+package com.marklogic.client.test.junit5;
+
+import com.marklogic.client.test.Common;
+import com.marklogic.client.test.MarkLogicVersion;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class RequiresML12Dot0OrLower implements ExecutionCondition {
+
+	private static MarkLogicVersion markLogicVersion;
+
+	@Override
+	public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+		if (markLogicVersion == null) {
+			markLogicVersion = Common.getMarkLogicVersion();
+		}
+		boolean isML12Dot0OrLower = markLogicVersion.getMajor() < 12 ||
+			(markLogicVersion.getMajor() == 12 && (markLogicVersion.getMinor() == null || markLogicVersion.getMinor() == 0));
+		return isML12Dot0OrLower ?
+			ConditionEvaluationResult.enabled("MarkLogic is version 12.0 or lower") :
+			ConditionEvaluationResult.disabled("MarkLogic is version 12.1 or higher");
+	}
+}

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/JoinDocTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/JoinDocTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2010-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.client.test.rows;
 
@@ -9,6 +9,8 @@ import com.marklogic.client.expression.PlanBuilder;
 import com.marklogic.client.row.RowRecord;
 import com.marklogic.client.test.Common;
 import com.marklogic.client.test.junit5.RequiresML11;
+import com.marklogic.client.test.junit5.RequiresML12Dot0OrLower;
+import com.marklogic.client.test.junit5.RequiresML12Dot1;
 import com.marklogic.client.type.CtsReferenceExpr;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -40,6 +42,7 @@ public class JoinDocTest extends AbstractOpticUpdateTest {
      * 2022-12-12 This is now running only on ML 11, as it's consistently failing on ML 10. We have a fix slated for
      * 11.x, and it's not clear yet if it'll be backported to ML 10.
      */
+	@ExtendWith(RequiresML12Dot0OrLower.class)
     @Test
     public void propertiesFragmentShouldNotBeReturnedByFromLexicons() {
         Map<String, CtsReferenceExpr> lexicons = new HashMap<>();
@@ -50,6 +53,29 @@ public class JoinDocTest extends AbstractOpticUpdateTest {
             .joinDoc(op.col("doc"), op.col("uri"));
 
         verifyPropertiesFragmentsAreNotReturned(plan);
+    }
+
+    /**
+     * In ML 12.1+, fromLexicons enumerates both content fragments and properties fragments, so joinDoc
+     * returns twice as many rows as written documents.
+     */
+    @ExtendWith(RequiresML12Dot1.class)
+    @Test
+    public void propertiesFragmentShouldBeReturnedByFromLexicons() {
+        Map<String, CtsReferenceExpr> lexicons = new HashMap<>();
+        lexicons.put("uri", op.cts.uriReference());
+
+        PlanBuilder.ModifyPlan plan = op.fromLexicons(lexicons, "", op.fragmentIdCol("fragmentId"))
+            .where(op.cts.directoryQuery("/acme/"))
+            .joinDoc(op.col("doc"), op.col("uri"));
+
+        final int docCount = 50;
+        writeDocs(docCount);
+
+        List<RowRecord> rows = resultRows(plan);
+        assertEquals(docCount * 2, rows.size(),
+            "In ML 12.1+, fromLexicons returns both content fragments and properties fragments, so the row " +
+                "count should be twice the number of written documents.");
     }
 
     private void verifyPropertiesFragmentsAreNotReturned(PlanBuilder.ModifyPlan plan) {

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/JoinDocTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/rows/JoinDocTest.java
@@ -57,7 +57,8 @@ public class JoinDocTest extends AbstractOpticUpdateTest {
 
     /**
      * In ML 12.1+, fromLexicons enumerates both content fragments and properties fragments, so joinDoc
-     * returns twice as many rows as written documents.
+     * returns twice as many rows as written documents. This behavior was introduced in ML 12.1 as part of
+	 * MLE-27052 and intended behavior was validated in MLE-31757 comments.
      */
     @ExtendWith(RequiresML12Dot1.class)
     @Test


### PR DESCRIPTION
propertiesFragmentShouldNotBeReturnedByFromLexicons() was failing against ML12.1 due to intended behavior change, validated in MLE-31757. The test has been updated to only run on ML version 12.0 or lower. A new test has been added to validate the new ML 12.1 fromLexicons behavior.

Jira Ticket: https://progresssoftware.atlassian.net/browse/MLE-31642
ML 12.1 behavior change verified in comments of: https://progresssoftware.atlassian.net/browse/MLE-31757