### PR TITLE
MLE-32054: [java-client-api][polaris]Improper Resource Shutdown or Release

### DIFF
--- a/examples/src/main/java/com/marklogic/client/example/cookbook/datamovement/OpticExportListener.java
+++ b/examples/src/main/java/com/marklogic/client/example/cookbook/datamovement/OpticExportListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2010-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.client.example.cookbook.datamovement;
 
@@ -18,6 +18,7 @@ import com.marklogic.client.datamovement.QueryBatchListener;
 import com.marklogic.client.expression.PlanBuilder;
 import com.marklogic.client.row.RowManager;
 import com.marklogic.client.row.RowRecord;
+import com.marklogic.client.row.RowSet;
 
 /**
  * Takes in a Function which takes QueryBatch as argument and converts it into a
@@ -74,12 +75,14 @@ public class OpticExportListener implements QueryBatchListener {
   public void processEvent(QueryBatch batch) {
     try {
       PlanBuilder.Plan exportPlan = exportFunction.apply(batch);
-      for (RowRecord record : rowManager.resultRows(exportPlan)) {
-        for (Consumer<RowRecord> listener : opticExportListeners) {
-          try {
-            listener.accept(record);
-          } catch (Throwable t) {
-            logger.error("Exception thrown by an onRowRecordReady listener ", t);
+      try (RowSet<RowRecord> rows = rowManager.resultRows(exportPlan)) {
+        for (RowRecord record : rows) {
+          for (Consumer<RowRecord> listener : opticExportListeners) {
+            try {
+              listener.accept(record);
+            } catch (Throwable t) {
+              logger.error("Exception thrown by an onRowRecordReady listener ", t);
+            }
           }
         }
       }

--- a/examples/src/main/java/com/marklogic/client/example/cookbook/datamovement/OpticExportToWriterListener.java
+++ b/examples/src/main/java/com/marklogic/client/example/cookbook/datamovement/OpticExportToWriterListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2010-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.client.example.cookbook.datamovement;
 
@@ -20,6 +20,7 @@ import com.marklogic.client.expression.PlanBuilder;
 import com.marklogic.client.expression.PlanBuilder.Plan;
 import com.marklogic.client.row.RowManager;
 import com.marklogic.client.row.RowRecord;
+import com.marklogic.client.row.RowSet;
 
 /**
  * An extension of OpticExportListener which facilitates writing all row records
@@ -92,28 +93,30 @@ public class OpticExportToWriterListener extends OpticExportListener {
     try {
       PlanBuilder.Plan exportPlan = exportFunction.apply(batch);
       synchronized (writer) {
-        for (RowRecord record : rowManager.resultRows(exportPlan)) {
-          try {
-            if (prefix != null)
-              writer.write(prefix);
-            if (outputListeners.size() > 0) {
-              for (OpticOutputListener listener : outputListeners) {
-                String output = null;
-                try {
-                  output = listener.generateOutput(record);
-                } catch (Throwable t) {
-                  logger.error("Exception thrown by an onGenerateOutput listener", t);
+        try (RowSet<RowRecord> rows = rowManager.resultRows(exportPlan)) {
+          for (RowRecord record : rows) {
+            try {
+              if (prefix != null)
+                writer.write(prefix);
+              if (outputListeners.size() > 0) {
+                for (OpticOutputListener listener : outputListeners) {
+                  String output = null;
+                  try {
+                    output = listener.generateOutput(record);
+                  } catch (Throwable t) {
+                    logger.error("Exception thrown by an onGenerateOutput listener", t);
+                  }
+                  if (output != null)
+                    writer.write(output);
                 }
-                if (output != null)
-                  writer.write(output);
+              } else {
+                writer.write(record.toString());
               }
-            } else {
-              writer.write(record.toString());
+              if (suffix != null)
+                writer.write(suffix);
+            } catch (IOException e) {
+              throw new DataMovementException("Failed to write the Optic API records", e);
             }
-            if (suffix != null)
-              writer.write(suffix);
-          } catch (IOException e) {
-            throw new DataMovementException("Failed to write the Optic API records", e);
           }
         }
       }


### PR DESCRIPTION
### PR Description
Fix CWE-404 resource leak in OpticExportListener and OpticExportToWriterListener

### Problem
RowSet<T> implements Closeable (it holds an open HTTP response stream from MarkLogic). Both OpticExportListener.processEvent() and OpticExportToWriterListener.processEvent() iterated over rowManager.resultRows(exportPlan) using a plain for-each loop, which never closes the RowSet. This leaks the underlying connection on every batch processed, reducing future resource availability (Polaris CWE-404, Risk Score 80).

### Fix
Wrapped rowManager.resultRows() in a try-with-resources block in both classes, ensuring the RowSet is closed on all exit paths including exceptions. This matches the pattern already established in RowTemplate.java.

### Files Changed

1. examples/src/main/java/.../OpticExportListener.java — added RowSet import; processEvent now uses try-with-resources
2. examples/src/main/java/.../OpticExportToWriterListener.java — same; try-with-resources wraps the RowSet inside the existing synchronized (writer) block

### Validation

1. Confirmed RowSet<T> extends Closeable (RowSet.java)
2. Verified identical fix pattern is used in RowTemplate.java
3. ./gradlew examples:compileJava passes with no warnings