### PR TITLE
MLE-32022 Avoid null pointer exception when FailedRequest is null

### DIFF
--- a/marklogic-client-api/src/main/java/com/marklogic/client/MarkLogicServerException.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/MarkLogicServerException.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2010-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2010-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.client;
 
 import com.marklogic.client.impl.FailedRequest;
+import com.marklogic.client.impl.RESTServices;
 
 /**
  * Abstract class that implements functionality for errors returned from a MarkLogic REST API instance.
@@ -51,7 +52,7 @@ public abstract class MarkLogicServerException extends RuntimeException {
    * @return  the status code
    */
   public int getServerStatusCode() {
-    return (failedRequest == null) ? null : failedRequest.getStatusCode();
+    return (failedRequest == null) ? RESTServices.STATUS_UNKNOWN : failedRequest.getStatusCode();
   }
   /**
    * Gets the HTTP status message (if any) associated with the error on the server.

--- a/marklogic-client-api/src/main/java/com/marklogic/client/impl/RESTServices.java
+++ b/marklogic-client-api/src/main/java/com/marklogic/client/impl/RESTServices.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2010-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.client.impl;
 
@@ -68,6 +68,7 @@ public interface RESTServices {
   String MIMETYPE_APPLICATION_XML = "application/xml";
   String MIMETYPE_MULTIPART_MIXED = "multipart/mixed";
 
+  int STATUS_UNKNOWN = -1;
   int STATUS_OK = 200;
   int STATUS_CREATED = 201;
   int STATUS_NO_CONTENT = 204;

--- a/marklogic-client-api/src/test/java/com/marklogic/client/test/FailedRequestTest.java
+++ b/marklogic-client-api/src/test/java/com/marklogic/client/test/FailedRequestTest.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2010-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2010-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.client.test;
 
 import com.marklogic.client.*;
 import com.marklogic.client.admin.QueryOptionsManager;
 import com.marklogic.client.document.XMLDocumentManager;
+import com.marklogic.client.impl.FailedRequest;
 import com.marklogic.client.io.Format;
 import com.marklogic.client.io.StringHandle;
 import org.junit.jupiter.api.Test;
@@ -99,5 +100,16 @@ public class FailedRequestTest {
     } catch (Exception e) {
       fail("Call failed with unexpected exception: "+e.getMessage());
     }
+  }
+
+  @Test
+  public void testNullFailedRequestInFailedRequestException() {
+    FailedRequestException e = new FailedRequestException("test", (FailedRequest) null);
+    assertEquals("test", e.getMessage());
+    assertEquals(-1, e.getServerStatusCode());
+    assertNull(e.getServerStatus());
+    assertNull(e.getServerMessageCode());
+    assertNull(e.getServerMessage());
+    assertNull(e.getServerStackTrace());
   }
 }


### PR DESCRIPTION
Addresses GitHub issue [#1969](https://github.com/marklogic/java-client-api/issues/1969)